### PR TITLE
fix(site): version CDN examples

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -27,6 +27,7 @@ import svgr from 'vite-plugin-svgr';
 import llmsMarkdown from './integrations/llms-markdown';
 import { demoPlaceholderPlugin } from './scripts/replace-demo-placeholders.ts';
 import { PRERELEASE_URL, PRODUCTION_URL } from './src/consts.ts';
+import { satteriCdnVersion } from './src/utils/satteriCdnVersion';
 import { satteriCodeFrame } from './src/utils/satteriCodeFrame';
 import { satteriConditionalHeadings } from './src/utils/satteriConditionalHeadings';
 import { satteriReadingTime } from './src/utils/satteriReadingTime';
@@ -150,7 +151,7 @@ export default defineConfig({
     // independently of the Markdown processor, so highlighting is configured
     // here while the processor's custom transforms live in `mdastPlugins`.
     processor: satteri({
-      mdastPlugins: [satteriReadingTime(), satteriConditionalHeadings(), satteriCodeFrame()],
+      mdastPlugins: [satteriReadingTime(), satteriConditionalHeadings(), satteriCdnVersion(), satteriCodeFrame()],
     }),
   },
 

--- a/site/scripts/ejected-skins/config.ts
+++ b/site/scripts/ejected-skins/config.ts
@@ -1,3 +1,5 @@
+import { VJS10_HTML_CDN_BASE } from '../../src/consts';
+
 export type MediaType = 'video' | 'audio';
 export type SkinVariant = 'default' | 'minimal';
 export type SkinStyle = 'css' | 'tailwind';
@@ -28,7 +30,7 @@ export interface ReactSkinDef extends SkinMetadata {
 
 export type SkinDef = HtmlSkinDef | ReactSkinDef;
 
-export const HTML_CDN_BASE = 'https://cdn.jsdelivr.net/npm/@videojs/html/cdn';
+export const HTML_CDN_BASE = VJS10_HTML_CDN_BASE;
 export const DEMO_VIDEO_SRC = 'https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4';
 export const DEMO_POSTER_SRC = 'https://image.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/thumbnail.webp';
 export const DEMO_LIVE_SRC = 'https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8';

--- a/site/src/components/home/Demo/baseCode.ts
+++ b/site/src/components/home/Demo/baseCode.ts
@@ -1,13 +1,11 @@
-import { VJS10_DEMO_VIDEO } from '@/consts';
+import { VJS10_DEMO_VIDEO, VJS10_HTML_CDN_BASE } from '@/consts';
 import type { Skin } from '@/stores/homePageDemos';
-
-const CDN_BASE = 'https://cdn.jsdelivr.net/npm/@videojs/html/cdn';
 
 export function generateHTMLCode(skin: Skin): string {
   const skinTag = skin === 'default' ? 'video-skin' : 'video-minimal-skin';
   const cdnFile = skin === 'default' ? 'video' : 'video-minimal';
 
-  return `<script type="module" src="${CDN_BASE}/${cdnFile}.js"></script>
+  return `<script type="module" src="${VJS10_HTML_CDN_BASE}/${cdnFile}.js"></script>
 
 <video-player>
   <${skinTag}>

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -1,3 +1,5 @@
+import htmlPackage from '../../packages/html/package.json' with { type: 'json' };
+
 // Always https://videojs.org. Unlike Astro.site, which varies per deploy
 // (e.g. deploy preview URLs), this is stable for canonical URLs and other
 // references that must always point to production.
@@ -15,6 +17,8 @@ export const MUX_SUPPORT_URL = 'https://www.mux.com/sales-contact?form=sales&utm
 export const THEME_KEY = 'vjs-site-theme';
 export const BANNER_DISMISS_KEY = 'vjs-legacy-banner-dismissed';
 export const BLOG_PAGE_SIZE = 10;
+export const VJS10_VERSION = htmlPackage.version;
+export const VJS10_HTML_CDN_BASE = `https://cdn.jsdelivr.net/npm/@videojs/html@${VJS10_VERSION}/cdn`;
 
 export function isPrereleaseSite(siteUrl: URL | undefined): boolean {
   return siteUrl?.origin === PRERELEASE_URL.origin;

--- a/site/src/content/docs/how-to/i18n-register-locale.mdx
+++ b/site/src/content/docs/how-to/i18n-register-locale.mdx
@@ -148,8 +148,8 @@ All keys are optional. Missing keys follow the <DocsLink slug="concepts/i18n">lo
 Load the player and a locale chunk. CDN locale modules call <DocsLink slug="reference/register-i18n">`registerI18n`</DocsLink> on import:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/locales/es.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/video.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/locales/es.js"></script>
 
 <html lang="es">
   <media-i18n>
@@ -169,7 +169,7 @@ CDN locale files import `registerI18n` from the shared `cdn/i18n.js` bundle so e
 ## Custom CDN locale
 
 ```js title="my-locale.js"
-import { registerI18n } from 'https://cdn.jsdelivr.net/npm/@videojs/html/cdn/i18n.js';
+import { registerI18n } from '{{VJS10_HTML_CDN_BASE}}/i18n.js';
 
 registerI18n('es', {
   buttons: {

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -67,9 +67,9 @@ Here's a typical Mux Player embed. A playback ID, a title and viewer ID for anal
 A <DocsLink slug="concepts/presets">preset</DocsLink> is a player, a skin, and a media element that already fit together. Everything else is its own import. From the CDN, that's one script for the video preset, one for the Mux media, and one for analytics:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/mux-video.js"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/mux-data.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/video.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/media/mux-video.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/media/mux-data.js"></script>
 
 <video-player>
   <video-skin class="aspect-video">

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -60,7 +60,7 @@ The closest Video.js skin to the Plyr skin is the Minimal skin, so we'll use tha
 The easiest path is the CDN:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video-minimal.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/video-minimal.js"></script>
 
 <video-player>
   <video-minimal-skin>
@@ -147,7 +147,7 @@ If you're using HLS or DASH to stream your media, you're in luck; we have prebui
 Replace `<video>` with `<hls-video>`. If you're using the CDN, add an additional script:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/hls-video.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/media/hls-video.js"></script>
 ```
 
 Or add an additional import:
@@ -179,7 +179,7 @@ Very similar to HLS in that we have a drop-in component.
 Replace `<video>` with `<dash-video>`. If you're using the CDN, add an additional script:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/dash-video.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/media/dash-video.js"></script>
 ```
 
 Or add an additional import:
@@ -284,7 +284,7 @@ For CDN users:
 
 ```html
 <script type="module">
-  import { registerI18n } from 'https://cdn.jsdelivr.net/npm/@videojs/html/cdn/i18n.js';
+  import { registerI18n } from '{{VJS10_HTML_CDN_BASE}}/i18n.js';
 
   registerI18n('en', {
     buttons: {
@@ -297,7 +297,7 @@ For CDN users:
   });
 </script>
 
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video-minimal.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/video-minimal.js"></script>
 
 <video-player>
   <video-minimal-skin>

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -80,7 +80,7 @@ Here's a standard v8 setup: one file, captions, a poster, and the default skin.
 v10 ships web components, so the migration keeps its declarative feel. One script from the CDN gives you the video <DocsLink slug="concepts/presets">preset</DocsLink>: a player, a skin, and a media element that already fit together.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/video.js"></script>
 
 <video-player>
   <video-skin class="aspect-video">
@@ -286,7 +286,7 @@ Each needs its own import.
 For HLS from the CDN:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/hls-video.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/media/hls-video.js"></script>
 ```
 
 Then swap the tag:

--- a/site/src/utils/installation/__tests__/cdn-code.test.ts
+++ b/site/src/utils/installation/__tests__/cdn-code.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { VJS10_HTML_CDN_BASE } from '@/consts';
+import htmlPackage from '../../../../../packages/html/package.json' with { type: 'json' };
 import { generateCdnCode, rendererSupportsCdn } from '../cdn-code';
 
 describe('generateCdnCode', () => {
@@ -6,82 +8,86 @@ describe('generateCdnCode', () => {
   // renderers whose subpath is in this set.
   const manifest = ['hlsjs-video', 'dash-video', 'mux-video', 'mux-audio'];
 
+  it('pins generated URLs to the current @videojs/html package version', () => {
+    expect(VJS10_HTML_CDN_BASE).toBe(`https://cdn.jsdelivr.net/npm/@videojs/html@${htmlPackage.version}/cdn`);
+  });
+
   it('generates video preset CDN tags for html5-video', () => {
     expect(generateCdnCode('default-video', 'video', 'html5-video', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/video.js"></script>`
     );
   });
 
   it('includes hls media bundle when renderer is hls', () => {
     expect(generateCdnCode('default-video', 'minimal-video', 'hls', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video-minimal.js"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/hlsjs-video.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/video-minimal.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/hlsjs-video.js"></script>`
     );
   });
 
   it('includes the dash media bundle when renderer is dash', () => {
     expect(generateCdnCode('default-video', 'video', 'dash', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/dash-video.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/video.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/dash-video.js"></script>`
     );
   });
 
   it('includes the mux media bundle when renderer is mux-video', () => {
     expect(generateCdnCode('default-video', 'video', 'mux-video', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/mux-video.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/video.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-video.js"></script>`
     );
   });
 
   it('omits the media script for a media renderer absent from the manifest', () => {
     expect(generateCdnCode('default-video', 'video', 'vimeo', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/video.js"></script>`
     );
   });
 
   it('generates background preset CDN tags', () => {
     expect(generateCdnCode('background-video', 'video', 'background-video', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/background.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/background.js"></script>`
     );
   });
 
   it('generates the skinless video CDN tag when skin is none', () => {
     expect(generateCdnCode('default-video', 'none', 'html5-video', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video-player.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/video-player.js"></script>`
     );
   });
 
   it('generates the skinless audio CDN tag when skin is none', () => {
     expect(generateCdnCode('default-audio', 'none', 'html5-audio', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/audio-player.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/audio-player.js"></script>`
     );
   });
 
   it('generates live video CDN tags alongside the media bundle', () => {
     expect(generateCdnCode('live-video', 'video', 'hls', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/live-video.js"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/hlsjs-video.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/live-video.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/hlsjs-video.js"></script>`
     );
   });
 
   it('generates the minimal live video CDN tag', () => {
     expect(generateCdnCode('live-video', 'minimal-video', 'mux-video', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/live-video-minimal.js"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/mux-video.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/live-video-minimal.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-video.js"></script>`
     );
   });
 
   it('generates the skinless live video CDN tag when skin is none', () => {
     expect(generateCdnCode('live-video', 'none', 'hls', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/live-video-player.js"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/hlsjs-video.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/live-video-player.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/hlsjs-video.js"></script>`
     );
   });
 
   it('generates live audio CDN tags for each skin variant', () => {
     expect(generateCdnCode('live-audio', 'audio', 'mux-audio', manifest)).toEqual(
-      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/live-audio.js"></script>
-<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/mux-audio.js"></script>`
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/live-audio.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-audio.js"></script>`
     );
     expect(generateCdnCode('live-audio', 'minimal-audio', 'mux-audio', manifest)).toContain(
       'cdn/live-audio-minimal.js'

--- a/site/src/utils/installation/cdn-code.ts
+++ b/site/src/utils/installation/cdn-code.ts
@@ -1,3 +1,4 @@
+import { VJS10_HTML_CDN_BASE } from '@/consts';
 import {
   getInstallationPreset,
   getMediaSubpath,
@@ -6,8 +7,6 @@ import {
   type Skin,
   type UseCase,
 } from '@/utils/installation/types';
-
-const CDN_BASE = 'https://cdn.jsdelivr.net/npm/@videojs/html/cdn';
 
 // Every installation preset ships default, minimal, and skinless CDN bundles.
 // The skinless bundle is named for the element it defines (e.g. `video-player`).
@@ -45,14 +44,14 @@ export function generateCdnCode(
   const name = getCdnFileName(useCase, skin);
   const mediaSubpath = getMediaSubpath(renderer);
 
-  const scriptLines = [`<script type="module" src="${CDN_BASE}/${name}.js"></script>`];
+  const scriptLines = [`<script type="module" src="${VJS10_HTML_CDN_BASE}/${name}.js"></script>`];
 
   // Emit a media script only when that media ships a CDN build, per the
   // manifest. A media renderer whose subpath isn't in the manifest gets just the
   // preset script; if it gains a CDN build later, the manifest carries it and
   // this starts emitting automatically — no code change needed.
   if (mediaSubpath !== null && cdnMediaSubpaths.includes(mediaSubpath)) {
-    scriptLines.push(`<script type="module" src="${CDN_BASE}/media/${mediaSubpath}.js"></script>`);
+    scriptLines.push(`<script type="module" src="${VJS10_HTML_CDN_BASE}/media/${mediaSubpath}.js"></script>`);
   }
 
   return scriptLines.join('\n');

--- a/site/src/utils/satteriCdnVersion.ts
+++ b/site/src/utils/satteriCdnVersion.ts
@@ -1,0 +1,25 @@
+import { defineMdastPlugin } from 'satteri';
+import { VJS10_HTML_CDN_BASE } from '../consts';
+
+export const VJS10_HTML_CDN_PLACEHOLDER = '{{VJS10_HTML_CDN_BASE}}';
+
+/** Replace CDN placeholders in documentation code with the current package version. */
+export function satteriCdnVersion() {
+  return defineMdastPlugin({
+    name: 'videojs-cdn-version',
+    code: (node, ctx) => {
+      if (!node.value.includes(VJS10_HTML_CDN_PLACEHOLDER)) return;
+      ctx.replaceNode(node, {
+        ...node,
+        value: node.value.replaceAll(VJS10_HTML_CDN_PLACEHOLDER, VJS10_HTML_CDN_BASE),
+      });
+    },
+    inlineCode: (node, ctx) => {
+      if (!node.value.includes(VJS10_HTML_CDN_PLACEHOLDER)) return;
+      ctx.replaceNode(node, {
+        ...node,
+        value: node.value.replaceAll(VJS10_HTML_CDN_PLACEHOLDER, VJS10_HTML_CDN_BASE),
+      });
+    },
+  });
+}

--- a/site/src/utils/tests/satteriCdnVersion.test.ts
+++ b/site/src/utils/tests/satteriCdnVersion.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+// Sätteri's native binding builds typed-array buffers that fail against jsdom's
+// patched ArrayBuffer/DataView globals; run these against the real node realm.
+import { mdxToJs } from 'satteri';
+import { describe, expect, it } from 'vitest';
+import { VJS10_HTML_CDN_BASE } from '@/consts';
+import { satteriCdnVersion, VJS10_HTML_CDN_PLACEHOLDER } from '../satteriCdnVersion';
+
+function compile(source: string): string {
+  const data = {
+    astro: {
+      frontmatter: {},
+      headings: [],
+      localImagePaths: new Set<string>(),
+      remoteImagePaths: new Set<string>(),
+    },
+  };
+  const { code } = mdxToJs(source, { mdastPlugins: [satteriCdnVersion()], data });
+  return code;
+}
+
+describe('satteriCdnVersion', () => {
+  it('uses the current @videojs/html version in fenced code', () => {
+    const code = compile(`\`\`\`html
+<script src="${VJS10_HTML_CDN_PLACEHOLDER}/video.js"></script>
+\`\`\``);
+
+    expect(code).toContain(`${VJS10_HTML_CDN_BASE}/video.js`);
+    expect(code).not.toContain(VJS10_HTML_CDN_PLACEHOLDER);
+  });
+
+  it('uses the current @videojs/html version in inline code', () => {
+    const code = compile(`Use \`${VJS10_HTML_CDN_PLACEHOLDER}/video.js\`.`);
+
+    expect(code).toContain(`${VJS10_HTML_CDN_BASE}/video.js`);
+    expect(code).not.toContain(VJS10_HTML_CDN_PLACEHOLDER);
+  });
+});


### PR DESCRIPTION
## Summary

Pin Video.js 10 CDN examples to the exact @videojs/html workspace version so copied snippets do not depend on npm dist-tags.

## Changes

- Derive the shared jsDelivr base from the workspace package version
- Apply it to installation, homepage, ejected-skin, migration, and i18n examples
- Resolve authored-code placeholders during Markdown processing so releases update rendered examples automatically

## Testing

- CI=true pnpm -F site test src/utils/installation/__tests__/cdn-code.test.ts src/utils/tests/satteriCdnVersion.test.ts
- CI=true pnpm -F site astro check
- CI=true env -u SENTRY_AUTH_TOKEN pnpm -F site build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and snippet-generation only; no player, auth, or runtime behavior changes. Risk is limited to incorrect CDN URLs in copied examples if the version import is wrong.
> 
> **Overview**
> Pins all Video.js 10 HTML CDN snippets to the workspace `@videojs/html` version so copied examples no longer follow the unversioned jsDelivr dist-tag.
> 
> `VJS10_HTML_CDN_BASE` is derived from `packages/html/package.json` and reused by installation snippet generation, homepage demo code, and ejected-skin config. Docs MDX uses a `{{VJS10_HTML_CDN_BASE}}` placeholder that a new Sätteri mdast plugin rewrites at build time, so migration and i18n examples stay in sync on each release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eafe0f4bf9d66d2be6ec07862442175d7869f325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->