### PR TITLE
docs(site): tiny docs chores

### DIFF
--- a/site/src/content/docs/concepts/overview.mdx
+++ b/site/src/content/docs/concepts/overview.mdx
@@ -7,7 +7,6 @@ import FrameworkCase from '@/components/docs/FrameworkCase.astro';
 import { TabsRoot, TabsList, TabsPanel, Tab } from '@/components/Tabs';
 import DocsLink from '@/components/docs/DocsLink.astro';
 import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
-import Aside from '@/components/Aside.astro';
 
 Video.js v10 is built around a three-part architecture that separates concerns and maximizes flexibility. Each part is designed to work independently or together, allowing you to use as much or as little of Video.js as you need.
 
@@ -119,10 +118,6 @@ Media components can be format specific (HLS, DASH), service specific (YouTube, 
 <FrameworkCase frameworks={["html"]}>
 Media elements are discovered automatically. Plain `<video>` and `<audio>` elements are found via a `querySelector`, while custom media elements like `<hlsjs-video>` register themselves.
 </FrameworkCase>
-
-<Aside type="note">
-DASH, YouTube, Vimeo, Mux, and more media elements are currently under development.
-</Aside>
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx

--- a/site/src/content/docs/concepts/presets.mdx
+++ b/site/src/content/docs/concepts/presets.mdx
@@ -53,6 +53,7 @@ The default presets are `/video` and `/audio`. These cover the baseline controls
 
 ## What's in a preset
 
+<FrameworkCase frameworks={["react"]}>
 Each React preset exports a named, preconfigured player component and typed `usePlayer` hook, plus the building blocks needed to customize or eject from it:
 
 - **Player** — A player component named for the preset, such as `VideoPlayer`, already configured with the preset's feature bundle.
@@ -60,6 +61,11 @@ Each React preset exports a named, preconfigured player component and typed `use
 - **Feature bundle** — An array of <DocsLink slug="concepts/features">features</DocsLink> that define the player's state and actions. For example, the video feature bundle includes playback, volume, time, fullscreen, and more.
 - **Skins** — Pre-built UIs designed for that feature bundle. For example, a video skin renders fullscreen and PiP controls because the video feature bundle includes those features. An audio skin doesn't.
 - **Media element** — A media component suited to the use case. For example, the background video element bakes in autoplay, mute, and loop.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+Each HTML preset provides registration entry points for a preconfigured player element, its skins, and any preset-specific media element, plus the feature bundle needed to compose your own player. For example, `@videojs/html/video/player` registers `<video-player>`, while `@videojs/html/video/skin` registers `<video-skin>`.
+</FrameworkCase>
 
 These parts aren't equally tied together. Skins depend tightly on their feature bundle — a skin expects specific features to exist. Media elements are more interchangeable — you can swap in an HLS or DASH provider without changing your skin or features.
 

--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -46,7 +46,7 @@ Use [CSS custom properties](#root-css-custom-properties) to style the fill and p
 <FrameworkCase frameworks={["html"]}>
 ```css
 media-volume-slider::before {
-  width: calc(var(--media-slider-fill) * 1%);
+  width: var(--media-slider-fill);
 }
 ```
 </FrameworkCase>
@@ -56,7 +56,7 @@ React renders a `<div>` element. Add a `className` to style it:
 
 ```css
 .volume-slider::before {
-  width: calc(var(--media-slider-fill) * 1%);
+  width: var(--media-slider-fill);
 }
 ```
 </FrameworkCase>


### PR DESCRIPTION
## Summary

Correct three independently observed documentation errors that remained reproducible against current source, tests, examples, and generated references.

## Changes

- Use the already-unitized slider fill custom property directly in volume slider CSS examples
- Keep React preset hooks and components out of the HTML documentation variant, with HTML registration guidance in their place
- Remove stale media-provider readiness guidance now that those providers ship with references and examples

## Testing

- `pnpm -F site astro check`
- `env -u SENTRY_AUTH_TOKEN pnpm build:site`
- `pnpm exec prettier --check site/src/content/docs/reference/volume-slider.mdx site/src/content/docs/concepts/presets.mdx site/src/content/docs/concepts/overview.mdx`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, API, or security impact.
> 
> **Overview**
> Corrects a few docs mismatches with current Video.js v10 APIs.
> 
> Volume slider styling examples now use `var(--media-slider-fill)` directly (the property already includes `%`). Preset docs split React vs HTML: HTML readers get registration entry points instead of React player/hook details. The overview no longer claims DASH/YouTube/Vimeo/Mux media elements are still under development.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208c674371f5a4689003cc3c068459ba6501642c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->