### PR TITLE
docs(site): clarify plyr and media-chrome migration guides

### DIFF
--- a/site/src/content/docs/concepts/ui-components.mdx
+++ b/site/src/content/docs/concepts/ui-components.mdx
@@ -11,6 +11,8 @@ UI components are controls like buttons, sliders, and time displays.
 
 Every UI component renders exactly one HTML element, taking inspiration from projects like [shadcn/ui](https://ui.shadcn.com/) and [Base UI](https://base-ui.com/). This approach gives you control over styling and behavior while handling the complex interactions for you.
 
+Individual controls provide interaction, accessible names, and state. You add their visible text or icons and CSS. Sliders also need the child elements and styles shown on their reference pages.
+
 ## Where to put your components
 <FrameworkCase frameworks={["react"]}>
 UI Components can go anywhere inside a <DocsLink slug="reference/player-provider">`<Player>`</DocsLink>.
@@ -37,10 +39,13 @@ However, you should consider placing your components in `<player-container>`. Co
 The `render` prop is the primary customization mechanism. It accepts a function that receives `props` and `state`, and returns your element. The `props` object includes event handlers, ARIA attributes, data attributes, and a ref — always spread `{...props}` to keep everything working:
 
 ```tsx
+import { PlayButton } from '@videojs/react';
+import { PauseIcon, PlayIcon } from '@videojs/react/icons';
+
 <PlayButton
   render={(props, state) => (
     <button {...props}>
-      {state.paused ? 'Play' : 'Pause'}
+      {state.paused ? <PlayIcon /> : <PauseIcon />}
     </button>
   )}
 />
@@ -79,24 +84,40 @@ Some components also expose **CSS custom properties** for continuous values like
 
 <FrameworkCase frameworks={["html"]}>
 
-Components reflect player state as `data-*` attributes on their element. For example, `data-paused` or `data-volume-level="high"`.
+### Add icons
 
-This lets you style state changes in pure CSS:
+Import `@videojs/html/icons/element` once in your app's JavaScript to register `<media-icon>`. Choose an icon with `name`. Set `family="minimal"` to use the Minimal skin's icon designs. You can also use your own text or SVG.
+
+```js
+import '@videojs/html/icons/element';
+```
 
 ```html
 <media-play-button class="my-play-button">
-  <span class="play-icon">Play</span>
-  <span class="pause-icon">Pause</span>
+  <media-icon class="play-icon" name="play"></media-icon>
+  <media-icon class="pause-icon" name="pause"></media-icon>
 </media-play-button>
 ```
 
-```css
-media-play-button .play-icon  { display: none; }
-media-play-button .pause-icon { display: none; }
+### Style components with state
 
-media-play-button[data-paused] .play-icon        { display: inline; }
-media-play-button:not([data-paused]) .pause-icon  { display: inline; }
+Components add `data-*` attributes to describe their current state. For example, a play button adds `data-paused` while the media is paused. Use those attributes in CSS:
+
+```css
+.my-play-button .pause-icon {
+  display: none;
+}
+
+.my-play-button:defined:not([data-paused]) .play-icon {
+  display: none;
+}
+
+.my-play-button:defined:not([data-paused]) .pause-icon {
+  display: inline-flex;
+}
 ```
+
+The browser matches `:defined` after it loads the custom element. This keeps the play icon visible while JavaScript loads.
 
 Each component's reference page documents its full set of data attributes.
 

--- a/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
+++ b/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
@@ -6,6 +6,7 @@ description: Map Media Chrome's controller, elements, and attributes onto Video.
 import Aside from '@/components/Aside.astro';
 import DocsLink from '@/components/docs/DocsLink.astro';
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
+import { Tab, TabsList, TabsPanel, TabsRoot } from '@/components/Tabs.tsx';
 
 Video.js v10's HTML player uses the same `media-*` custom-element convention as Media Chrome, so most of the work is **renaming and reshaping**, not rewriting. This guide maps Media Chrome's API to Video.js v10.
 
@@ -15,7 +16,7 @@ Scoped to apps that compose their own player from Media Chrome elements. If you 
 
 ## Before you begin
 
-Install Video.js and pick a preset and skin (see <DocsLink slug="how-to/installation">Installation</DocsLink>). The fastest path is to start from a <DocsLink slug="concepts/presets">preset</DocsLink>, then replace its controls with your migrated markup.
+Install Video.js and choose a <DocsLink slug="concepts/presets">preset</DocsLink> (see <DocsLink slug="how-to/installation">Installation</DocsLink>). Start with its ready-made skin if those controls fit your player. If you need to keep a custom control bar, build it from the individual Video.js UI components instead.
 
 <FrameworkCase frameworks={["html"]}>
 ```bash
@@ -44,17 +45,52 @@ Media Chrome wraps a slotted `<video slot="media">` in a single `<media-controll
 ```
 
 <FrameworkCase frameworks={["html"]}>
-```html
-<!-- Video.js -->
-<video-player>
-  <media-container>
-    <video src="video.mp4"></video>
-    <media-controls>
-      <media-play-button></media-play-button>
-    </media-controls>
-  </media-container>
-</video-player>
-```
+<TabsRoot client:idle>
+  <TabsList client:idle label="Video.js HTML player source">
+    <Tab client:idle value="javascript" initial>JavaScript</Tab>
+    <Tab client:idle value="html">HTML</Tab>
+    <Tab client:idle value="css">CSS</Tab>
+  </TabsList>
+  <TabsPanel client:idle value="javascript" initial>
+    ```js
+    import '@videojs/html/video/player';
+    import '@videojs/html/ui/controls';
+    import '@videojs/html/ui/play-button';
+    import '@videojs/html/icons/element';
+    ```
+  </TabsPanel>
+  <TabsPanel client:idle value="html">
+    ```html
+    <!-- Video.js -->
+    <video-player>
+      <media-container>
+        <video src="video.mp4"></video>
+        <media-controls>
+          <media-play-button class="player-play-button">
+            <media-icon class="player-play-icon" name="play"></media-icon>
+            <media-icon class="player-pause-icon" name="pause"></media-icon>
+          </media-play-button>
+        </media-controls>
+      </media-container>
+    </video-player>
+    ```
+  </TabsPanel>
+  <TabsPanel client:idle value="css">
+    ```css
+    .player-pause-icon {
+      display: none;
+    }
+
+    .player-play-button:defined:not([data-paused]) .player-play-icon {
+      display: none;
+    }
+
+    .player-play-button:defined:not([data-paused]) .player-pause-icon {
+      display: inline-flex;
+    }
+    ```
+  </TabsPanel>
+</TabsRoot>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
@@ -72,7 +108,13 @@ export function MyPlayer() {
     <VideoPlayer>
       <Container>
         <Video src="video.mp4" />
-        <PlayButton />
+        <PlayButton
+          render={(props, state) => (
+            <button {...props} className="play-button">
+              {state.paused ? <span className="play-icon">Play</span> : <span className="pause-icon">Pause</span>}
+            </button>
+          )}
+        />
       </Container>
     </VideoPlayer>
   );
@@ -93,12 +135,14 @@ Where Media Chrome asks you to restyle a shadow root, Video.js components take a
 ```tsx
 <PlayButton
   render={(props, state) => (
-    <button {...props}>{state.paused ? 'Play' : 'Pause'}</button>
+    <button {...props} className="play-button">
+      {state.paused ? <span className="play-icon">Play</span> : <span className="pause-icon">Pause</span>}
+    </button>
   )}
 />
 ```
 
-Read player state with <DocsLink slug="reference/use-player">`usePlayer`</DocsLink>, <DocsLink slug="reference/use-media">`useMedia`</DocsLink>, and <DocsLink slug="reference/use-store">`useStore`</DocsLink>.
+Read player state with <DocsLink slug="reference/use-player">`usePlayer`</DocsLink>, <DocsLink slug="reference/use-media">`useMedia`</DocsLink>, and <DocsLink slug="reference/use-store">`useStore`</DocsLink>. Player hooks must run in a descendant component rendered inside `VideoPlayer` or the `Player` returned by `createPlayer`. A hook in the same component that returns the provider is still outside that provider.
 
 </FrameworkCase>
 
@@ -170,7 +214,19 @@ Most names match. These are the renames that bite:
 
 Unchanged names: `media-play-button`, `media-mute-button`, `media-fullscreen-button`, `media-pip-button`, `media-airplay-button`, `media-cast-button`, `media-captions-button`, `media-playback-rate-button`, `media-tooltip`, and `media-thumbnail`.
 
-Sliders are compound in both, using `media-slider-track`, `media-slider-fill`, and `media-slider-thumb`.
+<Aside type="caution">
+Matching tag names do not mean matching appearance. Media Chrome buttons include default icons and styles. Individual Video.js buttons provide behavior, state, and an accessible name, but no visible content or finished styling. Add text, an SVG, or a `<media-icon>`, plus your own CSS. Without visible content, a button can work while showing nothing. Sliders also need their child elements and CSS. Use a ready-made skin when you want finished controls.
+</Aside>
+
+Video.js sliders use `media-slider-track`, `media-slider-fill`, and `media-slider-thumb`. See <DocsLink slug="reference/time-slider">`media-time-slider`</DocsLink> and <DocsLink slug="reference/volume-slider">`media-volume-slider`</DocsLink> for copy-paste markup and CSS.
+
+<FrameworkCase frameworks={["html"]}>
+Media Chrome's named icon slots do not carry over. Remove attributes such as `slot="play"` and put the icon directly inside the Video.js button. Import `@videojs/html/icons/element` to use `<media-icon>`, as shown in [Map the controller](#map-the-controller). Set `family="minimal"` to use the Minimal skin's icon designs. You can also use your own text or SVG.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+React buttons do not include visible content either. Use a button's `render` prop to add it, as shown in [Map the controller](#map-the-controller). Build sliders from parts such as `TimeSlider.Track`, `TimeSlider.Fill`, and `TimeSlider.Thumb`, then add your own CSS.
+</FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
 `media-poster` is the one rename that changes shape. Where `media-poster-image` took its own `src`, `media-poster` wraps the image you bring:
@@ -185,10 +241,14 @@ Sliders are compound in both, using `media-slider-track`, `media-slider-fill`, a
 <FrameworkCase frameworks={["react"]}>
 These are PascalCase components rather than tags — `TimeSlider`, `VolumeSlider`, `BufferingIndicator`, `Poster`, `QualityRadioGroup` — and the compound parts are namespaced, so `media-slider-track` becomes `TimeSlider.Track`. See the <DocsLink slug="concepts/ui-components">UI components</DocsLink> concept for the full set.
 
-`Poster` is the one rename that changes shape. It *is* the image rather than a wrapper around one, so `media-poster-image`'s attributes go straight on it:
+`Poster` is the one rename that changes shape. Put the poster URL on `VideoPlayer`; `Poster` renders the image and accepts image attributes such as `alt`, `srcSet`, and `sizes`:
 
 ```tsx
-<Poster src="/poster.jpg" alt="" />
+<VideoPlayer poster="/poster.jpg">
+  <Container>
+    <Poster alt="" />
+  </Container>
+</VideoPlayer>
 ```
 </FrameworkCase>
 
@@ -199,16 +259,54 @@ Media Chrome reflects state as `media*` attributes such as `mediapaused`; Video.
 ```css
 /* Media Chrome */
 media-play-button[mediapaused] .play-icon { display: inline; }
-
-/* Video.js */
-media-play-button[data-paused] .play-icon { display: inline; }
 ```
 
+<FrameworkCase frameworks={["html"]}>
+```css
+/* Video.js HTML */
+media-play-button[data-paused] .play-icon { display: inline; }
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+```css
+/* Video.js React: target the className on your rendered button */
+.play-button[data-paused] .play-icon { display: inline; }
+```
+</FrameworkCase>
+
 Continuous values use CSS custom properties: sliders expose `--media-slider-fill` and `--media-slider-pointer`.
+
+### Map theme variables by meaning
+
+Media Chrome and Video.js both use names beginning with `--media-`, but that shared prefix is a naming convention, not a compatibility layer. Keep a variable only when its documented meaning matches.
+
+| Media Chrome theme variable | Packaged Video.js skin | Migration |
+|---|---|---|
+| `--media-accent-color` or `--media-range-bar-color` | `--media-accent-color` | Closest match for slider fills and accented controls. |
+| `--media-primary-color` | no direct equivalent | Often colors every control icon in Media Chrome; Video.js's accent variable has narrower semantics. |
+| `--media-secondary-color` | no direct equivalent | Author CSS or eject when you need this palette role. |
+| `--media-control-background` | no direct equivalent | Author CSS or eject. |
+| `--media-control-hover-background` | no direct equivalent | Author CSS or eject. |
+| `--media-range-track-height` | no direct equivalent | Author slider CSS or eject. |
+
+The packaged Video.js skins expose `--media-accent-color`, `--media-accent-text-color`, `--media-border-radius`, and `--media-scale-unit` for broad customization. Do not assume another Media Chrome variable will work because its name starts with `--media-`.
 
 ## Themes become skins
 
 Media Chrome's `<template>`-based themes (`media-theme`) become Video.js <DocsLink slug="concepts/skins">skins</DocsLink> and <DocsLink slug="concepts/presets">presets</DocsLink>. Start from a preset, then eject and customize with <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>, rather than authoring a template.
+
+<FrameworkCase frameworks={["html"]}>
+Ready-made HTML skins keep their controls inside Shadow DOM. Code outside the skin sees a click as coming from the skin, not the button inside it. Some control events also stay inside the skin. Do not use an outside listener to identify which built-in button was clicked.
+
+Keep playback event handlers on your `<video>` or `<audio>`. When you build a custom control bar, attach click and input handlers directly to those controls. With a ready-made skin, read media or player state instead of listening for clicks inside the skin.
+
+Keep the skin when its CSS variables and content slots cover your changes. Build a custom control bar when you want to start from scratch. Eject the skin when you want its existing layout and styles but need to change the controls inside it.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+React skins do not use Shadow DOM. Use `render` props when you build individual controls. Eject a ready-made skin when you need to change its control set or layout.
+</FrameworkCase>
 
 ## Known gaps
 

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -112,8 +112,8 @@ interface AppVideoPlayerProps {
 
 export function AppVideoPlayer({ origin }: AppVideoPlayerProps) {
   return (
-    <VideoPlayer>
-      <MinimalVideoSkin poster={`${origin}/poster.jpg`}>
+    <VideoPlayer poster={`${origin}/poster.jpg`}>
+      <MinimalVideoSkin className="app-video-player">
         <Video src={`${origin}/video.mp4`} playsInline>
           <track kind="captions" label="English" src={`${origin}/captions/en.vtt`} srclang="en" default />
           <track kind="metadata" label="thumbnails" src={`${origin}/storyboard.vtt`} default />
@@ -127,7 +127,7 @@ export function AppVideoPlayer({ origin }: AppVideoPlayerProps) {
 ### Notes
 
 - `@videojs/react/video` is a <DocsLink slug="concepts/presets">preset</DocsLink>: a player, a skin, and a media element that already fit together. `VideoPlayer` is the piece that owns the state, built from the standard set of <DocsLink slug="concepts/features">features</DocsLink> for video.
-- The poster is a prop on the skin rather than a `poster` attribute on the media, which gives the skin control over how it appears. That's much like Plyr's `data-poster`.
+- The poster URL is metadata on `VideoPlayer`. The skin reads that metadata and controls how the poster appears. To replace the rendered image, pass `renderPoster` to the skin.
 - This example assumes all your files for a given asset live in the same path, using consistent filenames. This will almost certainly need adjusting for your implementation.
 - If `origin` points somewhere other than your page's origin, add `crossOrigin="anonymous"` to `<Video>` and serve those files with CORS headers. A cross-origin thumbnail track only loads when the media element is CORS-enabled. See <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink>.
 - There's also a default skin with a modern, frosted appearance that some may prefer. Try it by switching the CSS import filename to `skin.css` and the `MinimalVideoSkin` import and usage to `VideoSkin`.
@@ -358,7 +358,7 @@ Here's a matrix for configuration options in Plyr and how each maps to Video.js 
 | `controls` | The <DocsLink slug="concepts/skins">skins</DocsLink> include all the common controls, laid out in a familiar way that users would expect. If you want to customize the skin beyond basic colors, you can [eject the skin](#ejecting) and change layout, styles, or icons. |
 | `settings` | Included automatically in the skins when quality, speed, audio tracks, or captions are available. |
 | `autoplay`, `muted`, `loop`, `playsinline`, `preload` | These are attributes on your media (e.g. `<video>`) component. |
-| `poster` / `data-poster` | The skin owns the poster, as shown in [Basic migration](#basic-migration) above. |
+| `poster` / `data-poster` | In HTML, slot an image into the skin. In React, set `poster` on `VideoPlayer`. See [Basic migration](#basic-migration). |
 | `ratio` | Set `aspect-ratio` in CSS on the skin component. |
 | `hideControls` | Preset skins auto-hide controls based on activity. The delay is currently not configurable. |
 | `clickToPlay` | Preset video skins include click and tap gestures. [Eject the skin](#ejecting) to remove or change them. |
@@ -374,6 +374,20 @@ Here's a matrix for configuration options in Plyr and how each maps to Video.js 
 | `storage` | Unsupported at this time. |
 | `i18n` | The most common languages are available by default but you can also provide custom translations, if required. See [Internationalization](#internationalization) above for more info. |
 | `ads` | Unsupported at this time. |
+
+## Customize the controls
+
+Plyr's `controls` option chooses which controls appear. Video.js skins come with their own control set and layout. Keep the skin when that UI fits your player. To remove, reorder, or restyle its controls, [eject the skin](#ejecting) and edit the copied implementation. Adding a child to a skin does not place it inside the control bar.
+
+If your app already has a custom control bar, build it from individual <DocsLink slug="concepts/ui-components">UI components</DocsLink>. Video.js handles the media action, accessible name, and state. You add the visible contents, layout, and CSS.
+
+<FrameworkCase frameworks={["html"]}>
+Individual HTML buttons include no text, icon, or finished styling. Add your own content, or import `@videojs/html/icons/element` and place a `<media-icon>` inside the button. Attach click handlers directly to controls you add, and keep playback event handlers on the `<video>` or `<audio>`. To change or listen to a button inside a ready-made skin, eject the skin first.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+Individual React buttons do not include visible content. Use their `render` props to add an icon or text and style the element you return. Eject a ready-made skin when you need to change its control set or layout.
+</FrameworkCase>
 
 ## Dynamic sources
 
@@ -397,12 +411,27 @@ Use the media element for standard playback operations:
 For custom UI, read and write through the Video.js player store.
 
 <FrameworkCase frameworks={["react"]}>
-Import the preset's <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> hook and call it directly or with a selector:
+Import the preset's <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> hook and call it from a descendant of `VideoPlayer`. The component that creates `VideoPlayer` cannot also consume its context, so put store access in a child component:
 
 ```tsx
-import { usePlayer } from '@videojs/react/video';
+import '@videojs/react/video/minimal-skin.css';
+import { MinimalVideoSkin, usePlayer, Video, VideoPlayer } from '@videojs/react/video';
 
-const currentTime = usePlayer((state) => state.currentTime);
+function CurrentTime() {
+  const currentTime = usePlayer((state) => state.currentTime);
+  return <output>{Math.round(currentTime)} seconds</output>;
+}
+
+export function AppVideoPlayer() {
+  return (
+    <VideoPlayer>
+      <MinimalVideoSkin>
+        <Video src="/video.mp4" playsInline />
+        <CurrentTime />
+      </MinimalVideoSkin>
+    </VideoPlayer>
+  );
+}
 ```
 </FrameworkCase>
 
@@ -427,12 +456,25 @@ Video.js v10 skins offer similar color customization via CSS custom properties. 
 .plyr {
   --plyr-color-main: rebeccapurple;
 }
+```
 
-/* Video.js */
+<FrameworkCase frameworks={["html"]}>
+```css
+/* Video.js HTML */
 video-player {
   --media-accent-color: rebeccapurple;
 }
 ```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+```css
+/* Video.js React: the className from the basic example */
+.app-video-player {
+  --media-accent-color: rebeccapurple;
+}
+```
+</FrameworkCase>
 
 `--media-accent-color` reaches the sliders, active buttons, and accent surfaces, so it's the closest match for Plyr's `--plyr-color-main`. Video.js picks a readable text color to sit on top of it; set `--media-accent-text-color` to choose that yourself. `--media-border-radius` and `--media-scale-unit` cover rounding and control sizing. See <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink> for the full list.
 


### PR DESCRIPTION
## Summary

Clarify the Plyr and Media Chrome migration paths using current package behavior and the original migration friction logs.

## Changes

- fix React poster placement, framework-specific selectors, and player-context examples
- show complete visible custom-control examples for HTML and React, including `<media-icon>`
- explain when to keep a ready-made skin, eject it, or build a custom control bar
- document HTML Shadow DOM event boundaries and semantic CSS-variable differences
- add an HTML-only icons section to the UI components concept

## Testing

- `pnpm exec prettier --check site/src/content/docs/concepts/ui-components.mdx site/src/content/docs/how-to/migrate-from-media-chrome.mdx site/src/content/docs/how-to/migrate-from-plyr.mdx`
- `git diff --check`
- `pnpm -F site astro check`
- `pnpm -F @videojs/html test src/icons/tests/index.test.ts src/ui/slider/tests/slider-element.test.ts`
- `pnpm -F @videojs/react test src/ui/play-button/tests/play-button.test.tsx src/player/tests/create-player.test.tsx src/presets/video/tests/skin.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to migration and UI-component guides; no runtime or API code changes.
> 
> **Overview**
> Clarifies how to migrate custom players from Media Chrome and Plyr, emphasizing that individual Video.js controls supply behavior and state but not icons or finished styling.
> 
> The Media Chrome guide now shows complete HTML (JS/HTML/CSS tabs with `<media-icon>`) and React `render` examples, warns that matching tag names are not a visual drop-in, maps theme variables by meaning, and documents HTML Shadow DOM event boundaries plus when to keep, eject, or rebuild a skin.
> 
> The Plyr guide moves the React poster onto `VideoPlayer`, splits CSS selectors by framework, shows `usePlayer` in a child of the provider, and adds a **Customize the controls** section. UI components docs add HTML icon registration and `:defined` state styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4871f36787904502550d7fc52fa6e9745aa7c28f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->