### PR TITLE
fix(react)!: acquire media instances after commit

### DIFF
--- a/packages/react/src/media/hls-background-video/media.tsx
+++ b/packages/react/src/media/hls-background-video/media.tsx
@@ -58,6 +58,7 @@ export const HlsBackgroundVideo = forwardRef<HTMLVideoElement, HlsBackgroundVide
   // typed for, and anything else listening on the node — the consumer's own
   // `addEventListener`, a testing-library assertion — sees the same failure.
   useEffect(() => {
+    if (!media) return;
     const forward = () => videoRef.current?.dispatchEvent(new Event('error'));
     media.addEventListener('error', forward);
     return () => media.removeEventListener('error', forward);

--- a/packages/react/src/media/mux-video/hls-js.tsx
+++ b/packages/react/src/media/mux-video/hls-js.tsx
@@ -34,7 +34,7 @@ export const MuxVideo = forwardRef<HTMLVideoElement, MuxVideoProps>(function Mux
 
   return (
     <video ref={composedRef} {...htmlProps}>
-      <MuxStoryboard media={media} />
+      {media && <MuxStoryboard media={media} />}
       {children}
     </video>
   );

--- a/packages/react/src/media/mux-video/spf.tsx
+++ b/packages/react/src/media/mux-video/spf.tsx
@@ -34,7 +34,7 @@ export const MuxVideo = forwardRef<HTMLVideoElement, MuxVideoProps>(function Mux
 
   return (
     <video ref={composedRef} {...htmlProps}>
-      <MuxStoryboard media={media} />
+      {media && <MuxStoryboard media={media} />}
       {children}
     </video>
   );

--- a/packages/react/src/media/tests/mux-video.test.tsx
+++ b/packages/react/src/media/tests/mux-video.test.tsx
@@ -1,7 +1,8 @@
 import { render } from '@testing-library/react';
 import { HlsJsMedia } from '@videojs/media/dom/hls-js';
 import { MuxMedia } from '@videojs/media/dom/mux';
-import type { ReactElement } from 'react';
+import { createRef, type ReactElement } from 'react';
+import { renderToString } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 import { MuxVideo } from '../mux-video';
 
@@ -19,6 +20,36 @@ function renderWithMedia(ui: ReactElement) {
 }
 
 describe('MuxVideo', () => {
+  it('server-renders its host without acquiring or attaching media', () => {
+    const attach = vi.spyOn(MuxMedia.prototype, 'attach');
+    const source = vi.spyOn(MuxMedia.prototype, 'source', 'set');
+
+    const html = renderToString(<MuxVideo source={{ playbackId: 'abc123' }} data-testid="mux-video" />);
+
+    expect(html).toContain('<video');
+    expect(html).toContain('data-testid="mux-video"');
+    expect(attach).not.toHaveBeenCalled();
+    expect(source).not.toHaveBeenCalled();
+    attach.mockRestore();
+    source.mockRestore();
+  });
+
+  it('forwards its host ref after media acquisition', () => {
+    const ref = createRef<HTMLVideoElement>();
+
+    render(<MuxVideo ref={ref} />);
+
+    expect(ref.current).toBeInstanceOf(HTMLVideoElement);
+  });
+
+  it('attaches the acquired media to the existing host', () => {
+    const attach = vi.spyOn(MuxMedia.prototype, 'attach');
+    const { container } = render(<MuxVideo />);
+
+    expect(attach).toHaveBeenCalledWith(container.querySelector('video'));
+    attach.mockRestore();
+  });
+
   it('does not spread the source prop onto the element', () => {
     const { container } = render(<MuxVideo source={{ playbackId: 'abc123', preferPlayback: 'native' }} />);
 

--- a/packages/react/src/utils/media-instance-lifecycle.ts
+++ b/packages/react/src/utils/media-instance-lifecycle.ts
@@ -1,0 +1,31 @@
+interface DestroyableMedia {
+  detach?(): void;
+  destroy(): void;
+}
+
+const terminationCallbacks = new WeakMap<object, Set<() => void>>();
+
+export function onMediaInstanceTermination(instance: object, callback: () => void): () => void {
+  let callbacks = terminationCallbacks.get(instance);
+  if (!callbacks) terminationCallbacks.set(instance, (callbacks = new Set()));
+  callbacks.add(callback);
+
+  return () => {
+    callbacks.delete(callback);
+    if (callbacks.size === 0 && terminationCallbacks.get(instance) === callbacks) {
+      terminationCallbacks.delete(instance);
+    }
+  };
+}
+
+export function destroyMediaInstance(instance: DestroyableMedia): void {
+  const callbacks = terminationCallbacks.get(instance);
+  terminationCallbacks.delete(instance);
+
+  try {
+    for (const callback of callbacks ?? []) callback();
+    instance.detach?.();
+  } finally {
+    instance.destroy();
+  }
+}

--- a/packages/react/src/utils/tests/use-attach-media.test.tsx
+++ b/packages/react/src/utils/tests/use-attach-media.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render } from '@testing-library/react';
+import type { MediaEngineHost } from '@videojs/media';
+import type { RefCallback } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useAttachMedia } from '../use-attach-media';
+import { useComposedRefs } from '../use-composed-refs';
+
+afterEach(cleanup);
+
+describe('useAttachMedia', () => {
+  it('attaches acquired media without cycling a forwarded ref', () => {
+    const forwardedRef = vi.fn<RefCallback<HTMLVideoElement>>();
+    const media = {
+      engine: null,
+      attach: vi.fn(),
+      detach: vi.fn(),
+      destroy: vi.fn(),
+    } satisfies MediaEngineHost;
+
+    function Host({ currentMedia }: { currentMedia: MediaEngineHost | null }) {
+      const attachRef = useAttachMedia(currentMedia);
+      const ref = useComposedRefs(attachRef, forwardedRef);
+      return (
+        <video ref={ref}>
+          <track kind="captions" />
+        </video>
+      );
+    }
+
+    const { container, rerender, unmount } = render(<Host currentMedia={null} />);
+    const target = container.querySelector('video')!;
+
+    expect(forwardedRef).toHaveBeenCalledOnce();
+    expect(forwardedRef).toHaveBeenLastCalledWith(target);
+    expect(media.attach).not.toHaveBeenCalled();
+
+    rerender(<Host currentMedia={media} />);
+
+    expect(media.attach).toHaveBeenCalledOnce();
+    expect(media.attach).toHaveBeenCalledWith(target);
+    expect(forwardedRef).toHaveBeenCalledOnce();
+
+    unmount();
+
+    expect(media.detach).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/utils/tests/use-media-instance.test.tsx
+++ b/packages/react/src/utils/tests/use-media-instance.test.tsx
@@ -1,0 +1,199 @@
+import { cleanup, render, renderHook } from '@testing-library/react';
+import type { Media } from '@videojs/media';
+import { Component, type ErrorInfo, type ReactNode, StrictMode, useEffect } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+
+import { createPlayerWrapper } from '../../testing/mocks';
+import { useMediaInstance } from '../use-media-instance';
+
+class TestMedia extends EventTarget {
+  static instances: TestMedia[] = [];
+
+  readonly engine = null;
+  readonly destroy = vi.fn();
+
+  constructor() {
+    super();
+    TestMedia.instances.push(this);
+  }
+}
+
+const TestMediaClass = TestMedia as unknown as new () => TestMedia & Media;
+
+class Boundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  override componentDidCatch(_error: Error, _info: ErrorInfo) {}
+
+  override render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
+beforeEach(() => {
+  TestMedia.instances = [];
+});
+
+afterEach(cleanup);
+
+describe('useMediaInstance', () => {
+  it('exposes an explicit nullable readiness contract', () => {
+    const { result } = renderHook(() => useMediaInstance(TestMediaClass));
+
+    expectTypeOf(result.current).toEqualTypeOf<(TestMedia & Media) | null>();
+    expect(result.current).toBe(TestMedia.instances[0]);
+  });
+
+  it('does not acquire during server rendering', () => {
+    function ServerComponent() {
+      const media = useMediaInstance(TestMediaClass);
+      return <div data-ready={media ? 'true' : 'false'} />;
+    }
+
+    expect(renderToString(<ServerComponent />)).toContain('data-ready="false"');
+    expect(TestMedia.instances).toHaveLength(0);
+  });
+
+  it('does not acquire from an abandoned render', () => {
+    function Abandoned(): ReactNode {
+      useMediaInstance(TestMediaClass);
+      throw new Error('abandon render');
+    }
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <Boundary>
+        <Abandoned />
+      </Boundary>
+    );
+
+    expect(TestMedia.instances).toHaveLength(0);
+    consoleError.mockRestore();
+  });
+
+  it('runs setup before publishing and owns cleanup', () => {
+    const events: string[] = [];
+    const setup = vi.fn(() => events.push('setup'));
+    const { value, Wrapper } = createPlayerWrapper();
+    value.setMedia = vi.fn(() => events.push('publish'));
+
+    const { result, unmount } = renderHook(() => useMediaInstance(TestMediaClass, setup), { wrapper: Wrapper });
+    const instance = result.current!;
+
+    expect(setup).toHaveBeenCalledOnce();
+    expect(setup).toHaveBeenCalledWith(instance);
+    expect(events).toEqual(['setup', 'publish']);
+    expect(value.setMedia).toHaveBeenCalledWith(instance);
+
+    unmount();
+
+    expect(instance.destroy).toHaveBeenCalledOnce();
+    const detach = vi.mocked(value.setMedia).mock.calls.at(-1)![0];
+    expect(detach).toBeTypeOf('function');
+    if (typeof detach === 'function') {
+      expect(detach(instance)).toBeNull();
+      expect(detach({} as Media)).not.toBeNull();
+    }
+  });
+
+  it('acquires and publishes before passive effects', () => {
+    const events: string[] = [];
+    const { value, Wrapper } = createPlayerWrapper();
+    value.setMedia = vi.fn(() => events.push('publish'));
+
+    function PassiveProbe() {
+      useEffect(() => {
+        events.push('passive');
+      }, []);
+
+      return null;
+    }
+
+    function AcquisitionProbe() {
+      const media = useMediaInstance(TestMediaClass, () => events.push('setup'));
+      return <div data-ready={media ? 'true' : 'false'} />;
+    }
+
+    const { container } = render(
+      <>
+        <PassiveProbe />
+        <AcquisitionProbe />
+      </>,
+      { wrapper: Wrapper }
+    );
+
+    expect(events).toEqual(['setup', 'publish', 'passive']);
+    expect(container.firstElementChild?.getAttribute('data-ready')).toBe('true');
+  });
+
+  it('cleans up the old class before publishing its replacement', () => {
+    class ReplacementMedia extends TestMedia {}
+
+    const ReplacementMediaClass = ReplacementMedia as unknown as new () => ReplacementMedia & Media;
+    const events: string[] = [];
+    let current: Media | null = null;
+    const { value, Wrapper } = createPlayerWrapper();
+    value.setMedia = vi.fn((next) => {
+      if (typeof next === 'function') {
+        events.push('detach:old');
+        current = next(current);
+      } else {
+        events.push(next instanceof ReplacementMedia ? 'publish:new' : 'publish:old');
+        current = next;
+      }
+    });
+
+    const { result, rerender } = renderHook(({ MediaClass }) => useMediaInstance(MediaClass), {
+      initialProps: { MediaClass: TestMediaClass },
+      wrapper: Wrapper,
+    });
+    const first = result.current!;
+    first.destroy.mockImplementation(() => events.push('destroy:old'));
+    events.length = 0;
+
+    rerender({ MediaClass: ReplacementMediaClass });
+
+    expect(events).toEqual(['detach:old', 'destroy:old', 'publish:new']);
+    expect(current).toBe(result.current);
+    expect(result.current).toBeInstanceOf(ReplacementMedia);
+  });
+
+  it('destroys an instance when setup fails before publication', () => {
+    const error = new Error('setup failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() =>
+      renderHook(() =>
+        useMediaInstance(TestMediaClass, () => {
+          throw error;
+        })
+      )
+    ).toThrow(error);
+
+    expect(TestMedia.instances).toHaveLength(1);
+    expect(TestMedia.instances[0]!.destroy).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+
+  it('cleans up and reacquires during the StrictMode effect replay', () => {
+    const setup = vi.fn();
+    const { result, unmount } = renderHook(() => useMediaInstance(TestMediaClass, setup), {
+      wrapper: StrictMode,
+    });
+
+    expect(TestMedia.instances).toHaveLength(2);
+    expect(TestMedia.instances[0]!.destroy).toHaveBeenCalledOnce();
+    expect(result.current).toBe(TestMedia.instances[1]);
+    expect(setup).toHaveBeenCalledTimes(2);
+
+    unmount();
+
+    expect(TestMedia.instances[1]!.destroy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/utils/tests/use-media-instance.test.tsx
+++ b/packages/react/src/utils/tests/use-media-instance.test.tsx
@@ -1,10 +1,12 @@
-import { cleanup, render, renderHook } from '@testing-library/react';
+import { act, cleanup, render, renderHook } from '@testing-library/react';
 import type { Media } from '@videojs/media';
-import { Component, type ErrorInfo, type ReactNode, StrictMode, useEffect } from 'react';
+import { Component, type ErrorInfo, type ReactNode, type RefCallback, StrictMode, Suspense, useEffect } from 'react';
 import { renderToString } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { createPlayerWrapper } from '../../testing/mocks';
+import { useAttachMedia } from '../use-attach-media';
+import { useComposedRefs } from '../use-composed-refs';
 import { useMediaInstance } from '../use-media-instance';
 
 class TestMedia extends EventTarget {
@@ -20,6 +22,54 @@ class TestMedia extends EventTarget {
 }
 
 const TestMediaClass = TestMedia as unknown as new () => TestMedia & Media;
+
+interface AttachedTestMedia {
+  readonly engine: null;
+  readonly destroyed: boolean;
+  attach(target: HTMLVideoElement): void;
+  detach(): void;
+  destroy(): void;
+}
+
+function createAttachedTestMediaClass(label: string, events: string[]): new () => AttachedTestMedia & Media {
+  return class extends EventTarget {
+    readonly engine = null;
+    destroyed = false;
+
+    attach(_target: HTMLVideoElement) {
+      if (this.destroyed) throw new Error(`${label} attached after destroy`);
+      events.push(`${label}:attach`);
+    }
+
+    detach() {
+      if (this.destroyed) throw new Error(`${label} detached after destroy`);
+      events.push(`${label}:detach`);
+    }
+
+    destroy() {
+      events.push(`${label}:destroy`);
+      this.destroyed = true;
+    }
+  } as unknown as new () => AttachedTestMedia & Media;
+}
+
+function AttachedHost({
+  MediaClass,
+  forwardedRef,
+}: {
+  MediaClass: new () => AttachedTestMedia & Media;
+  forwardedRef?: RefCallback<HTMLVideoElement>;
+}) {
+  const media = useMediaInstance(MediaClass);
+  const attachRef = useAttachMedia(media);
+  const ref = useComposedRefs(attachRef, forwardedRef);
+
+  return (
+    <video ref={ref}>
+      <track kind="captions" />
+    </video>
+  );
+}
 
 class Boundary extends Component<{ children: ReactNode }, { failed: boolean }> {
   state = { failed: false };
@@ -162,6 +212,85 @@ describe('useMediaInstance', () => {
     expect(events).toEqual(['detach:old', 'destroy:old', 'publish:new']);
     expect(current).toBe(result.current);
     expect(result.current).toBeInstanceOf(ReplacementMedia);
+  });
+
+  it('detaches its target before destroying on unmount', () => {
+    const events: string[] = [];
+    const MediaClass = createAttachedTestMediaClass('media', events);
+    const { unmount } = render(<AttachedHost MediaClass={MediaClass} />);
+    events.length = 0;
+
+    expect(() => unmount()).not.toThrow();
+    expect(events).toEqual(['media:detach', 'media:destroy']);
+  });
+
+  it('detaches before destroying a replaced class without cycling the forwarded ref', () => {
+    const events: string[] = [];
+    const FirstMedia = createAttachedTestMediaClass('first', events);
+    const ReplacementMedia = createAttachedTestMediaClass('replacement', events);
+    const forwardedRef = vi.fn<RefCallback<HTMLVideoElement>>();
+    const { rerender } = render(<AttachedHost MediaClass={FirstMedia} forwardedRef={forwardedRef} />);
+    events.length = 0;
+
+    expect(() => rerender(<AttachedHost MediaClass={ReplacementMedia} forwardedRef={forwardedRef} />)).not.toThrow();
+    expect(events).toEqual(['first:detach', 'first:destroy', 'replacement:attach']);
+    expect(forwardedRef).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a destroyed acquisition unavailable while a suspended tree reconnects', async () => {
+    const events: string[] = [];
+    const renders: Array<(AttachedTestMedia & Media) | null> = [];
+    const MediaClass = createAttachedTestMediaClass('media', events);
+    let resolveSuspension!: () => void;
+    const suspension = new Promise<void>((resolve) => {
+      resolveSuspension = resolve;
+    });
+
+    function Host() {
+      const media = useMediaInstance(MediaClass);
+      const ref = useAttachMedia(media);
+      renders.push(media);
+      return (
+        <video ref={ref}>
+          <track kind="captions" />
+        </video>
+      );
+    }
+
+    function Gate({ suspended }: { suspended: boolean }) {
+      if (suspended) throw suspension;
+      return <Host />;
+    }
+
+    function App({ suspended }: { suspended: boolean }) {
+      return (
+        <Suspense fallback={null}>
+          <Gate suspended={suspended} />
+        </Suspense>
+      );
+    }
+
+    const { rerender } = render(<App suspended={false} />);
+    const initial = renders.at(-1)!;
+    events.length = 0;
+    renders.length = 0;
+
+    rerender(<App suspended />);
+
+    expect(events).toEqual(['media:detach', 'media:destroy']);
+    events.length = 0;
+
+    expect(() => rerender(<App suspended={false} />)).not.toThrow();
+    expect(renders).toHaveLength(2);
+    expect(renders[0]).toBeNull();
+    expect(renders[1]).not.toBe(initial);
+    expect(renders[1]?.destroyed).toBe(false);
+    expect(events).toEqual(['media:attach']);
+
+    await act(async () => {
+      resolveSuspension();
+      await suspension;
+    });
   });
 
   it('destroys an instance when setup fails before publication', () => {

--- a/packages/react/src/utils/tests/use-sync-props.test.tsx
+++ b/packages/react/src/utils/tests/use-sync-props.test.tsx
@@ -156,6 +156,19 @@ describe('useSyncProps', () => {
     expect(target.src).toBe('');
   });
 
+  it('waits until a nullable target is committed', () => {
+    const target: TargetProps = { ...defaults };
+    const { rerender } = renderHook(({ current }) => useSyncProps(current, { src: 'video.mp4' }, defaults), {
+      initialProps: { current: null as TargetProps | null },
+    });
+
+    expect(target.src).toBe('');
+
+    rerender({ current: target });
+
+    expect(target.src).toBe('video.mp4');
+  });
+
   it('keeps committed writes idempotent under StrictMode effect replay', () => {
     let src = '';
     const write = vi.fn((value: string) => {

--- a/packages/react/src/utils/use-attach-iframe.ts
+++ b/packages/react/src/utils/use-attach-iframe.ts
@@ -1,14 +1,8 @@
 import type { MediaEngineHost } from '@videojs/media';
 import type { RefCallback } from 'react';
-import { useCallback } from 'react';
 
-export function useAttachIframe<T extends HTMLIFrameElement>(media: MediaEngineHost): RefCallback<T> {
-  return useCallback(
-    (element: T | null) => {
-      if (element) media.attach?.(element);
-      else media.detach?.();
-      return () => media.detach?.();
-    },
-    [media]
-  );
+import { useAttachTarget } from './use-attach-target';
+
+export function useAttachIframe<T extends HTMLIFrameElement>(media: MediaEngineHost | null): RefCallback<T> {
+  return useAttachTarget<T>(media);
 }

--- a/packages/react/src/utils/use-attach-media.ts
+++ b/packages/react/src/utils/use-attach-media.ts
@@ -1,14 +1,15 @@
 import type { MediaEngineHost } from '@videojs/media';
 import type { RefCallback } from 'react';
-import { useCallback } from 'react';
 
-export function useAttachMedia<T extends HTMLMediaElement>(media: MediaEngineHost): RefCallback<T> {
-  return useCallback(
-    (element: T | null) => {
-      if (element) media.attach?.(element);
-      else media.detach?.();
-      return () => media.detach?.();
-    },
-    [media]
-  );
+import { useAttachTarget } from './use-attach-target';
+
+/**
+ * Attach a committed media instance to a React media element ref.
+ *
+ * A `null` media leaves the ref inert until an instance is acquired.
+ *
+ * @param media - Committed media instance, or `null` while acquisition is pending.
+ */
+export function useAttachMedia<T extends HTMLMediaElement>(media: MediaEngineHost | null): RefCallback<T> {
+  return useAttachTarget<T>(media);
 }

--- a/packages/react/src/utils/use-attach-target.ts
+++ b/packages/react/src/utils/use-attach-target.ts
@@ -2,9 +2,12 @@ import type { MediaEngineHost } from '@videojs/media';
 import type { RefCallback } from 'react';
 import { useCallback, useLayoutEffect, useRef } from 'react';
 
+import { onMediaInstanceTermination } from './media-instance-lifecycle';
+
 interface TargetAttachment<Target> {
   media: MediaEngineHost;
   target: Target;
+  releaseTermination: () => void;
 }
 
 export function useAttachTarget<Target>(media: MediaEngineHost | null): RefCallback<Target> {
@@ -12,8 +15,12 @@ export function useAttachTarget<Target>(media: MediaEngineHost | null): RefCallb
   const attachmentRef = useRef<TargetAttachment<Target> | null>(null);
 
   const detach = useCallback(() => {
-    attachmentRef.current?.media.detach?.();
+    const attachment = attachmentRef.current;
+    if (!attachment) return;
+
     attachmentRef.current = null;
+    attachment.releaseTermination();
+    attachment.media.detach?.();
   }, []);
 
   useLayoutEffect(() => {
@@ -24,7 +31,15 @@ export function useAttachTarget<Target>(media: MediaEngineHost | null): RefCallb
 
     if (media && target && !attachmentRef.current) {
       media.attach?.(target);
-      attachmentRef.current = { media, target };
+      const nextAttachment: TargetAttachment<Target> = {
+        media,
+        target,
+        releaseTermination: () => {},
+      };
+      attachmentRef.current = nextAttachment;
+      nextAttachment.releaseTermination = onMediaInstanceTermination(media, () => {
+        if (attachmentRef.current === nextAttachment) attachmentRef.current = null;
+      });
     }
   });
 

--- a/packages/react/src/utils/use-attach-target.ts
+++ b/packages/react/src/utils/use-attach-target.ts
@@ -1,0 +1,36 @@
+import type { MediaEngineHost } from '@videojs/media';
+import type { RefCallback } from 'react';
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+interface TargetAttachment<Target> {
+  media: MediaEngineHost;
+  target: Target;
+}
+
+export function useAttachTarget<Target>(media: MediaEngineHost | null): RefCallback<Target> {
+  const targetRef = useRef<Target | null>(null);
+  const attachmentRef = useRef<TargetAttachment<Target> | null>(null);
+
+  const detach = useCallback(() => {
+    attachmentRef.current?.media.detach?.();
+    attachmentRef.current = null;
+  }, []);
+
+  useLayoutEffect(() => {
+    const target = targetRef.current;
+    const attachment = attachmentRef.current;
+
+    if (attachment && (attachment.media !== media || attachment.target !== target)) detach();
+
+    if (media && target && !attachmentRef.current) {
+      media.attach?.(target);
+      attachmentRef.current = { media, target };
+    }
+  });
+
+  useLayoutEffect(() => detach, [detach]);
+
+  return useCallback((target) => {
+    targetRef.current = target;
+  }, []);
+}

--- a/packages/react/src/utils/use-media-instance.ts
+++ b/packages/react/src/utils/use-media-instance.ts
@@ -1,36 +1,52 @@
 import type { Media } from '@videojs/media';
-import { useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 import { useMediaAttach } from '../player/context';
-import { useDestroy } from './use-destroy';
+import { useLatestRef } from './use-latest-ref';
+
+interface MediaAcquisition<Instance> {
+  MediaClass: new () => Instance;
+  instance: Instance;
+}
 
 /**
- * Create and manage a media instance lifecycle within a player context.
+ * Acquire and manage a media instance after the component commits.
  *
- * Instantiates the media class once, attaches it to the player on mount,
- * and safely detaches on unmount using a functional updater to avoid race
- * conditions when swapping media components (e.g. DashVideo → HlsJsVideo).
+ * Returns `null` during server rendering and until the acquisition layout
+ * effect has committed. The acquired instance is attached to the surrounding
+ * player and destroyed when its component unmounts or the media class changes.
  *
- * An optional `setup` callback runs once on mount — e.g. to add media
- * components via `addMediaComponent`. Components registered there are destroyed
- * together with the media instance on unmount (`media.destroy()` destroys
- * all of its registered components).
+ * @param MediaClass - Media class to acquire. Pass a stable class reference.
+ * @param setup - Optional initialization that runs once for each acquired
+ * instance, before it is published to the player. Resources registered with the
+ * media are owned and destroyed by that instance.
  */
 export function useMediaInstance<Instance extends Media & { destroy(): void }>(
   MediaClass: new () => Instance,
   setup?: (media: Instance) => void
-): Instance {
-  const [instance] = useState(() => new MediaClass());
+): Instance | null {
+  const [acquisition, setAcquisition] = useState<MediaAcquisition<Instance> | null>(null);
   const setMedia = useMediaAttach();
+  const setupRef = useLatestRef(setup);
 
-  useDestroy(
-    instance,
-    () => {
-      setup?.(instance);
-      setMedia?.(instance);
-    },
-    () => setMedia?.((prev) => (prev === instance ? null : prev))
-  );
+  useLayoutEffect(() => {
+    const instance = new MediaClass();
 
-  return instance;
+    try {
+      setupRef.current?.(instance);
+    } catch (error) {
+      instance.destroy();
+      throw error;
+    }
+
+    setAcquisition({ MediaClass, instance });
+    setMedia?.(instance);
+
+    return () => {
+      setMedia?.((prev) => (prev === instance ? null : prev));
+      instance.destroy();
+    };
+  }, [MediaClass, setMedia]);
+
+  return acquisition?.MediaClass === MediaClass ? acquisition.instance : null;
 }

--- a/packages/react/src/utils/use-media-instance.ts
+++ b/packages/react/src/utils/use-media-instance.ts
@@ -1,7 +1,8 @@
 import type { Media } from '@videojs/media';
-import { useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import { useMediaAttach } from '../player/context';
+import { destroyMediaInstance } from './media-instance-lifecycle';
 import { useLatestRef } from './use-latest-ref';
 
 interface MediaAcquisition<Instance> {
@@ -26,6 +27,7 @@ export function useMediaInstance<Instance extends Media & { destroy(): void }>(
   setup?: (media: Instance) => void
 ): Instance | null {
   const [acquisition, setAcquisition] = useState<MediaAcquisition<Instance> | null>(null);
+  const activeAcquisitionRef = useRef<MediaAcquisition<Instance> | null>(null);
   const setMedia = useMediaAttach();
   const setupRef = useLatestRef(setup);
 
@@ -39,14 +41,19 @@ export function useMediaInstance<Instance extends Media & { destroy(): void }>(
       throw error;
     }
 
-    setAcquisition({ MediaClass, instance });
+    const nextAcquisition = { MediaClass, instance };
+    activeAcquisitionRef.current = nextAcquisition;
+    setAcquisition(nextAcquisition);
     setMedia?.(instance);
 
     return () => {
+      if (activeAcquisitionRef.current === nextAcquisition) activeAcquisitionRef.current = null;
       setMedia?.((prev) => (prev === instance ? null : prev));
-      instance.destroy();
+      destroyMediaInstance(instance);
     };
   }, [MediaClass, setMedia]);
 
-  return acquisition?.MediaClass === MediaClass ? acquisition.instance : null;
+  return acquisition?.MediaClass === MediaClass && activeAcquisitionRef.current === acquisition
+    ? acquisition.instance
+    : null;
 }

--- a/packages/react/src/utils/use-sync-props.ts
+++ b/packages/react/src/utils/use-sync-props.ts
@@ -2,7 +2,7 @@ import { isUndefined } from '@videojs/utils/predicate';
 import { useLayoutEffect, useRef } from 'react';
 
 export function useSyncProps<Props extends object, Rest extends Record<string, unknown>>(
-  target: Props,
+  target: Props | null,
   props: Partial<Props> & Rest,
   defaults: Props
 ): Omit<Rest, keyof Props> {
@@ -22,6 +22,8 @@ export function useSyncProps<Props extends object, Rest extends Record<string, u
   }
 
   useLayoutEffect(() => {
+    if (!target) return;
+
     const sync = (key: string, value: unknown) => {
       if (target[key as keyof Props] !== value) target[key as keyof Props] = value as Props[keyof Props];
     };


### PR DESCRIPTION
Refs #1679

Depends on #2316.

## Summary

Acquire engine-bearing media instances only after React commits, then initialize and publish them before paint. This prevents SSR and abandoned mounts from constructing playback engines and makes readiness explicit through a nullable useMediaInstance return.

## Changes

- Change useMediaInstance to return Instance | null until its layout-effect acquisition commits
- Initialize before player publication and own detachment/destruction on class swap or unmount
- Coordinate DOM attachment teardown so ownership clears, the target detaches once, and only then the instance is destroyed
- Keep destroyed acquisitions unavailable across Suspense hide/reveal until a fresh committed instance exists
- Attach acquired media to an existing host through one stable ref without cycling forwarded refs
- Allow prop synchronization to wait for a nullable target
- Guard the few adapters that directly consume the media instance
- Cover SSR, abandoned render, StrictMode recreation, setup failure, pre-passive readiness, class replacement, integrated teardown order, and Suspense reconnection

## Breaking change

External useMediaInstance callers must handle null until commit readiness. The built-in adapters already do so.

## Testing

- pnpm -F @videojs/react test: 525 tests
- pnpm build --filter=@videojs/react
- pnpm typecheck
- pnpm -F site api-docs
- Biome and git diff --check