### PR TITLE
refactor(react)!: separate slider render and motion state

### DIFF
--- a/packages/core/src/core/ui/slider/slider-segments-core.ts
+++ b/packages/core/src/core/ui/slider/slider-segments-core.ts
@@ -85,7 +85,11 @@ export class SliderSegmentsCore {
     });
   }
 
-  getState(segment: SliderSegmentGeometry, slider: SliderState, pointerValue: number): SliderSegmentState {
+  getState<Slider extends Pick<SliderState, 'value' | 'pointing' | 'dragging' | 'interactive'>>(
+    segment: SliderSegmentGeometry,
+    slider: Slider,
+    pointerValue: number
+  ): SliderSegmentState {
     const { last, ...geometry } = segment;
     const contains = (value: number): boolean =>
       value >= segment.start && (value < segment.end || (last && value === segment.end));

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -114,7 +114,14 @@ export { Gesture, type GestureProps, MediaGesture, type MediaGestureProps } from
 export { type UseDoubleTapGestureOptions, useDoubleTapGesture } from './ui/gesture/use-doubletap-gesture';
 export { type UseTapGestureOptions, useTapGesture } from './ui/gesture/use-tap-gesture';
 export { useButton } from './ui/hooks/use-button';
-export { useSlider } from './ui/hooks/use-slider';
+export {
+  type SliderInteractionState,
+  type SliderMotionState,
+  type SliderRenderState,
+  type UseSliderOptions,
+  type UseSliderReturnValue,
+  useSlider,
+} from './ui/hooks/use-slider';
 export { Hotkey, type HotkeyProps, MediaHotkey, type MediaHotkeyProps } from './ui/hotkey/hotkey';
 export { type UseHotkeyOptions, useHotkey } from './ui/hotkey/use-hotkey';
 export { useHotkeyShortcut } from './ui/hotkey/use-hotkey-shortcut';
@@ -155,6 +162,7 @@ export { SeekIndicator } from './ui/seek-indicator';
 export type { SeekIndicatorRootProps } from './ui/seek-indicator/seek-indicator-root';
 export type { SeekIndicatorValueProps } from './ui/seek-indicator/seek-indicator-value';
 export { Slider } from './ui/slider';
+export { type SliderMotionValue, useSliderMotion } from './ui/slider/context';
 export type { SliderBufferProps } from './ui/slider/slider-buffer';
 export type { SliderFillProps } from './ui/slider/slider-fill';
 export type { SliderRootProps } from './ui/slider/slider-root';

--- a/packages/react/src/ui/hooks/use-slider.ts
+++ b/packages/react/src/ui/hooks/use-slider.ts
@@ -1,4 +1,5 @@
 import type { SliderInput, SliderState } from '@videojs/core';
+import { SliderCSSVars } from '@videojs/core';
 import {
   createSlider,
   type SliderApi,
@@ -8,14 +9,25 @@ import {
   type SliderThumbProps,
   selectControls,
 } from '@videojs/core/dom';
+import type { State as StoreState } from '@videojs/store';
 import { useSnapshot } from '@videojs/store/react';
-import { applyStyles } from '@videojs/utils/dom';
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { observeResize } from '@videojs/utils/dom';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useOptionalPlayer } from '../../player/context';
 import { useCommittedRef } from '../../utils/use-committed-ref';
 import { useDestroy } from '../../utils/use-destroy';
-import { useForceRender } from '../../utils/use-force-render';
+import { useIsomorphicLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 
+/** Discrete slider interaction fields observed by React. */
+export type SliderInteractionState = Pick<SliderInput, 'dragging' | 'pointing' | 'focused'>;
+
+/** High-frequency slider positions available through `useSliderMotion`. */
+export type SliderMotionState = Pick<SliderInput, 'pointerPercent' | 'dragPercent'>;
+
+/** Slider state exposed to React render callbacks, excluding high-frequency pointer position. */
+export type SliderRenderState<State extends SliderState = SliderState> = Omit<State, keyof SliderMotionState>;
+
+/** Options for projecting a core slider onto React render and motion channels. */
 export interface UseSliderOptions<State extends SliderState = SliderState>
   extends Pick<
     SliderOptions,
@@ -28,18 +40,24 @@ export interface UseSliderOptions<State extends SliderState = SliderState>
     | 'onDragStart'
     | 'onDragEnd'
   > {
-  computeState: (input: SliderInput) => State;
+  /** Compute semantic render state from the discrete interaction fields React observes. */
+  computeState: (interaction: SliderInteractionState) => State;
   orientation?: 'horizontal' | 'vertical' | undefined;
   disabled?: boolean | undefined;
+  thumbAlignment?: 'center' | 'edge' | undefined;
   /** Adjust a raw 0–100 percent for thumb alignment. Called for fill and pointer percents. */
   adjustPercent?: ((rawPercent: number, thumbSize: number, trackSize: number) => number) | undefined;
   /** Compute CSS variable map from the (possibly alignment-adjusted) state. */
   getCSSVars: (state: State) => Record<string, string>;
 }
 
+/** Semantic state, motion state, and element bindings returned by `useSlider`. */
 export interface UseSliderReturnValue<State extends SliderState = SliderState> {
-  state: State;
-  input: SliderApi['input'];
+  /** Semantic state safe to consume during render. */
+  state: SliderRenderState<State>;
+  /** High-frequency position source. Prefer `useSliderMotion` inside slider parts. */
+  motion: StoreState<SliderMotionState>;
+  /** React-owned CSS custom properties. Pointer motion is bound separately after commit. */
   cssVars: Record<string, string>;
   rootRef: React.RefCallback<HTMLElement>;
   thumbRef: React.RefCallback<HTMLElement>;
@@ -48,19 +66,68 @@ export interface UseSliderReturnValue<State extends SliderState = SliderState> {
   thumbProps: SliderThumbProps;
 }
 
+interface SliderLayout {
+  rootWidth: number;
+  rootHeight: number;
+  thumbWidth: number;
+  thumbHeight: number;
+}
+
+const emptyLayout: SliderLayout = {
+  rootWidth: 0,
+  rootHeight: 0,
+  thumbWidth: 0,
+  thumbHeight: 0,
+};
+
+function isSameLayout(a: SliderLayout, b: SliderLayout): boolean {
+  return (
+    a.rootWidth === b.rootWidth &&
+    a.rootHeight === b.rootHeight &&
+    a.thumbWidth === b.thumbWidth &&
+    a.thumbHeight === b.thumbHeight
+  );
+}
+
+function getAlignmentSizes(layout: SliderLayout, orientation: SliderState['orientation']) {
+  return orientation === 'horizontal'
+    ? { thumbSize: layout.thumbWidth, trackSize: layout.rootWidth }
+    : { thumbSize: layout.thumbHeight, trackSize: layout.rootHeight };
+}
+
+function alignState<State extends SliderState>(
+  state: State,
+  layout: SliderLayout,
+  adjustPercent: UseSliderOptions<State>['adjustPercent']
+): State {
+  if (!adjustPercent || state.thumbAlignment !== 'edge') return state;
+
+  const { thumbSize, trackSize } = getAlignmentSizes(layout, state.orientation);
+  if (trackSize === 0) return state;
+
+  return {
+    ...state,
+    fillPercent: adjustPercent(state.fillPercent, thumbSize, trackSize),
+    pointerPercent: adjustPercent(state.pointerPercent, thumbSize, trackSize),
+  };
+}
+
 /**
  * Manages slider input lifecycle for React.
  *
  * Wraps `createSlider()` from `@videojs/core/dom` and subscribes to its
- * input state via `useSnapshot`. Returns split props for the root
- * (pointer events) and thumb (keyboard/focus) elements.
+ * discrete input state via `useSnapshot`. Pointer positions remain on a
+ * separate motion channel so ordinary render callbacks do not re-render for
+ * every pointer move.
+ *
+ * @param options - Slider state projection, event callbacks, and value mapping.
  */
 export function useSlider<State extends SliderState = SliderState>(
   options: UseSliderOptions<State>
 ): UseSliderReturnValue<State> {
-  const optionsRef = useCommittedRef(options);
   const controls = useOptionalPlayer(selectControls);
   const requestControlsLock = controls?.requestControlsLock;
+  const committedRef = useCommittedRef({ options, requestControlsLock });
   const releaseControlsLockRef = useRef<(() => void) | null>(null);
 
   const releaseControlsLock = useCallback(() => {
@@ -72,29 +139,30 @@ export function useSlider<State extends SliderState = SliderState>(
 
   const rootElementRef = useRef<HTMLElement | null>(null);
   const thumbElementRef = useRef<HTMLElement | null>(null);
-  const forceRender = useForceRender();
+  const [rootElement, setRootElement] = useState<HTMLElement | null>(null);
+  const [thumbElement, setThumbElement] = useState<HTMLElement | null>(null);
+  const [layout, setLayout] = useState<SliderLayout>(emptyLayout);
 
   // Lazy-init the slider handle. Stable across re-renders.
   const [slider] = useState<SliderApi>(() => {
     const stableOptions: SliderOptions = {
       getElement: () => rootElementRef.current!,
       getThumbElement: () => thumbElementRef.current,
-      getOrientation: () => optionsRef.current.orientation ?? 'horizontal',
-      isDisabled: () => optionsRef.current.disabled ?? false,
-      getPercent: () => optionsRef.current.getPercent(),
-      getStepPercent: () => optionsRef.current.getStepPercent(),
-      getLargeStepPercent: () => optionsRef.current.getLargeStepPercent(),
-      changeThrottle: optionsRef.current.changeThrottle,
-      adjustPercent: optionsRef.current.adjustPercent,
-      onValueChange: (percent) => optionsRef.current.onValueChange?.(percent),
-      onValueCommit: (percent) => optionsRef.current.onValueCommit?.(percent),
+      getOrientation: () => committedRef.current.options.orientation ?? 'horizontal',
+      isDisabled: () => committedRef.current.options.disabled ?? false,
+      getPercent: () => committedRef.current.options.getPercent(),
+      getStepPercent: () => committedRef.current.options.getStepPercent(),
+      getLargeStepPercent: () => committedRef.current.options.getLargeStepPercent(),
+      changeThrottle: committedRef.current.options.changeThrottle,
+      onValueChange: (percent) => committedRef.current.options.onValueChange?.(percent),
+      onValueCommit: (percent) => committedRef.current.options.onValueCommit?.(percent),
       onDragStart: () => {
-        releaseControlsLockRef.current ??= requestControlsLock?.() ?? null;
-        optionsRef.current.onDragStart?.();
+        releaseControlsLockRef.current ??= committedRef.current.requestControlsLock?.() ?? null;
+        committedRef.current.options.onDragStart?.();
       },
       onDragEnd: () => {
         releaseControlsLock();
-        optionsRef.current.onDragEnd?.();
+        committedRef.current.options.onDragEnd?.();
       },
     };
 
@@ -103,60 +171,89 @@ export function useSlider<State extends SliderState = SliderState>(
 
   useDestroy(slider);
 
-  // Percentage changes are rendered directly below. React only needs to
-  // re-render when interaction state changes.
-  const interaction = useSnapshot(slider.input, ({ dragging, pointing, focused }) => ({
-    dragging,
-    pointing,
-    focused,
-  }));
-  const input = { ...slider.input.current, ...interaction };
+  const interaction = useSnapshot(
+    slider.input,
+    ({ dragging, pointing, focused }): SliderInteractionState => ({
+      dragging,
+      pointing,
+      focused,
+    })
+  );
+  const fullState = options.computeState(interaction);
+  const alignedState = alignState(fullState, layout, options.adjustPercent);
+  const { [SliderCSSVars.pointer]: _pointerCSSVar, ...cssVars } = options.getCSSVars(alignedState);
+  const { pointerPercent: _pointerPercent, ...renderState } = fullState;
+  const state = renderState as SliderRenderState<State>;
+  const motion = slider.input as StoreState<SliderMotionState>;
 
-  // Compute derived state from input + caller-provided projection.
-  const state = options.computeState(input);
+  const measureAlignment = useCallback(() => {
+    const root = rootElementRef.current;
+    const thumb = thumbElementRef.current;
+    if (!root || !thumb) return;
 
-  // Force a synchronous re-render after mount so edge thumb alignment
-  // can read DOM measurements from the now-populated element refs.
-  useLayoutEffect(() => {
-    if (state.thumbAlignment === 'edge' && rootElementRef.current && thumbElementRef.current) {
-      forceRender();
-    }
-  }, [state.thumbAlignment]);
+    const next = {
+      rootWidth: root.offsetWidth,
+      rootHeight: root.offsetHeight,
+      thumbWidth: thumb.offsetWidth,
+      thumbHeight: thumb.offsetHeight,
+    };
+    setLayout((current) => (isSameLayout(current, next) ? current : next));
+  }, []);
 
-  // Adjust CSS var percents for edge thumb alignment using live DOM measurements.
-  const cssVars = options.getCSSVars(slider.adjustForAlignment(state));
+  useIsomorphicLayoutEffect(() => {
+    if (fullState.thumbAlignment !== 'edge' || !rootElement || !thumbElement) return;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: the retained callback reads commit-published options without changing identity
-  const syncStyles = useCallback(
+    // Establish initial geometry after commit, then keep it current without
+    // coupling future measurements to React renders.
+    measureAlignment();
+    return observeResize([rootElement, thumbElement], measureAlignment);
+  }, [fullState.thumbAlignment, measureAlignment, rootElement, thumbElement]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the retained callback reads insertion-committed options without changing identity
+  const syncPointer = useCallback(
     (element = rootElementRef.current) => {
       if (!element) return;
-      const next = optionsRef.current.computeState(slider.input.current);
-      applyStyles(element, optionsRef.current.getCSSVars(slider.adjustForAlignment(next)));
+
+      const current = committedRef.current.options;
+      let pointerPercent = slider.input.current.pointerPercent;
+
+      if (current.thumbAlignment === 'edge' && current.adjustPercent) {
+        const orientation = current.orientation ?? 'horizontal';
+        const { thumbSize, trackSize } = getAlignmentSizes(layout, orientation);
+        if (trackSize > 0) pointerPercent = current.adjustPercent(pointerPercent, thumbSize, trackSize);
+      }
+
+      element.style.setProperty(SliderCSSVars.pointer, `${pointerPercent.toFixed(3)}%`);
     },
-    [slider]
+    [layout, slider]
   );
 
-  useLayoutEffect(() => {
-    syncStyles();
-    return slider.input.subscribe(syncStyles);
-  }, [slider, syncStyles]);
+  useIsomorphicLayoutEffect(() => {
+    syncPointer();
+  });
+
+  useIsomorphicLayoutEffect(() => {
+    return slider.input.subscribe(syncPointer);
+  }, [slider, syncPointer]);
 
   // Ref callbacks for root and thumb elements.
   const rootRef = useCallback(
     (element: HTMLElement | null) => {
       rootElementRef.current = element;
-      syncStyles(element);
+      setRootElement(element);
+      syncPointer(element);
     },
-    [syncStyles]
+    [syncPointer]
   );
 
   const thumbRef = useCallback((element: HTMLElement | null) => {
     thumbElementRef.current = element;
+    setThumbElement(element);
   }, []);
 
   return {
     state,
-    input: slider.input,
+    motion,
     cssVars,
     rootRef,
     thumbRef,
@@ -167,6 +264,6 @@ export function useSlider<State extends SliderState = SliderState>(
 }
 
 export namespace useSlider {
-  export type Options = UseSliderOptions;
-  export type ReturnValue = UseSliderReturnValue;
+  export type Options<State extends SliderState = SliderState> = UseSliderOptions<State>;
+  export type ReturnValue<State extends SliderState = SliderState> = UseSliderReturnValue<State>;
 }

--- a/packages/react/src/ui/slider/context.tsx
+++ b/packages/react/src/ui/slider/context.tsx
@@ -1,19 +1,24 @@
-import type { SliderInput, SliderState, StateAttrMap } from '@videojs/core';
+import type { StateAttrMap } from '@videojs/core';
 import type { SliderThumbProps } from '@videojs/core/dom';
 import type { State } from '@videojs/store';
 import type { ProviderProps, RefCallback } from 'react';
-import { createContext, useContext, useSyncExternalStore } from 'react';
+import { createContext, useCallback, useContext, useSyncExternalStore } from 'react';
+import type { SliderMotionState, SliderRenderState } from '../hooks/use-slider';
+
+/** Live slider motion exposed to components that explicitly subscribe with `useSliderMotion`. */
+export interface SliderMotionValue extends SliderMotionState {
+  /** Pointer position converted from percent into the slider's value domain. */
+  pointerValue: number;
+}
 
 export interface SliderContextValue {
-  state: SliderState;
-  /** Pointer position converted to the value domain (not 0–100 percent). */
-  pointerValue: number;
-  input?: State<SliderInput> | undefined;
-  getPointerValue?: ((percent: number) => number) | undefined;
+  state: SliderRenderState;
+  motion: State<SliderMotionState>;
+  getPointerValue: (percent: number) => number;
   thumbRef: RefCallback<HTMLElement>;
   thumbProps: SliderThumbProps;
-  stateAttrMap: StateAttrMap<SliderState>;
-  getAttrs: (state: SliderState) => object;
+  stateAttrMap: StateAttrMap<SliderRenderState>;
+  getAttrs: (state: SliderRenderState, pointer: Pick<SliderMotionValue, 'pointerPercent' | 'pointerValue'>) => object;
   formatValue?: ((value: number, type: 'current' | 'pointer') => string) | undefined;
 }
 
@@ -31,12 +36,24 @@ export function useSliderContext(): SliderContextValue {
   return ctx;
 }
 
-export function useSliderPointerValue(enabled = true): number {
+/**
+ * Subscribe to high-frequency pointer and drag positions for a slider part.
+ *
+ * Ordinary slider render callbacks receive semantic state only. Use this hook
+ * inside a `Slider.Root` when custom preview content must follow pointer motion.
+ */
+export function useSliderMotion(): SliderMotionValue {
   const context = useSliderContext();
-  const percent = useSyncExternalStore(
-    (onChange) => context.input?.subscribe(onChange) ?? (() => {}),
-    () => (enabled ? (context.input?.current.pointerPercent ?? null) : null),
-    () => (enabled ? (context.input?.current.pointerPercent ?? null) : null)
+  const subscribe = useCallback((onChange: () => void) => context.motion.subscribe(onChange), [context.motion]);
+  const motion = useSyncExternalStore(
+    subscribe,
+    () => context.motion.current,
+    () => context.motion.current
   );
-  return percent === null ? context.pointerValue : (context.getPointerValue?.(percent) ?? context.pointerValue);
+
+  return {
+    pointerPercent: motion.pointerPercent,
+    dragPercent: motion.dragPercent,
+    pointerValue: context.getPointerValue(motion.pointerPercent),
+  };
 }

--- a/packages/react/src/ui/slider/slider-buffer.tsx
+++ b/packages/react/src/ui/slider/slider-buffer.tsx
@@ -1,13 +1,12 @@
-import type { SliderState } from '@videojs/core';
-
 import type { UIComponentProps } from '../../utils/types';
 import { createContextPart } from '../create-context-part';
+import type { SliderRenderState } from '../hooks/use-slider';
 import { useSliderContext } from './context';
 
-export interface SliderBufferProps extends UIComponentProps<'div', SliderState> {}
+export interface SliderBufferProps extends UIComponentProps<'div', SliderRenderState> {}
 
 /** Displays the buffered range on the slider track. */
-export const SliderBuffer = createContextPart<SliderBufferProps, SliderState>({
+export const SliderBuffer = createContextPart<SliderBufferProps, SliderRenderState>({
   displayName: 'SliderBuffer',
   tag: 'div',
   useContext: useSliderContext,

--- a/packages/react/src/ui/slider/slider-fill.tsx
+++ b/packages/react/src/ui/slider/slider-fill.tsx
@@ -1,13 +1,12 @@
-import type { SliderState } from '@videojs/core';
-
 import type { UIComponentProps } from '../../utils/types';
 import { createContextPart } from '../create-context-part';
+import type { SliderRenderState } from '../hooks/use-slider';
 import { useSliderContext } from './context';
 
-export interface SliderFillProps extends UIComponentProps<'div', SliderState> {}
+export interface SliderFillProps extends UIComponentProps<'div', SliderRenderState> {}
 
 /** Displays the filled portion from start to the current value. */
-export const SliderFill = createContextPart<SliderFillProps, SliderState>({
+export const SliderFill = createContextPart<SliderFillProps, SliderRenderState>({
   displayName: 'SliderFill',
   tag: 'div',
   useContext: useSliderContext,

--- a/packages/react/src/ui/slider/slider-preview.tsx
+++ b/packages/react/src/ui/slider/slider-preview.tsx
@@ -1,4 +1,4 @@
-import type { SliderPreviewProps as CoreSliderPreviewProps, SliderState } from '@videojs/core';
+import type { SliderPreviewProps as CoreSliderPreviewProps } from '@videojs/core';
 import { getSliderPreviewStyle } from '@videojs/core/dom';
 import { observeResize } from '@videojs/utils/dom';
 import type { ForwardedRef } from 'react';
@@ -6,9 +6,10 @@ import { forwardRef, useEffect, useRef, useState } from 'react';
 
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
+import type { SliderRenderState } from '../hooks/use-slider';
 import { useSliderContext } from './context';
 
-export interface SliderPreviewProps extends CoreSliderPreviewProps, UIComponentProps<'div', SliderState> {}
+export interface SliderPreviewProps extends CoreSliderPreviewProps, UIComponentProps<'div', SliderRenderState> {}
 
 /** Positioning container for preview content that tracks the pointer along the slider. */
 export const SliderPreview = forwardRef(function SliderPreview(

--- a/packages/react/src/ui/slider/slider-root.tsx
+++ b/packages/react/src/ui/slider/slider-root.tsx
@@ -2,14 +2,16 @@ import { SliderCore, SliderDataAttrs } from '@videojs/core';
 import { getSliderCSSVars } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';
 import type { ForwardedRef } from 'react';
-import { forwardRef, useState } from 'react';
+import { forwardRef } from 'react';
 import { useTranslator } from '../../i18n/context';
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
-import { useSlider } from '../hooks/use-slider';
+import { type SliderRenderState, useSlider } from '../hooks/use-slider';
 import { SliderProvider } from './context';
 
-export interface SliderRootProps extends UIComponentProps<'div', SliderCore.State>, SliderCore.Props {
+export interface SliderRootProps
+  extends UIComponentProps<'div', SliderRenderState<SliderCore.State>>,
+    SliderCore.Props {
   onValueChange?: ((value: number) => void) | undefined;
   onValueCommit?: ((value: number) => void) | undefined;
   onDragStart?: (() => void) | undefined;
@@ -40,13 +42,12 @@ export const SliderRoot = forwardRef(function SliderRoot(
     ...elementProps
   } = componentProps;
 
-  const [core] = useState(() => new SliderCore());
   const translator = useTranslator();
-  core.setProps({ label, min, max, step, largeStep, orientation, disabled, thumbAlignment });
+  const core = new SliderCore({ label, min, max, step, largeStep, orientation, disabled, thumbAlignment });
 
   const {
     state,
-    input,
+    motion,
     cssVars,
     rootRef,
     thumbRef: sliderThumbRef,
@@ -55,7 +56,7 @@ export const SliderRoot = forwardRef(function SliderRoot(
     thumbProps,
   } = useSlider({
     computeState: (input) => {
-      core.setInput(input);
+      core.setInput({ ...SliderCore.defaultInput, ...input });
       return core.getSliderState(value);
     },
     getPercent: () => core.percentFromValue(value),
@@ -63,6 +64,7 @@ export const SliderRoot = forwardRef(function SliderRoot(
     getLargeStepPercent: () => core.getLargeStepPercent(),
     orientation,
     disabled,
+    thumbAlignment,
     adjustPercent: (rawPercent, thumbSize, trackSize) =>
       core.adjustPercentForAlignment(rawPercent, thumbSize, trackSize),
     getCSSVars: getSliderCSSVars,
@@ -76,14 +78,17 @@ export const SliderRoot = forwardRef(function SliderRoot(
     <SliderProvider
       value={{
         state,
-        pointerValue: core.valueFromPercent(state.pointerPercent),
-        input,
+        motion,
         getPointerValue: (percent) => core.valueFromPercent(percent),
         thumbRef: sliderThumbRef,
         thumbProps,
         stateAttrMap: SliderDataAttrs,
-        getAttrs: (sliderState) => {
-          const attrs = core.getAttrs(sliderState);
+        getAttrs: (sliderState, sliderMotion) => {
+          const attrs = core.getAttrs({
+            ...sliderState,
+            pointerPercent: sliderMotion.pointerPercent,
+            value: sliderState.dragging ? sliderMotion.pointerValue : sliderState.value,
+          });
           return { ...attrs, 'aria-label': translateText(attrs['aria-label'], translator) };
         },
         formatValue: undefined,
@@ -105,5 +110,5 @@ export const SliderRoot = forwardRef(function SliderRoot(
 
 export namespace SliderRoot {
   export type Props = SliderRootProps;
-  export type State = SliderCore.State;
+  export type State = SliderRenderState<SliderCore.State>;
 }

--- a/packages/react/src/ui/slider/slider-thumb.tsx
+++ b/packages/react/src/ui/slider/slider-thumb.tsx
@@ -1,12 +1,12 @@
-import type { SliderState } from '@videojs/core';
 import type { ForwardedRef } from 'react';
-import { forwardRef } from 'react';
+import { forwardRef, useCallback, useSyncExternalStore } from 'react';
 
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
+import type { SliderRenderState } from '../hooks/use-slider';
 import { useSliderContext } from './context';
 
-export interface SliderThumbProps extends UIComponentProps<'div', SliderState> {}
+export interface SliderThumbProps extends UIComponentProps<'div', SliderRenderState> {}
 
 /** Draggable handle for setting the slider value. Receives focus and handles keyboard interaction. */
 export const SliderThumb = forwardRef(function SliderThumb(
@@ -17,7 +17,19 @@ export const SliderThumb = forwardRef(function SliderThumb(
 
   const context = useSliderContext();
   const { state, thumbRef, thumbProps, getAttrs } = context;
-  const attrs = getAttrs(state);
+  const subscribeToPointer = useCallback(
+    (onChange: () => void) => (state.dragging ? context.motion.subscribe(onChange) : () => {}),
+    [context.motion, state.dragging]
+  );
+  const pointerPercent = useSyncExternalStore(
+    subscribeToPointer,
+    () => context.motion.current.pointerPercent,
+    () => context.motion.current.pointerPercent
+  );
+  const attrs = getAttrs(state, {
+    pointerPercent,
+    pointerValue: context.getPointerValue(pointerPercent),
+  });
 
   return renderElement(
     'div',

--- a/packages/react/src/ui/slider/slider-thumbnail.tsx
+++ b/packages/react/src/ui/slider/slider-thumbnail.tsx
@@ -2,13 +2,13 @@ import type { ThumbnailCore } from '@videojs/core';
 import { forwardRef } from 'react';
 
 import { Thumbnail, type ThumbnailProps } from '../thumbnail/thumbnail';
-import { useSliderPointerValue } from './context';
+import { useSliderMotion } from './context';
 
 export interface SliderThumbnailProps extends Omit<ThumbnailProps, 'time'> {}
 
 export const SliderThumbnail = forwardRef<HTMLDivElement, SliderThumbnailProps>(
   function SliderThumbnail(componentProps, forwardedRef) {
-    const pointerValue = useSliderPointerValue();
+    const { pointerValue } = useSliderMotion();
     return <Thumbnail ref={forwardedRef} {...componentProps} time={pointerValue} />;
   }
 );

--- a/packages/react/src/ui/slider/slider-track.tsx
+++ b/packages/react/src/ui/slider/slider-track.tsx
@@ -1,13 +1,12 @@
-import type { SliderState } from '@videojs/core';
-
 import type { UIComponentProps } from '../../utils/types';
 import { createContextPart } from '../create-context-part';
+import type { SliderRenderState } from '../hooks/use-slider';
 import { useSliderContext } from './context';
 
-export interface SliderTrackProps extends UIComponentProps<'div', SliderState> {}
+export interface SliderTrackProps extends UIComponentProps<'div', SliderRenderState> {}
 
 /** Contains the slider's visual track and interactive hit zone. */
-export const SliderTrack = createContextPart<SliderTrackProps, SliderState>({
+export const SliderTrack = createContextPart<SliderTrackProps, SliderRenderState>({
   displayName: 'SliderTrack',
   tag: 'div',
   useContext: useSliderContext,

--- a/packages/react/src/ui/slider/slider-value.tsx
+++ b/packages/react/src/ui/slider/slider-value.tsx
@@ -1,16 +1,30 @@
-import type { SliderState } from '@videojs/core';
-import type { ForwardedRef } from 'react';
+import type { ForwardedRef, ReactNode } from 'react';
 import { forwardRef } from 'react';
 
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
-import { useSliderContext, useSliderPointerValue } from './context';
+import type { SliderRenderState } from '../hooks/use-slider';
+import { useSliderContext, useSliderMotion } from './context';
 
-export interface SliderValueProps extends UIComponentProps<'output', SliderState> {
+export interface SliderValueProps extends UIComponentProps<'output', SliderRenderState> {
   /** Which slider value to display: the current position or the pointer position. */
   type?: 'current' | 'pointer' | undefined;
   /** Custom formatter for the displayed value. Overrides the root's `formatValue`. */
   format?: ((value: number) => string) | undefined;
+}
+
+interface MotionValueProps {
+  format: ((value: number) => string) | undefined;
+  formatValue: ((value: number, type: 'current' | 'pointer') => string) | undefined;
+}
+
+function MotionValue({ format, formatValue }: MotionValueProps): ReactNode {
+  const { pointerValue } = useSliderMotion();
+  return format
+    ? format(pointerValue)
+    : formatValue
+      ? formatValue(pointerValue, 'pointer')
+      : String(Math.round(pointerValue));
 }
 
 /** Displays a formatted text representation of the slider value. Renders an `<output>` element. */
@@ -22,11 +36,16 @@ export const SliderValue = forwardRef(function SliderValue(
 
   const context = useSliderContext();
   const { state, formatValue } = context;
-  const pointerValue = useSliderPointerValue(type === 'pointer');
-
-  const rawValue = type === 'pointer' ? pointerValue : state.value;
-
-  const text = format ? format(rawValue) : formatValue ? formatValue(rawValue, type) : String(Math.round(rawValue));
+  const text =
+    type === 'pointer' ? (
+      <MotionValue format={format} formatValue={formatValue} />
+    ) : format ? (
+      format(state.value)
+    ) : formatValue ? (
+      formatValue(state.value, 'current')
+    ) : (
+      String(Math.round(state.value))
+    );
 
   return renderElement(
     'output',

--- a/packages/react/src/ui/slider/tests/slider-motion.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider-motion.test.tsx
@@ -1,0 +1,142 @@
+import { act, cleanup, render } from '@testing-library/react';
+import { SliderCSSVars, type SliderState } from '@videojs/core';
+import { getSliderCSSVars } from '@videojs/core/dom';
+import { createState, flush, type WritableState } from '@videojs/store';
+import type { CSSProperties } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { type SliderMotionState, type SliderRenderState, useSlider } from '../../hooks/use-slider';
+import { SliderProvider, useSliderMotion } from '../context';
+import { SliderThumb } from '../slider-thumb';
+
+const renderState: SliderRenderState = {
+  value: 10,
+  fillPercent: 10,
+  dragging: true,
+  pointing: true,
+  interactive: true,
+  orientation: 'horizontal',
+  disabled: false,
+  thumbAlignment: 'center',
+};
+
+afterEach(cleanup);
+
+describe('useSlider', () => {
+  it('does not re-render semantic state when only pointer motion changes', () => {
+    const renderState = vi.fn();
+    let motion: WritableState<SliderMotionState> | undefined;
+
+    function SliderHarness() {
+      const slider = useSlider({
+        computeState: ({ dragging, pointing, focused }): SliderState => ({
+          value: 40,
+          fillPercent: 40,
+          pointerPercent: 0,
+          dragging,
+          pointing,
+          interactive: dragging || pointing || focused,
+          orientation: 'horizontal',
+          disabled: false,
+          thumbAlignment: 'center',
+        }),
+        getPercent: () => 40,
+        getStepPercent: () => 1,
+        getLargeStepPercent: () => 10,
+        getCSSVars: getSliderCSSVars,
+      });
+      motion = slider.motion as WritableState<SliderMotionState>;
+      renderState(slider.state);
+
+      return (
+        <div ref={slider.rootRef} style={slider.cssVars as CSSProperties}>
+          <div ref={slider.thumbRef} />
+        </div>
+      );
+    }
+
+    const { container } = render(<SliderHarness />);
+    const root = container.firstElementChild as HTMLElement;
+    const renderCount = renderState.mock.calls.length;
+
+    expect(renderState.mock.calls.at(-1)?.[0]).not.toHaveProperty('pointerPercent');
+    expect(root.style.getPropertyValue(SliderCSSVars.fill)).toBe('40.000%');
+
+    act(() => {
+      motion!.patch({ pointerPercent: 55 });
+      flush();
+    });
+
+    expect(renderState).toHaveBeenCalledTimes(renderCount);
+    expect(root.style.getPropertyValue(SliderCSSVars.pointer)).toBe('55.000%');
+    expect(root.style.getPropertyValue(SliderCSSVars.fill)).toBe('40.000%');
+  });
+});
+
+describe('useSliderMotion', () => {
+  it('subscribes explicitly to percent motion and derives the pointer value', () => {
+    const motion = createState({ pointerPercent: 10, dragPercent: 5 });
+    const subscribe = vi.spyOn(motion, 'subscribe');
+
+    function MotionReader() {
+      const value = useSliderMotion();
+      return <output>{`${value.pointerPercent}:${value.dragPercent}:${value.pointerValue}`}</output>;
+    }
+
+    const { container } = render(
+      <SliderProvider
+        value={{
+          state: renderState,
+          motion,
+          getPointerValue: (percent) => percent * 2,
+          thumbRef: vi.fn(),
+          thumbProps: { onKeyDown: vi.fn(), onFocus: vi.fn(), onBlur: vi.fn() },
+          stateAttrMap: {},
+          getAttrs: () => ({}),
+        }}
+      >
+        <MotionReader />
+      </SliderProvider>
+    );
+
+    expect(container.querySelector('output')?.textContent).toBe('10:5:20');
+    expect(subscribe).toHaveBeenCalledOnce();
+
+    act(() => {
+      motion.replace({ pointerPercent: 30, dragPercent: 25 });
+      flush();
+    });
+
+    expect(container.querySelector('output')?.textContent).toBe('30:25:60');
+    expect(subscribe).toHaveBeenCalledOnce();
+  });
+
+  it('keeps thumb ARIA synchronized with live drag motion', () => {
+    const motion = createState({ pointerPercent: 10, dragPercent: 10 });
+    const { container } = render(
+      <SliderProvider
+        value={{
+          state: renderState,
+          motion,
+          getPointerValue: (percent) => percent,
+          thumbRef: vi.fn(),
+          thumbProps: { onKeyDown: vi.fn(), onFocus: vi.fn(), onBlur: vi.fn() },
+          stateAttrMap: {},
+          getAttrs: (state, value) => ({ 'aria-valuenow': state.dragging ? value.pointerValue : state.value }),
+        }}
+      >
+        <SliderThumb />
+      </SliderProvider>
+    );
+    const thumb = container.querySelector('[role="slider"], div') as HTMLElement;
+
+    expect(thumb.getAttribute('aria-valuenow')).toBe('10');
+
+    act(() => {
+      motion.patch({ pointerPercent: 65, dragPercent: 65 });
+      flush();
+    });
+
+    expect(thumb.getAttribute('aria-valuenow')).toBe('65');
+  });
+});

--- a/packages/react/src/ui/slider/tests/slider-root-lifecycle.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider-root-lifecycle.test.tsx
@@ -1,0 +1,235 @@
+import { cleanup, render } from '@testing-library/react';
+import type { SliderOptions } from '@videojs/core/dom';
+import { Component, type ErrorInfo, type ReactNode, useLayoutEffect } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { TimeSliderRoot } from '../../time-slider/time-slider-root';
+import { VolumeSliderRoot } from '../../volume-slider/volume-slider-root';
+import { type SliderContextValue, useSliderContext } from '../context';
+import { SliderRoot } from '../slider-root';
+
+const { capturedOptions, featureState, sliderInput } = vi.hoisted(() => ({
+  capturedOptions: { current: undefined as SliderOptions | undefined },
+  sliderInput: {
+    pointerPercent: 0,
+    dragPercent: 0,
+    dragging: false,
+    pointing: false,
+    focused: false,
+  },
+  featureState: {
+    current: {} as Record<string, unknown>,
+  },
+}));
+
+vi.mock('@videojs/core/dom', async (importOriginal) => {
+  const original: Record<string, unknown> = await importOriginal();
+  return {
+    ...original,
+    createSlider: vi.fn((options: SliderOptions) => {
+      capturedOptions.current = options;
+      return {
+        input: {
+          current: sliderInput,
+          subscribe: vi.fn(() => vi.fn()),
+        },
+        rootProps: {
+          onPointerDown: vi.fn(),
+          onPointerMove: vi.fn(),
+          onPointerUp: vi.fn(),
+          onPointerLeave: vi.fn(),
+          onLostPointerCapture: vi.fn(),
+        },
+        rootStyle: { touchAction: 'none', userSelect: 'none' },
+        thumbProps: {
+          onKeyDown: vi.fn(),
+          onFocus: vi.fn(),
+          onBlur: vi.fn(),
+        },
+        adjustForAlignment: <State,>(state: State): State => state,
+        destroy: vi.fn(),
+      };
+    }),
+  };
+});
+
+vi.mock('@videojs/store/react', () => ({
+  useSnapshot: vi.fn(
+    (state: { current: object }, selector?: (snapshot: object) => unknown) => selector?.(state.current) ?? state.current
+  ),
+  useStore: vi.fn((_store: unknown, selector?: (snapshot: object) => unknown) => {
+    if (!selector) return _store;
+    const flat = Object.assign({}, ...Object.values(featureState.current));
+    return selector(flat);
+  }),
+}));
+
+class Boundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  override componentDidCatch(_error: Error, _info: ErrorInfo) {}
+
+  override render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
+let committedContext: SliderContextValue | undefined;
+
+function CaptureContext({ abandon = false }: { abandon?: boolean }) {
+  const context = useSliderContext();
+
+  useLayoutEffect(() => {
+    committedContext = context;
+  }, [context]);
+
+  if (abandon) throw new Error('abandon slider render');
+  return null;
+}
+
+afterEach(() => {
+  cleanup();
+  committedContext = undefined;
+  capturedOptions.current = undefined;
+  featureState.current = {};
+  Object.assign(sliderInput, {
+    pointerPercent: 0,
+    dragPercent: 0,
+    dragging: false,
+    pointing: false,
+    focused: false,
+  });
+  vi.restoreAllMocks();
+});
+
+describe('slider root committed state', () => {
+  it('keeps base slider handlers and attributes on committed props after an abandoned render', () => {
+    const onCommittedChange = vi.fn();
+    const onAbandonedChange = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <Boundary>
+        <SliderRoot label="Committed" min={0} max={100} step={10} value={20} onValueChange={onCommittedChange}>
+          <CaptureContext />
+        </SliderRoot>
+      </Boundary>
+    );
+    const options = capturedOptions.current!;
+    const context = committedContext!;
+
+    rerender(
+      <Boundary>
+        <SliderRoot label="Abandoned" min={100} max={200} step={50} value={150} onValueChange={onAbandonedChange}>
+          <CaptureContext abandon />
+        </SliderRoot>
+      </Boundary>
+    );
+
+    options.onValueChange?.(30);
+    const attrs = context.getAttrs(context.state, { pointerPercent: 20, pointerValue: 20 });
+
+    expect(options.getStepPercent()).toBe(10);
+    expect(onCommittedChange).toHaveBeenCalledWith(30);
+    expect(onAbandonedChange).not.toHaveBeenCalled();
+    expect(attrs).toMatchObject({ 'aria-label': 'Committed', 'aria-valuemin': 0, 'aria-valuemax': 100 });
+    consoleError.mockRestore();
+  });
+
+  it('keeps time slider mapping, drag policy, and attributes on committed props', () => {
+    const seek = vi.fn(() => Promise.resolve(0));
+    const pause = vi.fn();
+    const onCommittedDrag = vi.fn();
+    const onAbandonedDrag = vi.fn();
+    featureState.current = {
+      time: { currentTime: 30, duration: 120, seeking: false, seek },
+      buffer: { buffered: [[0, 60]], seekable: [[0, 120]] },
+      playback: { paused: false, ended: false, started: true, waiting: false, play: vi.fn(), pause },
+    };
+    const { Wrapper } = createPlayerWrapper();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <Boundary>
+        <Wrapper>
+          <TimeSliderRoot label="Committed time" step={10} pauseOnDrag={false} onDragStart={onCommittedDrag}>
+            <CaptureContext />
+          </TimeSliderRoot>
+        </Wrapper>
+      </Boundary>
+    );
+    const options = capturedOptions.current!;
+    const context = committedContext!;
+
+    rerender(
+      <Boundary>
+        <Wrapper>
+          <TimeSliderRoot label="Abandoned time" step={60} pauseOnDrag onDragStart={onAbandonedDrag}>
+            <CaptureContext abandon />
+          </TimeSliderRoot>
+        </Wrapper>
+      </Boundary>
+    );
+
+    options.onValueCommit?.(50);
+    options.onDragStart?.();
+    const attrs = context.getAttrs(context.state, { pointerPercent: 25, pointerValue: 30 });
+
+    expect(options.getStepPercent()).toBeCloseTo((10 / 120) * 100, 5);
+    expect(seek).toHaveBeenCalledWith(60);
+    expect(pause).not.toHaveBeenCalled();
+    expect(onCommittedDrag).toHaveBeenCalledOnce();
+    expect(onAbandonedDrag).not.toHaveBeenCalled();
+    expect(attrs).toMatchObject({ 'aria-label': 'Committed time', 'aria-valuemax': 120 });
+    consoleError.mockRestore();
+  });
+
+  it('keeps volume slider handlers and attributes on committed props', () => {
+    const onCommittedDrag = vi.fn();
+    const onAbandonedDrag = vi.fn();
+    featureState.current = {
+      volume: {
+        volume: 0.8,
+        muted: false,
+        volumeAvailability: 'available',
+        setVolume: vi.fn(),
+        toggleMuted: vi.fn(),
+      },
+    };
+    const { Wrapper } = createPlayerWrapper();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <Boundary>
+        <Wrapper>
+          <VolumeSliderRoot label="Committed volume" step={10} onDragStart={onCommittedDrag}>
+            <CaptureContext />
+          </VolumeSliderRoot>
+        </Wrapper>
+      </Boundary>
+    );
+    const options = capturedOptions.current!;
+    const context = committedContext!;
+
+    rerender(
+      <Boundary>
+        <Wrapper>
+          <VolumeSliderRoot label="Abandoned volume" step={40} onDragStart={onAbandonedDrag}>
+            <CaptureContext abandon />
+          </VolumeSliderRoot>
+        </Wrapper>
+      </Boundary>
+    );
+
+    options.onDragStart?.();
+    const attrs = context.getAttrs(context.state, { pointerPercent: 80, pointerValue: 80 });
+
+    expect(options.getStepPercent()).toBe(10);
+    expect(onCommittedDrag).toHaveBeenCalledOnce();
+    expect(onAbandonedDrag).not.toHaveBeenCalled();
+    expect(attrs).toMatchObject({ 'aria-label': 'Committed volume', 'aria-valuenow': 80 });
+    consoleError.mockRestore();
+  });
+});

--- a/packages/react/src/ui/slider/tests/slider.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider.test.tsx
@@ -1,6 +1,6 @@
-import { cleanup, render } from '@testing-library/react';
+import { act, cleanup, render } from '@testing-library/react';
 import { createRef } from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { createPlayerWrapper } from '../../../testing/mocks';
 import { SliderBuffer } from '../slider-buffer';
@@ -10,7 +10,24 @@ import { SliderThumb } from '../slider-thumb';
 import { SliderTrack } from '../slider-track';
 import { SliderValue } from '../slider-value';
 
-const { mockSliderApi, sliderOptionsRef } = vi.hoisted(() => {
+const resizeObservers: { callback: ResizeObserverCallback }[] = [];
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class ResizeObserver {
+    readonly callback: ResizeObserverCallback;
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+      resizeObservers.push(this);
+    }
+
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof globalThis.ResizeObserver;
+});
+
+const { mockSliderApi, mockSliderInput, sliderInputListeners, sliderOptionsRef } = vi.hoisted(() => {
   const sliderOptionsRef: {
     current:
       | {
@@ -19,8 +36,18 @@ const { mockSliderApi, sliderOptionsRef } = vi.hoisted(() => {
         }
       | undefined;
   } = { current: undefined };
+  const sliderInputListeners = new Set<() => void>();
+  const mockSliderInput = {
+    pointerPercent: 0,
+    dragPercent: 0,
+    dragging: false,
+    pointing: false,
+    focused: false,
+  };
 
   return {
+    mockSliderInput,
+    sliderInputListeners,
     sliderOptionsRef,
     mockSliderApi: (options?: {
       getElement?: () => HTMLElement;
@@ -33,14 +60,11 @@ const { mockSliderApi, sliderOptionsRef } = vi.hoisted(() => {
 
       return {
         input: {
-          current: {
-            pointerPercent: 0,
-            dragPercent: 0,
-            dragging: false,
-            pointing: false,
-            focused: false,
-          },
-          subscribe: vi.fn(() => vi.fn()),
+          current: mockSliderInput,
+          subscribe: vi.fn((callback: () => void) => {
+            sliderInputListeners.add(callback);
+            return () => sliderInputListeners.delete(callback);
+          }),
         },
         rootProps: {
           onPointerDown: vi.fn(),
@@ -86,7 +110,18 @@ vi.mock('@videojs/store/react', () => ({
   ),
 }));
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  resizeObservers.length = 0;
+  sliderInputListeners.clear();
+  Object.assign(mockSliderInput, {
+    pointerPercent: 0,
+    dragPercent: 0,
+    dragging: false,
+    pointing: false,
+    focused: false,
+  });
+});
 
 describe('SliderRoot', () => {
   it('renders a div element', () => {
@@ -124,6 +159,42 @@ describe('SliderRoot', () => {
 
     expect(el.style.getPropertyValue('--media-slider-fill')).toBeTruthy();
     expect(el.style.getPropertyValue('--media-slider-pointer')).toBeTruthy();
+  });
+
+  it('exposes semantic render state without pointer motion', () => {
+    const renderState = vi.fn();
+    render(
+      <SliderRoot
+        value={50}
+        className={(state) => {
+          expectTypeOf(state).toEqualTypeOf<SliderRoot.State>();
+          // @ts-expect-error Pointer motion requires useSliderMotion().
+          state.pointerPercent;
+          renderState(state);
+          return undefined;
+        }}
+      />
+    );
+
+    expect(renderState).toHaveBeenCalledWith(expect.objectContaining({ value: 50, fillPercent: 50, dragging: false }));
+    expect(renderState.mock.calls[0]?.[0]).not.toHaveProperty('pointerPercent');
+    expect(renderState.mock.calls[0]?.[0]).not.toHaveProperty('dragPercent');
+  });
+
+  it('imperatively binds pointer motion without rewriting React-owned fill', () => {
+    const { container } = render(<SliderRoot value={50} />);
+    const root = container.firstElementChild as HTMLElement;
+
+    expect(root.style.getPropertyValue('--media-slider-fill')).toBe('50.000%');
+    expect(root.style.getPropertyValue('--media-slider-pointer')).toBe('0.000%');
+
+    act(() => {
+      mockSliderInput.pointerPercent = 75;
+      for (const listener of sliderInputListeners) listener();
+    });
+
+    expect(root.style.getPropertyValue('--media-slider-pointer')).toBe('75.000%');
+    expect(root.style.getPropertyValue('--media-slider-fill')).toBe('50.000%');
   });
 
   it('holds a controls visibility lock for the duration of a drag', () => {
@@ -304,7 +375,7 @@ describe('thumbAlignment', () => {
   });
 
   it('adjusts CSS vars for edge alignment', () => {
-    const { container, rerender } = render(
+    const { container } = render(
       <SliderRoot value={0} thumbAlignment="edge">
         <SliderThumb />
       </SliderRoot>
@@ -317,19 +388,17 @@ describe('thumbAlignment', () => {
     Object.defineProperty(root, 'offsetWidth', { value: 200, configurable: true });
     Object.defineProperty(thumb, 'offsetWidth', { value: 20, configurable: true });
 
-    // Re-render so the root reads the now-available element measurements.
-    rerender(
-      <SliderRoot value={0} thumbAlignment="edge">
-        <SliderThumb />
-      </SliderRoot>
-    );
+    act(() => {
+      const observer = resizeObservers.at(-1)!;
+      observer.callback([], observer as unknown as ResizeObserver);
+    });
 
     // thumbHalf = (20/200 * 100) / 2 = 5%.  Adjusted 0% → 5%.
     expect(root.style.getPropertyValue('--media-slider-fill')).toBe('5.000%');
   });
 
   it('adjusts CSS vars at max value for edge alignment', () => {
-    const { container, rerender } = render(
+    const { container } = render(
       <SliderRoot value={100} thumbAlignment="edge">
         <SliderThumb />
       </SliderRoot>
@@ -341,14 +410,62 @@ describe('thumbAlignment', () => {
     Object.defineProperty(root, 'offsetWidth', { value: 200, configurable: true });
     Object.defineProperty(thumb, 'offsetWidth', { value: 20, configurable: true });
 
-    rerender(
-      <SliderRoot value={100} thumbAlignment="edge">
-        <SliderThumb />
-      </SliderRoot>
-    );
+    act(() => {
+      const observer = resizeObservers.at(-1)!;
+      observer.callback([], observer as unknown as ResizeObserver);
+    });
 
     // thumbHalf = 5%.  Adjusted 100% → 95%.
     expect(root.style.getPropertyValue('--media-slider-fill')).toBe('95.000%');
+  });
+
+  it('updates edge alignment when the root or thumb resizes', () => {
+    const { container } = render(
+      <SliderRoot value={0} thumbAlignment="edge">
+        <SliderThumb />
+      </SliderRoot>
+    );
+    const root = container.firstElementChild as HTMLElement;
+    const thumb = root.querySelector('[role="slider"]') as HTMLElement;
+
+    Object.defineProperty(root, 'offsetWidth', { value: 200, configurable: true });
+    Object.defineProperty(thumb, 'offsetWidth', { value: 20, configurable: true });
+
+    act(() => {
+      const observer = resizeObservers.at(-1)!;
+      observer.callback([], observer as unknown as ResizeObserver);
+    });
+    expect(root.style.getPropertyValue('--media-slider-fill')).toBe('5.000%');
+
+    Object.defineProperty(root, 'offsetWidth', { value: 100, configurable: true });
+    act(() => {
+      const observer = resizeObservers.at(-1)!;
+      observer.callback([], observer as unknown as ResizeObserver);
+    });
+    expect(root.style.getPropertyValue('--media-slider-fill')).toBe('10.000%');
+  });
+
+  it('updates pointer alignment when alignment props change', () => {
+    const { container, rerender } = render(
+      <SliderRoot value={0} thumbAlignment="center">
+        <SliderThumb />
+      </SliderRoot>
+    );
+    const root = container.firstElementChild as HTMLElement;
+    const thumb = root.querySelector('[role="slider"]') as HTMLElement;
+
+    Object.defineProperty(root, 'offsetWidth', { value: 200, configurable: true });
+    Object.defineProperty(thumb, 'offsetWidth', { value: 20, configurable: true });
+    expect(resizeObservers).toHaveLength(0);
+    expect(root.style.getPropertyValue('--media-slider-pointer')).toBe('0.000%');
+
+    rerender(
+      <SliderRoot value={0} thumbAlignment="edge">
+        <SliderThumb />
+      </SliderRoot>
+    );
+    expect(resizeObservers).toHaveLength(1);
+    expect(root.style.getPropertyValue('--media-slider-pointer')).toBe('5.000%');
   });
 });
 

--- a/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
+++ b/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render } from '@testing-library/react';
 import { formatTimeAsPhrase } from '@videojs/utils/time';
 import type { HTMLAttributes } from 'react';
 import { createRef } from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { I18nProvider } from '../../../i18n';
 import { createPlayerWrapper } from '../../../testing/mocks';
@@ -191,6 +191,30 @@ describe('TimeSliderRoot', () => {
     expect(el?.style.getPropertyValue('--media-slider-fill')).toBeTruthy();
     expect(el?.style.getPropertyValue('--media-slider-pointer')).toBeTruthy();
     expect(el?.style.getPropertyValue('--media-slider-buffer')).toBeTruthy();
+  });
+
+  it('exposes semantic time state without pointer motion', () => {
+    const renderState = vi.fn();
+    const { Wrapper } = createPlayerWrapper();
+    render(
+      <Wrapper>
+        <TimeSliderRoot
+          className={(state) => {
+            expectTypeOf(state.currentTime).toBeNumber();
+            expectTypeOf(state.bufferPercent).toBeNumber();
+            // @ts-expect-error Pointer motion requires useSliderMotion().
+            state.pointerPercent;
+            renderState(state);
+            return undefined;
+          }}
+        />
+      </Wrapper>
+    );
+
+    expect(renderState).toHaveBeenCalledWith(
+      expect.objectContaining({ currentTime: 30, bufferPercent: 50, dragging: false })
+    );
+    expect(renderState.mock.calls[0]?.[0]).not.toHaveProperty('pointerPercent');
   });
 });
 

--- a/packages/react/src/ui/time-slider/time-slider-chapters/slider-segments.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-chapters/slider-segments.tsx
@@ -10,7 +10,7 @@ import { Fragment, forwardRef, useMemo, useState } from 'react';
 
 import type { HTMLProps, UIComponentProps } from '../../../utils/types';
 import { renderElement } from '../../../utils/use-render';
-import { useSliderContext, useSliderPointerValue } from '../../slider/context';
+import { useSliderContext, useSliderMotion } from '../../slider/context';
 
 type SegmentProps = Omit<HTMLProps<HTMLElement>, 'ref'>;
 
@@ -26,7 +26,7 @@ export const SliderSegments = forwardRef<HTMLDivElement, SliderSegmentsProps>(
   function SliderSegments(componentProps, ref) {
     const { ranges, min, max, renderSegment, render, className, style, ...elementProps } = componentProps;
     const slider = useSliderContext();
-    const pointerValue = useSliderPointerValue();
+    const { pointerValue } = useSliderMotion();
     const [core] = useState(() => new SliderSegmentsCore());
     const geometry = useMemo(
       () => core.getGeometry({ ranges, min, max, orientation: slider.state.orientation }),

--- a/packages/react/src/ui/time-slider/time-slider-chapters/time-slider-chapter-title.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-chapters/time-slider-chapter-title.tsx
@@ -6,7 +6,7 @@ import { forwardRef, useMemo, useState } from 'react';
 import { usePlayer } from '../../../player/context';
 import type { UIComponentProps } from '../../../utils/types';
 import { renderElement } from '../../../utils/use-render';
-import { useSliderContext, useSliderPointerValue } from '../../slider/context';
+import { useSliderContext, useSliderMotion } from '../../slider/context';
 
 export interface TimeSliderChapterTitleState {
   /** Chapter at the current interaction value. */
@@ -22,7 +22,7 @@ export const TimeSliderChapterTitle = forwardRef<HTMLSpanElement, TimeSliderChap
   function TimeSliderChapterTitle(componentProps, ref) {
     const { render, className, style, ...elementProps } = componentProps;
     const slider = useSliderContext();
-    const pointerValue = useSliderPointerValue();
+    const { pointerValue } = useSliderMotion();
     const textTrack = usePlayer(selectTextTrack);
     const time = usePlayer(selectTime);
     const [core] = useState(() => new TimeSliderChaptersCore());

--- a/packages/react/src/ui/time-slider/time-slider-root.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-root.tsx
@@ -1,20 +1,24 @@
 import { TimeSliderCore, TimeSliderDataAttrs } from '@videojs/core';
-import { getTimeSliderCSSVars, logMissingFeature, selectBuffer, selectPlayback, selectTime } from '@videojs/core/dom';
+import { getTimeSliderCSSVars, selectBuffer, selectPlayback, selectTime } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';
 import { formatTime } from '@videojs/utils/time';
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useEffect, useMemo, useState } from 'react';
 
 import { useLocale, useTranslator } from '../../i18n/context';
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { useCommittedRef } from '../../utils/use-committed-ref';
+import { useIsomorphicLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 import { renderElement } from '../../utils/use-render';
-import { useSlider } from '../hooks/use-slider';
+import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
+import { type SliderRenderState, useSlider } from '../hooks/use-slider';
 import { SliderProvider } from '../slider/context';
 
 const noopSeek = (): Promise<number> => Promise.resolve(0);
 
-export interface TimeSliderRootProps extends UIComponentProps<'div', TimeSliderCore.State>, TimeSliderCore.Props {
+export interface TimeSliderRootProps
+  extends UIComponentProps<'div', SliderRenderState<TimeSliderCore.State>>,
+    TimeSliderCore.Props {
   onDragStart?: (() => void) | undefined;
   onDragEnd?: (() => void) | undefined;
 }
@@ -44,36 +48,34 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
     const translator = useTranslator();
     const locale = useLocale();
 
-    const [core] = useState(() => new TimeSliderCore());
-    core.setProps({
-      label,
-      step,
-      largeStep,
-      orientation,
-      disabled,
-      thumbAlignment,
-      pauseOnDrag,
-      changeThrottle,
-    });
+    const coreProps: TimeSliderCore.Props = useMemo(
+      () => ({ label, step, largeStep, orientation, disabled, thumbAlignment, pauseOnDrag, changeThrottle }),
+      [label, step, largeStep, orientation, disabled, thumbAlignment, pauseOnDrag, changeThrottle]
+    );
+    const core = new TimeSliderCore(coreProps);
     core.setFormatLocale(locale);
 
-    // Keep a ref to the latest media state for callbacks that fire outside the render cycle.
-    const mediaRef = useCommittedRef(time && buffer ? { ...time, ...buffer } : null);
+    // Drag pause/resume spans renders, so this is the only retained core. Its
+    // configuration and cleanup input become visible only after commit.
+    const [dragCore] = useState(() => new TimeSliderCore());
     const playbackRef = useCommittedRef(playback);
+    useIsomorphicLayoutEffect(() => {
+      dragCore.setProps(coreProps);
+    }, [coreProps, dragCore]);
 
     // Resume playback if the slider unmounts mid-drag — createSlider's destroy()
     // does not fire onDragEnd, so without this the player would stay paused.
     // biome-ignore lint/correctness/useExhaustiveDependencies: cleanup reads commit-published playback without reinstalling the effect
     useEffect(() => {
-      return () => core.endDrag(playbackRef.current);
-    }, [core]);
+      return () => dragCore.endDrag(playbackRef.current);
+    }, [dragCore]);
 
     const duration = time?.duration ?? 0;
 
-    const { state, input, cssVars, rootRef, thumbRef, rootProps, rootStyle, thumbProps } =
+    const { state, motion, cssVars, rootRef, thumbRef, rootProps, rootStyle, thumbProps } =
       useSlider<TimeSliderCore.State>({
         computeState: (input) => {
-          core.setInput(input);
+          core.setInput({ ...TimeSliderCore.defaultInput, ...input });
           if (!time || !buffer) {
             core.setMedia({
               currentTime: 0,
@@ -94,49 +96,47 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
         getLargeStepPercent: () => core.getLargeStepPercent(),
         orientation,
         disabled,
+        thumbAlignment,
         changeThrottle,
         adjustPercent: (rawPercent, thumbSize, trackSize) =>
           core.adjustPercentForAlignment(rawPercent, thumbSize, trackSize),
         getCSSVars: getTimeSliderCSSVars,
         onValueCommit: (percent) => {
-          const media = mediaRef.current;
-          if (media) media.seek(core.rawValueFromPercent(percent));
+          if (time) time.seek(core.rawValueFromPercent(percent));
         },
         onDragStart: () => {
-          core.startDrag(playbackRef.current);
+          dragCore.startDrag(playback);
           onDragStart?.();
         },
         onDragEnd: () => {
-          core.endDrag(playbackRef.current);
+          dragCore.endDrag(playback);
           onDragEnd?.();
         },
       });
 
-    if (!time) {
-      if (__DEV__) logMissingFeature('TimeSlider', 'time');
-      return null;
-    }
+    useLogMissingFeature(!time, 'TimeSlider', 'time');
+
+    if (!time) return null;
 
     return (
       <SliderProvider
         value={{
           state,
-          pointerValue: core.rawValueFromPercent(state.pointerPercent),
-          input,
+          motion,
           getPointerValue: (percent) => core.rawValueFromPercent(percent),
           thumbRef,
           thumbProps,
           stateAttrMap: TimeSliderDataAttrs,
-          getAttrs: (sliderState) => {
-            const attrs = core.getAttrs(sliderState as TimeSliderCore.State);
+          getAttrs: (sliderState, sliderMotion) => {
+            const liveState = {
+              ...sliderState,
+              pointerPercent: sliderMotion.pointerPercent,
+            } as TimeSliderCore.State;
+            const attrs = core.getAttrs(liveState);
             return {
               ...attrs,
               'aria-label': translateText(attrs['aria-label'], translator),
-              'aria-valuetext': translateText(
-                attrs['aria-valuetext'],
-                translator,
-                core.getValueTextParams(sliderState as TimeSliderCore.State)
-              ),
+              'aria-valuetext': translateText(attrs['aria-valuetext'], translator, core.getValueTextParams(liveState)),
             };
           },
           formatValue: (value) => formatTime(value, duration, { locale }),
@@ -159,5 +159,5 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
 
 export namespace TimeSliderRoot {
   export type Props = TimeSliderRootProps;
-  export type State = TimeSliderCore.State;
+  export type State = SliderRenderState<TimeSliderCore.State>;
 }

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render } from '@testing-library/react';
 import { createRef } from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { createPlayerWrapper } from '../../../testing/mocks';
 import { SliderFill } from '../../slider/slider-fill';
@@ -11,7 +11,7 @@ import { VolumeSliderRoot } from '../volume-slider-root';
 
 // --- Hoisted mock data (available inside vi.mock factories) ---
 
-const { mockSliderApi, mockVolumeState, mutableVolume } = vi.hoisted(() => {
+const { mockSliderApi, mockSliderInput, mockVolumeState, mutableVolume } = vi.hoisted(() => {
   const volumeState = {
     volume: 0.8,
     muted: false,
@@ -19,17 +19,19 @@ const { mockSliderApi, mockVolumeState, mutableVolume } = vi.hoisted(() => {
     setVolume: vi.fn(),
     toggleMuted: vi.fn(),
   };
+  const mockSliderInput = {
+    pointerPercent: 0,
+    dragPercent: 0,
+    dragging: false,
+    pointing: false,
+    focused: false,
+  };
 
   return {
+    mockSliderInput,
     mockSliderApi: () => ({
       input: {
-        current: {
-          pointerPercent: 0,
-          dragPercent: 0,
-          dragging: false,
-          pointing: false,
-          focused: false,
-        },
+        current: mockSliderInput,
         subscribe: vi.fn(() => vi.fn()),
       },
       rootProps: {
@@ -89,6 +91,13 @@ afterEach(() => {
   mutableVolume.current = mockVolumeState;
   mockVolumeState.setVolume.mockClear();
   mockVolumeState.toggleMuted.mockClear();
+  Object.assign(mockSliderInput, {
+    pointerPercent: 0,
+    dragPercent: 0,
+    dragging: false,
+    pointing: false,
+    focused: false,
+  });
 });
 
 // --- Tests ---
@@ -166,6 +175,32 @@ describe('VolumeSliderRoot', () => {
     expect(el?.style.getPropertyValue('--media-slider-fill')).toBeTruthy();
     expect(el?.style.getPropertyValue('--media-slider-pointer')).toBeTruthy();
   });
+
+  it('keeps React render value aligned with media volume while dragging', () => {
+    mockSliderInput.dragging = true;
+    mockSliderInput.dragPercent = 20;
+    const renderState = vi.fn();
+    const { Wrapper } = createPlayerWrapper();
+    render(
+      <Wrapper>
+        <VolumeSliderRoot
+          className={(state) => {
+            expectTypeOf(state.volume).toBeNumber();
+            expectTypeOf(state.value).toBeNumber();
+            // @ts-expect-error Pointer motion requires useSliderMotion().
+            state.pointerPercent;
+            renderState(state);
+            return undefined;
+          }}
+        />
+      </Wrapper>
+    );
+
+    expect(renderState).toHaveBeenCalledWith(
+      expect.objectContaining({ volume: 0.8, value: 80, fillPercent: 80, dragging: true })
+    );
+    expect(renderState.mock.calls[0]?.[0]).not.toHaveProperty('pointerPercent');
+  });
 });
 
 describe('VolumeSlider compound', () => {
@@ -221,6 +256,55 @@ describe('VolumeSlider compound', () => {
 });
 
 describe('VolumeSliderRoot wheel handling', () => {
+  it('keeps one effective wheel listener across renders and removes it on unmount', () => {
+    const activeListeners = new Set<EventListenerOrEventListenerObject>();
+    const originalAdd = HTMLDivElement.prototype.addEventListener;
+    const originalRemove = HTMLDivElement.prototype.removeEventListener;
+
+    HTMLDivElement.prototype.addEventListener = function (
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions
+    ) {
+      if (type === 'wheel' && typeof options === 'object' && options.passive === false) {
+        activeListeners.add(listener);
+      }
+      return originalAdd.call(this, type, listener, options);
+    };
+    HTMLDivElement.prototype.removeEventListener = function (
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions
+    ) {
+      if (type === 'wheel') activeListeners.delete(listener);
+      return originalRemove.call(this, type, listener, options);
+    };
+
+    try {
+      const { Wrapper } = createPlayerWrapper();
+      const view = render(
+        <Wrapper>
+          <VolumeSliderRoot label="First" />
+        </Wrapper>
+      );
+
+      expect(activeListeners).toHaveLength(1);
+
+      view.rerender(
+        <Wrapper>
+          <VolumeSliderRoot label="Second" />
+        </Wrapper>
+      );
+      expect(activeListeners).toHaveLength(1);
+
+      view.unmount();
+      expect(activeListeners).toHaveLength(0);
+    } finally {
+      HTMLDivElement.prototype.addEventListener = originalAdd;
+      HTMLDivElement.prototype.removeEventListener = originalRemove;
+    }
+  });
+
   it('attaches a non-passive wheel listener on the root element', () => {
     // Capture the raw options before jsdom normalizes them.
     const capturedOptions: AddEventListenerOptions[] = [];

--- a/packages/react/src/ui/volume-slider/volume-slider-root.tsx
+++ b/packages/react/src/ui/volume-slider/volume-slider-root.tsx
@@ -1,15 +1,15 @@
 import { VolumeSliderCore, VolumeSliderDataAttrs } from '@videojs/core';
-import { createWheelStep, getSliderCSSVars, logMissingFeature, selectVolume } from '@videojs/core/dom';
+import { createWheelStep, getSliderCSSVars, selectVolume } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';
 import { listen } from '@videojs/utils/dom';
-import { forwardRef, useCallback, useRef, useState } from 'react';
+import { forwardRef, useRef } from 'react';
 
 import { useLocale, useTranslator } from '../../i18n/context';
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
-import { useCommittedRef } from '../../utils/use-committed-ref';
 import { renderElement } from '../../utils/use-render';
-import { useSlider } from '../hooks/use-slider';
+import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
+import { type SliderRenderState, useSlider } from '../hooks/use-slider';
 import { SliderProvider } from '../slider/context';
 
 const noopVolume = {
@@ -21,7 +21,9 @@ const noopVolume = {
   toggleMuted: () => false,
 };
 
-export interface VolumeSliderRootProps extends UIComponentProps<'div', VolumeSliderCore.State>, VolumeSliderCore.Props {
+export interface VolumeSliderRootProps
+  extends UIComponentProps<'div', SliderRenderState<VolumeSliderCore.State>>,
+    VolumeSliderCore.Props {
   onDragStart?: (() => void) | undefined;
   onDragEnd?: (() => void) | undefined;
 }
@@ -50,30 +52,35 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
     const isUnavailable = volume?.volumeAvailability !== 'available';
     const isDisabled = Boolean(disabled) || isUnavailable;
 
-    const [core] = useState(() => new VolumeSliderCore());
-    core.setProps({ label, orientation, step, largeStep, wheelStep, disabled, thumbAlignment });
+    const core = new VolumeSliderCore({ label, orientation, step, largeStep, wheelStep, disabled, thumbAlignment });
     core.setFormatLocale(locale);
 
-    // Keep refs to the latest dynamic values for stable closures.
-    const volumeRef = useCommittedRef(volume);
-    const disabledRef = useCommittedRef(isDisabled);
-
-    const getPercent = () => (volumeRef.current?.volume ?? 0) * 100;
+    const getPercent = () => (volume?.volume ?? 0) * 100;
     const getStepPercent = () => core.getStepPercent();
-    const setVolume = (percent: number) => volumeRef.current?.setVolume(percent / 100);
+    const setVolume = (percent: number) => volume?.setVolume(percent / 100);
 
-    const { state, input, cssVars, rootRef, thumbRef, rootProps, rootStyle, thumbProps } =
+    const { state, motion, cssVars, rootRef, thumbRef, rootProps, rootStyle, thumbProps } =
       useSlider<VolumeSliderCore.State>({
         computeState: (input) => {
-          core.setInput(input);
+          core.setInput({ ...VolumeSliderCore.defaultInput, ...input });
           core.setMedia(volume ?? noopVolume);
-          return core.getState();
+          const state = core.getState();
+          const value = state.volume * 100;
+
+          // Core and HTML retain transient drag values. React render state
+          // reflects the observed media value; live drag position is motion.
+          return {
+            ...state,
+            value,
+            fillPercent: state.muted ? 0 : core.percentFromValue(value),
+          };
         },
         getPercent,
         getStepPercent,
         getLargeStepPercent: () => core.getLargeStepPercent(),
         orientation,
         disabled: isDisabled,
+        thumbAlignment,
         adjustPercent: (rawPercent, thumbSize, trackSize) =>
           core.adjustPercentForAlignment(rawPercent, thumbSize, trackSize),
         getCSSVars: getSliderCSSVars,
@@ -83,33 +90,27 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
         onDragEnd,
       });
 
-    const [wheelHandler] = useState(() =>
-      createWheelStep({
-        isDisabled: () => disabledRef.current,
-        getPercent: () => (volumeRef.current?.volume ?? 0) * 100,
-        getStepPercent: () => core.getWheelStepPercent(),
-        onValueChange: (percent) => volumeRef.current?.setVolume(percent / 100),
-      })
-    );
+    const wheelHandler = createWheelStep({
+      isDisabled: () => isDisabled,
+      getPercent,
+      getStepPercent: () => core.getWheelStepPercent(),
+      onValueChange: setVolume,
+    });
 
     // Attach non-passive wheel listener via callback ref so it covers
     // late-mounted elements (null → mounted after volume appears).
     const wheelCleanupRef = useRef<(() => void) | null>(null);
-    const wheelRef = useCallback(
-      (element: HTMLDivElement | null) => {
-        wheelCleanupRef.current?.();
-        wheelCleanupRef.current = null;
-        if (element) {
-          wheelCleanupRef.current = listen(element, 'wheel', wheelHandler.onWheel, { passive: false });
-        }
-      },
-      [wheelHandler]
-    );
+    const wheelRef = (element: HTMLDivElement | null) => {
+      wheelCleanupRef.current?.();
+      wheelCleanupRef.current = null;
+      if (element) {
+        wheelCleanupRef.current = listen(element, 'wheel', wheelHandler.onWheel, { passive: false });
+      }
+    };
 
-    if (!volume) {
-      if (__DEV__) logMissingFeature('VolumeSlider', 'volume');
-      return null;
-    }
+    useLogMissingFeature(!volume, 'VolumeSlider', 'volume');
+
+    if (!volume) return null;
 
     if (state.hidden) return null;
 
@@ -117,22 +118,22 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
       <SliderProvider
         value={{
           state,
-          pointerValue: core.valueFromPercent(state.pointerPercent),
-          input,
+          motion,
           getPointerValue: (percent) => core.valueFromPercent(percent),
           thumbRef,
           thumbProps,
           stateAttrMap: VolumeSliderDataAttrs,
-          getAttrs: (sliderState) => {
-            const attrs = core.getAttrs(sliderState as VolumeSliderCore.State);
+          getAttrs: (sliderState, sliderMotion) => {
+            const liveState = {
+              ...sliderState,
+              pointerPercent: sliderMotion.pointerPercent,
+              value: sliderState.dragging ? sliderMotion.pointerValue : sliderState.value,
+            } as VolumeSliderCore.State;
+            const attrs = core.getAttrs(liveState);
             return {
               ...attrs,
               'aria-label': translateText(attrs['aria-label'], translator),
-              'aria-valuetext': translateText(
-                attrs['aria-valuetext'],
-                translator,
-                core.getValueTextParams(sliderState as VolumeSliderCore.State)
-              ),
+              'aria-valuetext': translateText(attrs['aria-valuetext'], translator, core.getValueTextParams(liveState)),
             };
           },
           formatValue: (value) => `${Math.round(value)}%`,
@@ -155,5 +156,5 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
 
 export namespace VolumeSliderRoot {
   export type Props = VolumeSliderRootProps;
-  export type State = VolumeSliderCore.State;
+  export type State = SliderRenderState<VolumeSliderCore.State>;
 }

--- a/site/src/content/docs/reference/slider.mdx
+++ b/site/src/content/docs/reference/slider.mdx
@@ -67,6 +67,9 @@ The base Slider provides a generic range input. It manages value, pointer tracki
 
 The slider supports vertical orientation via the `orientation` prop (defaults to `"horizontal"`).
 
+<FrameworkCase frameworks={["react"]}>
+  Slider `render`, `className`, and `style` callbacks receive semantic state such as `value`, `fillPercent`, and interaction flags. They do not receive the high-frequency `pointerPercent` field. Custom preview content that must follow pointer movement can opt in with <DocsLink slug="reference/use-slider-motion">`useSliderMotion`</DocsLink>.
+</FrameworkCase>
 
 ## Styling
 

--- a/site/src/content/docs/reference/use-slider-motion.mdx
+++ b/site/src/content/docs/reference/use-slider-motion.mdx
@@ -1,0 +1,33 @@
+---
+title: useSliderMotion
+description: Subscribe a React slider part to live pointer and drag positions
+---
+
+import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
+
+## Import
+
+```tsx
+import { useSliderMotion } from '@videojs/react';
+```
+
+## Usage
+
+Call `useSliderMotion` inside a `Slider.Root`, `TimeSlider.Root`, or `VolumeSlider.Root` when custom content must follow pointer motion. The hook returns `pointerPercent`, `dragPercent`, and `pointerValue`, which is converted into the root slider's value domain.
+
+```tsx
+function PointerReadout() {
+  const { pointerValue } = useSliderMotion();
+  return <output>{Math.round(pointerValue)}</output>;
+}
+
+<Slider.Root>
+  <Slider.Preview>
+    <PointerReadout />
+  </Slider.Preview>
+</Slider.Root>;
+```
+
+Slider `render`, `className`, and `style` callbacks receive semantic render state and do not subscribe to pointer motion. Keep ordinary parts on that channel, and use `useSliderMotion` only for previews or other content that must update on every pointer move.
+
+<UtilReference util="useSliderMotion" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -209,6 +209,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/use-player-context', frameworks: ['react'] },
           { slug: 'reference/use-quality-options', frameworks: ['react'] },
           { slug: 'reference/use-selector', frameworks: ['react'] },
+          { slug: 'reference/use-slider-motion', frameworks: ['react'] },
           { slug: 'reference/use-snapshot', frameworks: ['react'] },
           { slug: 'reference/container-mixin', frameworks: ['html'] },
           { slug: 'reference/media-attach-mixin', frameworks: ['html'] },


### PR DESCRIPTION
Refs #1679

Depends on #2325.

## Summary

- Split React slider data into semantic render state and an explicit high-frequency motion channel.
- Add `useSliderMotion()` for pointer-driven custom content while keeping ordinary render, className, and style callbacks stable.
- Keep Thumb ARIA synchronized with live drag motion.
- Give React ownership of fill and buffer CSS variables while the imperative binder owns only `--media-slider-pointer`.
- Make slider projection cores render-local and keep retained drag/event machinery commit-synchronized.
- Observe geometry only for edge-aligned thumbs.
- Document the new hook and migration path. Core and HTML slider state remain unchanged.

## Breaking changes

- `useSlider()` returns `motion` instead of `input`.
- `computeState` receives discrete `SliderInteractionState` rather than the full input object.
- React slider callback state is now `SliderRenderState` and omits high-frequency pointer motion.
- Pointer-driven custom UI should call `useSliderMotion()` inside a slider root.

## Verification

- React: 67 files, 547 tests passed.
- Focused slider lifecycle/motion/variants: 5 files, 72 tests passed.
- React build and workspace typecheck passed.
- API generation and API builder: 225 tests passed.
- Astro check: 0 errors.
- Independent stacked-branch review found no actionable issues.