### PR TITLE
fix(html): rebind UI APIs safely across reconnects

### DIFF
--- a/packages/html/src/ui/slider/slider-element.ts
+++ b/packages/html/src/ui/slider/slider-element.ts
@@ -71,7 +71,7 @@ export class SliderElement extends UIElement {
       getElement: () => this,
       getThumbElement: () => this.querySelector<HTMLElement>('media-slider-thumb'),
       getOrientation: () => this.orientation,
-      isDisabled: () => this.disabled,
+      isDisabled: () => this.destroyed || this.disabled,
       getPercent: () => this.#core.percentFromValue(this.value),
       getStepPercent: () => this.#core.getStepPercent(),
       getLargeStepPercent: () => this.#core.getLargeStepPercent(),
@@ -100,19 +100,29 @@ export class SliderElement extends UIElement {
     applyElementProps(this, this.#slider.rootProps, { signal });
     applyStyles(this, this.#slider.rootStyle);
     this.#slider.input.subscribe(() => this.requestUpdate(), { signal });
+    this.requestUpdate();
   }
 
   override disconnectedCallback(): void {
-    this.#releaseControlsVisibilityLock();
+    this.#disposeSlider();
     super.disconnectedCallback();
-    this.#disconnect?.abort();
-    this.#disconnect = null;
   }
 
   override destroyCallback(): void {
-    this.#releaseControlsVisibilityLock();
-    this.#slider?.destroy();
+    this.#disposeSlider();
     super.destroyCallback();
+  }
+
+  // Each connection owns one slider API. Destroying it on disconnect releases
+  // the ResizeObserver and pointer capture instead of leaking them on reconnect.
+  #disposeSlider(): void {
+    this.#releaseControlsVisibilityLock();
+
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+
+    this.#slider?.destroy();
+    this.#slider = null;
   }
 
   #releaseControlsVisibilityLock(): void {

--- a/packages/html/src/ui/slider/tests/slider-element.test.ts
+++ b/packages/html/src/ui/slider/tests/slider-element.test.ts
@@ -13,6 +13,23 @@ import { SliderThumbElement } from '../slider-thumb-element';
 import { SliderTrackElement } from '../slider-track-element';
 import { SliderValueElement } from '../slider-value-element';
 
+class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = [];
+
+  readonly observe = vi.fn();
+  readonly unobserve = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(_callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+}
+
+function stubResizeObserver(): void {
+  ResizeObserverStub.instances.length = 0;
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+}
+
 // Unique tag names to avoid customElements.define collisions across tests.
 let tagCounter = 0;
 
@@ -50,6 +67,7 @@ class TestPlayerProviderElement extends UIElement {
 }
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   document.body.innerHTML = '';
 });
 
@@ -207,6 +225,91 @@ describe('SliderElement', () => {
     slider.dispatchEvent(new PointerEvent('lostpointercapture', { bubbles: true, pointerId: 1 }));
 
     expect(provider.releaseControlsLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('recreates its API and rebinds pointer listeners once after a reconnect', async () => {
+    stubResizeObserver();
+    const slider = createElement(SliderElement);
+    const onValueChange = vi.fn();
+
+    slider.addEventListener('value-change', onValueChange);
+    document.body.append(slider);
+    await slider.updateComplete;
+
+    const firstObserver = ResizeObserverStub.instances[0]!;
+
+    expect(ResizeObserverStub.instances).toHaveLength(1);
+
+    slider.remove();
+    document.body.append(slider);
+    await slider.updateComplete;
+
+    expect(firstObserver.disconnect).toHaveBeenCalledOnce();
+    expect(ResizeObserverStub.instances).toHaveLength(2);
+    expect(ResizeObserverStub.instances[1]!.disconnect).not.toHaveBeenCalled();
+
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+    slider.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientX: 50 }));
+
+    expect(onValueChange).toHaveBeenCalledOnce();
+  });
+
+  it('releases its API and disables interaction listeners when destroyed while connected', async () => {
+    stubResizeObserver();
+    const slider = createElement(SliderElement);
+    const thumb = createElement(SliderThumbElement);
+    const onValueChange = vi.fn();
+
+    slider.addEventListener('value-change', onValueChange);
+    slider.append(thumb);
+    document.body.append(slider);
+    await slider.updateComplete;
+    await thumb.updateComplete;
+
+    const observer = ResizeObserverStub.instances[0]!;
+
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+
+    slider.destroy();
+
+    expect(observer.disconnect).toHaveBeenCalledOnce();
+
+    slider.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientX: 50 }));
+    thumb.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowRight' }));
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('discards interrupted drag state and releases its controls lock before reconnecting', async () => {
+    stubResizeObserver();
+    const provider = createElement(TestPlayerProviderElement);
+    const slider = createElement(SliderElement);
+
+    provider.append(slider);
+    document.body.append(provider);
+    await slider.updateComplete;
+
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+    slider.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientX: 50 }));
+    slider.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerId: 1, clientX: 55, buttons: 1 }));
+
+    const firstObserver = ResizeObserverStub.instances[0]!;
+
+    expect(provider.requestControlsLock).toHaveBeenCalledOnce();
+
+    slider.remove();
+
+    expect(provider.releaseControlsLock).toHaveBeenCalledOnce();
+    expect(firstObserver.disconnect).toHaveBeenCalledOnce();
+
+    provider.append(slider);
+    await slider.updateComplete;
+
+    expect(ResizeObserverStub.instances).toHaveLength(2);
+    expect(ResizeObserverStub.instances[1]!.disconnect).not.toHaveBeenCalled();
+    expect(slider.hasAttribute('data-dragging')).toBe(false);
   });
 
   it('supports vertical orientation', async () => {

--- a/packages/html/src/ui/thumbnail/tests/thumbnail-element.test.ts
+++ b/packages/html/src/ui/thumbnail/tests/thumbnail-element.test.ts
@@ -8,6 +8,23 @@ import { playerContext } from '../../../player/context';
 import { UIElement } from '../../ui-element';
 import { ThumbnailElement } from '../thumbnail-element';
 
+class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = [];
+
+  readonly observe = vi.fn();
+  readonly unobserve = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(_callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+}
+
+function stubResizeObserver(): void {
+  ResizeObserverStub.instances.length = 0;
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+}
+
 function createTextTrackStore(
   thumbnailTrackCrossOrigin: MediaTextTrackState['thumbnailTrackCrossOrigin']
 ): AnyPlayerStore {
@@ -73,7 +90,56 @@ async function renderCrossOrigin(
 
 describe('ThumbnailElement', () => {
   afterEach(() => {
+    vi.unstubAllGlobals();
     document.body.innerHTML = '';
+  });
+
+  it('reuses one API and its bindings across a rapid reconnect', async () => {
+    stubResizeObserver();
+    const thumbnail = document.createElement(ThumbnailElement.tagName) as ThumbnailElement;
+
+    thumbnail.thumbnails = [{ url: 'thumbnail.jpg', startTime: 0 }];
+    document.body.append(thumbnail);
+    await thumbnail.updateComplete;
+
+    const observer = ResizeObserverStub.instances[0]!;
+
+    expect(ResizeObserverStub.instances).toHaveLength(1);
+
+    thumbnail.remove();
+    document.body.append(thumbnail);
+    await thumbnail.updateComplete;
+
+    expect(ResizeObserverStub.instances).toHaveLength(1);
+    expect(observer.disconnect).not.toHaveBeenCalled();
+
+    const requestUpdate = vi.spyOn(thumbnail, 'requestUpdate');
+
+    requestUpdate.mockClear();
+    thumbnail.shadowRoot!.querySelector('img')!.dispatchEvent(new Event('load'));
+
+    expect(requestUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('releases its observer and image listeners when destroyed while connected', async () => {
+    stubResizeObserver();
+    const thumbnail = document.createElement(ThumbnailElement.tagName) as ThumbnailElement;
+
+    thumbnail.thumbnails = [{ url: 'thumbnail.jpg', startTime: 0 }];
+    document.body.append(thumbnail);
+    await thumbnail.updateComplete;
+
+    const observer = ResizeObserverStub.instances[0]!;
+    const requestUpdate = vi.spyOn(thumbnail, 'requestUpdate');
+
+    requestUpdate.mockClear();
+
+    thumbnail.destroy();
+
+    expect(observer.disconnect).toHaveBeenCalledOnce();
+
+    thumbnail.shadowRoot!.querySelector('img')!.dispatchEvent(new Event('load'));
+    expect(requestUpdate).not.toHaveBeenCalled();
   });
 
   describe('crossorigin', () => {

--- a/packages/html/src/ui/thumbnail/thumbnail-element.ts
+++ b/packages/html/src/ui/thumbnail/thumbnail-element.ts
@@ -83,19 +83,18 @@ export class ThumbnailElement extends UIElement {
 
     if (this.destroyed) return;
 
-    this.#api = createThumbnail({
+    this.#api ??= createThumbnail({
       getContainer: () => this,
       getImg: () => this.#img,
       onStateChange: () => this.requestUpdate(),
     });
-  }
-
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
+    this.#api.connect();
+    this.requestUpdate();
   }
 
   override destroyCallback(): void {
     this.#api?.destroy();
+    this.#api = null;
     super.destroyCallback();
   }
 

--- a/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
+++ b/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
@@ -1,7 +1,11 @@
 import { SliderDataAttrs, type SliderState } from '@videojs/core';
+import type { AnyPlayerStore } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
+import type { MediaPlaybackState, MediaTimeState } from '@videojs/media';
+import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { playerContext } from '../../../player/context';
 import { sliderContext } from '../../slider/context';
 import { SliderThumbElement } from '../../slider/slider-thumb-element';
 import { SliderValueElement } from '../../slider/slider-value-element';
@@ -9,6 +13,23 @@ import { UIElement } from '../../ui-element';
 import { TimeSliderChapterTitleElement } from '../time-slider-chapters/time-slider-chapter-title-element';
 import { TimeSliderChaptersElement } from '../time-slider-chapters/time-slider-chapters-element';
 import { TimeSliderElement } from '../time-slider-element';
+
+class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = [];
+
+  readonly observe = vi.fn();
+  readonly unobserve = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(_callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+}
+
+function stubResizeObserver(): void {
+  ResizeObserverStub.instances.length = 0;
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+}
 
 let tagCounter = 0;
 
@@ -27,6 +48,31 @@ class TestSliderProviderElement extends UIElement {
   readonly provider = new ContextProvider(this, {
     context: sliderContext,
     initialValue: createSliderContext(),
+  });
+}
+
+class TestPlayerProviderElement extends UIElement {
+  readonly pause = vi.fn();
+  readonly play = vi.fn(async () => {});
+  readonly store = createStore<unknown>()<MediaTimeState & MediaPlaybackState>({
+    name: 'time-slider',
+    state: () => ({
+      currentTime: 0,
+      duration: 100,
+      seeking: false,
+      seek: vi.fn(),
+      paused: false,
+      ended: false,
+      started: true,
+      waiting: false,
+      play: this.play,
+      pause: this.pause,
+      togglePaused: vi.fn(),
+    }),
+  }) as unknown as AnyPlayerStore;
+  readonly provider = new ContextProvider(this, {
+    context: playerContext,
+    initialValue: this.store,
   });
 }
 
@@ -52,6 +98,7 @@ function createSliderContext(state: Partial<SliderState> = {}, pointerValue = 0)
 }
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   document.body.innerHTML = '';
 });
 
@@ -158,6 +205,88 @@ describe('TimeSliderElement', () => {
     // Without store, context is not populated so thumb has no ARIA.
     // This verifies no errors occur in the context chain.
     expect(thumb.isConnected).toBe(true);
+  });
+
+  it('recreates its API and rebinds pointer listeners once after a reconnect', async () => {
+    stubResizeObserver();
+    const provider = createElement(TestPlayerProviderElement);
+    const slider = createElement(TimeSliderElement);
+    const onDragStart = vi.fn();
+
+    slider.addEventListener('drag-start', onDragStart);
+    provider.append(slider);
+    document.body.append(provider);
+    await slider.updateComplete;
+
+    const firstObserver = ResizeObserverStub.instances[0]!;
+
+    expect(ResizeObserverStub.instances).toHaveLength(1);
+
+    slider.remove();
+    provider.append(slider);
+    await slider.updateComplete;
+
+    expect(firstObserver.disconnect).toHaveBeenCalledOnce();
+    expect(ResizeObserverStub.instances).toHaveLength(2);
+    expect(ResizeObserverStub.instances[1]!.disconnect).not.toHaveBeenCalled();
+
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+    slider.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientX: 50 }));
+    slider.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerId: 1, clientX: 55, buttons: 1 }));
+
+    expect(onDragStart).toHaveBeenCalledOnce();
+  });
+
+  it('releases its API and pointer listeners when destroyed while connected', async () => {
+    stubResizeObserver();
+    const provider = createElement(TestPlayerProviderElement);
+    const slider = createElement(TimeSliderElement);
+    const onDragStart = vi.fn();
+
+    slider.addEventListener('drag-start', onDragStart);
+    provider.append(slider);
+    document.body.append(provider);
+    await slider.updateComplete;
+
+    const observer = ResizeObserverStub.instances[0]!;
+
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+
+    slider.destroy();
+
+    expect(observer.disconnect).toHaveBeenCalledOnce();
+
+    slider.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientX: 50 }));
+    slider.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerId: 1, clientX: 55, buttons: 1 }));
+    expect(onDragStart).not.toHaveBeenCalled();
+  });
+
+  it('resumes playback and discards its API when disconnected during a paused drag', async () => {
+    stubResizeObserver();
+    const provider = createElement(TestPlayerProviderElement);
+    const slider = createElement(TimeSliderElement);
+
+    slider.pauseOnDrag = true;
+
+    provider.append(slider);
+    document.body.append(provider);
+    await slider.updateComplete;
+
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+    slider.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientX: 50 }));
+    slider.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerId: 1, clientX: 55, buttons: 1 }));
+
+    const observer = ResizeObserverStub.instances[0]!;
+
+    expect(provider.pause).toHaveBeenCalledOnce();
+
+    slider.remove();
+
+    expect(provider.play).toHaveBeenCalledOnce();
+    expect(observer.disconnect).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -75,7 +75,7 @@ export class TimeSliderElement extends UIElement {
       getElement: () => this,
       getThumbElement: () => this.querySelector<HTMLElement>('media-slider-thumb'),
       getOrientation: () => this.orientation,
-      isDisabled: () => this.disabled || !this.#timeState.value,
+      isDisabled: () => this.destroyed || this.disabled || !this.#timeState.value,
       getPercent: () => {
         const media = this.#timeState.value;
         if (!media) return 0;
@@ -109,6 +109,7 @@ export class TimeSliderElement extends UIElement {
     applyElementProps(this, this.#slider.rootProps, { signal });
     applyStyles(this, this.#slider.rootStyle);
     this.#slider.input.subscribe(() => this.requestUpdate(), { signal });
+    this.requestUpdate();
 
     if (__DEV__ && !this.#timeState.value) {
       logMissingFeature(this.localName, this.#timeState.displayName!);
@@ -116,18 +117,26 @@ export class TimeSliderElement extends UIElement {
   }
 
   override disconnectedCallback(): void {
-    this.#releaseControlsVisibilityLock();
-    this.#resumeIfDragPaused();
+    this.#disposeSlider();
     super.disconnectedCallback();
-    this.#disconnect?.abort();
-    this.#disconnect = null;
   }
 
   override destroyCallback(): void {
+    this.#disposeSlider();
+    super.destroyCallback();
+  }
+
+  // Each connection owns one slider API. Destroying it on disconnect releases
+  // the ResizeObserver and pointer capture instead of leaking them on reconnect.
+  #disposeSlider(): void {
     this.#releaseControlsVisibilityLock();
     this.#resumeIfDragPaused();
+
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+
     this.#slider?.destroy();
-    super.destroyCallback();
+    this.#slider = null;
   }
 
   // createSlider's destroy() does not fire onDragEnd, so a teardown mid-drag

--- a/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
+++ b/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
@@ -9,6 +9,23 @@ import { SliderThumbElement } from '../../slider/slider-thumb-element';
 import { UIElement } from '../../ui-element';
 import { VolumeSliderElement } from '../volume-slider-element';
 
+class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = [];
+
+  readonly observe = vi.fn();
+  readonly unobserve = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(_callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+}
+
+function stubResizeObserver(): void {
+  ResizeObserverStub.instances.length = 0;
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+}
+
 let tagCounter = 0;
 
 function uniqueTag(base: string): string {
@@ -22,7 +39,10 @@ function createElement<Element extends HTMLElement>(Base: abstract new () => Ele
   return document.createElement(tag) as Element;
 }
 
-function createVolumeStore(volumeAvailability: MediaVolumeState['volumeAvailability']): AnyPlayerStore {
+function createVolumeStore(
+  volumeAvailability: MediaVolumeState['volumeAvailability'],
+  setVolume = vi.fn()
+): AnyPlayerStore {
   return createStore<unknown>()<MediaVolumeState>({
     name: 'volume',
     state: () => ({
@@ -32,7 +52,7 @@ function createVolumeStore(volumeAvailability: MediaVolumeState['volumeAvailabil
       // Mute has an availability of its own, and this slider reads the level's;
       // these tests vary that one and leave the mute available throughout.
       mutedAvailability: 'available',
-      setVolume: vi.fn(),
+      setVolume,
       toggleMuted: vi.fn(),
     }),
   }) as unknown as AnyPlayerStore;
@@ -54,6 +74,7 @@ if (!customElements.get('test-volume-slider-player')) {
 }
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   document.body.innerHTML = '';
 });
 
@@ -156,5 +177,56 @@ describe('VolumeSliderElement', () => {
 
     // Verifies no errors during disconnect/cleanup.
     expect(slider.isConnected).toBe(false);
+  });
+
+  it('recreates its API and rebinds wheel listeners once after a reconnect', async () => {
+    stubResizeObserver();
+    const setVolume = vi.fn();
+    const provider = document.createElement('test-volume-slider-player') as TestPlayerProviderElement;
+
+    provider.store = createVolumeStore('available', setVolume);
+    const slider = createElement(VolumeSliderElement);
+
+    document.body.append(provider);
+    provider.append(slider);
+    await slider.updateComplete;
+
+    const firstObserver = ResizeObserverStub.instances[0]!;
+
+    expect(ResizeObserverStub.instances).toHaveLength(1);
+
+    slider.remove();
+    provider.append(slider);
+    await slider.updateComplete;
+
+    expect(firstObserver.disconnect).toHaveBeenCalledOnce();
+    expect(ResizeObserverStub.instances).toHaveLength(2);
+    expect(ResizeObserverStub.instances[1]!.disconnect).not.toHaveBeenCalled();
+
+    slider.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 1 }));
+
+    expect(setVolume).toHaveBeenCalledOnce();
+  });
+
+  it('releases its API and wheel listener when destroyed while connected', async () => {
+    stubResizeObserver();
+    const setVolume = vi.fn();
+    const provider = document.createElement('test-volume-slider-player') as TestPlayerProviderElement;
+
+    provider.store = createVolumeStore('available', setVolume);
+    const slider = createElement(VolumeSliderElement);
+
+    document.body.append(provider);
+    provider.append(slider);
+    await slider.updateComplete;
+
+    const observer = ResizeObserverStub.instances[0]!;
+
+    slider.destroy();
+
+    expect(observer.disconnect).toHaveBeenCalledOnce();
+
+    slider.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 1 }));
+    expect(setVolume).not.toHaveBeenCalled();
   });
 });

--- a/packages/html/src/ui/volume-slider/volume-slider-element.ts
+++ b/packages/html/src/ui/volume-slider/volume-slider-element.ts
@@ -68,7 +68,7 @@ export class VolumeSliderElement extends UIElement {
     const isDisabled = () => {
       const volume = this.#volumeState.value;
 
-      return this.disabled || !volume || volume.volumeAvailability !== 'available';
+      return this.destroyed || this.disabled || !volume || volume.volumeAvailability !== 'available';
     };
 
     const getPercent = () => (this.#volumeState.value?.volume ?? 0) * 100;
@@ -110,6 +110,7 @@ export class VolumeSliderElement extends UIElement {
     applyElementProps(this, wheelProps, { signal });
     applyStyles(this, this.#slider.rootStyle);
     this.#slider.input.subscribe(() => this.requestUpdate(), { signal });
+    this.requestUpdate();
 
     if (__DEV__ && !this.#volumeState.value) {
       logMissingFeature(this.localName, this.#volumeState.displayName!);
@@ -117,16 +118,25 @@ export class VolumeSliderElement extends UIElement {
   }
 
   override disconnectedCallback(): void {
-    this.#releaseControlsVisibilityLock();
+    this.#disposeSlider();
     super.disconnectedCallback();
-    this.#disconnect?.abort();
-    this.#disconnect = null;
   }
 
   override destroyCallback(): void {
-    this.#releaseControlsVisibilityLock();
-    this.#slider?.destroy();
+    this.#disposeSlider();
     super.destroyCallback();
+  }
+
+  // Each connection owns one slider API. Destroying it on disconnect releases
+  // the ResizeObserver and pointer capture instead of leaking them on reconnect.
+  #disposeSlider(): void {
+    this.#releaseControlsVisibilityLock();
+
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+
+    this.#slider?.destroy();
+    this.#slider = null;
   }
 
   #releaseControlsVisibilityLock(): void {


### PR DESCRIPTION
Refs #2365

## Summary

Give the observer-owning thumbnail and slider elements a reconnect-safe lifecycle. Reconnecting a slider previously called `createSlider()` again without destroying the prior instance, leaking the `ResizeObserver` it owns. The thumbnail API is reused across reconnects because it carries durable state; slider APIs are recreated per connection.

## Changes

- Thumbnail: reuse one `createThumbnail` API across reconnects (retains `lastSrc`, failed sources, and image bindings) and call `connect()` on each connect
- Slider, time slider, volume slider: create the `createSlider` API per connection and destroy it in `disconnectedCallback`, sharing teardown with `destroyCallback` through a single private `#disposeSlider()`
- Keep controls-lock release and pause-on-drag resume in the shared teardown, before `super` so the player controller is still attached
- Request an update after each connect so the fresh API's `thumbProps` and input are republished through slider context
- Tests: assert the previous observer is disconnected and a new one created across reconnects, handlers are rebound exactly once, destroy while connected releases the observer and disables handlers, and mid-drag disconnect releases the controls lock and resumes paused playback

## Testing

- `pnpm -F @videojs/html test src/ui/slider src/ui/thumbnail src/ui/time-slider src/ui/volume-slider` (82 tests pass)
- `pnpm -F @videojs/html test` (460 tests pass)
- `pnpm exec vp run @videojs/html#build` (`@videojs/html` has no standalone `build` script)
- `pnpm lint:fix:file` on all touched files
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pointer/wheel/keyboard binding and teardown for primary playback controls, including pause-on-drag resume on disconnect; behavior is covered by new lifecycle tests but affects hot interaction paths.
> 
> **Overview**
> Fixes **ResizeObserver and listener leaks** when slider and thumbnail custom elements disconnect and reconnect in the DOM.
> 
> **Sliders** (`media-slider`, `media-time-slider`, `media-volume-slider`) now treat each DOM connection as owning one `createSlider` instance: `#disposeSlider()` runs on both `disconnectedCallback` and `destroyCallback`, aborting bound props, destroying the prior API, and clearing `#slider`. Reconnect creates a fresh API and calls `requestUpdate()` so thumb context and input state republish. `isDisabled` also checks `destroyed` so teardown cannot accept input. Time slider teardown still releases controls locks, resumes playback after **pause-on-drag** mid-disconnect, and clears drag state.
> 
> **Thumbnail** keeps a single `createThumbnail` API across reconnects (cached src/error state) and calls `#api.connect()` on each connect instead of recreating; `destroyCallback` nulls the API after destroy.
> 
> **Tests** stub `ResizeObserver` and cover reconnect (observer disconnect + one new binding), destroy-while-connected (no handlers), and slider-specific cases (controls lock + drag state; time slider play resume on disconnect during drag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92dcb79797f062bf849ec3595bff3221b76216c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->