### PR TITLE
fix(site): prevent menu demo sizing loop

### DIFF
--- a/site/src/components/docs/demos/menu/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/menu/html/css/BasicUsage.css
@@ -71,9 +71,16 @@
   transition-property: width, height, opacity, filter;
 }
 
+.menu:is([data-starting-style], [data-ending-style]) {
+  /* Only animate size while navigating between already-open menu views. */
+  transition-property: opacity, filter;
+}
+
 .menu-panel {
   position: absolute;
-  inset: 0;
+  /* Keep block-end unconstrained so the menu can measure intrinsic panel height. */
+  inset-inline: 0;
+  top: 0;
   display: grid;
   gap: 2px;
   padding: 6px;

--- a/site/src/components/docs/demos/menu/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/menu/react/css/BasicUsage.css
@@ -71,9 +71,16 @@
   transition-property: width, height, opacity, filter;
 }
 
+.menu:is([data-starting-style], [data-ending-style]) {
+  /* Only animate size while navigating between already-open menu views. */
+  transition-property: opacity, filter;
+}
+
 .menu-panel {
   position: absolute;
-  inset: 0;
+  /* Keep block-end unconstrained so the menu can measure intrinsic panel height. */
+  inset-inline: 0;
+  top: 0;
   display: grid;
   gap: 2px;
   padding: 6px;

--- a/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
+++ b/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
@@ -206,6 +206,16 @@ media-play-button[data-paused] .play-icon { display: inline; }
 
 Continuous values use CSS custom properties: sliders expose `--media-slider-fill` and `--media-slider-pointer`.
 
+### Keep menu panels intrinsically sized
+
+Video.js measures the active menu panel with an observer and publishes the result through `--media-menu-width` and `--media-menu-height`. These properties are measurement outputs, not ordinary author-controlled sizing variables. Use them to size the menu viewport, while leaving each panel's block-size intrinsic.
+
+<Aside type="caution">
+Do not constrain a panel to the menu viewport with `bottom: 0`, `inset: 0`, or `height: 100%`. That makes the panel's size depend on the viewport while the viewport's measured size depends on the panel, creating a cycle that can make the menu grow continuously.
+
+For an absolutely positioned panel, use `inset-inline: 0; top: 0` and leave block-end unconstrained.
+</Aside>
+
 ## Themes become skins
 
 Media Chrome's `<template>`-based themes (`media-theme`) become Video.js <DocsLink slug="concepts/skins">skins</DocsLink> and <DocsLink slug="concepts/presets">presets</DocsLink>. Start from a preset, then eject and customize with <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>, rather than authoring a template.

--- a/site/src/content/docs/reference/menu.mdx
+++ b/site/src/content/docs/reference/menu.mdx
@@ -2,9 +2,12 @@
 title: Menu
 frameworkTitle:
   html: media-menu
-description: A composable menu component for settings, option selection, and actions
+description: >-
+  A composable menu component. Keep panels intrinsically block-sized: bottom: 0, inset: 0, or height:
+  100% cause measurement cycles; --media-menu-width and --media-menu-height are observer outputs
 ---
 
+import Aside from "@/components/Aside.astro";
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
@@ -113,6 +116,12 @@ Set `type="playback-rate"`, `type="quality"`, `type="audio-track"`, or `type="ca
 ## Styling
 
 Use data attributes to style open state, highlighted items, selected radio items, and submenu views:
+
+<Aside type="caution" title="Keep menu panels intrinsically sized">
+`--media-menu-width` and `--media-menu-height` are outputs from the menu's observer-driven measurement system, not ordinary author-controlled sizing variables. Consume them on the menu viewport, but let each panel keep an intrinsic block-size so Video.js can measure its content.
+
+Do not constrain a panel's block-size to the viewport with `bottom: 0`, `inset: 0`, or `height: 100%`. That makes the panel depend on the measured viewport while the viewport depends on the panel, creating a measurement cycle. For an absolutely positioned panel, use `inset-inline: 0; top: 0` and leave block-end unconstrained.
+</Aside>
 
 `data-highlighted` is added to the current menu item. The highlighted item is the item that keyboard selection will act on. It changes when the menu opens, when the pointer moves over another item, when the user presses arrow keys, or when type-ahead search finds a match.
 


### PR DESCRIPTION
## Summary
- keep the HTML and React demo panels intrinsically measurable instead of pinning both block edges to the menu viewport
- avoid width and height transitions during menu open/close while preserving size animation between open submenu views
- document that `--media-menu-width` and `--media-menu-height` are observer outputs and that panels require intrinsic block-size
- surface the warning in the generated `llms.txt` index and the Media Chrome migration guide for agent-driven migrations

## Test plan
- [x] `corepack pnpm dlx @biomejs/biome@2.5.5 check site/src/components/docs/demos/menu/html/css/BasicUsage.css site/src/components/docs/demos/menu/react/css/BasicUsage.css`
- [x] `git diff --check main...HEAD`
- [x] Browser reproduction: confirmed the menu height remains stable after opening when block-end is unconstrained