### PR TITLE
docs(site): document playback failure recovery

### DIFF
--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -532,19 +532,19 @@ The SPF flavor doesn't license DRM ([#1776](https://github.com/videojs/v10/issue
 | Mux Player | Video.js v10 |
 |---|---|
 | `media.nativeEl` | `.target` on the element |
-| the hls.js instance | `.host.engine` on the hls.js-backed flavor |
+| the hls.js instance | `.engine` on the hls.js-backed media element |
 | `prefer-playback` | `source.preferPlayback`, or pick <DocsLink slug="reference/native-hls-video">native HLS</DocsLink> outright |
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
 | Mux Player | Video.js v10 |
 |---|---|
-| `media.nativeEl` | a `ref` on the media component, then `.target` |
-| the hls.js instance | `.host.engine` through that same `ref`, on the hls.js-backed flavor |
+| `media.nativeEl` | a `ref` on the media component; the ref is the native media element |
+| the hls.js instance | `useMedia()`, narrowed to `HlsJsMedia`, then `.engine` |
 | `prefer-playback` | `source.preferPlayback`, or pick <DocsLink slug="reference/native-hls-video">native HLS</DocsLink> outright |
 </FrameworkCase>
 
-`source.preferPlayback` is the closest mapping: set it to `'native'` and the Mux media hands playback to the browser's own HLS support instead of building an MSE pipeline, which is what `prefer-playback="native"` did.
+`source.preferPlayback` is the closest mapping: set it to `'native'` and the Mux media hands playback to the browser's own HLS support instead of building an MSE pipeline, which is what `prefer-playback="native"` did. See <DocsLink slug="how-to/recover-from-playback-failures">Recover from playback failures</DocsLink> for complete engine-access examples.
 
 Program Date Time has no convenience surface: no `getStartDate()`, no `currentPdt`. The player exposes `liveEdgeStart` and `targetLiveWindow`; for PDT itself, reach into the engine.
 

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -518,16 +518,16 @@ v8 used accessor methods for everything: `player.currentTime()` to read, `player
 | `player.duration()` | `media.duration`, or `duration` in player state |
 | `player.volume()`, `player.muted()` | `media.volume`, `media.muted` |
 | `player.playbackRate()` | `media.playbackRate`, or the player's `setPlaybackRate` |
-| `player.src({ src, type })` | set `src` on the media |
+| `player.src({ src, type })` | set `src` on the media, or call the player's `loadSource` action |
 | `player.requestFullscreen()`, `exitFullscreen()` | the player's `enterFullscreen`, `exitFullscreen`, `toggleFullscreen` |
 | `player.textTracks()`, `addRemoteTextTrack()` | `<track>` elements, and `textTrackList` in player state |
 | `player.audioTracks()` | `audioTracks` in player state |
 | `player.error()` | `error` in player state |
 | `player.dispose()` | remove the element, or unmount the component |
-| `player.tech()` | `.host.engine` on engine-backed media, where one exists |
+| `player.tech()` | `.engine` on an engine-backed media object; see <DocsLink slug="how-to/recover-from-playback-failures">Recover from playback failures</DocsLink> |
 | `videojs.getPlayer(id)` | hold a reference to the element |
 
-Swapping sources is the change most likely to surprise you. There's no `player.src()`; you set `src` on the media element, or replace the media element entirely, and the UI follows. Changing formats is changing tags.
+Swapping sources is the change most likely to surprise you. Set `src` on the media element, call the player's `loadSource` action, or replace the media element entirely, and the UI follows. Changing formats is changing tags.
 
 ## Languages
 

--- a/site/src/content/docs/how-to/recover-from-playback-failures.mdx
+++ b/site/src/content/docs/how-to/recover-from-playback-failures.mdx
@@ -1,0 +1,162 @@
+---
+title: 'Recover from playback failures'
+description: 'Observe terminal playback errors, present recovery UI, and restart a failed source'
+---
+
+import DocsLink from '@/components/docs/DocsLink.astro';
+import FrameworkCase from '@/components/docs/FrameworkCase.astro';
+
+Video.js lets each playback engine retry recoverable failures. Your application takes over when the media reports a terminal error. Observe that error, explain it to the viewer, and reload the source when retrying makes sense.
+
+## Tell a retry from a terminal failure
+
+A stall or `waiting` state is not a terminal error. The media may resume after buffering, and engines such as hls.js retry transient network and media failures within their configured retry budgets.
+
+The <DocsLink slug="reference/feature-error">error feature</DocsLink> updates when the media dispatches an `error` event. For hls.js-backed media, Video.js ignores non-fatal hls.js errors and publishes an error only after hls.js marks the failure as fatal. At that point, hls.js has stopped loading. Restoring connectivity or calling `play()` does not restart its loader.
+
+Terminal describes the current load, not whether the source can ever play again. A fatal network error can become recoverable at the application level once connectivity returns and you reload the source.
+
+Use the error code to choose the next action:
+
+| Code | Failure | Usual response |
+| --- | --- | --- |
+| `1` | Playback was aborted | No retry is normally needed |
+| `2` | Network or server failure | Reload the current source, or fetch a fresh signed URL and load it |
+| `3` | Decode failure | Try another rendition or source; use engine-specific recovery only when you need it |
+| `4` | Unsupported or unavailable source | Load a source the browser and engine can play |
+| `5` | Encrypted playback failure | Refresh authorization or correct the DRM configuration before loading again |
+| `100` | Provider-specific failure | Follow the provider's error context |
+
+The exact retry count and delay belong to the playback engine and its source configuration. Live playlist requests can exhaust their retry budget sooner than segment requests, so a network interruption that on-demand playback rides through may become terminal for a live stream.
+
+## Present the error
+
+Packaged skins include an accessible error dialog. It opens when `error` becomes non-null, presents the translated error message, and offers a Dismiss action. Dismissing clears player error state; it does not resume playback.
+
+For a custom or <DocsLink slug="how-to/customize-skins">ejected skin</DocsLink>, subscribe with `selectError` and render your own recovery actions. The React example replaces the skin's dismiss-only dialog with Retry and Dismiss actions:
+
+<FrameworkCase frameworks={["react"]}>
+
+```tsx title="PlaybackFailure.tsx"
+import { ErrorDialog, selectError, selectSource } from '@videojs/react';
+import { usePlayer } from '@videojs/react/live-video';
+
+export function PlaybackFailure() {
+  const failure = usePlayer(selectError);
+  const source = usePlayer(selectSource);
+
+  function retry() {
+    if (!source?.source) return;
+
+    source.loadSource(source.source);
+    failure?.dismissError();
+  }
+
+  return (
+    <ErrorDialog.Root>
+      <ErrorDialog.Popup>
+        <ErrorDialog.Title />
+        <ErrorDialog.Description />
+        <button type="button" onClick={retry} disabled={!source?.source}>
+          Retry
+        </button>
+        <ErrorDialog.Close>Dismiss</ErrorDialog.Close>
+      </ErrorDialog.Popup>
+    </ErrorDialog.Root>
+  );
+}
+```
+
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+
+The packaged `<media-error-dialog>` handles presentation. Connect an application Retry button to the player store, or use the same handler for a Retry action in an ejected skin:
+
+```ts title="playback-failure.ts"
+import '@videojs/html/live-video';
+
+const player = document.querySelector('live-video-player');
+const retryButton = document.querySelector<HTMLButtonElement>('[data-retry-playback]');
+
+if (!player || !retryButton) throw new Error('Playback recovery UI is missing');
+
+function syncError() {
+  const error = player.store.error;
+  retryButton.hidden = !error;
+  retryButton.disabled = !player.store.source;
+}
+
+retryButton.addEventListener('click', () => {
+  const source = player.store.source;
+  if (!source) return;
+
+  player.store.loadSource(source);
+  player.store.dismissError();
+});
+
+syncError();
+player.store.subscribe(syncError);
+```
+
+</FrameworkCase>
+
+## Reload the source before playing
+
+The supported recovery sequence is:
+
+1. Resolve the URL you want to retry. For expiring or signed live URLs, obtain a fresh URL first.
+2. Call `loadSource(url)` from the <DocsLink slug="reference/feature-source">source feature</DocsLink>. Passing the URL already in `source` deliberately reloads it.
+3. Call `dismissError()` after starting the reload. Loading a new resource may also clear the error through an `emptied` event, but explicitly dismissing it keeps recovery UI consistent across media engines.
+4. Call `play()` only if playback was paused and the retry came from a user gesture. A source that was already playing normally starts loading immediately; browser autoplay policy still applies.
+
+`loadSource` sets the media's `src`, calls its `load()` method, and clears pending player operations. On the hls.js path, loading the manifest re-arms the loader after a fatal error. Calling `play()` before reloading cannot do that work.
+
+## Recover live playback without a remount
+
+Reloading a live manifest asks the engine for the current playlist and resumes from the stream's current live position. You do not need to remount the player, media component, or skin for a terminal hls.js network error.
+
+Remount only when your application is replacing the media implementation, switching to another engine, or intentionally resetting other component-owned state. A routine network retry should preserve the player and reload its source.
+
+## Use the engine escape hatch
+
+Prefer `loadSource` for recovery because it works through public player state and coordinates the media lifecycle. When you need an hls.js-specific operation, use the public `engine` property on the HLS media object. The property is `null` when `HlsJsVideo` falls back to the browser's native HLS implementation.
+
+<FrameworkCase frameworks={["react"]}>
+
+`useMedia()` returns the media object, not the rendered `<video>` element. Narrow it to the public `HlsJsMedia` class before accessing hls.js. Add `@videojs/media` as a direct application dependency when you import its public subpath.
+
+```tsx title="RestartHlsJs.tsx"
+import { HlsJsMedia } from '@videojs/media/dom/hls-js';
+import { useMedia } from '@videojs/react';
+
+export function RestartHlsJs() {
+  const media = useMedia();
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (media instanceof HlsJsMedia) media.engine?.startLoad(-1);
+      }}
+    >
+      Restart HLS
+    </button>
+  );
+}
+```
+
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+
+The custom media element exposes the engine directly:
+
+```ts
+const media = document.querySelector('hlsjs-video');
+media?.engine?.startLoad(-1);
+```
+
+</FrameworkCase>
+
+Direct engine calls bypass the source feature and do not clear player error state. After an engine-specific recovery, dismiss the error through the player store or error feature.

--- a/site/src/content/docs/reference/feature-error.mdx
+++ b/site/src/content/docs/reference/feature-error.mdx
@@ -11,6 +11,8 @@ Tracks media errors.
 
 <FeatureReference feature="error" />
 
+`dismissError` clears the current error and closes the packaged error dialog. It does not retry playback. See <DocsLink slug="how-to/recover-from-playback-failures">Recover from playback failures</DocsLink> to classify terminal errors and reload a failed source.
+
 ### Selector
 
 <FrameworkCase frameworks={["react"]}>

--- a/site/src/content/docs/reference/feature-source.mdx
+++ b/site/src/content/docs/reference/feature-source.mdx
@@ -11,6 +11,8 @@ Tracks the current media source and readiness.
 
 <FeatureReference feature="source" />
 
+`loadSource` can load a new URL or deliberately reload the URL already in `source`. See <DocsLink slug="how-to/recover-from-playback-failures">Recover from playback failures</DocsLink> for the supported recovery sequence.
+
 ### Selector
 
 <FrameworkCase frameworks={["react"]}>
@@ -29,7 +31,7 @@ function SourceInfo() {
   const source = usePlayer(selectSource);
   if (!source) return null;
 
-  return <span>{source.src}</span>;
+  return <span>{source.source}</span>;
 }
 ```
 </FrameworkCase>

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -65,6 +65,7 @@ export const sidebar: Sidebar = [
     llmsDescription:
       'Task-oriented guides with step-by-step instructions to achieve a specific outcome by applying one or more concepts. Each guide may assume you already understand the relevant concepts.',
     contents: [
+      { slug: 'how-to/recover-from-playback-failures' },
       { slug: 'how-to/customize-skins' },
       { slug: 'how-to/add-a-poster-placeholder' },
       { slug: 'how-to/build-your-own-component' },


### PR DESCRIPTION
## Summary

Document how applications distinguish recoverable playback stalls from terminal failures and recover after retry exhaustion, especially for hls.js-backed live streams.

## Changes

- Explain terminal hls.js errors and why restoring connectivity or calling play alone does not restart loading
- Document observing and presenting errors in React and HTML players
- Describe the supported loadSource then dismissError recovery sequence and when play is needed
- Clarify that routine live recovery does not require remounting the player
- Correct migration guidance to use the public media.engine escape hatch instead of internal host paths

## Testing

- env -u SENTRY_AUTH_TOKEN pnpm build:site
- pnpm -F site astro check
- pnpm -F @videojs/core test src/dom/store/features/tests/source.test.ts src/dom/store/features/tests/error.test.ts
- pnpm -F @videojs/media test src/dom/hls-js/tests/preload.test.ts src/dom/hls-js/tests/errors.test.ts src/dom/hls-js/tests/hls-media.test.ts
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to site guides and API examples; no runtime or security behavior is modified.
> 
> **Overview**
> Adds a **Recover from playback failures** guide that explains how to tell engine retries from terminal errors, present recovery UI, and restart playback with `loadSource` then `dismissError`—without remounting the player for routine live HLS failures.
> 
> Migration and feature docs now point at that sequence. They also replace internal `.host.engine` access with the public `engine` property (and `useMedia()` + `HlsJsMedia` in React), and document `loadSource` as the v8 `player.src()` equivalent. The source feature example now reads `source.source`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393b05f884e3d937a07a553b91713d1acb509cba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->