### PR TITLE
docs(site): add vue and svelte integration guides

### DIFF
--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -80,11 +80,17 @@ Otherwise, answer the questions below to get started quickly with your first emb
 
 ## Choose your JS framework
 
-Video.js aims to provide idiomatic development experiences in your favorite JS and CSS frameworks. More to come.
+Video.js aims to provide idiomatic development experiences in React components or HTML custom elements.
 
 <ContentWidth margins="lg">
   <JSPicker />
 </ContentWidth>
+
+Complete the installation steps below, then visit the guide for your framework for more detailed integration information. We're planning on adding official support in the future.
+
+<DocsLinkCard slug="how-to/use-videojs-with-vue">Vue and Nuxt</DocsLinkCard>
+
+<DocsLinkCard slug="how-to/use-videojs-with-svelte">Svelte and SvelteKit</DocsLinkCard>
 
 ## Choose your use case
 

--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -86,11 +86,13 @@ Video.js aims to provide idiomatic development experiences in React components o
   <JSPicker />
 </ContentWidth>
 
-Complete the installation steps below, then visit the guide for your framework for more detailed integration information. We're planning on adding official support in the future.
+<FrameworkCase frameworks={["html"]}>
+  Complete the installation steps below, then visit the guide for your framework for more detailed integration information. We're planning on adding official support in the future.
 
-<DocsLinkCard slug="how-to/use-videojs-with-vue">Vue and Nuxt</DocsLinkCard>
+  <DocsLinkCard slug="how-to/use-videojs-with-vue">Vue and Nuxt</DocsLinkCard>
 
-<DocsLinkCard slug="how-to/use-videojs-with-svelte">Svelte and SvelteKit</DocsLinkCard>
+  <DocsLinkCard slug="how-to/use-videojs-with-svelte">Svelte and SvelteKit</DocsLinkCard>
+</FrameworkCase>
 
 ## Choose your use case
 

--- a/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
+++ b/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
@@ -7,9 +7,52 @@ import DocsLink from '@/components/docs/DocsLink.astro';
 
 Follow the <DocsLink slug="how-to/installation">installation guide</DocsLink> first. Keep its `@videojs/html` imports and player markup in your Svelte component, then apply the Svelte-specific patterns below.
 
+## Read player state in `onMount`
+
+If your component needs to react to player state or call a player action, wait until Svelte has mounted and bound `<video-player>`. The React API's `usePlayer` hook is not part of `@videojs/html`, so bind the element to a variable and subscribe to its store in `onMount`:
+
+```svelte
+<script lang="ts">
+  import type { VideoPlayerElement } from '@videojs/html/video/player';
+  import { onMount } from 'svelte';
+
+  let player: VideoPlayerElement;
+  let paused = $state(true);
+
+  onMount(() => {
+    const sync = () => (paused = player.store.paused);
+    sync();
+    return player.store.subscribe(sync);
+  });
+</script>
+
+<video-player bind:this={player}><!-- skin and media --></video-player>
+<p>{paused ? 'Paused' : 'Playing'}</p>
+```
+
+Return the store's unsubscribe function from `onMount` so Svelte cleans up the subscription. Use the store for player state and actions. You can still listen for native media events on the `<video>`, `<audio>`, or media custom element when you need the event itself.
+
+## Keep runtime styles global
+
+If a style depends on a Video.js `data-*` state, Svelte may remove its selector because that attribute is not present in your component markup. Wrap these runtime-state selectors in Svelte's [`:global(...)`](https://svelte.dev/docs/svelte/global-styles#global) modifier:
+
+```svelte
+<style>
+  :global(media-mute-button:not(:defined)) {
+    visibility: hidden;
+  }
+
+  :global(media-mute-button:defined[data-muted]) {
+    color: var(--muted-control-color);
+  }
+</style>
+```
+
+`:defined` applies the state style only after the browser loads the element. These selectors matter when you eject a skin or compose controls yourself. Styles cannot reach controls inside a packaged skin; use its CSS custom properties, or <DocsLink slug="how-to/customize-skins">eject the skin</DocsLink> to own its markup and CSS.
+
 ## Pass objects as properties
 
-HTML attributes contain text. Assign structured values, such as a Mux source, to the element's JavaScript property from a Svelte effect:
+If you need to pass structured data, such as a Mux source, an HTML attribute will not work because attributes contain text. Bind the element to a variable and assign the object to its JavaScript property from a Svelte effect:
 
 ```svelte
 <script lang="ts">
@@ -38,57 +81,8 @@ HTML attributes contain text. Assign structured values, such as a Mux source, to
 
 The effect runs in the browser, so Svelte does not turn the object into a text attribute during server rendering. Video.js also preserves properties assigned before the custom element finishes loading.
 
-## Read player state
+## Use SvelteKit
 
-The React API's `usePlayer` hook is not part of `@videojs/html`. In Svelte, bind `<video-player>` to a variable and subscribe to its store:
+If you use server rendering, keep the element imports from the installation guide static. SvelteKit renders the custom-element markup on the server, and the browser upgrades it when the page loads. Put code that needs the bound element or browser APIs in `onMount`, as shown above.
 
-```svelte
-<script lang="ts">
-  import type { VideoPlayerElement } from '@videojs/html/video/player';
-  import { onMount } from 'svelte';
-
-  let player: VideoPlayerElement;
-  let paused = $state(true);
-
-  onMount(() => {
-    const sync = () => (paused = player.store.paused);
-    sync();
-    return player.store.subscribe(sync);
-  });
-</script>
-
-<video-player bind:this={player}><!-- skin and media --></video-player>
-<p>{paused ? 'Paused' : 'Playing'}</p>
-```
-
-Use the store for player state and actions. You can still listen for native media events on the `<video>`, `<audio>`, or media custom element when you need the event itself.
-
-## Keep runtime styles global
-
-Svelte can remove a scoped selector when its matching `data-*` attribute only appears at runtime. Wrap these selectors in Svelte's [`:global(...)`](https://svelte.dev/docs/svelte/global-styles#global) modifier:
-
-```svelte
-<style>
-  :global(media-mute-button:not(:defined)) {
-    visibility: hidden;
-  }
-
-  :global(media-mute-button:defined[data-muted]) {
-    color: var(--muted-control-color);
-  }
-</style>
-```
-
-`:defined` applies the state style only after the browser loads the element. These selectors matter when you eject a skin or compose controls yourself. Styles cannot reach controls inside a packaged skin; use its CSS custom properties, or <DocsLink slug="how-to/customize-skins">eject the skin</DocsLink> to own its markup and CSS.
-
-## Use SvelteKit and wrapper libraries
-
-Keep the element imports from the installation guide static. SvelteKit renders the custom-element markup on the server, and the browser upgrades it when the page loads. If you intentionally import Video.js later from `onMount`, wait for `customElements.whenDefined('video-player')` before reading its store or calling its methods.
-
-For a published wrapper, declare `@videojs/html` as a peer dependency and externalize its root and deep imports:
-
-```ts
-const external = (id: string) => id === '@videojs/html' || id.startsWith('@videojs/html/');
-```
-
-Let the consuming app import the global skin CSS. If Svelte reports a type error for a custom tag or event, add it to `SvelteHTMLElements` by following Svelte's [DOM type guidance](https://svelte.dev/docs/svelte/typescript#enhancing-built-in-dom-types).
+If you intentionally import Video.js later from `onMount`, wait for `customElements.whenDefined('video-player')` before reading its store or calling its methods. If Svelte reports a type error for a custom tag or event, add it to `SvelteHTMLElements` by following Svelte's [DOM type guidance](https://svelte.dev/docs/svelte/typescript#enhancing-built-in-dom-types).

--- a/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
+++ b/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
@@ -1,0 +1,94 @@
+---
+title: Use Video.js with Svelte and SvelteKit
+description: Add Video.js to a Svelte or SvelteKit app
+---
+
+import DocsLink from '@/components/docs/DocsLink.astro';
+
+Follow the <DocsLink slug="how-to/installation">installation guide</DocsLink> first. Keep its `@videojs/html` imports and player markup in your Svelte component, then apply the Svelte-specific patterns below.
+
+## Pass objects as properties
+
+HTML attributes contain text. Assign structured values, such as a Mux source, to the element's JavaScript property from a Svelte effect:
+
+```svelte
+<script lang="ts">
+  import '@videojs/html/video/player';
+  import '@videojs/html/video/skin';
+  import '@videojs/html/media/mux-video';
+  import type { MuxVideoElement } from '@videojs/html/media/mux-video';
+
+  const source = {
+    playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
+    playback: { maxResolution: '1080p' },
+  } as const;
+  let muxVideo: MuxVideoElement | undefined;
+
+  $effect(() => {
+    if (muxVideo) muxVideo.source = source;
+  });
+</script>
+
+<video-player>
+  <video-skin>
+    <mux-video bind:this={muxVideo}></mux-video>
+  </video-skin>
+</video-player>
+```
+
+The effect runs in the browser, so Svelte does not turn the object into a text attribute during server rendering. Video.js also preserves properties assigned before the custom element finishes loading.
+
+## Read player state
+
+The React API's `usePlayer` hook is not part of `@videojs/html`. In Svelte, bind `<video-player>` to a variable and subscribe to its store:
+
+```svelte
+<script lang="ts">
+  import type { VideoPlayerElement } from '@videojs/html/video/player';
+  import { onMount } from 'svelte';
+
+  let player: VideoPlayerElement;
+  let paused = $state(true);
+
+  onMount(() => {
+    const sync = () => (paused = player.store.paused);
+    sync();
+    return player.store.subscribe(sync);
+  });
+</script>
+
+<video-player bind:this={player}><!-- skin and media --></video-player>
+<p>{paused ? 'Paused' : 'Playing'}</p>
+```
+
+Use the store for player state and actions. You can still listen for native media events on the `<video>`, `<audio>`, or media custom element when you need the event itself.
+
+## Keep runtime styles global
+
+Svelte can remove a scoped selector when its matching `data-*` attribute only appears at runtime. Wrap these selectors in Svelte's [`:global(...)`](https://svelte.dev/docs/svelte/global-styles#global) modifier:
+
+```svelte
+<style>
+  :global(media-mute-button:not(:defined)) {
+    visibility: hidden;
+  }
+
+  :global(media-mute-button:defined[data-muted]) {
+    color: var(--muted-control-color);
+  }
+</style>
+```
+
+`:defined` applies the state style only after the browser loads the element. These selectors matter when you eject a skin or compose controls yourself. Styles cannot reach controls inside a packaged skin; use its CSS custom properties, or <DocsLink slug="how-to/customize-skins">eject the skin</DocsLink> to own its markup and CSS.
+
+## Use SvelteKit and wrapper libraries
+
+Keep the element imports from the installation guide static. SvelteKit renders the custom-element markup on the server, and the browser upgrades it when the page loads. If you intentionally import Video.js later from `onMount`, wait for `customElements.whenDefined('video-player')` before reading its store or calling its methods.
+
+For a published wrapper, declare `@videojs/html` as a peer dependency and externalize its root and deep imports:
+
+```ts
+const external = (id: string) => id === '@videojs/html' || id.startsWith('@videojs/html/');
+```
+
+Let the consuming app import the global skin CSS. If Svelte reports a type error for a custom tag or event, add it to `SvelteHTMLElements` by following Svelte's [DOM type guidance](https://svelte.dev/docs/svelte/typescript#enhancing-built-in-dom-types).

--- a/site/src/content/docs/how-to/use-videojs-with-vue.mdx
+++ b/site/src/content/docs/how-to/use-videojs-with-vue.mdx
@@ -9,7 +9,7 @@ Follow the <DocsLink slug="how-to/installation">installation guide</DocsLink> fi
 
 ## Configure custom element tags
 
-Vue normally treats an unfamiliar tag as a Vue component. Use Vue's [`isCustomElement`](https://vuejs.org/guide/extras/web-components.html#skipping-component-resolution) compiler option to identify the exact Video.js tags in your templates.
+If Vue warns that it cannot resolve a Video.js tag, the compiler is treating that tag as a Vue component. Use Vue's [`isCustomElement`](https://vuejs.org/guide/extras/web-components.html#skipping-component-resolution) option to identify the exact Video.js tags in your templates.
 
 For a Vue app built with Vite:
 
@@ -48,36 +48,9 @@ export default defineNuxtConfig({
 
 List only the tags that appear in your templates. Avoid broad rules such as allowing every hyphenated tag or every tag with one prefix: Video.js uses several tag families, and broad rules can also hide misspelled Vue components.
 
-## Pass objects as properties
-
-HTML attributes contain text. Vue's [`.prop` modifier](https://vuejs.org/api/built-in-directives.html#v-bind) assigns a structured value to the element's JavaScript property:
-
-```vue
-<script setup lang="ts">
-import '@videojs/html/video/player';
-import '@videojs/html/video/skin';
-import '@videojs/html/media/mux-video';
-
-const source = {
-  playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
-  playback: { maxResolution: '1080p' },
-} as const;
-</script>
-
-<template>
-  <video-player>
-    <video-skin>
-      <mux-video :source.prop="source"></mux-video>
-    </video-skin>
-  </video-player>
-</template>
-```
-
-Use `.prop` explicitly. An ordinary binding or render-function prop can become an attribute if Vue runs before the custom element finishes loading. Video.js preserves explicitly assigned properties during that upgrade.
-
 ## Read player state
 
-The React API's `usePlayer` hook is not part of `@videojs/html`. In Vue, use a template ref and subscribe to the `<video-player>` store after the component mounts:
+If your Vue component needs to react to player state or call a player action, wait until Vue has mounted `<video-player>`. The React API's `usePlayer` hook is not part of `@videojs/html`, so use a template ref and subscribe to the element's store:
 
 ```vue
 <script setup lang="ts">
@@ -109,7 +82,7 @@ Use the store for player state and actions. You can still listen for native medi
 
 ## Style Vue components
 
-Vue's scoped styles can style a custom-element tag rendered by the component. Use `:defined` to hide a tag until the browser loads it:
+If you want to hide an element until the browser loads it, use `:defined` in your component's scoped styles:
 
 ```vue
 <style scoped>
@@ -121,14 +94,35 @@ video-skin:not(:defined) {
 
 Scoped styles cannot reach controls inside a packaged skin. Use its CSS custom properties, or <DocsLink slug="how-to/customize-skins">eject the skin</DocsLink> to own its markup and CSS.
 
-## Use Nuxt and wrapper libraries
+## Pass objects as properties
 
-Keep the element imports from the installation guide static. Nuxt renders the custom-element markup on the server, and the browser upgrades it when the page loads. If you intentionally keep registration client-only, import the elements from a `.client.ts` plugin and wait for `customElements.whenDefined('video-player')` before reading its store or calling its methods.
+If you need to pass structured data, such as a Mux source, an HTML attribute will not work because attributes contain text. Vue's [`.prop` modifier](https://vuejs.org/api/built-in-directives.html#v-bind) assigns the value to the element's JavaScript property:
 
-For a published wrapper, declare `@videojs/html` as a peer dependency and externalize its root and deep imports:
+```vue
+<script setup lang="ts">
+import '@videojs/html/video/player';
+import '@videojs/html/video/skin';
+import '@videojs/html/media/mux-video';
 
-```ts
-const external = (id: string) => id === '@videojs/html' || id.startsWith('@videojs/html/');
+const source = {
+  playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
+  playback: { maxResolution: '1080p' },
+} as const;
+</script>
+
+<template>
+  <video-player>
+    <video-skin>
+      <mux-video :source.prop="source"></mux-video>
+    </video-skin>
+  </video-player>
+</template>
 ```
 
-Configure the wrapper library's compiler for the tags inside the wrapper. Consumers only need to allowlist Video.js tags they write in their own templates. Let the consuming app import the global skin CSS. For custom tag or event types, follow Vue's [TypeScript guidance for non-Vue custom elements](https://vuejs.org/guide/extras/web-components.html#non-vue-web-components-and-typescript).
+Use `.prop` explicitly. An ordinary binding or render-function prop can become an attribute if Vue runs before the custom element finishes loading. Video.js preserves explicitly assigned properties during that upgrade.
+
+## Use Nuxt
+
+If you use server rendering, keep the element imports from the installation guide static. Nuxt renders the custom-element markup on the server, and the browser upgrades it when the page loads.
+
+If you intentionally keep registration client-only, import the elements from a `.client.ts` plugin and wait for `customElements.whenDefined('video-player')` before reading its store or calling its methods. For custom tag or event types, follow Vue's [TypeScript guidance for non-Vue custom elements](https://vuejs.org/guide/extras/web-components.html#non-vue-web-components-and-typescript).

--- a/site/src/content/docs/how-to/use-videojs-with-vue.mdx
+++ b/site/src/content/docs/how-to/use-videojs-with-vue.mdx
@@ -1,0 +1,134 @@
+---
+title: Use Video.js with Vue and Nuxt
+description: Add Video.js to a Vue or Nuxt app
+---
+
+import DocsLink from '@/components/docs/DocsLink.astro';
+
+Follow the <DocsLink slug="how-to/installation">installation guide</DocsLink> first. Keep its `@videojs/html` imports and player markup in your Vue component, then apply the Vue-specific configuration below.
+
+## Configure custom element tags
+
+Vue normally treats an unfamiliar tag as a Vue component. Use Vue's [`isCustomElement`](https://vuejs.org/guide/extras/web-components.html#skipping-component-resolution) compiler option to identify the exact Video.js tags in your templates.
+
+For a Vue app built with Vite:
+
+```ts title="vite.config.ts"
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vite';
+
+const videoJsElements = new Set(['video-player', 'video-skin', 'mux-video']);
+
+export default defineConfig({
+  plugins: [
+    vue({
+      template: {
+        compilerOptions: {
+          isCustomElement: (tag) => videoJsElements.has(tag),
+        },
+      },
+    }),
+  ],
+});
+```
+
+For Nuxt:
+
+```ts title="nuxt.config.ts"
+const videoJsElements = new Set(['video-player', 'video-skin', 'mux-video']);
+
+export default defineNuxtConfig({
+  vue: {
+    compilerOptions: {
+      isCustomElement: (tag) => videoJsElements.has(tag),
+    },
+  },
+});
+```
+
+List only the tags that appear in your templates. Avoid broad rules such as allowing every hyphenated tag or every tag with one prefix: Video.js uses several tag families, and broad rules can also hide misspelled Vue components.
+
+## Pass objects as properties
+
+HTML attributes contain text. Vue's [`.prop` modifier](https://vuejs.org/api/built-in-directives.html#v-bind) assigns a structured value to the element's JavaScript property:
+
+```vue
+<script setup lang="ts">
+import '@videojs/html/video/player';
+import '@videojs/html/video/skin';
+import '@videojs/html/media/mux-video';
+
+const source = {
+  playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
+  playback: { maxResolution: '1080p' },
+} as const;
+</script>
+
+<template>
+  <video-player>
+    <video-skin>
+      <mux-video :source.prop="source"></mux-video>
+    </video-skin>
+  </video-player>
+</template>
+```
+
+Use `.prop` explicitly. An ordinary binding or render-function prop can become an attribute if Vue runs before the custom element finishes loading. Video.js preserves explicitly assigned properties during that upgrade.
+
+## Read player state
+
+The React API's `usePlayer` hook is not part of `@videojs/html`. In Vue, use a template ref and subscribe to the `<video-player>` store after the component mounts:
+
+```vue
+<script setup lang="ts">
+import type { VideoPlayerElement } from '@videojs/html/video/player';
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+
+const player = ref<VideoPlayerElement | null>(null);
+const paused = ref(true);
+let unsubscribe = () => {};
+
+onMounted(async () => {
+  await customElements.whenDefined('video-player');
+  const store = player.value!.store;
+  const sync = () => (paused.value = store.paused);
+  sync();
+  unsubscribe = store.subscribe(sync);
+});
+
+onBeforeUnmount(() => unsubscribe());
+</script>
+
+<template>
+  <video-player ref="player"><!-- skin and media --></video-player>
+  <p>{{ paused ? 'Paused' : 'Playing' }}</p>
+</template>
+```
+
+Use the store for player state and actions. You can still listen for native media events on the `<video>`, `<audio>`, or media custom element when you need the event itself.
+
+## Style Vue components
+
+Vue's scoped styles can style a custom-element tag rendered by the component. Use `:defined` to hide a tag until the browser loads it:
+
+```vue
+<style scoped>
+video-skin:not(:defined) {
+  visibility: hidden;
+}
+</style>
+```
+
+Scoped styles cannot reach controls inside a packaged skin. Use its CSS custom properties, or <DocsLink slug="how-to/customize-skins">eject the skin</DocsLink> to own its markup and CSS.
+
+## Use Nuxt and wrapper libraries
+
+Keep the element imports from the installation guide static. Nuxt renders the custom-element markup on the server, and the browser upgrades it when the page loads. If you intentionally keep registration client-only, import the elements from a `.client.ts` plugin and wait for `customElements.whenDefined('video-player')` before reading its store or calling its methods.
+
+For a published wrapper, declare `@videojs/html` as a peer dependency and externalize its root and deep imports:
+
+```ts
+const external = (id: string) => id === '@videojs/html' || id.startsWith('@videojs/html/');
+```
+
+Configure the wrapper library's compiler for the tags inside the wrapper. Consumers only need to allowlist Video.js tags they write in their own templates. Let the consuming app import the global skin CSS. For custom tag or event types, follow Vue's [TypeScript guidance for non-Vue custom elements](https://vuejs.org/guide/extras/web-components.html#non-vue-web-components-and-typescript).

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -65,6 +65,14 @@ export const sidebar: Sidebar = [
     llmsDescription:
       'Task-oriented guides with step-by-step instructions to achieve a specific outcome by applying one or more concepts. Each guide may assume you already understand the relevant concepts.',
     contents: [
+      {
+        sidebarLabel: 'Integrate with a framework',
+        defaultOpen: false,
+        contents: [
+          { slug: 'how-to/use-videojs-with-vue', sidebarLabel: 'Vue and Nuxt', frameworks: ['html'] },
+          { slug: 'how-to/use-videojs-with-svelte', sidebarLabel: 'Svelte and SvelteKit', frameworks: ['html'] },
+        ],
+      },
       { slug: 'how-to/customize-skins' },
       { slug: 'how-to/add-a-poster-placeholder' },
       { slug: 'how-to/build-your-own-component' },


### PR DESCRIPTION
## Summary

Add focused Vue/Nuxt and Svelte/SvelteKit integration guides for using the HTML custom-element API, and link them from installation.

## Changes

- document exact Vue compiler allowlists, property binding, store subscriptions, scoped CSS, and Nuxt boundaries
- document Svelte object properties, store subscriptions, runtime `:global()` selectors, and SvelteKit boundaries
- add framework-guide links after installation and group them under “Integrate with a framework”

## Testing

- `pnpm -F site test`
- `pnpm -F site astro check`
- `pnpm check:workspace`
- `env -u SENTRY_AUTH_TOKEN CI=true pnpm -F site exec astro build`
- rendered-page review for installation and both guides

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only site content and sidebar entries; no runtime or security changes.
> 
> **Overview**
> Adds HTML-framework how-tos for using `@videojs/html` in Vue/Nuxt and Svelte/SvelteKit, covering custom-element compiler config, store subscriptions, object property assignment, styling, and SSR.
> 
> Installation now points HTML users at those guides after the framework picker. The sidebar groups them under **Integrate with a framework** (HTML-only). The framework picker copy now describes React vs HTML custom elements instead of “more to come.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0fa9f89109845fd1af1cf5ebf0a0b1f1d355de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->