### PR TITLE
feat(html): publish skin stylesheets to the CDN build

### DIFF
--- a/build/plugins/copy-css-plugin.ts
+++ b/build/plugins/copy-css-plugin.ts
@@ -1,6 +1,8 @@
 import { existsSync, globSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+import { transform } from 'lightningcss';
+
 import { resolveImports } from './resolve-css-imports.ts';
 import type { BuildPlugin } from './types.ts';
 
@@ -9,10 +11,30 @@ interface CopyCssPluginOptions {
   outDir: string;
   inline?: boolean;
   rebuild?: boolean;
+  /**
+   * Map a source path to an output path relative to `outDir`, or null to skip the file. Defaults to mirroring the `src`
+   * tree.
+   */
+  rename?: (file: string) => string | null;
+  /** Drop an `@import`ed file, by resolved absolute path, instead of inlining it. */
+  omitImport?: (file: string) => boolean;
+  minify?: boolean;
+}
+
+function mirrorSrcTree(file: string): string {
+  return file.replace(/^src\//, '');
 }
 
 export function copyCssPlugin(options: CopyCssPluginOptions): BuildPlugin {
-  const { skinsDir, outDir, inline = true, rebuild = true } = options;
+  const {
+    skinsDir,
+    outDir,
+    inline = true,
+    rebuild = true,
+    rename = mirrorSrcTree,
+    omitImport,
+    minify = false,
+  } = options;
   let poll: ReturnType<typeof setInterval> | undefined;
   let state = new Map<string, string>();
 
@@ -32,9 +54,17 @@ export function copyCssPlugin(options: CopyCssPluginOptions): BuildPlugin {
 
   function writeCss() {
     for (const file of globSync('src/**/*.css')) {
+      const target = rename(file);
+      if (target === null) continue;
+
       const content = readFileSync(file, 'utf-8');
-      const output = inline ? resolveImports(content, dirname(file), skinsDir) : content;
-      const outFile = join(outDir, file.replace(/^src\//, ''));
+      let output = inline ? resolveImports(content, dirname(file), skinsDir, omitImport) : content;
+
+      if (minify) {
+        output = transform({ filename: file, code: Buffer.from(output), minify: true }).code.toString();
+      }
+
+      const outFile = join(outDir, target);
       if (existsSync(outFile) && readFileSync(outFile, 'utf-8') === output) continue;
 
       mkdirSync(dirname(outFile), { recursive: true });

--- a/build/plugins/resolve-css-imports.ts
+++ b/build/plugins/resolve-css-imports.ts
@@ -1,8 +1,18 @@
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
-/** Resolves `@import` directives in CSS content, inlining referenced files. */
-export function resolveImports(content: string, baseDir: string, skinsDir: string): string {
+/**
+ * Resolves `@import` directives in CSS content, inlining referenced files.
+ *
+ * `omit` drops an imported file, by resolved absolute path, instead of inlining it. It applies at every depth, so
+ * excluding a leaf removes it from every sheet that transitively pulls it in.
+ */
+export function resolveImports(
+  content: string,
+  baseDir: string,
+  skinsDir: string,
+  omit?: (file: string) => boolean
+): string {
   return content.replace(/@import\s+['"]([^'"]+)['"]\s*;/g, (match, importPath: string) => {
     let file: string;
 
@@ -14,8 +24,10 @@ export function resolveImports(content: string, baseDir: string, skinsDir: strin
       return match;
     }
 
+    if (omit?.(file)) return '';
+
     const nested = readFileSync(file, 'utf-8');
 
-    return resolveImports(nested, dirname(file), skinsDir);
+    return resolveImports(nested, dirname(file), skinsDir, omit);
   });
 }

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -28,7 +28,8 @@
     "./dist/*/i18n/locales/*/register.js",
     "./dist/*/icons/element/**/*.js",
     "./dist/*/icons/dist/element/**/*.js",
-    "./cdn/**/*.js"
+    "./cdn/**/*.js",
+    "./cdn/*.css"
   ],
   "main": "dist/default/index.js",
   "module": "dist/default/index.js",
@@ -150,6 +151,7 @@
       "development": "./cdn/locales/*.dev.js",
       "default": "./cdn/locales/*.js"
     },
+    "./cdn/*.css": "./cdn/*.css",
     "./cdn/*": {
       "types": "./cdn/*.dev.d.ts",
       "development": "./cdn/*.dev.js",

--- a/packages/html/scripts/build-dist-archive.ts
+++ b/packages/html/scripts/build-dist-archive.ts
@@ -13,7 +13,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, globSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -93,6 +93,15 @@ async function main() {
     process.exit(1);
   }
 
+  // Stylesheets are unreachable through the module graph — the bundles inline their CSS, and these
+  // are the separate `<link>`-able copies — so they come from a directory listing instead. They are
+  // excluded from the check above, which reads JavaScript.
+  const stylesheets = globSync('*.css', { cwd: CDN_DIR }).sort();
+
+  for (const file of stylesheets) {
+    cpSync(resolve(CDN_DIR, file), join(stageDir, file));
+  }
+
   cpSync(resolve(REPO_ROOT, 'LICENSE'), resolve(stageDir, 'LICENSE'));
   cpSync(resolve(PACKAGE_DIR, 'README.md'), resolve(stageDir, 'README.md'));
   writeFileSync(resolve(stageDir, 'VERSION'), `${pkg.version}\n`);
@@ -107,7 +116,7 @@ async function main() {
     `${archives.map((archive) => `${sha256(resolve(OUT_DIR, archive))}  ${archive}`).join('\n')}\n`
   );
 
-  log.info(`✅ ${files.length} bundles from ${roots.length} entries`);
+  log.info(`✅ ${files.length} bundles from ${roots.length} entries, ${stylesheets.length} stylesheets`);
 
   for (const archive of archives) {
     const size = (statSync(resolve(OUT_DIR, archive)).size / 1024).toFixed(0);

--- a/packages/html/vite.config.ts
+++ b/packages/html/vite.config.ts
@@ -23,6 +23,10 @@ type CdnBuildMode = 'dev' | 'prod';
 
 const packageDir = dirname(fileURLToPath(import.meta.url));
 const skinsDir = resolve(packageDir, '../skins/src');
+
+/** The light-DOM sheet every non-background skin pulls in. Kept out of the shadow sheets. */
+const globalCss = resolve(packageDir, 'src/define/global.css');
+
 const srcDir = new URL('./src', import.meta.url).pathname;
 const srcAlias = { '@': srcDir };
 const localeTags = [...LOCALES, ...localeAliases(LOCALES)];
@@ -159,6 +163,43 @@ export const entries = [
   ...cdnMediaEntries,
 ];
 
+/**
+ * Flat CDN filename for a stylesheet, or null for a source file that is not published.
+ *
+ * A bundle inlines its own CSS and applies it on upgrade, so these files are not needed to run the player. They exist
+ * for the two things a running element cannot do for a page:
+ *
+ * - **Light DOM, `<link>` in `<head>`.** `global.css` and `background.css` are what the elements inject into
+ *   `document.head` themselves. Linking them instead applies the host and media box rules before the custom element
+ *   upgrades, which is what stops the pre-upgrade layout shift.
+ * - **Shadow DOM, `<link>` inside a `<template shadowrootmode>`.** `SkinElement` skips styling when a shadow root already
+ *   exists, so a declaratively rendered skin has to carry its own sheet. Nothing is exposed through `::part`, so a
+ *   document-level `<link>` cannot reach it.
+ *
+ * A tarball CDN serves paths and ignores `package.json` exports, so the filename _is_ the public URL. Shadow sheets are
+ * named after the bundle they pair with (`video.css` beside `video.js`), which is what lets a page derive one URL from
+ * the other.
+ *
+ * Everything under `src/__generated__` is an ejected-skin partial that the flattened skins already inline, so it is
+ * skipped rather than published twice.
+ */
+function cdnStylesheetName(file: string): string | null {
+  const match = /^src\/define\/(?:([\w-]+)\/)?([\w-]+)\.css$/.exec(file);
+  if (!match) return null;
+
+  const [, preset, name] = match;
+  // Light DOM: `global.css`, and `shared.css` as a base for hand-written shadow skins.
+  if (!preset) return `${name}.css`;
+
+  // The background skin is light DOM only — its shadow root holds a bare container and no styles.
+  if (preset === 'background') return name === 'skin' ? 'background.css' : null;
+
+  const suffix = name === 'skin' ? '' : name === 'minimal-skin' ? '-minimal' : null;
+  if (suffix === null) return null;
+
+  return `${preset}${suffix}.css`;
+}
+
 /** Generate empty declaration stubs for side-effect-only dev CDN entries. */
 function dtsStubsPlugin(outDir: string) {
   function generate(dir: string) {
@@ -217,6 +258,21 @@ for (const mode of cdnBuildModes) {
       cdnI18nExternalPlugin({ prod: isProd }),
       inlineCssPlugin({ skinsDir, minify: isProd }),
       inlineTemplatePlugin({ minify: isProd }),
+      // Stylesheets have no dev/prod variant, so they are emitted once. The prod pass runs after the dev pass, which
+      // is the one that cleans `outDir`.
+      ...(isProd
+        ? [
+            copyCssPlugin({
+              skinsDir,
+              outDir: cdnOutDir,
+              rename: cdnStylesheetName,
+              // Skin sheets are for a shadow root, where the light-DOM rules are dead weight. `global.css` ships on
+              // its own instead, for the `<head>`.
+              omitImport: (imported) => imported === globalCss,
+              minify: true,
+            }),
+          ]
+        : []),
       ...(!isProd ? [dtsStubsPlugin(cdnOutDir)] : []),
     ],
     inputOptions: {

--- a/site/src/content/docs/concepts/skins.mdx
+++ b/site/src/content/docs/concepts/skins.mdx
@@ -104,6 +104,8 @@ Import the stylesheet listed for each skin in the [preset table](#skins-features
 
 The skin registration entry point imports its styles automatically.
 
+Either way the styles travel inside the skin's JavaScript and apply when the element upgrades, so there is no stylesheet to add. The CDN publishes them as files as well, which matters when you want the player's box styled before that upgrade — see <DocsLink slug="how-to/self-host-the-player">Self-host the player</DocsLink>.
+
 </FrameworkCase>
 
 To use Tailwind or change the underlying CSS, [eject the skin](../how-to/customize-skins#ejecting) and edit its styles in your app.

--- a/site/src/content/docs/how-to/self-host-the-player.mdx
+++ b/site/src/content/docs/how-to/self-host-the-player.mdx
@@ -88,7 +88,10 @@ Composer strips the archive's top-level directory, so the player lands directly 
 To skip the bundler, copy the prebuilt CDN bundle to your server as-is.
 
 <Aside type="caution" title="Copy the whole cdn/ directory">
-The CDN entry files like `video.js` and `media/hlsjs-video.js` are not standalone. They import shared, content-hashed chunks (`default-*.js`, `ui-*.js`, and more) that live alongside them. Copying a single file breaks at runtime, so mirror the entire `cdn/` directory and keep its layout intact.
+  The CDN entry files like `video.js` and `media/hlsjs-video.js` are not standalone. They import
+  shared, content-hashed chunks (`default-*.js`, `ui-*.js`, and more) that live alongside them.
+  Copying a single file breaks at runtime, so mirror the entire `cdn/` directory and keep its layout
+  intact.
 </Aside>
 
 ```bash
@@ -106,6 +109,25 @@ Then point the script tag at your copy instead of the CDN:
 The file name matches your player: `video.js`, `audio.js`, `background.js`, and so on. Every option is present in the `cdn/` folder you copied.
 
 Hashed chunk names change between releases, so re-copy the directory whenever you upgrade `@videojs/html`.
+
+## Stylesheets
+
+Every bundle inlines its own CSS and applies it when the custom element upgrades, so a mirrored copy renders correctly with no extra `<link>`. Alongside the bundles, `cdn/` publishes those styles as separate files for the one thing a script cannot do: style the page before that upgrade happens.
+
+`global.css` holds the light-DOM rules — `display: contents` on `<video-player>`, and the box the media and poster stretch to fill. Link it ahead of the bundle and the player reserves its space on first paint instead of on upgrade:
+
+```html
+<link rel="stylesheet" href="/videojs/global.css" />
+<script type="module" src="/videojs/video.js"></script>
+```
+
+The background preset keeps its light-DOM rules in `background.css` instead.
+
+The rest — `video.css`, `audio.css`, one per skin, and the `shared.css` they build on — are shadow-DOM styles. No skin exposes a `::part`, so linking these from the document has no effect. They apply only inside a shadow root, which each skin builds and styles itself.
+
+<Aside type="note" title="Declarative shadow DOM">
+A skin skips building and styling its shadow root when one already exists, so markup that ships a `<template shadowrootmode="open">` has to carry the matching stylesheet inside that template. Today only `background-video-skin` exposes its template for server rendering; the other skins keep theirs in JavaScript, so this path needs a hand-written template.
+</Aside>
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Each CDN bundle inlines its own CSS and applies it on upgrade, so `cdn/` shipped zero stylesheets. That leaves two gaps a script cannot close: the light-DOM rules can't apply *before* the custom element upgrades, and a shadow root rendered ahead of the upgrade has no sheet to link. This publishes those styles as files, split along the DOM boundary.

## Changes

- `cdn/global.css` and `cdn/background.css` — the light-DOM rules the elements inject into `document.head` themselves. Linking them in `<head>` styles the player's box on first paint instead of on upgrade.
- `cdn/video.css`, `cdn/audio.css`, one per skin, plus `cdn/shared.css` — shadow-DOM rules only, named to pair with the bundle they style (`video.css` beside `video.js`). A tarball CDN serves paths and ignores `package.json` exports, so the filename is the public URL.
- New `./cdn/*.css` export, and the stylesheets are included in the release archive.
- Docs: a `Stylesheets` section in *Self-host the player*, plus a pointer from the Skins concept page.

No change to the npm `dist/` output, and no change to how a bundle behaves on its own — these files are additive.

<details>
<summary>Implementation details</summary>

**Why the split.** `SkinElement` does two different things with CSS: `ensureGlobalStyle(globalStyles)` into `document.head`, and `applyShadowStyles([sharedSheet, ctor.styles])` into the shadow root. The source `define/*/skin.css` mixes both via `@import`, which is fine for a single inlined string but wrong for two files with different destinations. `resolveImports` gained an optional `omit(file)` predicate so the CDN pass can drop `global.css` from the skin sheets at any depth. Verified structurally — `video-player`, `live-video-player`, and `media-i18n` appear 0 times across all 9 shadow sheets, and each one shrank by exactly `global.css`'s minified 475 bytes.

`background.css` is light-DOM only and keeps the preset name rather than joining `global.css`, because `BackgroundVideoSkinElement`'s shadow root holds a bare container with no styles. That's the one asymmetry in the flat naming.

**Shared plugin.** `copyCssPlugin` gained `rename`, `omitImport`, and `minify`, all defaulting to today's behavior so the npm build is untouched. The plugin runs on the prod CDN pass only — stylesheets have no dev/prod variant, and prod runs after the dev pass that cleans `outDir`.

**Archive.** `resolveClosure` walks JS imports, so stylesheets are unreachable through it and are copied by directory listing instead. They're excluded from `findUnresolvableSpecifiers`, which reads JavaScript.

**Declarative shadow DOM is not yet reachable.** `SkinElement` tolerates a pre-existing shadow root (`if (!this.shadowRoot)`), but only `background-video-skin` exposes `static getTemplateHTML`. The other skins keep their template in JS, so DSD needs a hand-written template today. The shadow sheets are the artifact that path will need; the docs say so plainly rather than implying a supported recipe.

**Rebased onto the Vite+ migration (#2035).** The CDN stylesheet emission originally lived in `packages/html/tsdown.cdn.config.ts`, which `main` deleted. It now lives in the `cdn` Pack config in `packages/html/vite.config.ts` — same `cdnStylesheetName` mapping and same prod-only `copyCssPlugin` call, wired into `cdnPackConfigs` instead. The docs section also picked up `main`'s rename of *HLS and other media types* to *Troubleshooting*.

</details>

## Testing

Re-verified after the rebase onto `main` (`306c7333f`):

- `pnpm build:cdn` → 11 stylesheets, minified, no unresolved `@import`
- `pnpm -F @videojs/html exec vp pack --filter package` → all 82 `dist` stylesheets byte-identical to `main` (SHA-256 compared against a build using `main`'s copy of both plugins)
- `pnpm -F @videojs/html check:cdn` → 414 bundles, every specifier resolves inside `cdn/`
- `pnpm -F @videojs/html build:archive` → 205 bundles + 11 stylesheets
- `pnpm -F @videojs/html test` (449), `pnpm -F site test` (577), `pnpm typecheck`, `pnpm lint`, `pnpm check:workspace` (10/10)
- `pnpm build:site` → MDX renders; `self-host-the-player` and both `skins` pages prerender with no warnings
- Node resolution: `./cdn/*.css` doesn't shadow `./cdn/*`, `./cdn/media/*`, or `./cdn/locales/*`

Manual check:

```html
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/global.css">
<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
```
