### PR TITLE
feat(packages): add backdrop component parts

### DIFF
--- a/packages/core/src/core/ui/controls/controls-component.ts
+++ b/packages/core/src/core/ui/controls/controls-component.ts
@@ -7,6 +7,7 @@ export default defineComponent({
   root: 'Root',
   parts: {
     Root: defineComponent(),
+    Backdrop: defineComponent(),
     Group: defineComponent(),
   },
   dataAttrs: ControlsDataAttrs,

--- a/packages/core/src/core/ui/error-dialog/error-dialog-component.ts
+++ b/packages/core/src/core/ui/error-dialog/error-dialog-component.ts
@@ -7,6 +7,7 @@ export default defineComponent({
   root: 'Root',
   parts: {
     Root: defineComponent(),
+    Backdrop: defineComponent(),
     Popup: defineComponent(),
     Title: defineComponent(),
     Description: defineComponent(),

--- a/packages/html/src/define/tests/registration.test.ts
+++ b/packages/html/src/define/tests/registration.test.ts
@@ -146,6 +146,7 @@ describe('composite define registration', () => {
   describe('ui/alert-dialog', () => {
     it('registers media-alert-dialog before sub-elements', async () => {
       const before = spy.mock.calls.length;
+
       await import('../ui/alert-dialog');
       const batch = batchSince(before);
 
@@ -161,6 +162,7 @@ describe('composite define registration', () => {
   describe('ui/error-dialog', () => {
     it('registers media-error-dialog and reuses alert-dialog parts', async () => {
       const before = spy.mock.calls.length;
+
       await import('../ui/error-dialog');
       const batch = batchSince(before);
 

--- a/packages/html/src/define/tests/registration.test.ts
+++ b/packages/html/src/define/tests/registration.test.ts
@@ -143,6 +143,33 @@ describe('composite define registration', () => {
     });
   });
 
+  describe('ui/alert-dialog', () => {
+    it('registers media-alert-dialog before sub-elements', async () => {
+      const before = spy.mock.calls.length;
+      await import('../ui/alert-dialog');
+      const batch = batchSince(before);
+
+      expect(batch[0]).toBe('media-alert-dialog');
+      expect(batch).toContain('media-alert-dialog-backdrop');
+      expect(batch).toContain('media-alert-dialog-popup');
+      expect(batch).toContain('media-alert-dialog-close');
+      expect(batch).toContain('media-alert-dialog-description');
+      expect(batch).toContain('media-alert-dialog-title');
+    });
+  });
+
+  describe('ui/error-dialog', () => {
+    it('registers media-error-dialog and reuses alert-dialog parts', async () => {
+      const before = spy.mock.calls.length;
+      await import('../ui/error-dialog');
+      const batch = batchSince(before);
+
+      expect(batch).toContain('media-error-dialog');
+      expect(batch).not.toContain('media-alert-dialog-backdrop');
+      expect(batch).not.toContain('media-alert-dialog-popup');
+    });
+  });
+
   describe('ui/controls', () => {
     it('registers media-controls before sub-elements', async () => {
       const before = spy.mock.calls.length;
@@ -151,6 +178,7 @@ describe('composite define registration', () => {
       const batch = batchSince(before);
 
       expect(batch[0]).toBe('media-controls');
+      expect(batch).toContain('media-controls-backdrop');
       expect(batch).toContain('media-controls-group');
     });
   });
@@ -196,7 +224,16 @@ describe('composite define registration', () => {
         'media-time-separator',
         // Controls
         'media-controls',
+        'media-controls-backdrop',
         'media-controls-group',
+        // Dialogs
+        'media-alert-dialog',
+        'media-alert-dialog-backdrop',
+        'media-alert-dialog-popup',
+        'media-alert-dialog-close',
+        'media-alert-dialog-description',
+        'media-alert-dialog-title',
+        'media-error-dialog',
       ];
 
       for (const tagName of expected) {

--- a/packages/html/src/define/ui/alert-dialog-backdrop.ts
+++ b/packages/html/src/define/ui/alert-dialog-backdrop.ts
@@ -1,0 +1,10 @@
+import { AlertDialogBackdropElement } from '../../ui/alert-dialog/alert-dialog-backdrop-element';
+import { safeDefine } from '../safe-define';
+
+safeDefine(AlertDialogBackdropElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [AlertDialogBackdropElement.tagName]: AlertDialogBackdropElement;
+  }
+}

--- a/packages/html/src/define/ui/alert-dialog-popup.ts
+++ b/packages/html/src/define/ui/alert-dialog-popup.ts
@@ -1,0 +1,10 @@
+import { AlertDialogPopupElement } from '../../ui/alert-dialog/alert-dialog-popup-element';
+import { safeDefine } from '../safe-define';
+
+safeDefine(AlertDialogPopupElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [AlertDialogPopupElement.tagName]: AlertDialogPopupElement;
+  }
+}

--- a/packages/html/src/define/ui/alert-dialog.ts
+++ b/packages/html/src/define/ui/alert-dialog.ts
@@ -1,11 +1,15 @@
+import { AlertDialogBackdropElement } from '../../ui/alert-dialog/alert-dialog-backdrop-element';
 import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
 import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
 import { AlertDialogElement } from '../../ui/alert-dialog/alert-dialog-element';
+import { AlertDialogPopupElement } from '../../ui/alert-dialog/alert-dialog-popup-element';
 import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
 import { safeDefine } from '../safe-define';
 
 // Parent first — child elements consume its context.
 safeDefine(AlertDialogElement);
+safeDefine(AlertDialogBackdropElement);
+safeDefine(AlertDialogPopupElement);
 safeDefine(AlertDialogCloseElement);
 safeDefine(AlertDialogDescriptionElement);
 safeDefine(AlertDialogTitleElement);
@@ -13,6 +17,8 @@ safeDefine(AlertDialogTitleElement);
 declare global {
   interface HTMLElementTagNameMap {
     [AlertDialogElement.tagName]: AlertDialogElement;
+    [AlertDialogBackdropElement.tagName]: AlertDialogBackdropElement;
+    [AlertDialogPopupElement.tagName]: AlertDialogPopupElement;
     [AlertDialogCloseElement.tagName]: AlertDialogCloseElement;
     [AlertDialogDescriptionElement.tagName]: AlertDialogDescriptionElement;
     [AlertDialogTitleElement.tagName]: AlertDialogTitleElement;

--- a/packages/html/src/define/ui/alert-dialog.ts
+++ b/packages/html/src/define/ui/alert-dialog.ts
@@ -4,15 +4,9 @@ import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialo
 import { AlertDialogElement } from '../../ui/alert-dialog/alert-dialog-element';
 import { AlertDialogPopupElement } from '../../ui/alert-dialog/alert-dialog-popup-element';
 import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
-import { safeDefine } from '../safe-define';
+import { defineAlertDialog } from './compounds';
 
-// Parent first — child elements consume its context.
-safeDefine(AlertDialogElement);
-safeDefine(AlertDialogBackdropElement);
-safeDefine(AlertDialogPopupElement);
-safeDefine(AlertDialogCloseElement);
-safeDefine(AlertDialogDescriptionElement);
-safeDefine(AlertDialogTitleElement);
+defineAlertDialog();
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/html/src/define/ui/compounds.ts
+++ b/packages/html/src/define/ui/compounds.ts
@@ -1,6 +1,7 @@
 import { AlertDialogBackdropElement } from '../../ui/alert-dialog/alert-dialog-backdrop-element';
 import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
 import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
+import { AlertDialogElement } from '../../ui/alert-dialog/alert-dialog-element';
 import { AlertDialogPopupElement } from '../../ui/alert-dialog/alert-dialog-popup-element';
 import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
 import { ControlsBackdropElement } from '../../ui/controls/controls-backdrop-element';
@@ -64,14 +65,24 @@ export function defineControls(): void {
   safeDefine(ControlsGroupElement);
 }
 
-export function defineErrorDialog(): void {
-  // Parent first — child elements consume its context.
-  safeDefine(ErrorDialogElement);
+function defineAlertDialogParts(): void {
   safeDefine(AlertDialogBackdropElement);
   safeDefine(AlertDialogPopupElement);
   safeDefine(AlertDialogCloseElement);
   safeDefine(AlertDialogDescriptionElement);
   safeDefine(AlertDialogTitleElement);
+}
+
+export function defineAlertDialog(): void {
+  // Parent first — child elements consume its context.
+  safeDefine(AlertDialogElement);
+  defineAlertDialogParts();
+}
+
+export function defineErrorDialog(): void {
+  // Parent first — child elements consume its context.
+  safeDefine(ErrorDialogElement);
+  defineAlertDialogParts();
 }
 
 export function defineInputIndicators(): void {

--- a/packages/html/src/define/ui/compounds.ts
+++ b/packages/html/src/define/ui/compounds.ts
@@ -1,6 +1,9 @@
+import { AlertDialogBackdropElement } from '../../ui/alert-dialog/alert-dialog-backdrop-element';
 import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
 import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
+import { AlertDialogPopupElement } from '../../ui/alert-dialog/alert-dialog-popup-element';
 import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
+import { ControlsBackdropElement } from '../../ui/controls/controls-backdrop-element';
 import { ControlsElement } from '../../ui/controls/controls-element';
 import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
 import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
@@ -57,12 +60,15 @@ export function defineMenu(): void {
 
 export function defineControls(): void {
   safeDefine(ControlsElement);
+  safeDefine(ControlsBackdropElement);
   safeDefine(ControlsGroupElement);
 }
 
 export function defineErrorDialog(): void {
   // Parent first — child elements consume its context.
   safeDefine(ErrorDialogElement);
+  safeDefine(AlertDialogBackdropElement);
+  safeDefine(AlertDialogPopupElement);
   safeDefine(AlertDialogCloseElement);
   safeDefine(AlertDialogDescriptionElement);
   safeDefine(AlertDialogTitleElement);

--- a/packages/html/src/define/ui/controls-backdrop.ts
+++ b/packages/html/src/define/ui/controls-backdrop.ts
@@ -1,0 +1,10 @@
+import { ControlsBackdropElement } from '../../ui/controls/controls-backdrop-element';
+import { safeDefine } from '../safe-define';
+
+safeDefine(ControlsBackdropElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [ControlsBackdropElement.tagName]: ControlsBackdropElement;
+  }
+}

--- a/packages/html/src/define/ui/controls.ts
+++ b/packages/html/src/define/ui/controls.ts
@@ -1,3 +1,4 @@
+import { ControlsBackdropElement } from '../../ui/controls/controls-backdrop-element';
 import { ControlsElement } from '../../ui/controls/controls-element';
 import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
 import { defineControls } from './compounds';
@@ -7,6 +8,7 @@ defineControls();
 declare global {
   interface HTMLElementTagNameMap {
     [ControlsElement.tagName]: ControlsElement;
+    [ControlsBackdropElement.tagName]: ControlsBackdropElement;
     [ControlsGroupElement.tagName]: ControlsGroupElement;
   }
 }

--- a/packages/html/src/define/ui/error-dialog.ts
+++ b/packages/html/src/define/ui/error-dialog.ts
@@ -1,5 +1,7 @@
+import { AlertDialogBackdropElement } from '../../ui/alert-dialog/alert-dialog-backdrop-element';
 import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
 import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
+import { AlertDialogPopupElement } from '../../ui/alert-dialog/alert-dialog-popup-element';
 import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
 import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
 import { defineErrorDialog } from './compounds';
@@ -9,6 +11,8 @@ defineErrorDialog();
 declare global {
   interface HTMLElementTagNameMap {
     [ErrorDialogElement.tagName]: ErrorDialogElement;
+    [AlertDialogBackdropElement.tagName]: AlertDialogBackdropElement;
+    [AlertDialogPopupElement.tagName]: AlertDialogPopupElement;
     [AlertDialogCloseElement.tagName]: AlertDialogCloseElement;
     [AlertDialogDescriptionElement.tagName]: AlertDialogDescriptionElement;
     [AlertDialogTitleElement.tagName]: AlertDialogTitleElement;

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -72,9 +72,11 @@ export * from './store/media-attach-mixin';
 export * from './store/provider-mixin';
 export * from './store/types';
 export { AirPlayButtonElement } from './ui/airplay-button/airplay-button-element';
+export { AlertDialogBackdropElement } from './ui/alert-dialog/alert-dialog-backdrop-element';
 export { AlertDialogCloseElement } from './ui/alert-dialog/alert-dialog-close-element';
 export { AlertDialogDescriptionElement } from './ui/alert-dialog/alert-dialog-description-element';
 export { AlertDialogElement } from './ui/alert-dialog/alert-dialog-element';
+export { AlertDialogPopupElement } from './ui/alert-dialog/alert-dialog-popup-element';
 export { AlertDialogTitleElement } from './ui/alert-dialog/alert-dialog-title-element';
 export { type AlertDialogContextValue, alertDialogContext } from './ui/alert-dialog/context';
 // UI Components
@@ -85,6 +87,7 @@ export { CaptionsRadioGroupElement } from './ui/captions-radio-group/captions-ra
 export { CastButtonElement } from './ui/cast-button/cast-button-element';
 export { ContainerElement } from './ui/container/container-element';
 export { ContextPartElement, type PartContextValue } from './ui/context-part-element';
+export { ControlsBackdropElement } from './ui/controls/controls-backdrop-element';
 export { ControlsElement } from './ui/controls/controls-element';
 export { ControlsGroupElement } from './ui/controls/controls-group-element';
 export { ErrorDialogElement } from './ui/error-dialog/error-dialog-element';

--- a/packages/html/src/ui/alert-dialog/alert-dialog-backdrop-element.ts
+++ b/packages/html/src/ui/alert-dialog/alert-dialog-backdrop-element.ts
@@ -1,0 +1,17 @@
+import type { AlertDialogState } from '@videojs/core';
+import { ContextConsumer } from '@videojs/element/context';
+
+import { ContextPartElement } from '../context-part-element';
+import { alertDialogContext } from './context';
+
+/** Presentational backdrop that reflects its owning alert dialog's state. */
+export class AlertDialogBackdropElement extends ContextPartElement<AlertDialogState> {
+  static readonly tagName = 'media-alert-dialog-backdrop';
+
+  protected readonly consumer = new ContextConsumer(this, { context: alertDialogContext, subscribe: true });
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.setAttribute('aria-hidden', 'true');
+  }
+}

--- a/packages/html/src/ui/alert-dialog/alert-dialog-backdrop-element.ts
+++ b/packages/html/src/ui/alert-dialog/alert-dialog-backdrop-element.ts
@@ -12,6 +12,7 @@ export class AlertDialogBackdropElement extends ContextPartElement<AlertDialogSt
 
   override connectedCallback(): void {
     super.connectedCallback();
+    this.setAttribute('role', 'presentation');
     this.setAttribute('aria-hidden', 'true');
   }
 }

--- a/packages/html/src/ui/alert-dialog/alert-dialog-popup-element.ts
+++ b/packages/html/src/ui/alert-dialog/alert-dialog-popup-element.ts
@@ -1,0 +1,12 @@
+import type { AlertDialogState } from '@videojs/core';
+import { ContextConsumer } from '@videojs/element/context';
+
+import { ContextPartElement } from '../context-part-element';
+import { alertDialogContext } from './context';
+
+/** Visual popup that reflects its owning alert dialog's state. */
+export class AlertDialogPopupElement extends ContextPartElement<AlertDialogState> {
+  static readonly tagName = 'media-alert-dialog-popup';
+
+  protected readonly consumer = new ContextConsumer(this, { context: alertDialogContext, subscribe: true });
+}

--- a/packages/html/src/ui/alert-dialog/tests/alert-dialog-element.test.ts
+++ b/packages/html/src/ui/alert-dialog/tests/alert-dialog-element.test.ts
@@ -24,6 +24,7 @@ function createDefinedElement<Class extends CustomElementConstructor & { readonl
   if (!customElements.get(Constructor.tagName)) {
     customElements.define(Constructor.tagName, Constructor);
   }
+
   return document.createElement(Constructor.tagName) as InstanceType<Class>;
 }
 
@@ -220,6 +221,7 @@ describe('AlertDialogBackdropElement', () => {
   it('is presentational and receives dialog state attributes', async () => {
     const dialog = createElement(AlertDialogElement);
     const backdrop = createDefinedElement(AlertDialogBackdropElement);
+
     dialog.open = true;
     dialog.append(backdrop);
 
@@ -241,6 +243,7 @@ describe('AlertDialogPopupElement', () => {
   it('receives dialog state attributes', async () => {
     const dialog = createElement(AlertDialogElement);
     const popup = createDefinedElement(AlertDialogPopupElement);
+
     dialog.open = true;
     dialog.append(popup);
 

--- a/packages/html/src/ui/alert-dialog/tests/alert-dialog-element.test.ts
+++ b/packages/html/src/ui/alert-dialog/tests/alert-dialog-element.test.ts
@@ -1,7 +1,9 @@
 import { flush } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
+import { AlertDialogBackdropElement } from '../alert-dialog-backdrop-element';
 import { AlertDialogElement } from '../alert-dialog-element';
+import { AlertDialogPopupElement } from '../alert-dialog-popup-element';
 
 let tagCounter = 0;
 
@@ -14,6 +16,15 @@ function createElement<Element extends HTMLElement>(Base: abstract new () => Ele
 
   customElements.define(tag, class extends (Base as unknown as typeof HTMLElement) {});
   return document.createElement(tag) as Element;
+}
+
+function createDefinedElement<Class extends CustomElementConstructor & { readonly tagName: string }>(
+  Constructor: Class
+): InstanceType<Class> {
+  if (!customElements.get(Constructor.tagName)) {
+    customElements.define(Constructor.tagName, Constructor);
+  }
+  return document.createElement(Constructor.tagName) as InstanceType<Class>;
 }
 
 afterEach(() => {
@@ -198,5 +209,46 @@ describe('AlertDialogElement', () => {
 
     // Dialog was destroyed on disconnect, so open should still be true.
     expect(el.open).toBe(true);
+  });
+});
+
+describe('AlertDialogBackdropElement', () => {
+  it('has the correct tag name', () => {
+    expect(AlertDialogBackdropElement.tagName).toBe('media-alert-dialog-backdrop');
+  });
+
+  it('is presentational and receives dialog state attributes', async () => {
+    const dialog = createElement(AlertDialogElement);
+    const backdrop = createDefinedElement(AlertDialogBackdropElement);
+    dialog.open = true;
+    dialog.append(backdrop);
+
+    document.body.append(dialog);
+    await dialog.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(backdrop.getAttribute('aria-hidden')).toBe('true');
+      expect(backdrop.hasAttribute('data-open')).toBe(true);
+    });
+  });
+});
+
+describe('AlertDialogPopupElement', () => {
+  it('has the correct tag name', () => {
+    expect(AlertDialogPopupElement.tagName).toBe('media-alert-dialog-popup');
+  });
+
+  it('receives dialog state attributes', async () => {
+    const dialog = createElement(AlertDialogElement);
+    const popup = createDefinedElement(AlertDialogPopupElement);
+    dialog.open = true;
+    dialog.append(popup);
+
+    document.body.append(dialog);
+    await dialog.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(popup.hasAttribute('data-open')).toBe(true);
+    });
   });
 });

--- a/packages/html/src/ui/alert-dialog/tests/alert-dialog-element.test.ts
+++ b/packages/html/src/ui/alert-dialog/tests/alert-dialog-element.test.ts
@@ -229,6 +229,7 @@ describe('AlertDialogBackdropElement', () => {
     await dialog.updateComplete;
 
     await vi.waitFor(() => {
+      expect(backdrop.getAttribute('role')).toBe('presentation');
       expect(backdrop.getAttribute('aria-hidden')).toBe('true');
       expect(backdrop.hasAttribute('data-open')).toBe(true);
     });

--- a/packages/html/src/ui/controls/controls-backdrop-element.ts
+++ b/packages/html/src/ui/controls/controls-backdrop-element.ts
@@ -12,6 +12,7 @@ export class ControlsBackdropElement extends ContextPartElement<ControlsState> {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    this.setAttribute('role', 'presentation');
     this.setAttribute('aria-hidden', 'true');
   }
 }

--- a/packages/html/src/ui/controls/controls-backdrop-element.ts
+++ b/packages/html/src/ui/controls/controls-backdrop-element.ts
@@ -1,0 +1,17 @@
+import type { ControlsState } from '@videojs/core';
+import { ContextConsumer } from '@videojs/element/context';
+
+import { ContextPartElement } from '../context-part-element';
+import { controlsContext } from './context';
+
+/** Presentational backdrop that reflects its owning controls surface's state. */
+export class ControlsBackdropElement extends ContextPartElement<ControlsState> {
+  static readonly tagName = 'media-controls-backdrop';
+
+  protected readonly consumer = new ContextConsumer(this, { context: controlsContext, subscribe: true });
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.setAttribute('aria-hidden', 'true');
+  }
+}

--- a/packages/html/src/ui/controls/tests/controls-element.test.ts
+++ b/packages/html/src/ui/controls/tests/controls-element.test.ts
@@ -194,6 +194,7 @@ describe('ControlsBackdropElement', () => {
     const provider = document.createElement('test-controls-player-provider') as TestPlayerProviderElement;
     const controls = createDefinedElement(ControlsElement);
     const backdrop = createDefinedElement(ControlsBackdropElement);
+
     controls.append(backdrop);
 
     document.body.append(provider);

--- a/packages/html/src/ui/controls/tests/controls-element.test.ts
+++ b/packages/html/src/ui/controls/tests/controls-element.test.ts
@@ -202,6 +202,7 @@ describe('ControlsBackdropElement', () => {
     await controls.updateComplete;
 
     await waitForAssertion(() => {
+      expect(backdrop.getAttribute('role')).toBe('presentation');
       expect(backdrop.getAttribute('aria-hidden')).toBe('true');
       expect(backdrop.hasAttribute('data-visible')).toBe(true);
       expect(backdrop.hasAttribute('data-user-active')).toBe(true);

--- a/packages/html/src/ui/controls/tests/controls-element.test.ts
+++ b/packages/html/src/ui/controls/tests/controls-element.test.ts
@@ -10,6 +10,7 @@ import { MenuElement } from '../../menu/menu-element';
 import { PopoverElement } from '../../popover/popover-element';
 import { TooltipElement } from '../../tooltip/tooltip-element';
 import { UIElement } from '../../ui-element';
+import { ControlsBackdropElement } from '../controls-backdrop-element';
 import { ControlsElement } from '../controls-element';
 
 function ensureCustomElementDefined(Constructor: CustomElementConstructor & { readonly tagName: string }): void {
@@ -181,5 +182,28 @@ describe('ControlsElement', () => {
     await controls.updateComplete;
 
     expect(() => provider.setVisible(false)).not.toThrow();
+  });
+});
+
+describe('ControlsBackdropElement', () => {
+  it('has the correct tag name', () => {
+    expect(ControlsBackdropElement.tagName).toBe('media-controls-backdrop');
+  });
+
+  it('is presentational and receives controls state attributes', async () => {
+    const provider = document.createElement('test-controls-player-provider') as TestPlayerProviderElement;
+    const controls = createDefinedElement(ControlsElement);
+    const backdrop = createDefinedElement(ControlsBackdropElement);
+    controls.append(backdrop);
+
+    document.body.append(provider);
+    provider.append(controls);
+    await controls.updateComplete;
+
+    await waitForAssertion(() => {
+      expect(backdrop.getAttribute('aria-hidden')).toBe('true');
+      expect(backdrop.hasAttribute('data-visible')).toBe(true);
+      expect(backdrop.hasAttribute('data-user-active')).toBe(true);
+    });
   });
 });

--- a/packages/react/src/ui/alert-dialog/alert-dialog-backdrop.tsx
+++ b/packages/react/src/ui/alert-dialog/alert-dialog-backdrop.tsx
@@ -26,7 +26,7 @@ export const AlertDialogBackdrop = forwardRef<HTMLDivElement, AlertDialogBackdro
       state,
       stateAttrMap,
       ref: [forwardedRef],
-      props: [elementProps, { 'aria-hidden': true }],
+      props: [{ 'aria-hidden': true }, elementProps],
     }
   );
 });

--- a/packages/react/src/ui/alert-dialog/alert-dialog-backdrop.tsx
+++ b/packages/react/src/ui/alert-dialog/alert-dialog-backdrop.tsx
@@ -8,15 +8,14 @@ import { useAlertDialogContext } from './context';
 export interface AlertDialogBackdropProps extends UIComponentProps<'div', AlertDialogCore.State> {}
 
 /**
- * Presentational layer behind an open alert dialog. Renders a `<div>` while the dialog is present,
- * including its exit transition, and receives the dialog state data attributes.
+ * Presentational layer behind an open alert dialog. Renders a `<div>` while the dialog is present, including its exit
+ * transition, and receives the dialog state data attributes.
  */
 export const AlertDialogBackdrop = forwardRef<HTMLDivElement, AlertDialogBackdropProps>(function AlertDialogBackdrop(
   { render, className, style, ...elementProps },
   forwardedRef
 ) {
   const { state, stateAttrMap } = useAlertDialogContext();
-
   if (!state.open) return null;
 
   return renderElement(

--- a/packages/react/src/ui/alert-dialog/alert-dialog-backdrop.tsx
+++ b/packages/react/src/ui/alert-dialog/alert-dialog-backdrop.tsx
@@ -1,0 +1,37 @@
+import type { AlertDialogCore } from '@videojs/core';
+import { forwardRef } from 'react';
+
+import type { UIComponentProps } from '../../utils/types';
+import { renderElement } from '../../utils/use-render';
+import { useAlertDialogContext } from './context';
+
+export interface AlertDialogBackdropProps extends UIComponentProps<'div', AlertDialogCore.State> {}
+
+/**
+ * Presentational layer behind an open alert dialog. Renders a `<div>` while the dialog is present,
+ * including its exit transition, and receives the dialog state data attributes.
+ */
+export const AlertDialogBackdrop = forwardRef<HTMLDivElement, AlertDialogBackdropProps>(function AlertDialogBackdrop(
+  { render, className, style, ...elementProps },
+  forwardedRef
+) {
+  const { state, stateAttrMap } = useAlertDialogContext();
+
+  if (!state.open) return null;
+
+  return renderElement(
+    'div',
+    { render, className, style },
+    {
+      state,
+      stateAttrMap,
+      ref: [forwardedRef],
+      props: [elementProps, { 'aria-hidden': true }],
+    }
+  );
+});
+
+export namespace AlertDialogBackdrop {
+  export type Props = AlertDialogBackdropProps;
+  export type State = AlertDialogCore.State;
+}

--- a/packages/react/src/ui/alert-dialog/alert-dialog-backdrop.tsx
+++ b/packages/react/src/ui/alert-dialog/alert-dialog-backdrop.tsx
@@ -25,7 +25,7 @@ export const AlertDialogBackdrop = forwardRef<HTMLDivElement, AlertDialogBackdro
       state,
       stateAttrMap,
       ref: [forwardedRef],
-      props: [{ 'aria-hidden': true }, elementProps],
+      props: [{ role: 'presentation', 'aria-hidden': true }, elementProps],
     }
   );
 });

--- a/packages/react/src/ui/alert-dialog/index.parts.ts
+++ b/packages/react/src/ui/alert-dialog/index.parts.ts
@@ -1,3 +1,7 @@
+export {
+  AlertDialogBackdrop as Backdrop,
+  type AlertDialogBackdropProps as BackdropProps,
+} from './alert-dialog-backdrop';
 export { AlertDialogClose as Close, type AlertDialogCloseProps as CloseProps } from './alert-dialog-close';
 export {
   AlertDialogDescription as Description,

--- a/packages/react/src/ui/alert-dialog/tests/alert-dialog-backdrop.test.tsx
+++ b/packages/react/src/ui/alert-dialog/tests/alert-dialog-backdrop.test.tsx
@@ -39,6 +39,7 @@ describe('AlertDialogBackdrop', () => {
 
     const backdrop = getByTestId('backdrop');
 
+    expect(backdrop.getAttribute('role')).toBe('presentation');
     expect(backdrop.getAttribute('aria-hidden')).toBe('true');
     expect(backdrop.hasAttribute('data-open')).toBe(true);
   });

--- a/packages/react/src/ui/alert-dialog/tests/alert-dialog-backdrop.test.tsx
+++ b/packages/react/src/ui/alert-dialog/tests/alert-dialog-backdrop.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, render } from '@testing-library/react';
+import { createRef } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AlertDialogBackdrop } from '../alert-dialog-backdrop';
+import { AlertDialogPopup } from '../alert-dialog-popup';
+import { AlertDialogRoot } from '../alert-dialog-root';
+
+afterEach(cleanup);
+
+describe('AlertDialogBackdrop', () => {
+  it('renders only while the dialog is present', () => {
+    const { queryByTestId, rerender } = render(
+      <AlertDialogRoot open={false}>
+        <AlertDialogBackdrop data-testid="backdrop" />
+        <AlertDialogPopup>content</AlertDialogPopup>
+      </AlertDialogRoot>
+    );
+
+    expect(queryByTestId('backdrop')).toBeNull();
+
+    rerender(
+      <AlertDialogRoot open>
+        <AlertDialogBackdrop data-testid="backdrop" />
+        <AlertDialogPopup>content</AlertDialogPopup>
+      </AlertDialogRoot>
+    );
+
+    expect(queryByTestId('backdrop')).not.toBeNull();
+  });
+
+  it('is presentational and receives dialog state attributes', () => {
+    const { getByTestId } = render(
+      <AlertDialogRoot open>
+        <AlertDialogBackdrop data-testid="backdrop" />
+        <AlertDialogPopup>content</AlertDialogPopup>
+      </AlertDialogRoot>
+    );
+
+    const backdrop = getByTestId('backdrop');
+    expect(backdrop.getAttribute('aria-hidden')).toBe('true');
+    expect(backdrop.hasAttribute('data-open')).toBe(true);
+  });
+
+  it('stays rendered with ending state while the dialog closes', () => {
+    const { getByTestId, rerender } = render(
+      <AlertDialogRoot open>
+        <AlertDialogBackdrop data-testid="backdrop" />
+        <AlertDialogPopup>content</AlertDialogPopup>
+      </AlertDialogRoot>
+    );
+
+    rerender(
+      <AlertDialogRoot open={false}>
+        <AlertDialogBackdrop data-testid="backdrop" />
+        <AlertDialogPopup>content</AlertDialogPopup>
+      </AlertDialogRoot>
+    );
+
+    expect(getByTestId('backdrop').hasAttribute('data-ending-style')).toBe(true);
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+
+    render(
+      <AlertDialogRoot open>
+        <AlertDialogBackdrop ref={ref} />
+        <AlertDialogPopup>content</AlertDialogPopup>
+      </AlertDialogRoot>
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/packages/react/src/ui/alert-dialog/tests/alert-dialog-backdrop.test.tsx
+++ b/packages/react/src/ui/alert-dialog/tests/alert-dialog-backdrop.test.tsx
@@ -38,6 +38,7 @@ describe('AlertDialogBackdrop', () => {
     );
 
     const backdrop = getByTestId('backdrop');
+
     expect(backdrop.getAttribute('aria-hidden')).toBe('true');
     expect(backdrop.hasAttribute('data-open')).toBe(true);
   });

--- a/packages/react/src/ui/alert-dialog/tests/alert-dialog-backdrop.test.tsx
+++ b/packages/react/src/ui/alert-dialog/tests/alert-dialog-backdrop.test.tsx
@@ -42,6 +42,17 @@ describe('AlertDialogBackdrop', () => {
     expect(backdrop.hasAttribute('data-open')).toBe(true);
   });
 
+  it('allows the default aria-hidden value to be overridden', () => {
+    const { getByTestId } = render(
+      <AlertDialogRoot open>
+        <AlertDialogBackdrop aria-hidden={false} data-testid="backdrop" />
+        <AlertDialogPopup>content</AlertDialogPopup>
+      </AlertDialogRoot>
+    );
+
+    expect(getByTestId('backdrop').getAttribute('aria-hidden')).toBe('false');
+  });
+
   it('stays rendered with ending state while the dialog closes', () => {
     const { getByTestId, rerender } = render(
       <AlertDialogRoot open>

--- a/packages/react/src/ui/controls/controls-backdrop.tsx
+++ b/packages/react/src/ui/controls/controls-backdrop.tsx
@@ -1,0 +1,35 @@
+import type { ControlsCore } from '@videojs/core';
+import { forwardRef } from 'react';
+
+import type { UIComponentProps } from '../../utils/types';
+import { renderElement } from '../../utils/use-render';
+import { useControlsContext } from './context';
+
+export interface ControlsBackdropProps extends UIComponentProps<'div', ControlsCore.State> {}
+
+/**
+ * Presentational layer behind player controls. Renders a `<div>` with the controls state data attributes
+ * so skins can style it without reaching across sibling components.
+ */
+export const ControlsBackdrop = forwardRef<HTMLDivElement, ControlsBackdropProps>(function ControlsBackdrop(
+  { render, className, style, ...elementProps },
+  forwardedRef
+) {
+  const { state, stateAttrMap } = useControlsContext();
+
+  return renderElement(
+    'div',
+    { render, className, style },
+    {
+      state,
+      stateAttrMap,
+      ref: [forwardedRef],
+      props: [elementProps, { 'aria-hidden': true }],
+    }
+  );
+});
+
+export namespace ControlsBackdrop {
+  export type Props = ControlsBackdropProps;
+  export type State = ControlsCore.State;
+}

--- a/packages/react/src/ui/controls/controls-backdrop.tsx
+++ b/packages/react/src/ui/controls/controls-backdrop.tsx
@@ -8,8 +8,8 @@ import { useControlsContext } from './context';
 export interface ControlsBackdropProps extends UIComponentProps<'div', ControlsCore.State> {}
 
 /**
- * Presentational layer behind player controls. Renders a `<div>` with the controls state data attributes
- * so skins can style it without reaching across sibling components.
+ * Presentational layer behind player controls. Renders a `<div>` with the controls state data attributes so skins can
+ * style it without reaching across sibling components.
  */
 export const ControlsBackdrop = forwardRef<HTMLDivElement, ControlsBackdropProps>(function ControlsBackdrop(
   { render, className, style, ...elementProps },

--- a/packages/react/src/ui/controls/controls-backdrop.tsx
+++ b/packages/react/src/ui/controls/controls-backdrop.tsx
@@ -24,7 +24,7 @@ export const ControlsBackdrop = forwardRef<HTMLDivElement, ControlsBackdropProps
       state,
       stateAttrMap,
       ref: [forwardedRef],
-      props: [{ 'aria-hidden': true }, elementProps],
+      props: [{ role: 'presentation', 'aria-hidden': true }, elementProps],
     }
   );
 });

--- a/packages/react/src/ui/controls/controls-backdrop.tsx
+++ b/packages/react/src/ui/controls/controls-backdrop.tsx
@@ -24,7 +24,7 @@ export const ControlsBackdrop = forwardRef<HTMLDivElement, ControlsBackdropProps
       state,
       stateAttrMap,
       ref: [forwardedRef],
-      props: [elementProps, { 'aria-hidden': true }],
+      props: [{ 'aria-hidden': true }, elementProps],
     }
   );
 });

--- a/packages/react/src/ui/controls/index.parts.ts
+++ b/packages/react/src/ui/controls/index.parts.ts
@@ -1,2 +1,3 @@
+export { ControlsBackdrop as Backdrop, type ControlsBackdropProps as BackdropProps } from './controls-backdrop';
 export { ControlsGroup as Group, type ControlsGroupProps as GroupProps } from './controls-group';
 export { ControlsRoot as Root, type ControlsRootProps as RootProps } from './controls-root';

--- a/packages/react/src/ui/controls/tests/controls-backdrop.test.tsx
+++ b/packages/react/src/ui/controls/tests/controls-backdrop.test.tsx
@@ -22,6 +22,7 @@ describe('ControlsBackdrop', () => {
     );
 
     const backdrop = getByTestId('backdrop');
+
     expect(backdrop.getAttribute('aria-hidden')).toBe('true');
     expect(backdrop.hasAttribute('data-visible')).toBe(true);
     expect(backdrop.hasAttribute('data-user-active')).toBe(true);

--- a/packages/react/src/ui/controls/tests/controls-backdrop.test.tsx
+++ b/packages/react/src/ui/controls/tests/controls-backdrop.test.tsx
@@ -23,6 +23,7 @@ describe('ControlsBackdrop', () => {
 
     const backdrop = getByTestId('backdrop');
 
+    expect(backdrop.getAttribute('role')).toBe('presentation');
     expect(backdrop.getAttribute('aria-hidden')).toBe('true');
     expect(backdrop.hasAttribute('data-visible')).toBe(true);
     expect(backdrop.hasAttribute('data-user-active')).toBe(true);

--- a/packages/react/src/ui/controls/tests/controls-backdrop.test.tsx
+++ b/packages/react/src/ui/controls/tests/controls-backdrop.test.tsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { ControlsBackdrop } from '../controls-backdrop';
+import { ControlsRoot } from '../controls-root';
+
+describe('ControlsBackdrop', () => {
+  it('is presentational and receives controls state attributes', () => {
+    const { Wrapper } = createPlayerWrapper({
+      controlsVisible: true,
+      userActive: true,
+    });
+    const { getByTestId } = render(
+      <ControlsRoot>
+        <ControlsBackdrop data-testid="backdrop" />
+      </ControlsRoot>,
+      { wrapper: Wrapper }
+    );
+
+    const backdrop = getByTestId('backdrop');
+    expect(backdrop.getAttribute('aria-hidden')).toBe('true');
+    expect(backdrop.hasAttribute('data-visible')).toBe(true);
+    expect(backdrop.hasAttribute('data-user-active')).toBe(true);
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    const { Wrapper } = createPlayerWrapper({
+      controlsVisible: true,
+      userActive: true,
+    });
+
+    render(
+      <ControlsRoot>
+        <ControlsBackdrop ref={ref} />
+      </ControlsRoot>,
+      { wrapper: Wrapper }
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/packages/react/src/ui/controls/tests/controls-backdrop.test.tsx
+++ b/packages/react/src/ui/controls/tests/controls-backdrop.test.tsx
@@ -1,10 +1,12 @@
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import { createRef } from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { createPlayerWrapper } from '../../../testing/mocks';
 import { ControlsBackdrop } from '../controls-backdrop';
 import { ControlsRoot } from '../controls-root';
+
+afterEach(cleanup);
 
 describe('ControlsBackdrop', () => {
   it('is presentational and receives controls state attributes', () => {
@@ -40,5 +42,20 @@ describe('ControlsBackdrop', () => {
     );
 
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('allows the default aria-hidden value to be overridden', () => {
+    const { Wrapper } = createPlayerWrapper({
+      controlsVisible: true,
+      userActive: true,
+    });
+    const { getByTestId } = render(
+      <ControlsRoot>
+        <ControlsBackdrop aria-hidden={false} data-testid="backdrop" />
+      </ControlsRoot>,
+      { wrapper: Wrapper }
+    );
+
+    expect(getByTestId('backdrop').getAttribute('aria-hidden')).toBe('false');
   });
 });

--- a/packages/react/src/ui/error-dialog/index.parts.ts
+++ b/packages/react/src/ui/error-dialog/index.parts.ts
@@ -1,9 +1,4 @@
-export {
-  Backdrop,
-  type BackdropProps,
-  Popup,
-  type PopupProps,
-} from '../alert-dialog/index.parts';
+export { Backdrop, type BackdropProps, Popup, type PopupProps } from '../alert-dialog/index.parts';
 export { ErrorDialogClose as Close, type ErrorDialogCloseProps as CloseProps } from './error-dialog-close';
 export {
   ErrorDialogDescription as Description,

--- a/packages/react/src/ui/error-dialog/index.parts.ts
+++ b/packages/react/src/ui/error-dialog/index.parts.ts
@@ -1,4 +1,9 @@
-export { Popup, type PopupProps } from '../alert-dialog/index.parts';
+export {
+  Backdrop,
+  type BackdropProps,
+  Popup,
+  type PopupProps,
+} from '../alert-dialog/index.parts';
 export { ErrorDialogClose as Close, type ErrorDialogCloseProps as CloseProps } from './error-dialog-close';
 export {
   ErrorDialogDescription as Description,

--- a/packages/react/src/ui/error-dialog/tests/error-dialog.test.tsx
+++ b/packages/react/src/ui/error-dialog/tests/error-dialog.test.tsx
@@ -33,6 +33,7 @@ describe('ErrorDialog', () => {
       <Wrapper>
         <I18nProvider locale="es">
           <ErrorDialog.Root>
+            <ErrorDialog.Backdrop data-testid="backdrop" />
             <ErrorDialog.Popup>
               <ErrorDialog.Title data-testid="title" />
               <ErrorDialog.Description data-testid="description" />
@@ -43,6 +44,7 @@ describe('ErrorDialog', () => {
       </Wrapper>
     );
 
+    expect(screen.getByTestId('backdrop').getAttribute('aria-hidden')).toBe('true');
     expect(screen.getByTestId('title').textContent).toBe('Algo salió mal.');
     expect(screen.getByTestId('description').textContent).toBe('Error de red.');
     expect(screen.getByTestId('close').textContent).toBe('Aceptar');

--- a/site/src/content/docs/reference/controls.mdx
+++ b/site/src/content/docs/reference/controls.mdx
@@ -28,6 +28,7 @@ Import the component and assemble its parts:
 <FrameworkCase frameworks={["react"]}>
   ```tsx
   <Controls.Root>
+    <Controls.Backdrop />
     <Controls.Group />
   </Controls.Root>
   ```
@@ -36,6 +37,7 @@ Import the component and assemble its parts:
 <FrameworkCase frameworks={["html"]}>
   ```html
   <media-controls>
+    <media-controls-backdrop></media-controls-backdrop>
     <media-controls-group></media-controls-group>
   </media-controls>
   ```
@@ -48,6 +50,9 @@ If the user is active, or if the video is paused, this component will show contr
 User activity is tracked via pointer movement, keyboard input, and focus events on the player container. On touch devices, a quick tap toggles visibility. `mouseleave` immediately sets the user as inactive.
 
 ## Styling
+
+`Controls.Backdrop` / `<media-controls-backdrop>` is an optional presentational layer. It receives the same controls state data attributes as the root, allowing a skin to render a controls-visible scrim without selecting across sibling components.
+
 By default, controls have the following styles:
 
 <FrameworkCase frameworks={["html"]}>
@@ -59,6 +64,11 @@ media-controls {
 
 media-controls-group {
   pointer-events: auto;
+}
+
+media-controls-backdrop {
+  position: absolute;
+  inset: 0;
 }
 
 /* Fade transition */
@@ -85,6 +95,11 @@ React renders `<div>` elements. Add a `className` to style them:
   pointer-events: auto;
 }
 
+.controls-backdrop {
+  position: absolute;
+  inset: 0;
+}
+
 /* Fade transition */
 .controls {
   transition: opacity 0.25s;
@@ -99,11 +114,11 @@ React renders `<div>` elements. Add a `className` to style them:
 ## Accessibility
 
 <FrameworkCase frameworks={["html"]}>
-No ARIA role is applied to `<media-controls>` — it is a layout wrapper, not a landmark. `<media-controls-group>` automatically receives `role="group"` when an `aria-label` or `aria-labelledby` attribute is provided; otherwise no role is assigned.
+No ARIA role is applied to `<media-controls>` — it is a layout wrapper, not a landmark. `<media-controls-backdrop>` is always hidden from assistive technology. `<media-controls-group>` automatically receives `role="group"` when an `aria-label` or `aria-labelledby` attribute is provided; otherwise no role is assigned.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
-No ARIA role is applied to `Controls.Root` — it is a layout wrapper, not a landmark. `Controls.Group` automatically receives `role="group"` when an `aria-label` or `aria-labelledby` attribute is provided; otherwise no role is assigned.
+No ARIA role is applied to `Controls.Root` — it is a layout wrapper, not a landmark. `Controls.Backdrop` is always hidden from assistive technology. `Controls.Group` automatically receives `role="group"` when an `aria-label` or `aria-labelledby` attribute is provided; otherwise no role is assigned.
 </FrameworkCase>
 
 ## Examples


### PR DESCRIPTION
Refs #1972

Refs #2260

## Summary

Add explicit, optional backdrop anatomy for alert dialogs and controls so skins can style state-owned visual layers without cross-component selectors.

## Changes

- Add React and HTML Backdrop parts for AlertDialog/ErrorDialog and Controls
- Add an HTML alert-dialog Popup part so Backdrop and Popup can be siblings beneath the dialog state owner
- Preserve dialog transition attributes and rendered presence, and mark visual backdrops as `aria-hidden`
- Extend core VJSC schemas, custom-element registration coverage, generated API references, and Controls documentation

## Stack

1 of 9. Base: `main`. Next: #2347.

Full stack: #2343 → #2347 → #2348 → #2355 → #2344 → #2345 → #2376 → #2378 → #2381.

## Testing

- `pnpm -F @videojs/core test`
- `pnpm -F @videojs/react test`
- `pnpm -F @videojs/html test`
- `pnpm -F site api-docs`
- `pnpm -F site astro check`
- `pnpm typecheck`
- `pnpm check:workspace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional presentational parts and custom-element registration; no changes to dialog dismiss logic or player control behavior beyond new markup hooks.
> 
> **Overview**
> Adds optional **Backdrop** anatomy to **Controls** and **AlertDialog** (including **ErrorDialog** via shared alert-dialog parts) so skins can style scrims and overlays with the same state data attributes as the parent, without cross-sibling selectors.
> 
> **HTML** introduces `media-controls-backdrop`, `media-alert-dialog-backdrop`, and `media-alert-dialog-popup` as context-consuming part elements (`role="presentation"`, `aria-hidden`). Registration is centralized in `defineAlertDialog()` / shared `defineAlertDialogParts()` (used by `defineErrorDialog()` and `defineControls()`), with new standalone define entry points and package exports.
> 
> **React** adds `Controls.Backdrop` and `AlertDialog.Backdrop` (ErrorDialog re-exports the alert backdrop). Alert dialog backdrop mounts only while the dialog is present and keeps exit-transition state attributes when closing.
> 
> Core VJSC component schemas, registration tests, component tests, and Controls docs (anatomy, styling, a11y) are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9280da4818cbd6b1113296bcd8fe10979a53b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->