### PR TITLE
refactor(i18n): use Intl.NumberFormat and Intl.ListFormat instead of Intl.DurationFormat

### DIFF
--- a/packages/core/src/core/i18n/browser-translation.ts
+++ b/packages/core/src/core/i18n/browser-translation.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LOCALE } from '@videojs/utils/i18n';
+import { DEFAULT_LOCALE, isDefaultLocale } from '@videojs/utils/i18n';
 import en from './locales/en';
 import type { FlatTranslations, Locale } from './params';
 import { findLocaleKeys, hasRegisteredLocale } from './registry';
@@ -70,19 +70,15 @@ async function translateProtectingPlaceholders(translator: BrowserTranslatorInst
 
 const cache = new Map<string, Partial<FlatTranslations>>();
 
-function isEnglishLocaleTag(tag: string): boolean {
-  return tag === DEFAULT_LOCALE || tag.startsWith(`${DEFAULT_LOCALE}-`);
-}
-
 function getBrowserTranslator(): BrowserTranslatorConstructor | undefined {
   if (!('Translator' in globalThis)) return undefined;
   return (globalThis as typeof globalThis & { Translator: BrowserTranslatorConstructor }).Translator;
 }
 
-/** First non-English tag in the lookup chain used as the browser translation target. */
+/** First non-default tag in the lookup chain used as the browser translation target. */
 export function resolveBrowserTranslationTarget(locale: string): string | undefined {
   for (const tag of findLocaleKeys(locale)) {
-    if (!isEnglishLocaleTag(tag)) return tag;
+    if (!isDefaultLocale(tag)) return tag;
   }
   return undefined;
 }
@@ -95,11 +91,11 @@ export function shouldAttemptBrowserTranslation(
 ): boolean {
   const target = resolveBrowserTranslationTarget(locale);
   if (!target) return false;
-  if (loadedLazyTags.some((tag) => !isEnglishLocaleTag(tag))) {
+  if (loadedLazyTags.some((tag) => !isDefaultLocale(tag))) {
     return translations !== undefined && hasMissingEnglishTranslations(translations);
   }
 
-  return !findLocaleKeys(locale).some((tag) => !isEnglishLocaleTag(tag) && hasRegisteredLocale(tag));
+  return !findLocaleKeys(locale).some((tag) => !isDefaultLocale(tag) && hasRegisteredLocale(tag));
 }
 
 function hasMissingEnglishTranslations(translations: Partial<FlatTranslations>): boolean {

--- a/packages/utils/src/i18n/index.ts
+++ b/packages/utils/src/i18n/index.ts
@@ -1,4 +1,11 @@
 /** Default locale used when no player or ambient locale is available. */
 export const DEFAULT_LOCALE = 'en';
 
+/** Whether the first locale in a lookup list is the default locale or one of its regional variants. */
+export function isDefaultLocale(locale?: string | string[]): boolean {
+  const tag = Array.isArray(locale) ? locale[0] : locale;
+  if (!tag) return true;
+  return tag === DEFAULT_LOCALE || tag.startsWith(`${DEFAULT_LOCALE}-`);
+}
+
 export { getTextDirection, type TextDirection } from './direction';

--- a/packages/utils/src/time/format.ts
+++ b/packages/utils/src/time/format.ts
@@ -16,8 +16,7 @@ type DurationFormatter = { format: (duration: DurationRecord) => string };
 
 const durationFormatters = new Map<string, DurationFormatter>();
 
-// Use these widely supported formatters instead of Intl.DurationFormat so servers and browsers
-// cannot select different formatting paths and produce an SSR hydration mismatch.
+// Use one widely supported formatting path so server and browser output match during SSR hydration.
 function createDurationFormatter(
   style: NonNullable<TimeFormatOptions['style']>,
   hoursDisplay?: 'auto' | 'always',

--- a/packages/utils/src/time/format.ts
+++ b/packages/utils/src/time/format.ts
@@ -1,40 +1,24 @@
-import { DEFAULT_LOCALE } from '../i18n';
+import { DEFAULT_LOCALE, isDefaultLocale } from '../i18n';
 import { isNumber } from '../predicate/predicate';
 
 export type TimeFormatOptions = {
-  /** BCP 47 tag(s) for {@link Intl.DurationFormat}. */
+  /** BCP 47 tag(s) for the `Intl` formatters. */
   locale?: string | string[];
   /** Called only when `seconds` is negative; formats the localized remaining-time phrase for the duration body. */
   formatRemaining?: (duration: string) => string;
-  /** Passed to `Intl.DurationFormat`; defaults to `"long"`. */
+  /** Unit display style; defaults to `"long"`. */
   style?: 'long' | 'short' | 'narrow' | 'digital';
 };
 
 type DurationRecord = Partial<{ hours: number; minutes: number; seconds: number }>;
 
-type DurationFormatOptions = {
-  style?: TimeFormatOptions['style'];
-  hoursDisplay?: 'auto' | 'always';
-  secondsDisplay?: 'auto' | 'always';
-};
-
-type DurationFormatConstructor = new (
-  locales?: string | string[],
-  options?: DurationFormatOptions
-) => { format: (duration: DurationRecord) => string };
-
-const DurationFormat = (Intl as typeof Intl & { DurationFormat?: DurationFormatConstructor }).DurationFormat;
-
 type DurationFormatter = { format: (duration: DurationRecord) => string };
 
 const durationFormatters = new Map<string, DurationFormatter>();
 
-/**
- * `Intl.DurationFormat` is unavailable on Node < 23 (SSR/prerender) and pre-2024 evergreen
- * browsers, so degrade gracefully per the documented browser-support fallback policy.
- * Digital output stays exact; localized phrase styles fall back to English.
- */
-function createFallbackFormatter(
+// Use these widely supported formatters instead of Intl.DurationFormat so servers and browsers
+// cannot select different formatting paths and produce an SSR hydration mismatch.
+function createDurationFormatter(
   style: NonNullable<TimeFormatOptions['style']>,
   hoursDisplay?: 'auto' | 'always',
   locale?: string | string[]
@@ -51,20 +35,20 @@ function createFallbackFormatter(
     };
   }
 
-  const units: Array<[keyof DurationRecord, string]> = [
-    ['hours', 'hour'],
-    ['minutes', 'minute'],
-    ['seconds', 'second'],
+  const units: Array<[keyof DurationRecord, Intl.NumberFormat]> = [
+    ['hours', new Intl.NumberFormat(locale, { style: 'unit', unit: 'hour', unitDisplay: style })],
+    ['minutes', new Intl.NumberFormat(locale, { style: 'unit', unit: 'minute', unitDisplay: style })],
+    ['seconds', new Intl.NumberFormat(locale, { style: 'unit', unit: 'second', unitDisplay: style })],
   ];
+  const list = new Intl.ListFormat(locale, { type: 'unit', style });
+
   return {
     format: (duration) =>
-      units
-        .filter(([unit]) => duration[unit] !== undefined)
-        .map(([unit, label]) => {
-          const value = duration[unit] ?? 0;
-          return `${value} ${label}${value === 1 ? '' : 's'}`;
-        })
-        .join(', '),
+      list.format(
+        units
+          .filter(([unit]) => duration[unit] !== undefined)
+          .map(([unit, formatter]) => formatter.format(duration[unit] ?? 0))
+      ),
   };
 }
 
@@ -73,29 +57,15 @@ function localeCacheKey(locale?: string | string[]): string {
   return Array.isArray(locale) ? locale.join(':') : locale;
 }
 
-function isEnglishLocale(locale?: string | string[]): boolean {
-  const tag = Array.isArray(locale) ? locale[0] : locale;
-  if (!tag) return true;
-  return tag === DEFAULT_LOCALE || tag.startsWith(`${DEFAULT_LOCALE}-`);
-}
-
 function getDurationFormatter(
   locale?: string | string[],
   style: NonNullable<TimeFormatOptions['style']> = 'long',
-  hoursDisplay?: 'auto' | 'always',
-  secondsDisplay?: 'auto' | 'always'
+  hoursDisplay?: 'auto' | 'always'
 ): DurationFormatter {
-  const key = `${localeCacheKey(locale)}:${style}:${hoursDisplay ?? ''}:${secondsDisplay ?? ''}`;
+  const key = `${localeCacheKey(locale)}:${style}:${hoursDisplay ?? ''}`;
   let formatter = durationFormatters.get(key);
   if (!formatter) {
-    if (DurationFormat) {
-      const options: DurationFormatOptions = { style };
-      if (hoursDisplay !== undefined) options.hoursDisplay = hoursDisplay;
-      if (secondsDisplay !== undefined) options.secondsDisplay = secondsDisplay;
-      formatter = new DurationFormat(locale, options);
-    } else {
-      formatter = createFallbackFormatter(style, hoursDisplay, locale);
-    }
+    formatter = createDurationFormatter(style, hoursDisplay, locale);
     durationFormatters.set(key, formatter);
   }
   return formatter;
@@ -180,7 +150,7 @@ export function secondsToIsoDuration(seconds: number): string {
 }
 
 /**
- * Human-readable duration using {@link Intl.DurationFormat}.
+ * Human-readable duration using `Intl.NumberFormat` and `Intl.ListFormat`.
  *
  * Negative `seconds` denote remaining time: the absolute value is formatted, then wrapped in a
  * localized phrase via {@link TimeFormatOptions.formatRemaining}; otherwise `{duration} remaining`.
@@ -190,6 +160,7 @@ export function formatTimeAsPhrase(seconds: number, options?: TimeFormatOptions)
     return '';
   }
 
+  const { locale = DEFAULT_LOCALE, style = 'long', formatRemaining } = options ?? {};
   const negative = seconds < 0;
   const positiveSeconds = Math.abs(seconds);
   const totalSeconds = Math.floor(positiveSeconds);
@@ -202,15 +173,11 @@ export function formatTimeAsPhrase(seconds: number, options?: TimeFormatOptions)
   if (minutes > 0) record.minutes = minutes;
   if (secondsPart > 0 || (hours === 0 && minutes === 0)) record.seconds = secondsPart;
 
-  const secondsDisplay = totalSeconds === 0 ? 'always' : undefined;
-  const body = getDurationFormatter(options?.locale, options?.style ?? 'long', undefined, secondsDisplay).format(
-    record
-  );
+  const body = getDurationFormatter(locale, style).format(record);
 
   if (negative) {
-    const formatRemaining = options?.formatRemaining;
     if (formatRemaining) return formatRemaining(body);
-    if (isEnglishLocale(options?.locale)) return `${body} remaining`;
+    if (isDefaultLocale(locale)) return `${body} remaining`;
     return body;
   }
 

--- a/packages/utils/src/time/tests/format.test.ts
+++ b/packages/utils/src/time/tests/format.test.ts
@@ -1,28 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { formatTime, formatTimeAsPhrase, secondsToIsoDuration } from '../format';
-
-const hasDurationFormat = typeof (Intl as { DurationFormat?: unknown }).DurationFormat === 'function';
-
-type FormatModule = typeof import('../format');
-
-/**
- * Re-import the module with `Intl.DurationFormat` removed so the module-level capture
- * resolves to `undefined` and `getDurationFormatter` uses `createFallbackFormatter`.
- * Runs the fallback path deterministically regardless of the Node version.
- */
-async function loadWithFallback(): Promise<FormatModule> {
-  const intl = Intl as { DurationFormat?: unknown };
-  const original = intl.DurationFormat;
-  intl.DurationFormat = undefined;
-  vi.resetModules();
-  try {
-    return await import('../format');
-  } finally {
-    if (original === undefined) delete intl.DurationFormat;
-    else intl.DurationFormat = original;
-  }
-}
 
 describe('formatTime', () => {
   it('formats seconds only', () => {
@@ -82,7 +60,7 @@ describe('formatTime', () => {
     expect(formatTime(90)).toBe(english);
   });
 
-  it.runIf(hasDurationFormat)('uses locale digits', () => {
+  it('uses locale digits', () => {
     expect(formatTime(90, undefined, { locale: 'fa' })).toBe('۱:۳۰');
     expect(formatTime(35, 600, { locale: 'fa' })).toBe('۰۰:۳۵');
   });
@@ -118,12 +96,18 @@ describe('formatTimeAsPhrase', () => {
     expect(formatted).not.toMatch(/remaining$/i);
   });
 
-  it.runIf(hasDurationFormat)('uses Intl.DurationFormat', () => {
+  it('localizes duration units and lists', () => {
     const en = formatTimeAsPhrase(125, { locale: 'en' });
-    const de = formatTimeAsPhrase(125, { locale: 'de' });
-    expect(en.length).toBeGreaterThan(0);
-    expect(de.length).toBeGreaterThan(0);
-    expect(en).not.toBe(de);
+    const fr = formatTimeAsPhrase(125, { locale: 'fr' });
+    expect(formatTimeAsPhrase(125)).toBe(en);
+    expect(en).toBe('2 minutes, 5 seconds');
+    expect(fr).toContain('2 minutes');
+    expect(fr).toContain('5\u00a0secondes');
+  });
+
+  it('supports short and narrow unit styles', () => {
+    expect(formatTimeAsPhrase(125, { locale: 'en', style: 'short' })).toBe('2 min, 5 sec');
+    expect(formatTimeAsPhrase(125, { locale: 'en', style: 'narrow' })).toBe('2m 5s');
   });
 
   it('handles invalid values', () => {
@@ -131,14 +115,8 @@ describe('formatTimeAsPhrase', () => {
     expect(formatTimeAsPhrase(Infinity)).toBe('');
   });
 
-  it.runIf(hasDurationFormat)('throws when Intl.DurationFormat rejects the locale', () => {
+  it('throws when Intl formatters reject the locale', () => {
     expect(() => formatTimeAsPhrase(90, { locale: 'not-a-valid-bcp47-tag!!!' })).toThrow(RangeError);
-  });
-
-  it.skipIf(hasDurationFormat)('falls back to an English phrase without Intl.DurationFormat', () => {
-    expect(formatTimeAsPhrase(125)).toBe('2 minutes, 5 seconds');
-    expect(formatTimeAsPhrase(3661)).toBe('1 hour, 1 minute, 1 second');
-    expect(formatTimeAsPhrase(-30)).toMatch(/remaining$/i);
   });
 });
 
@@ -166,71 +144,5 @@ describe('secondsToIsoDuration', () => {
   it('handles invalid values', () => {
     expect(secondsToIsoDuration(NaN)).toBe('PT0S');
     expect(secondsToIsoDuration(Infinity)).toBe('PT0S');
-  });
-});
-
-describe('createFallbackFormatter', () => {
-  describe('digital style (via formatTime)', () => {
-    it('pads minutes and seconds', async () => {
-      const { formatTime: format } = await loadWithFallback();
-      expect(format(5)).toBe('0:05');
-      expect(format(65)).toBe('1:05');
-      expect(format(600)).toBe('10:00');
-    });
-
-    it('shows hours when present', async () => {
-      const { formatTime: format } = await loadWithFallback();
-      expect(format(3661)).toBe('1:01:01');
-      expect(format(36000)).toBe('10:00:00');
-    });
-
-    it('forces hours display when guided by an hours-long duration', async () => {
-      const { formatTime: format } = await loadWithFallback();
-      expect(format(35, 3600)).toBe('0:00:35');
-    });
-
-    it('uses locale digits', async () => {
-      const { formatTime: format } = await loadWithFallback();
-      expect(format(90, undefined, { locale: 'fa' })).toBe('۱:۳۰');
-    });
-  });
-
-  describe('text style (via formatTimeAsPhrase)', () => {
-    it('joins present units with a comma', async () => {
-      const { formatTimeAsPhrase: format } = await loadWithFallback();
-      expect(format(3661)).toBe('1 hour, 1 minute, 1 second');
-      expect(format(125)).toBe('2 minutes, 5 seconds');
-    });
-
-    it('pluralizes based on the unit value', async () => {
-      const { formatTimeAsPhrase: format } = await loadWithFallback();
-      expect(format(1)).toBe('1 second');
-      expect(format(2)).toBe('2 seconds');
-      expect(format(3600)).toBe('1 hour');
-      expect(format(7200)).toBe('2 hours');
-    });
-
-    it('omits units that are absent from the record', async () => {
-      const { formatTimeAsPhrase: format } = await loadWithFallback();
-      expect(format(30)).toBe('30 seconds');
-      expect(format(120)).toBe('2 minutes');
-      expect(format(0)).toBe('0 seconds');
-    });
-
-    it('ignores non-digital style variants (all render as long-form text)', async () => {
-      const { formatTimeAsPhrase: format } = await loadWithFallback();
-      expect(format(125, { style: 'short' })).toBe('2 minutes, 5 seconds');
-      expect(format(125, { style: 'narrow' })).toBe('2 minutes, 5 seconds');
-    });
-
-    it('wraps negative durations in the English remaining phrase', async () => {
-      const { formatTimeAsPhrase: format } = await loadWithFallback();
-      expect(format(-30)).toBe('30 seconds remaining');
-    });
-
-    it('applies formatRemaining for negative durations', async () => {
-      const { formatTimeAsPhrase: format } = await loadWithFallback();
-      expect(format(-30, { formatRemaining: (duration) => `${duration} left` })).toBe('30 seconds left');
-    });
   });
 });


### PR DESCRIPTION
Node 24 introduced support for `Intl.DurationFormat` but older versions end up using our fallback (English) to format the time durations. This results in a hydration error on platforms such as Next.js if they're running on Node 22. This PR makes the server and first client use `Intl.NumberFormat` and `Intl.ListFormat` instead, preventing the mismatch on older Node runtimes. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how duration strings are produced across locales, so UI copy can differ from `Intl.DurationFormat`. Low security impact, but user-visible formatting is core player UI.
> 
> **Overview**
> Stops using `Intl.DurationFormat` for human-readable times so SSR and the browser always take the same path. Phrase output now comes from `Intl.NumberFormat` (unit style) plus `Intl.ListFormat`, which are available on older Node and avoids hydration mismatches when the server lacks `DurationFormat`.
> 
> `short` and `narrow` styles now actually localize instead of falling back to English long form. Locale-default checks are centralized in a shared `isDefaultLocale` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d60953e3de834725f71abe7fbb0a9bc4cf7d25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->