### PR TITLE
docs(site): document browser and tooling compatibility

### DIFF
--- a/site/src/content/docs/concepts/browser-support.mdx
+++ b/site/src/content/docs/concepts/browser-support.mdx
@@ -1,11 +1,11 @@
 ---
-title: Browser and tooling compatibility
-description: Supported browsers, TypeScript, module resolution, bundlers, and rendering contexts for Video.js 10
+title: Browser support
+description: Browsers and rendering environments supported by Video.js 10
 ---
 
 import Aside from '@/components/Aside.astro';
 
-Video.js 10 targets modern browsers and build tools. This page describes the supported baseline and the integration boundaries to consider when adopting it.
+Video.js 10 targets modern browsers. This page describes the supported browser baseline and other rendering environments.
 
 ## Browser baseline
 
@@ -27,35 +27,6 @@ Video.js 10 builds directly on the web platform: custom elements, CSS custom pro
 
 When we use a platform feature that hasn't landed in all supported browsers yet, we provide a fallback. The player works either way; the experience may differ slightly in older browsers. For example, tooltips and popovers use CSS anchor positioning where available and fall back to absolute positioning where it isn't.
 
-## TypeScript and build tools
-
-If your project uses TypeScript, use **TypeScript 5.0 or newer**. Older versions cannot read the syntax in Video.js type files. The `skipLibCheck` option does not help because TypeScript must still read those files before it can skip checking them.
-
-Each Video.js package lists the import paths it supports in the `exports` field of its `package.json`, such as `@videojs/html/video/player` and `@videojs/react/live-video`. Most web applications should use this TypeScript configuration so TypeScript follows the same package rules as the application's build tool:
-
-```json title="tsconfig.json"
-{
-  "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "bundler"
-  }
-}
-```
-
-If Node.js runs files emitted directly by TypeScript, use `node16` for both `module` and `moduleResolution`, or use `nodenext` for both. Do not use the older `node` setting, now called `node10`. It does not understand the package rules Video.js uses and can report valid imports or types as missing.
-
-### If changing this setting reveals other errors
-
-The older `node` setting allowed applications to import almost any file inside a dependency. Modern settings allow only the import paths that dependency publishes. Changing the setting can therefore reveal an existing import into another package's private files.
-
-If the error names a package outside `@videojs/*`, it is a separate problem in that application or dependency. Update the dependency or use one of its supported import paths. A TypeScript `paths` override can be a temporary bridge when no supported replacement exists. Do not switch back to the older resolver because that also breaks Video.js type resolution.
-
-## Bundler compatibility
-
-Before the browser runs your application, a bundler such as Vite combines its imports into files the browser can load. The bundler must understand the supported import paths listed by each Video.js package.
-
-Vite 3.2.8 can load Video.js JavaScript, but it cannot load the exported `@videojs/html/video/skin.css` file. Vite 5.4.19 can load both. Upgrade Vite instead of adding aliases that bypass the package's supported import paths.
-
 ## Rendering contexts
 
 ### WebViews and PWAs
@@ -71,25 +42,3 @@ TV platforms run embedded browsers with limited standards support. Video.js 10's
 ### Server-side rendering
 
 Video.js components render valid markup on the server. Interactivity — state management, media playback, and event handling — requires the browser and kicks in after hydration.
-
-## Advanced: publish a wrapper library
-
-You can skip this section when building an application.
-
-If you publish a library that expects its users to install Video.js separately, leave Video.js out of your library's bundle. Rollup calls this marking a dependency as **external**. Its array form matches only the exact package name, so `external: ['@videojs/html']` misses imports such as `@videojs/html/video/player`.
-
-Match the package name and everything below it instead:
-
-```js title="rollup.config.js"
-const videojsPeers = ['@videojs/html'];
-
-export default {
-  external(id) {
-    return videojsPeers.some(
-      (packageName) => id === packageName || id.startsWith(`${packageName}/`)
-    );
-  }
-};
-```
-
-Add every `@videojs/*` package your library imports directly to `videojsPeers` and list it in `peerDependencies`.

--- a/site/src/content/docs/concepts/browser-support.mdx
+++ b/site/src/content/docs/concepts/browser-support.mdx
@@ -1,9 +1,13 @@
 ---
-title: Browser Support
-description: Which browsers Video.js 10 supports and how it handles newer platform features
+title: Browser and tooling compatibility
+description: Supported browsers, TypeScript, module resolution, bundlers, and rendering contexts for Video.js 10
 ---
 
 import Aside from '@/components/Aside.astro';
+
+Video.js 10 targets modern browsers and build tools. This page describes the supported baseline and the integration boundaries to consider when adopting it.
+
+## Browser baseline
 
 Video.js 10 currently targets **evergreen browsers**: the latest two stable versions of Chrome, Firefox, Safari, and Edge.
 
@@ -11,8 +15,7 @@ Video.js 10 currently targets **evergreen browsers**: the latest two stable vers
   Video.js 10 is in beta. The browser support matrix may expand as we approach GA based on community feedback and usage data.
 </Aside>
 
-
-## Why evergreen?
+### Why evergreen?
 
 Video.js 10 builds directly on the web platform: custom elements, CSS custom properties, anchor positioning, and modern JavaScript APIs. Targeting evergreen browsers lets us:
 
@@ -20,9 +23,38 @@ Video.js 10 builds directly on the web platform: custom elements, CSS custom pro
 - **Use platform-native features** like `popover` and anchor positioning instead of JavaScript equivalents
 - **Keep the core slim** so platform-specific adapters (HTML, React) add only what they need
 
-## Progressive enhancement
+### Progressive enhancement
 
 When we use a platform feature that hasn't landed in all supported browsers yet, we provide a fallback. The player works either way; the experience may differ slightly in older browsers. For example, tooltips and popovers use CSS anchor positioning where available and fall back to absolute positioning where it isn't.
+
+## TypeScript and build tools
+
+If your project uses TypeScript, use **TypeScript 5.0 or newer**. Older versions cannot read the syntax in Video.js type files. The `skipLibCheck` option does not help because TypeScript must still read those files before it can skip checking them.
+
+Each Video.js package lists the import paths it supports in the `exports` field of its `package.json`, such as `@videojs/html/video/player` and `@videojs/react/live-video`. Most web applications should use this TypeScript configuration so TypeScript follows the same package rules as the application's build tool:
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+If Node.js runs files emitted directly by TypeScript, use `node16` for both `module` and `moduleResolution`, or use `nodenext` for both. Do not use the older `node` setting, now called `node10`. It does not understand the package rules Video.js uses and can report valid imports or types as missing.
+
+### If changing this setting reveals other errors
+
+The older `node` setting allowed applications to import almost any file inside a dependency. Modern settings allow only the import paths that dependency publishes. Changing the setting can therefore reveal an existing import into another package's private files.
+
+If the error names a package outside `@videojs/*`, it is a separate problem in that application or dependency. Update the dependency or use one of its supported import paths. A TypeScript `paths` override can be a temporary bridge when no supported replacement exists. Do not switch back to the older resolver because that also breaks Video.js type resolution.
+
+## Bundler compatibility
+
+Before the browser runs your application, a bundler such as Vite combines its imports into files the browser can load. The bundler must understand the supported import paths listed by each Video.js package.
+
+Vite 3.2.8 can load Video.js JavaScript, but it cannot load the exported `@videojs/html/video/skin.css` file. Vite 5.4.19 can load both. Upgrade Vite instead of adding aliases that bypass the package's supported import paths.
 
 ## Rendering contexts
 
@@ -39,3 +71,25 @@ TV platforms run embedded browsers with limited standards support. Video.js 10's
 ### Server-side rendering
 
 Video.js components render valid markup on the server. Interactivity — state management, media playback, and event handling — requires the browser and kicks in after hydration.
+
+## Advanced: publish a wrapper library
+
+You can skip this section when building an application.
+
+If you publish a library that expects its users to install Video.js separately, leave Video.js out of your library's bundle. Rollup calls this marking a dependency as **external**. Its array form matches only the exact package name, so `external: ['@videojs/html']` misses imports such as `@videojs/html/video/player`.
+
+Match the package name and everything below it instead:
+
+```js title="rollup.config.js"
+const videojsPeers = ['@videojs/html'];
+
+export default {
+  external(id) {
+    return videojsPeers.some(
+      (packageName) => id === packageName || id.startsWith(`${packageName}/`)
+    );
+  }
+};
+```
+
+Add every `@videojs/*` package your library imports directly to `videojsPeers` and list it in `peerDependencies`.

--- a/site/src/content/docs/concepts/bundlers.mdx
+++ b/site/src/content/docs/concepts/bundlers.mdx
@@ -1,0 +1,40 @@
+---
+title: Bundlers
+description: Bundler requirements for Video.js package exports, CSS, and wrapper libraries
+---
+
+Before the browser runs your application, a bundler such as Vite combines its imports into files the browser can load. Your bundler must understand the import paths published by Video.js packages.
+
+## Package exports
+
+Each Video.js package has an `exports` field in its `package.json`. This field lists the import paths that applications and libraries can use, such as `@videojs/html/video/player` and `@videojs/react/live-video`.
+
+If an older bundler reports that one of these paths is missing or not exported, upgrade the bundler before adding an alias that bypasses the package's public API.
+
+## Vite compatibility
+
+Vite 3.2.8 can load Video.js JavaScript, but it cannot load the exported `@videojs/html/video/skin.css` file. Vite 5.4.19 can load both.
+
+## Publish a wrapper library
+
+You can skip this section when building an application.
+
+If you publish a library that expects its users to install Video.js separately, leave Video.js out of your library's bundle. Rollup calls a dependency left out of the bundle **external**.
+
+Rollup's array form matches only the exact package name, so `external: ['@videojs/html']` misses imports such as `@videojs/html/video/player`.
+
+Match the package name and everything below it instead:
+
+```js title="rollup.config.js"
+const videojsPeers = ['@videojs/html'];
+
+export default {
+  external(id) {
+    return videojsPeers.some(
+      (packageName) => id === packageName || id.startsWith(`${packageName}/`)
+    );
+  }
+};
+```
+
+Add every `@videojs/*` package your library imports directly to `videojsPeers` and list it in `peerDependencies`.

--- a/site/src/content/docs/concepts/typescript.mdx
+++ b/site/src/content/docs/concepts/typescript.mdx
@@ -1,0 +1,35 @@
+---
+title: TypeScript
+description: TypeScript version and module resolution requirements for Video.js packages
+---
+
+import DocsLink from '@/components/docs/DocsLink.astro';
+
+Video.js packages require **TypeScript 5.0 or newer**. TypeScript must also follow the import paths that each package publishes.
+
+## TypeScript version
+
+Video.js type files use syntax introduced in TypeScript 5.0. Older versions cannot read that syntax. The `skipLibCheck` option does not help because TypeScript must read a type file before it can skip checking it.
+
+## Module resolution
+
+Video.js packages define their supported import paths using <DocsLink slug="concepts/bundlers">package exports</DocsLink>. Most web applications should use the following configuration. It makes TypeScript follow the same package rules as the bundler that builds the application:
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+If Node.js runs files emitted directly by TypeScript, use `node16` for both `module` and `moduleResolution`, or use `nodenext` for both.
+
+Do not use the older `node` setting, now called `node10`. It does not understand package exports and can report valid Video.js imports or types as missing.
+
+## Errors from other dependencies
+
+The older `node` setting allowed applications to import almost any file inside a dependency. Modern settings allow only the paths that dependency publishes. Changing the setting can therefore reveal an existing import into another package's private files.
+
+If the error names a package outside `@videojs/*`, update that dependency or use one of its supported import paths. A TypeScript `paths` override can be a temporary bridge when no supported replacement exists. Do not switch back to the older resolver because that also breaks Video.js type resolution.

--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -185,6 +185,8 @@ Add it to your components folder in a new file.
 
 ## See also
 
+<DocsLinkCard slug="concepts/browser-support" description="Check browser and tooling requirements">Browser and tooling compatibility</DocsLinkCard>
+
 <DocsLinkCard slug="concepts/skins" anchor="styling" description="Some skins expose CSS custom properties">Skins</DocsLinkCard>
 
 <DocsLinkCard slug="concepts/security" description="Configure Content Security Policy for your player">Security</DocsLinkCard>

--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -185,7 +185,11 @@ Add it to your components folder in a new file.
 
 ## See also
 
-<DocsLinkCard slug="concepts/browser-support" description="Check browser and tooling requirements">Browser and tooling compatibility</DocsLinkCard>
+<DocsLinkCard slug="concepts/browser-support" description="Check supported browsers and rendering environments">Browser support</DocsLinkCard>
+
+<DocsLinkCard slug="concepts/typescript" description="Configure TypeScript for Video.js packages">TypeScript</DocsLinkCard>
+
+<DocsLinkCard slug="concepts/bundlers" description="Check bundler compatibility">Bundlers</DocsLinkCard>
 
 <DocsLinkCard slug="concepts/skins" anchor="styling" description="Some skins expose CSS custom properties">Skins</DocsLinkCard>
 

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -41,6 +41,8 @@ export const sidebar: Sidebar = [
       { slug: 'concepts/v10-roadmap', sidebarLabel: 'Roadmap' },
       { href: '/changelog', sidebarLabel: 'Changelog' },
       { slug: 'concepts/browser-support' },
+      { slug: 'concepts/typescript' },
+      { slug: 'concepts/bundlers' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Broaden the browser support concept into a browser and tooling compatibility guide while keeping Installation intentionally terse. The guide now explains the supported TypeScript and build-tool baseline in approachable terms and separates ordinary application setup from advanced wrapper-library configuration.

## Changes

- Document the TypeScript 5.0 floor and recommended module-resolution settings
- Explain how modern package rules can expose unrelated private imports in an application
- Record the verified Vite 3 CSS-export limitation and Vite 5 compatibility
- Move Rollup externalization guidance into an advanced wrapper-library section
- Link to the compatibility guide from Installation

## Testing

- `pnpm -F @videojs/react... build`
- `pnpm -F site astro check`
- `pnpm -F site build`
- TypeScript fixtures with 5.0.4 (`bundler`, `node16`, and legacy `node`) and 4.9.5
- Vite fixtures with 3.2.8 and 5.4.19

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime, auth, or build pipeline changes in the library itself.
> 
> **Overview**
> Expands the docs **Getting started** section with dedicated **TypeScript** and **Bundlers** concept pages, and reframes **Browser support** with clearer baseline wording and heading structure (without changing the evergreen / WebView / SSR substance).
> 
> The new **TypeScript** page documents the **TypeScript 5.0+** requirement, recommends `moduleResolution: "bundler"` (or `node16`/`nodenext` for Node), and explains why switching off legacy `node10` resolution can surface unrelated private imports from other packages.
> 
> The new **Bundlers** page covers **package `exports`**, records **Vite 3.2.8** vs **Vite 5.4.19** behavior for exported CSS, and adds an advanced **Rollup `external`** pattern for authors publishing wrapper libraries. **Installation**’s “See also” and `docs.config.ts` now link and list these pages alongside browser support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad942c18f49024de3b58d3d4c04253d62bfbbf43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->