### PR TITLE
docs(site): document non-interactive cli use

### DIFF
--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -44,17 +44,19 @@ npx @videojs/cli docs how-to/installation \
   --framework <html|react> \
   --preset <video|audio|live-video|live-audio|background-video> \
   --skin <default|minimal|none> \
-  --media <html5-video|html5-audio|hls|dash|mux-video|mux-audio|vimeo|background-video> \
+  --media <html5-video|html5-audio|hls|dash|mux-video|mux-audio|vimeo|youtube|cloudflare|tiktok|twitch|spotify|background-video> \
   --source-url <url> \
   --install-method <cdn|npm|pnpm|yarn|bun>
 ```
+
+The CLI does not currently detect non-interactive stdin. In automation, agents, and CI, include `--framework` and all five installation flags so no prompt starts. Pass `--source-url ''` to use the built-in demo without prompting.
 
 Here's what the flags mean:
 - *Framework*: Pick whether you're working in React or if you'd like to use HTML custom elements. (More to come!)
 - *Preset*: Pick a pre-built player. The default presets work well for general website playback; the live presets add a Live button and drop the on-demand time displays.
 - *Skin*: Pick what your player looks like
 - *Media*: Pick what kind of media you have. The `live-video` preset supports HLS and Mux video; `live-audio` supports Mux audio.
-- *Source URL*: Define where your media comes from (or omit for a sample URL)
+- *Source URL*: Define where your media comes from. In an interactive terminal, omit it to choose a sample URL. In automation, pass an empty value to choose the sample without prompting.
 - *Install method*: How do you want to install your package? (CDN is HTML-only<NoCdnMediaNote />.)
 
 If you're an agent, interview your user and offer to run the CLI for them, or offer them a precomposed CLI command. 


### PR DESCRIPTION
## Summary

Document the complete flag set required to generate the installation guide without prompts in automation, agents, and CI.

## Changes

- List every current media flag value exposed by the CLI help output
- Explain that the CLI does not detect non-interactive stdin
- Document the empty source URL value that selects the demo without prompting

## Testing

- `pnpm -F @videojs/cli test`
- `env -u SENTRY_AUTH_TOKEN pnpm build:site`
- `pnpm -F @videojs/cli build`
- `pnpm -F site astro check`
- Verified the complete built CLI invocation exits 0 with closed stdin
- Verified omitting `--source-url` with closed stdin reproduces the unsettled top-level-await warning and Node exit 13

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change to installation CLI usage notes; no runtime, auth, or data-handling code is modified.
> 
> **Overview**
> Updates the LLM-facing installation guide so agents and CI can generate tailored docs without hanging on prompts.
> 
> The `--media` example now lists every current CLI value (YouTube, Cloudflare, TikTok, Twitch, Spotify, and the rest). It also states that the CLI does not detect non-interactive stdin, so `--framework` plus all five installation flags are required, and `--source-url ''` selects the demo without prompting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aa49538f89592820c46970bd1d201aa9f28a6bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->