### PR TITLE
fix(react): add commit-safe ref and logging utilities

### DIFF
--- a/packages/react/src/ui/buffering-indicator/buffering-indicator.tsx
+++ b/packages/react/src/ui/buffering-indicator/buffering-indicator.tsx
@@ -1,5 +1,5 @@
 import { BufferingIndicatorCore, BufferingIndicatorDataAttrs } from '@videojs/core';
-import { logMissingFeature, selectPlayback } from '@videojs/core/dom';
+import { selectPlayback } from '@videojs/core/dom';
 import type { ForwardedRef } from 'react';
 import { forwardRef, useState, useSyncExternalStore } from 'react';
 
@@ -8,6 +8,7 @@ import type { UIComponentProps } from '../../utils/types';
 import { useDestroy } from '../../utils/use-destroy';
 import { useIsomorphicLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 import { renderElement } from '../../utils/use-render';
+import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
 
 export interface BufferingIndicatorProps
   extends UIComponentProps<'div', BufferingIndicatorCore.State>, BufferingIndicatorCore.Props {}
@@ -54,11 +55,9 @@ export const BufferingIndicator = forwardRef(function BufferingIndicator(
     if (playback) core.update(playback);
   }, [core, delay, playback]);
 
-  if (!playback) {
-    if (__DEV__) logMissingFeature('BufferingIndicator', 'playback');
+  useLogMissingFeature(!playback, 'BufferingIndicator', 'playback');
 
-    return null;
-  }
+  if (!playback) return null;
 
   return renderElement(
     'div',

--- a/packages/react/src/ui/controls/controls-root.tsx
+++ b/packages/react/src/ui/controls/controls-root.tsx
@@ -1,9 +1,10 @@
 import { ControlsCore, ControlsDataAttrs } from '@videojs/core';
-import { logMissingFeature, selectControls } from '@videojs/core/dom';
+import { selectControls } from '@videojs/core/dom';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { usePlayer } from '../../player/context';
+import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
 import { ControlsContextProvider } from './context';
 
 export interface ControlsRootProps {
@@ -15,11 +16,9 @@ export function ControlsRoot({ children }: ControlsRootProps): ReactNode {
   const controls = usePlayer(selectControls);
   const [core] = useState(() => new ControlsCore());
 
-  if (!controls) {
-    if (__DEV__) logMissingFeature('Controls.Root', 'controls');
+  useLogMissingFeature(!controls, 'Controls.Root', 'controls');
 
-    return null;
-  }
+  if (!controls) return null;
 
   core.setMedia(controls);
   const state = core.getState();

--- a/packages/react/src/ui/create-media-button.tsx
+++ b/packages/react/src/ui/create-media-button.tsx
@@ -1,5 +1,4 @@
 import type { InferComponentState, InferMediaState, MediaButtonComponent, StateAttrMap } from '@videojs/core';
-import { logMissingFeature } from '@videojs/core/dom';
 import { isText, translateText } from '@videojs/core/i18n';
 import type { Selector } from '@videojs/store';
 import { isUndefined } from '@videojs/utils/predicate';
@@ -11,6 +10,7 @@ import { useContainer, usePlayer } from '../player/context';
 import type { renderElement as renderElementFn } from '../utils/use-render';
 import { renderElement } from '../utils/use-render';
 import { useButton } from './hooks/use-button';
+import { useLogMissingFeature } from './hooks/use-log-missing-feature';
 import { useHotkeyShortcut } from './hotkey/use-hotkey-shortcut';
 import { useOptionalMenuTriggerChildContext } from './menu/context';
 import { useOptionalTooltipContext } from './tooltip/context';
@@ -133,11 +133,9 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
       return () => setTooltipContent(undefined);
     }, [setTooltipContent, tooltipText, shortcut.shortcut]);
 
-    if (!feature || !state) {
-      if (__DEV__) logMissingFeature(displayName, selector.displayName ?? displayName);
+    useLogMissingFeature(!feature, displayName, selector.displayName ?? displayName);
 
-      return null;
-    }
+    if (!feature || !state) return null;
 
     if (!supported) return null;
 

--- a/packages/react/src/ui/hooks/create-radio-options-hook.ts
+++ b/packages/react/src/ui/hooks/create-radio-options-hook.ts
@@ -1,11 +1,11 @@
 import type { RadioOption, RadioOptionsState } from '@videojs/core';
-import { logMissingFeature } from '@videojs/core/dom';
 import { type Text, type TextParams, translateText } from '@videojs/core/i18n';
 import type { UnknownState } from '@videojs/store';
 import { useCallback, useState } from 'react';
 
 import { useTranslator } from '../../i18n/context';
 import { usePlayer } from '../../player/context';
+import { useLogMissingFeature } from './use-log-missing-feature';
 
 interface RadioOptionsCore<Props, Media, State extends RadioOptionsState> {
   setProps(props: Props): void;
@@ -61,11 +61,9 @@ export function createRadioOptionsHook<Props, Media, State extends RadioOptionsS
 
     const setValue = useCallback((value: string) => core.selectValue(media!, value), [core, media]);
 
-    if (!media) {
-      if (__DEV__) logMissingFeature(name, selector.displayName ?? feature);
+    useLogMissingFeature(!media, name, selector.displayName ?? feature);
 
-      return null;
-    }
+    if (!media) return null;
 
     core.setMedia(media);
     const state = core.getState();

--- a/packages/react/src/ui/hooks/tests/use-log-missing-feature.test.tsx
+++ b/packages/react/src/ui/hooks/tests/use-log-missing-feature.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render } from '@testing-library/react';
+import { logMissingFeature } from '@videojs/core/dom';
+import type { ReactNode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { MockErrorBoundary } from '../../../testing/mocks';
+import { useLogMissingFeature } from '../use-log-missing-feature';
+
+vi.mock('@videojs/core/dom', () => ({
+  logMissingFeature: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('useLogMissingFeature', () => {
+  it('logs after a render missing the feature commits', () => {
+    function Probe() {
+      useLogMissingFeature(true, 'Control', 'playback');
+      return null;
+    }
+
+    render(<Probe />);
+
+    expect(logMissingFeature).toHaveBeenCalledWith('Control', 'playback');
+  });
+
+  it('does not log while the feature is present', () => {
+    function Probe() {
+      useLogMissingFeature(false, 'Control', 'playback');
+      return null;
+    }
+
+    render(<Probe />);
+
+    expect(logMissingFeature).not.toHaveBeenCalled();
+  });
+
+  it('does not log during server rendering', () => {
+    function Probe() {
+      useLogMissingFeature(true, 'Control', 'playback');
+      return null;
+    }
+
+    renderToString(<Probe />);
+
+    expect(logMissingFeature).not.toHaveBeenCalled();
+  });
+
+  it('does not log from an abandoned render', () => {
+    function Abandoned(): ReactNode {
+      useLogMissingFeature(true, 'Control', 'playback');
+      throw new Error('abandon render');
+    }
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <MockErrorBoundary>
+        <Abandoned />
+      </MockErrorBoundary>
+    );
+
+    expect(logMissingFeature).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/packages/react/src/ui/hooks/use-log-missing-feature.ts
+++ b/packages/react/src/ui/hooks/use-log-missing-feature.ts
@@ -1,0 +1,20 @@
+import { logMissingFeature } from '@videojs/core/dom';
+import { useEffect } from 'react';
+
+function useLogMissingFeatureDev(missing: boolean, displayName: string, featureName: string): void {
+  useEffect(() => {
+    if (missing) logMissingFeature(displayName, featureName);
+  }, [missing, displayName, featureName]);
+}
+
+function useLogMissingFeatureProd(_missing: boolean, _displayName: string, _featureName: string): void {}
+
+/**
+ * Warn once that a component rendered without the media feature it needs.
+ *
+ * Logging from render would also fire for speculative and server renders, so the warning waits for a commit. Production
+ * builds resolve to a no-op that registers no effect.
+ */
+export const useLogMissingFeature: (missing: boolean, displayName: string, featureName: string) => void = __DEV__
+  ? useLogMissingFeatureDev
+  : useLogMissingFeatureProd;

--- a/packages/react/src/ui/live-button/live-button.tsx
+++ b/packages/react/src/ui/live-button/live-button.tsx
@@ -1,5 +1,5 @@
 import { LiveButtonCore, LiveButtonDataAttrs, type LiveButtonMediaState } from '@videojs/core';
-import { logMissingFeature, selectBuffer, selectLive, selectTime } from '@videojs/core/dom';
+import { selectBuffer, selectLive, selectTime } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';
 import { forwardRef, type ReactNode, useLayoutEffect, useState } from 'react';
 
@@ -8,6 +8,7 @@ import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
 import { useButton } from '../hooks/use-button';
+import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
 import { useOptionalTooltipContext } from '../tooltip/context';
 
 const DISPLAY_NAME = 'LiveButton';
@@ -75,11 +76,9 @@ export const LiveButton = forwardRef<HTMLButtonElement, LiveButtonProps>(
       return () => tooltipCtx.setContent(undefined);
     }, [tooltipCtx, labelText]);
 
-    if (!media || !state) {
-      if (__DEV__) logMissingFeature(DISPLAY_NAME, selectLive.displayName ?? 'live');
+    useLogMissingFeature(!media, DISPLAY_NAME, selectLive.displayName ?? 'live');
 
-      return null;
-    }
+    if (!media || !state) return null;
 
     const attrs = core.getAttrs(state);
     const labelAttr = attrs['aria-label'];

--- a/packages/react/src/ui/poster/poster.tsx
+++ b/packages/react/src/ui/poster/poster.tsx
@@ -1,11 +1,12 @@
 import { PosterCore, PosterDataAttrs, type PosterImageLoadState } from '@videojs/core';
-import { logMissingFeature, selectMetadata, selectPlayback } from '@videojs/core/dom';
+import { selectMetadata, selectPlayback } from '@videojs/core/dom';
 import type { ForwardedRef } from 'react';
 import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
+import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
 
 export interface PosterProps extends UIComponentProps<'img', PosterCore.State> {}
 
@@ -120,11 +121,9 @@ export const Poster = forwardRef(function Poster(
     [src, authoredSrcSet]
   );
 
-  if (!playback || !state) {
-    if (__DEV__) logMissingFeature('Poster', 'playback');
+  useLogMissingFeature(!playback, 'Poster', 'playback');
 
-    return null;
-  }
+  if (!playback || !state) return null;
 
   return renderElement(
     'img',

--- a/packages/react/src/ui/time-slider/time-slider-root.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-root.tsx
@@ -1,5 +1,5 @@
 import { TimeSliderCore, TimeSliderDataAttrs } from '@videojs/core';
-import { getTimeSliderCSSVars, logMissingFeature, selectBuffer, selectPlayback, selectTime } from '@videojs/core/dom';
+import { getTimeSliderCSSVars, selectBuffer, selectPlayback, selectTime } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';
 import { formatTime } from '@videojs/utils/time';
 import { forwardRef, useEffect, useState } from 'react';
@@ -9,6 +9,7 @@ import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { useLatestRef } from '../../utils/use-latest-ref';
 import { renderElement } from '../../utils/use-render';
+import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
 import { useSlider } from '../hooks/use-slider';
 import { SliderProvider } from '../slider/context';
 
@@ -115,11 +116,9 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
         },
       });
 
-    if (!time) {
-      if (__DEV__) logMissingFeature('TimeSlider', 'time');
+    useLogMissingFeature(!time, 'TimeSlider', 'time');
 
-      return null;
-    }
+    if (!time) return null;
 
     return (
       <SliderProvider

--- a/packages/react/src/ui/time/time-value.tsx
+++ b/packages/react/src/ui/time/time-value.tsx
@@ -1,5 +1,5 @@
 import { TimeCore, TimeDataAttrs } from '@videojs/core';
-import { logMissingFeature, selectTime } from '@videojs/core/dom';
+import { selectTime } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';
 import { durationSuffixText, elapsedSuffixText, remainingSuffixText } from '@videojs/core/i18n/text/time';
 import { isInteractiveActivation } from '@videojs/utils/dom';
@@ -11,6 +11,7 @@ import { useLocale, useTranslator } from '../../i18n/context';
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
+import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
 
 export interface ValueProps extends Omit<UIComponentProps<'time', TimeCore.State>, 'children'>, TimeCore.Props {}
 
@@ -52,11 +53,9 @@ export const Value = forwardRef(function Value(
     toggle,
   });
 
-  if (!time) {
-    if (__DEV__) logMissingFeature('Time.Value', 'time');
+  useLogMissingFeature(!time, 'Time.Value', 'time');
 
-    return null;
-  }
+  if (!time) return null;
 
   core.setMedia(time);
   core.setFormatLocale(locale);

--- a/packages/react/src/ui/title/title.tsx
+++ b/packages/react/src/ui/title/title.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { TitleCore, TitleDataAttrs } from '@videojs/core';
-import { logMissingFeature, selectMetadata } from '@videojs/core/dom';
+import { selectMetadata } from '@videojs/core/dom';
 import type { ForwardedRef } from 'react';
 import { forwardRef, useState } from 'react';
 
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
+import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
 
 export interface TitleProps extends Omit<UIComponentProps<'span', TitleCore.State>, 'children'> {}
 
@@ -35,11 +36,9 @@ export const Title = forwardRef(function Title(
 
   const [core] = useState(() => new TitleCore());
 
-  if (!metadata) {
-    if (__DEV__) logMissingFeature('Title', 'metadata');
+  useLogMissingFeature(!metadata, 'Title', 'metadata');
 
-    return null;
-  }
+  if (!metadata) return null;
 
   const state = core.getState(metadata);
   if (state.hidden) return null;

--- a/packages/react/src/ui/volume-slider/volume-slider-root.tsx
+++ b/packages/react/src/ui/volume-slider/volume-slider-root.tsx
@@ -1,5 +1,5 @@
 import { VolumeSliderCore, VolumeSliderDataAttrs } from '@videojs/core';
-import { createWheelStep, getSliderCSSVars, logMissingFeature, selectVolume } from '@videojs/core/dom';
+import { createWheelStep, getSliderCSSVars, selectVolume } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';
 import { listen } from '@videojs/utils/dom';
 import { forwardRef, useCallback, useRef, useState } from 'react';
@@ -9,6 +9,7 @@ import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { useLatestRef } from '../../utils/use-latest-ref';
 import { renderElement } from '../../utils/use-render';
+import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
 import { useSlider } from '../hooks/use-slider';
 import { SliderProvider } from '../slider/context';
 
@@ -109,11 +110,9 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
       [wheelHandler]
     );
 
-    if (!volume) {
-      if (__DEV__) logMissingFeature('VolumeSlider', 'volume');
+    useLogMissingFeature(!volume, 'VolumeSlider', 'volume');
 
-      return null;
-    }
+    if (!volume) return null;
 
     if (state.hidden) return null;
 

--- a/packages/react/src/utils/tests/use-committed-ref.test.tsx
+++ b/packages/react/src/utils/tests/use-committed-ref.test.tsx
@@ -1,0 +1,130 @@
+import { cleanup, render } from '@testing-library/react';
+import { type ReactNode, StrictMode, useLayoutEffect, useState } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { MockErrorBoundary } from '../../testing/mocks';
+import { useCommittedRef } from '../use-committed-ref';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('useCommittedRef', () => {
+  it('makes the initial value available to a lazy initializer', () => {
+    const initialized: string[] = [];
+
+    function Probe({ value }: { value: string }) {
+      const committed = useCommittedRef(value);
+
+      useState(() => initialized.push(committed.current));
+      return null;
+    }
+
+    render(<Probe value="initial" />);
+
+    expect(initialized).toEqual(['initial']);
+  });
+
+  it('publishes committed updates but not abandoned ones', () => {
+    let read = () => 'unset';
+
+    function Probe({ value, abandon = false }: { value: string; abandon?: boolean }): ReactNode {
+      const committed = useCommittedRef(value);
+      const [reader] = useState(() => () => committed.current);
+
+      useLayoutEffect(() => {
+        read = reader;
+      }, [reader]);
+
+      if (abandon) throw new Error('abandon render');
+
+      return null;
+    }
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <MockErrorBoundary>
+        <Probe value="committed" />
+      </MockErrorBoundary>
+    );
+
+    expect(read()).toBe('committed');
+
+    rerender(
+      <MockErrorBoundary>
+        <Probe value="abandoned" abandon />
+      </MockErrorBoundary>
+    );
+
+    expect(read()).toBe('committed');
+  });
+
+  it('publishes updates before descendant layout effects', () => {
+    const observed: string[] = [];
+
+    function Child({ read, commit }: { read: () => string; commit: string }) {
+      useLayoutEffect(() => {
+        if (commit) observed.push(read());
+      }, [read, commit]);
+      return null;
+    }
+
+    function Parent({ value }: { value: string }) {
+      const committed = useCommittedRef(value);
+      const [read] = useState(() => () => committed.current);
+
+      return <Child read={read} commit={value} />;
+    }
+
+    const { rerender } = render(<Parent value="first" />);
+
+    rerender(<Parent value="second" />);
+
+    expect(observed).toEqual(['first', 'second']);
+  });
+
+  it('publishes the latest committed value under StrictMode', () => {
+    let read = () => 'unset';
+
+    function Probe({ value }: { value: string }) {
+      const committed = useCommittedRef(value);
+
+      useLayoutEffect(() => {
+        read = () => committed.current;
+      }, [committed]);
+
+      return null;
+    }
+
+    const { rerender } = render(
+      <StrictMode>
+        <Probe value="first" />
+      </StrictMode>
+    );
+
+    rerender(
+      <StrictMode>
+        <Probe value="second" />
+      </StrictMode>
+    );
+
+    expect(read()).toBe('second');
+  });
+
+  it('keeps the initial value available without effects during server rendering', () => {
+    let observed = '';
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    function Probe() {
+      observed = useCommittedRef('server').current;
+      return null;
+    }
+
+    renderToString(<Probe />);
+
+    expect(observed).toBe('server');
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/utils/tests/use-destroy.test.tsx
+++ b/packages/react/src/utils/tests/use-destroy.test.tsx
@@ -1,7 +1,8 @@
 import { render, renderHook } from '@testing-library/react';
-import { StrictMode } from 'react';
+import { type ReactNode, StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
+import { MockErrorBoundary } from '../../testing/mocks';
 import { useDestroy } from '../use-destroy';
 
 describe('useDestroy', () => {
@@ -145,5 +146,39 @@ describe('useDestroy', () => {
 
     expect(teardown).not.toHaveBeenCalled();
     expect(instance.destroy).not.toHaveBeenCalled();
+  });
+
+  it('runs the committed teardown rather than one from an abandoned render', () => {
+    const instance = { destroy: vi.fn() };
+    const committedTeardown = vi.fn();
+    const abandonedTeardown = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    function TestComponent({ teardown, abandon = false }: { teardown: () => void; abandon?: boolean }): ReactNode {
+      useDestroy(instance, undefined, teardown);
+
+      if (abandon) throw new Error('abandon render');
+
+      return null;
+    }
+
+    const { rerender } = render(
+      <MockErrorBoundary>
+        <TestComponent teardown={committedTeardown} />
+      </MockErrorBoundary>
+    );
+
+    // The boundary swallows the throw and unmounts the component, which tears down the committed instance.
+    rerender(
+      <MockErrorBoundary>
+        <TestComponent teardown={abandonedTeardown} abandon />
+      </MockErrorBoundary>
+    );
+    vi.runAllTimers();
+
+    expect(committedTeardown).toHaveBeenCalledOnce();
+    expect(abandonedTeardown).not.toHaveBeenCalled();
+    expect(instance.destroy).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
   });
 });

--- a/packages/react/src/utils/tests/use-latest-ref.test.tsx
+++ b/packages/react/src/utils/tests/use-latest-ref.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render } from '@testing-library/react';
+import { useState } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+
+import { useLatestRef } from '../use-latest-ref';
+
+afterEach(cleanup);
+
+describe('useLatestRef', () => {
+  it('makes the initial value available to a lazy initializer', () => {
+    const initialized: string[] = [];
+
+    function Probe({ value }: { value: string }) {
+      const latest = useLatestRef(value);
+
+      useState(() => initialized.push(latest.current));
+      return null;
+    }
+
+    render(<Probe value="initial" />);
+
+    expect(initialized).toEqual(['initial']);
+  });
+
+  it('updates the same ref during render', () => {
+    const observed: string[] = [];
+    const refs: useLatestRef.Result<string>[] = [];
+
+    function Probe({ value }: { value: string }) {
+      const latest = useLatestRef(value);
+
+      observed.push(latest.current);
+      refs.push(latest);
+      return null;
+    }
+
+    const { rerender } = render(<Probe value="first" />);
+
+    rerender(<Probe value="second" />);
+
+    expect(observed).toEqual(['first', 'second']);
+    expect(refs[1]).toBe(refs[0]);
+  });
+
+  it('keeps the initial value available during server rendering', () => {
+    let observed = '';
+
+    function Probe() {
+      observed = useLatestRef('server').current;
+      return null;
+    }
+
+    renderToString(<Probe />);
+
+    expect(observed).toBe('server');
+  });
+});

--- a/packages/react/src/utils/use-committed-ref.ts
+++ b/packages/react/src/utils/use-committed-ref.ts
@@ -1,0 +1,25 @@
+import { useInsertionEffect, useRef } from 'react';
+
+/**
+ * Keep a ref whose updates become visible only once the render that produced them commits.
+ *
+ * Unlike `useLatestRef`, which writes during render, this hook publishes in `useInsertionEffect`. Abandoned and
+ * speculative renders therefore never leak their callbacks or props into retained listeners, while the value is already
+ * current by the time any layout effect in the tree (including descendants) runs. The initial value stays synchronously
+ * available to lazy initializers.
+ *
+ * @param value - Value the ref should expose after the current render commits.
+ */
+export function useCommittedRef<Value>(value: Value): Readonly<{ current: Value }> {
+  const ref = useRef(value);
+
+  useInsertionEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref;
+}
+
+export namespace useCommittedRef {
+  export type Result<Value> = Readonly<{ current: Value }>;
+}

--- a/packages/react/src/utils/use-destroy.ts
+++ b/packages/react/src/utils/use-destroy.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import { useLatestRef } from './use-latest-ref';
+import { useCommittedRef } from './use-committed-ref';
 
 interface Destroyable {
   destroy(): void;
@@ -20,8 +20,8 @@ interface Destroyable {
  */
 export function useDestroy(instance: Destroyable, setup?: () => void, teardown?: () => void): void {
   const pendingRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const setupRef = useLatestRef(setup);
-  const teardownRef = useLatestRef(teardown);
+  const setupRef = useCommittedRef(setup);
+  const teardownRef = useCommittedRef(teardown);
 
   useEffect(() => {
     if (pendingRef.current !== null) {


### PR DESCRIPTION
Refs #1679

Depends on #2320.

## Summary

Introduce the commit-safe utilities the React UI lifecycle work builds on, and move dev-only missing-feature logging out of render. This replaces the earlier all-in-one version of this PR, which is now split into #2588 (commit-phase provider props), #2589 (render-local core projections), and #2590 (thumbnail listener retargeting, independent of this stack and based on `main`).

## Changes

- Add `useCommittedRef`, which publishes its value from `useInsertionEffect`: abandoned renders cannot leak callbacks into retained listeners, while descendant layout effects already read the committed value. `useLatestRef` keeps its public render-current contract and gains tests.
- Route the `useDestroy` `setup`/`teardown` callbacks through `useCommittedRef`, with a test that an abandoned render's teardown is never adopted.
- Add `useLogMissingFeature`, a dev-only hook that logs after commit and resolves to a no-op in production, and use it wherever `logMissingFeature` was called during render: `createMediaButton`, `LiveButton`, `Title`, `BufferingIndicator`, `Time.Value`, `Controls.Root`, `TimeSlider.Root`, `VolumeSlider.Root`, `Poster`, and `createRadioOptionsHook`.
- Reuse `useIsomorphicLayoutEffect` and `MockErrorBoundary` from #2316 instead of re-adding them.

## Dropped from the previous version

- The blanket `useLatestRef` to `useCommittedRef` swaps in `useTapGesture`, `useDoubleTapGesture`, `useHotkey`, `useSlider`, `TimeSlider.Root`, `VolumeSlider.Root`, `Menu.Root`, `Popover.Root`, `Tooltip.Root`, and the dialog roots. They fit none of the four split PRs and belong in a follow-up that audits retained event-listener callbacks as a group.
- The `Poster` change that moved its render-phase `setRequest` into a layout effect. Calling `setState` during render for derived request state is sanctioned React and unrelated to these utilities.
- The `ErrorDialog.Root` `lastError` ref rewrite; `main` has since moved that root onto `useDialogRoot`.
- A dedicated `useIsomorphicLayoutEffect` test; the hook landed in #2316.

## Testing

- `pnpm -F @videojs/react test`: 73 files, 571 tests passed
- `pnpm build --filter=@videojs/react`
- `pnpm typecheck`
- `pnpm lint:fix:file` on touched files and `git diff --check`
