### PR TITLE
feat(packages): add vjsc style diagnostics

### DIFF
--- a/packages/skins/vjsc/tests/vite.test.ts
+++ b/packages/skins/vjsc/tests/vite.test.ts
@@ -84,6 +84,26 @@ describe('Skins Vite workflow', () => {
     expect(htmlContainer?.code).toContain('/src/define/ui/container.ts');
   }, 30_000);
 
+  it('reports VJSC style diagnostics through the Vite logger', async () => {
+    const logger = createLogger('warn');
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const warnOnce = vi.spyOn(logger, 'warnOnce').mockImplementation(() => {});
+    server = await createServer({
+      configFile,
+      customLogger: logger,
+      logLevel: 'warn',
+      optimizeDeps: { include: [], noDiscovery: true },
+      server: { middlewareMode: true },
+    });
+
+    await server.transformRequest(reactPosterUrl);
+    const warnings = [...warn.mock.calls, ...warnOnce.mock.calls].flat().join('\n');
+
+    expect(warnings).toContain('[VJSC_STYLE_COMPLEX_SELECTOR]');
+    expect(warnings).toContain('Reason:');
+    expect(warnings).toContain('Recommendation:');
+  }, 30_000);
+
   it('passes trigger props to the concrete React render element', async () => {
     const logger = createLogger('silent');
     const warn = vi.spyOn(logger, 'warn');

--- a/packages/skins/vjsc/tests/vite.test.ts
+++ b/packages/skins/vjsc/tests/vite.test.ts
@@ -88,6 +88,7 @@ describe('Skins Vite workflow', () => {
     const logger = createLogger('warn');
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const warnOnce = vi.spyOn(logger, 'warnOnce').mockImplementation(() => {});
+
     server = await createServer({
       configFile,
       customLogger: logger,

--- a/packages/vjsc/src/plugins/index.ts
+++ b/packages/vjsc/src/plugins/index.ts
@@ -1,3 +1,4 @@
+export type { ComplexSelectorDiagnosticLevel, VjscDiagnosticsOptions } from '../styles/diagnostics';
 export { type ComponentSchemaPluginOptions, componentSchemaPlugin } from './component-schema';
 export { type ShadcnPluginOptions, shadcnPlugin } from './shadcn';
 export { type VjscModule, type VjscModuleConfig, type VjscPluginOptions, vjscPlugin } from './vjsc';

--- a/packages/vjsc/src/plugins/style.ts
+++ b/packages/vjsc/src/plugins/style.ts
@@ -207,7 +207,6 @@ function reportStyleDiagnostic(
 ): void {
   const message = formatStyleDiagnostic(diagnostic);
   const level = options.complexSelectors ?? 'warn';
-
   if (diagnostic.kind === 'error' || level === 'error') throw new Error(message);
 
   if (level === 'off' || reportedWarnings.has(message)) return;

--- a/packages/vjsc/src/plugins/style.ts
+++ b/packages/vjsc/src/plugins/style.ts
@@ -11,6 +11,13 @@ import { insertModuleImports } from '../ast/imports';
 import { compileStyles } from '../styles/compile';
 import { type DesignSystem, loadDesignSystem } from '../styles/design-system';
 import {
+  diagnoseCompiledStyles,
+  diagnoseStyleManifest,
+  formatStyleDiagnostic,
+  type StyleDiagnostic,
+  type VjscDiagnosticsOptions,
+} from '../styles/diagnostics';
+import {
   loadStyleManifest,
   ruleForToken,
   type StyleManifest,
@@ -51,11 +58,12 @@ interface VirtualCssModule {
   readonly owners: Set<string>;
 }
 
-export function stylePlugin(config: StylePluginConfig): Plugin {
+export function stylePlugin(config: StylePluginConfig, diagnostics: VjscDiagnosticsOptions = {}): Plugin {
   const designs = new Map<string, Promise<CachedDesignSystem>>();
   const manifests = new Map<string, CachedManifest>();
   const cssById = new Map<string, VirtualCssModule>();
   const cssByOwner = new Map<string, ReadonlySet<string>>();
+  const reportedWarnings = new Set<string>();
   let cwd = process.cwd();
 
   return {
@@ -63,6 +71,9 @@ export function stylePlugin(config: StylePluginConfig): Plugin {
     options(options) {
       cwd = resolve(options.cwd ?? process.cwd());
       return null;
+    },
+    buildStart() {
+      reportedWarnings.clear();
     },
     resolveId(id) {
       return cssById.has(id) ? `\0${id}` : null;
@@ -99,9 +110,17 @@ export function stylePlugin(config: StylePluginConfig): Plugin {
 
         for (const file of manifest.watchFiles) this.addWatchFile(file);
 
+        const styleDiagnostics = [...diagnoseStyleManifest(manifest, options.variants)];
+        const report = () => {
+          for (const diagnostic of mergeStyleDiagnostics(styleDiagnostics)) {
+            reportStyleDiagnostic(diagnostic, diagnostics, reportedWarnings, (message) => this.warn(message));
+          }
+        };
+
         const referencedRules = transformStyles(filename, transform.ast, transform.magicString, manifest, options);
 
         if (referencedRules.size === 0) {
+          report();
           replaceVirtualCss(cssById, cssByOwner, id, []);
           return null;
         }
@@ -110,6 +129,10 @@ export function stylePlugin(config: StylePluginConfig): Plugin {
           const input = resolve(cwd, options.stylesheet.input);
           const base = options.stylesheet.base ? resolve(cwd, options.stylesheet.base) : undefined;
           const cachedDesign = await cachedDesignSystem(designs, input);
+          styleDiagnostics.push(
+            ...diagnoseCompiledStyles(manifest, cachedDesign.design, referencedRules, options.variants)
+          );
+          report();
           const assets = await compileStyles({
             design: cachedDesign.design,
             manifest,
@@ -144,6 +167,7 @@ export function stylePlugin(config: StylePluginConfig): Plugin {
           replaceVirtualCss(cssById, cssByOwner, id, modules);
           insertModuleImports(transform.ast, transform.magicString, imports);
         } else {
+          report();
           replaceVirtualCss(cssById, cssByOwner, id, []);
         }
 
@@ -151,6 +175,42 @@ export function stylePlugin(config: StylePluginConfig): Plugin {
       },
     },
   };
+}
+
+function mergeStyleDiagnostics(diagnostics: readonly StyleDiagnostic[]): readonly StyleDiagnostic[] {
+  const merged = new Map<string, StyleDiagnostic>();
+
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic.code}:${diagnostic.rule.modulePath}:${diagnostic.rule.tokenPath.join('.')}`;
+    const previous = merged.get(key);
+    if (!previous) {
+      merged.set(key, diagnostic);
+      continue;
+    }
+
+    merged.set(key, {
+      ...previous,
+      utilities: [...new Set([...previous.utilities, ...diagnostic.utilities])],
+    });
+  }
+
+  return [...merged.values()];
+}
+
+function reportStyleDiagnostic(
+  diagnostic: StyleDiagnostic,
+  options: VjscDiagnosticsOptions,
+  reportedWarnings: Set<string>,
+  warn: (message: string) => void
+): void {
+  const message = formatStyleDiagnostic(diagnostic);
+  const level = options.complexSelectors ?? 'warn';
+
+  if (diagnostic.kind === 'error' || level === 'error') throw new Error(message);
+  if (level === 'off' || reportedWarnings.has(message)) return;
+
+  reportedWarnings.add(message);
+  warn(message);
 }
 
 function replaceVirtualCss(

--- a/packages/vjsc/src/plugins/style.ts
+++ b/packages/vjsc/src/plugins/style.ts
@@ -129,6 +129,7 @@ export function stylePlugin(config: StylePluginConfig, diagnostics: VjscDiagnost
           const input = resolve(cwd, options.stylesheet.input);
           const base = options.stylesheet.base ? resolve(cwd, options.stylesheet.base) : undefined;
           const cachedDesign = await cachedDesignSystem(designs, input);
+
           styleDiagnostics.push(
             ...diagnoseCompiledStyles(manifest, cachedDesign.design, referencedRules, options.variants)
           );
@@ -183,6 +184,7 @@ function mergeStyleDiagnostics(diagnostics: readonly StyleDiagnostic[]): readonl
   for (const diagnostic of diagnostics) {
     const key = `${diagnostic.code}:${diagnostic.rule.modulePath}:${diagnostic.rule.tokenPath.join('.')}`;
     const previous = merged.get(key);
+
     if (!previous) {
       merged.set(key, diagnostic);
       continue;
@@ -207,6 +209,7 @@ function reportStyleDiagnostic(
   const level = options.complexSelectors ?? 'warn';
 
   if (diagnostic.kind === 'error' || level === 'error') throw new Error(message);
+
   if (level === 'off' || reportedWarnings.has(message)) return;
 
   reportedWarnings.add(message);

--- a/packages/vjsc/src/plugins/tests/style.test.ts
+++ b/packages/vjsc/src/plugins/tests/style.test.ts
@@ -152,14 +152,69 @@ describe('stylePlugin', () => {
     expect(await resolvePluginId(styles, firstId!)).toBeNull();
     expect(await resolvePluginId(styles, secondId!)).toBe(`\0${secondId}`);
   });
+
+  it('warns once when authored and compiled checks find the same complex selector', async () => {
+    const complexManifest = createManifest([rule(['root'], 'media-root', ['[&_img]:block', '[&_video]:block'])]);
+    const styles = stylePlugin({
+      manifest: complexManifest,
+      mode: 'css',
+      stylesheet: { input: designPath },
+    });
+    const { warnings } = await transform(
+      `import styles from './fixtures/button.styles'; export const root = <div className={styles.root} />;`,
+      undefined,
+      styles
+    );
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('[VJSC_STYLE_COMPLEX_SELECTOR]');
+    expect(warnings[0]).toContain('`[&_img]:block`, `[&_video]:block`');
+    expect(warnings[0]).toContain('Reason:');
+    expect(warnings[0]).toContain('Recommendation:');
+  });
+
+  it('promotes or silences complex-selector warnings', async () => {
+    const complexManifest = createManifest([rule(['root'], 'media-root', ['[&_img]:block'])]);
+    const input = `import styles from './fixtures/button.styles'; export const root = <div className={styles.root} />;`;
+
+    await expect(
+      transform(
+        input,
+        undefined,
+        stylePlugin({ manifest: complexManifest, mode: 'tailwind' }, { complexSelectors: 'error' })
+      )
+    ).rejects.toThrow('[VJSC_STYLE_COMPLEX_SELECTOR]');
+
+    const { warnings } = await transform(
+      input,
+      undefined,
+      stylePlugin({ manifest: complexManifest, mode: 'tailwind' }, { complexSelectors: 'off' })
+    );
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('keeps isolation errors active when complex-selector warnings are off', async () => {
+    const peerManifest = createManifest([rule(['root'], 'media-root', ['peer/dialog'])]);
+    const input = `import styles from './fixtures/button.styles'; export const root = <div className={styles.root} />;`;
+
+    await expect(
+      transform(
+        input,
+        undefined,
+        stylePlugin({ manifest: peerManifest, mode: 'tailwind' }, { complexSelectors: 'off' })
+      )
+    ).rejects.toThrow('[VJSC_STYLE_PEER_RELATIONSHIP]');
+  });
 });
 
 async function transform(
   source: string,
   config: StylePluginConfig = { manifest, mode: 'tailwind' },
   styles: Plugin = stylePlugin(config)
-): Promise<{ readonly source: string }> {
+): Promise<{ readonly source: string; readonly warnings: readonly string[] }> {
   let meta: unknown;
+  const warnings: string[] = [];
   const inspect: Plugin = {
     name: 'fixture:inspect',
     buildEnd() {
@@ -172,6 +227,9 @@ async function transform(
     external: /^virtual:vjsc\/css\//,
     transform: { jsx: 'preserve' },
     plugins: [fixturePlugin(source), styles, componentSourcePlugin(), inspect],
+    onLog(level, log) {
+      if (level === 'warn') warnings.push(log.message);
+    },
   });
 
   await bundle.generate({ format: 'es' });
@@ -179,7 +237,7 @@ async function transform(
   const output = readComponentSource(meta);
   if (output === undefined) throw new Error('Fixture build did not retain editable source.');
 
-  return { source: output };
+  return { source: output, warnings };
 }
 
 function virtualCssIds(source: string): string[] {
@@ -233,5 +291,13 @@ function rule(tokenPath: readonly string[], className: string, utilities: readon
     utilities,
     variantGroups: {},
     variants: {},
+  };
+}
+
+function createManifest(items: readonly StyleManifestRule[]): StyleManifest {
+  return {
+    modules: new Map([[modulePath, new Map(items.map((item) => [item.tokenPath.join('.'), item]))]]),
+    rules: items,
+    watchFiles: [],
   };
 }

--- a/packages/vjsc/src/plugins/vjsc.ts
+++ b/packages/vjsc/src/plugins/vjsc.ts
@@ -35,14 +35,16 @@ export interface VjscPluginOptions {
  * Create the ordered compiler passes for query-selected component modules. Use this as the default VJSC integration for
  * Rolldown-compatible builds.
  *
- * @param options - Resolves targets and styles once for each module identity.
- * @example Promote suspicious structural selectors to build errors.
- * ```ts
- * vjscPlugin({
+ * @example
+ *   Promote suspicious structural selectors to build errors.
+ *   ```ts
+ *   vjscPlugin({
  *   diagnostics: { complexSelectors: 'error' },
  *   configure,
- * });
- * ```
+ *   });
+ *   ```
+ *
+ * @param options - Resolves targets and styles once for each module identity.
  */
 export function vjscPlugin(options: VjscPluginOptions): Plugin[] {
   return createVjscPluginPipeline(options);

--- a/packages/vjsc/src/plugins/vjsc.ts
+++ b/packages/vjsc/src/plugins/vjsc.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from 'rolldown';
+
 import type { VjscDiagnosticsOptions } from '../styles/diagnostics';
 import type { StylePluginOptions } from '../styles/options';
 import type { ComponentTarget } from '../target/definition';

--- a/packages/vjsc/src/plugins/vjsc.ts
+++ b/packages/vjsc/src/plugins/vjsc.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from 'rolldown';
-
+import type { VjscDiagnosticsOptions } from '../styles/diagnostics';
 import type { StylePluginOptions } from '../styles/options';
 import type { ComponentTarget } from '../target/definition';
 import type { ParsedModuleId } from '../utils/module-id';
@@ -25,6 +25,8 @@ export interface VjscModuleConfig {
 }
 
 export interface VjscPluginOptions {
+  /** Controls compiler warnings. Unsafe isolated-transform relationships always throw. */
+  readonly diagnostics?: VjscDiagnosticsOptions | undefined;
   configure(module: VjscModule): VjscModuleConfig | null;
 }
 
@@ -33,6 +35,13 @@ export interface VjscPluginOptions {
  * Rolldown-compatible builds.
  *
  * @param options - Resolves targets and styles once for each module identity.
+ * @example Promote suspicious structural selectors to build errors.
+ * ```ts
+ * vjscPlugin({
+ *   diagnostics: { complexSelectors: 'error' },
+ *   configure,
+ * });
+ * ```
  */
 export function vjscPlugin(options: VjscPluginOptions): Plugin[] {
   return createVjscPluginPipeline(options);
@@ -63,7 +72,7 @@ export function createVjscPluginPipeline(options: VjscPluginOptions): Plugin[] {
     htmlRuntimePlugin(),
     componentMetaPlugin(),
     targetJsxPlugin({ targets }),
-    stylePlugin((module) => configure(module)?.styles ?? null),
+    stylePlugin((module) => configure(module)?.styles ?? null, options.diagnostics),
     targetTransformPlugin({ targets }),
     targetTypePlugin({ targets }),
     primitiveTargetPlugin({ targets }),

--- a/packages/vjsc/src/styles/compile.ts
+++ b/packages/vjsc/src/styles/compile.ts
@@ -61,8 +61,14 @@ function compileRule(rule: StyleManifestRule, design: DesignSystem, variants: re
   for (const utility of utilitiesForRule(rule, variants)) {
     if (isGroupMarker(utility)) continue;
 
-    if (design.recognizesCandidate(utility)) candidates.push(utility);
-    else unsupported.push(utility);
+    const css = design.candidateCss(utility);
+
+    if (!css) {
+      unsupported.push(utility);
+      continue;
+    }
+
+    candidates.push(utility);
   }
 
   if (unsupported.length > 0) {

--- a/packages/vjsc/src/styles/design-system.ts
+++ b/packages/vjsc/src/styles/design-system.ts
@@ -9,6 +9,8 @@ export interface DesignSystem {
   readonly watchFiles: ReadonlySet<string>;
   /** Return whether Tailwind recognizes a candidate. */
   recognizesCandidate(candidate: string): boolean;
+  /** Return Tailwind's compiled CSS for one candidate. */
+  candidateCss(candidate: string): string | undefined;
   /** Compile semantic CSS containing Tailwind directives such as `@apply`. */
   compileCss(css: string): Promise<string>;
 }
@@ -20,9 +22,17 @@ export async function loadDesignSystem(cssPath: string): Promise<DesignSystem> {
   const raw = readFileSync(absolute, 'utf8');
   const reference = `@reference "${normalizePath(absolute)}";`;
   const design = await __unstable__loadDesignSystem(raw, { base });
-
-  const candidateCache = new Map<string, boolean>();
+  const candidateCache = new Map<string, string | undefined>();
   const watchFiles = new Set([absolute]);
+  const candidateCss = (candidate: string): string | undefined => {
+    if (candidateCache.has(candidate)) return candidateCache.get(candidate);
+
+    const css = design.candidatesToCss([candidate])[0];
+    const compiled = typeof css === 'string' && css.trim().length > 0 ? css : undefined;
+
+    candidateCache.set(candidate, compiled);
+    return compiled;
+  };
 
   const compileReferencedCss = async (css: string): Promise<string> => {
     const compiler = await compile(`${reference}\n${css}`, {
@@ -38,15 +48,9 @@ export async function loadDesignSystem(cssPath: string): Promise<DesignSystem> {
   return {
     watchFiles,
     recognizesCandidate(candidate: string): boolean {
-      const cached = candidateCache.get(candidate);
-      if (cached !== undefined) return cached;
-
-      const css = design.candidatesToCss([candidate])[0];
-      const recognized = typeof css === 'string' && css.trim().length > 0;
-
-      candidateCache.set(candidate, recognized);
-      return recognized;
+      return candidateCss(candidate) !== undefined;
     },
+    candidateCss,
     compileCss: compileReferencedCss,
   };
 }

--- a/packages/vjsc/src/styles/diagnostics.ts
+++ b/packages/vjsc/src/styles/diagnostics.ts
@@ -41,18 +41,22 @@ export function diagnoseStyleManifest(
     const unownedGroups = utilities.filter((utility) =>
       candidateVariants(utility).some((variant) => {
         const owner = groupOwnerForVariant(variant);
+
         return owner !== undefined && !owners.has(owner);
       })
     );
     const complex = utilities.filter(usesComplexSelector);
 
     if (peers.length > 0) diagnostics.push(createDiagnostic('VJSC_STYLE_PEER_RELATIONSHIP', rule, peers));
+
     if (implicitAncestors.length > 0) {
       diagnostics.push(createDiagnostic('VJSC_STYLE_IMPLICIT_ANCESTOR', rule, implicitAncestors));
     }
+
     if (unownedGroups.length > 0) {
       diagnostics.push(createDiagnostic('VJSC_STYLE_UNOWNED_GROUP', rule, unownedGroups));
     }
+
     if (complex.length > 0) diagnostics.push(createDiagnostic('VJSC_STYLE_COMPLEX_SELECTOR', rule, complex));
   }
 
@@ -83,6 +87,7 @@ export function diagnoseCompiledCandidate(
             }
 
             if (!selector.some((component) => component.type === 'nesting')) scopeEscape = true;
+
             if (selectorIsComplex(selector, groupOwners)) complex = true;
           }
         },
@@ -91,8 +96,11 @@ export function diagnoseCompiledCandidate(
   });
 
   const diagnostics: StyleDiagnostic[] = [];
+
   if (!hasRoot || scopeEscape) diagnostics.push(createDiagnostic('VJSC_STYLE_SCOPE_ESCAPE', rule, [candidate]));
+
   if (complex) diagnostics.push(createDiagnostic('VJSC_STYLE_COMPLEX_SELECTOR', rule, [candidate]));
+
   return diagnostics;
 }
 
@@ -111,7 +119,9 @@ export function diagnoseCompiledStyles(
 
     for (const candidate of utilitiesForRule(rule, variants)) {
       if (isGroupMarker(candidate)) continue;
+
       const css = design.candidateCss(candidate);
+
       if (css) diagnostics.push(...diagnoseCompiledCandidate(rule, candidate, css, groupOwners));
     }
   }
@@ -164,6 +174,7 @@ function collectGroupOwners(rules: readonly StyleManifestRule[], variants: reado
 
 function usesPeerRelationship(candidate: string): boolean {
   const { utility, variants } = splitCandidate(candidate);
+
   return isPeerPart(utility) || variants.some(isPeerPart);
 }
 
@@ -180,10 +191,13 @@ function usesImplicitAncestor(candidate: string): boolean {
 function usesComplexSelector(candidate: string): boolean {
   return candidateVariants(candidate).some((variant) => {
     if (variant === '*' || variant === '**') return true;
+
     if (variant.startsWith('has-') || variant.startsWith('group-has-')) return true;
+
     if (!variant.startsWith('[') || !variant.endsWith(']')) return false;
 
     const selector = variant.slice(1, -1);
+
     return selector.includes('&') && (selector.includes('_') || selector.includes(':has(') || hasCombinator(selector));
   });
 }
@@ -198,10 +212,12 @@ function hasCombinator(selector: string): boolean {
       escaped = false;
       continue;
     }
+
     if (character === '\\') {
       escaped = true;
       continue;
     }
+
     if (character === '[') squareDepth++;
     else if (character === ']') squareDepth--;
     else if (character === '(') parenthesisDepth++;
@@ -222,6 +238,7 @@ function groupOwnerForVariant(variant: string): string | undefined {
   if (!variant.startsWith('group-') && !variant.startsWith('group[')) return;
 
   const slash = lastTopLevelSlash(variant);
+
   return slash < 0 ? 'group' : `group/${variant.slice(slash + 1)}`;
 }
 
@@ -238,10 +255,12 @@ function lastTopLevelSlash(value: string): number {
       escaped = false;
       continue;
     }
+
     if (character === '\\') {
       escaped = true;
       continue;
     }
+
     if (character === '[') squareDepth++;
     else if (character === ']') squareDepth--;
     else if (character === '(') parenthesisDepth++;
@@ -270,10 +289,12 @@ function splitCandidate(candidate: string): { readonly variants: readonly string
       escaped = false;
       continue;
     }
+
     if (character === '\\') {
       escaped = true;
       continue;
     }
+
     if (character === '[') squareDepth++;
     else if (character === ']') squareDepth--;
     else if (character === '(') parenthesisDepth++;
@@ -298,19 +319,26 @@ function selectorIsComplex(selector: Selector, groupOwners: ReadonlySet<string>)
 
 function componentIsComplex(component: SelectorComponent, groupOwners: ReadonlySet<string>): boolean {
   if (component.type === 'combinator') return true;
+
   if (component.type !== 'pseudo-class') return false;
+
   if (component.kind === 'has') return true;
 
   const selectors = nestedSelectors(component);
+
   if (selectors.length === 0) return false;
+
   if (selectors.some((selector) => selectorContainsGroupOwner(selector, groupOwners))) return false;
+
   return selectors.some((selector) => selectorIsComplex(selector, groupOwners));
 }
 
 function selectorContainsGroupOwner(selector: Selector, groupOwners: ReadonlySet<string>): boolean {
   return selector.some((component) => {
     if (component.type === 'class' && groupOwners.has(component.name)) return true;
+
     if (component.type !== 'pseudo-class') return false;
+
     return nestedSelectors(component).some((nested) => selectorContainsGroupOwner(nested, groupOwners));
   });
 }

--- a/packages/vjsc/src/styles/diagnostics.ts
+++ b/packages/vjsc/src/styles/diagnostics.ts
@@ -325,7 +325,6 @@ function componentIsComplex(component: SelectorComponent, groupOwners: ReadonlyS
   if (component.kind === 'has') return true;
 
   const selectors = nestedSelectors(component);
-
   if (selectors.length === 0) return false;
 
   if (selectors.some((selector) => selectorContainsGroupOwner(selector, groupOwners))) return false;

--- a/packages/vjsc/src/styles/diagnostics.ts
+++ b/packages/vjsc/src/styles/diagnostics.ts
@@ -1,0 +1,334 @@
+import { type Selector, type SelectorComponent, transform } from 'lightningcss';
+
+import type { DesignSystem } from './design-system';
+import { isGroupMarker, type StyleManifest, type StyleManifestRule, utilitiesForRule } from './manifest';
+
+const encoder = new TextEncoder();
+
+export type ComplexSelectorDiagnosticLevel = 'warn' | 'error' | 'off';
+
+export interface VjscDiagnosticsOptions {
+  /** How suspicious structural selectors are reported. Hard isolation errors always throw. @default 'warn' */
+  readonly complexSelectors?: ComplexSelectorDiagnosticLevel | undefined;
+}
+
+export type StyleDiagnosticCode =
+  | 'VJSC_STYLE_PEER_RELATIONSHIP'
+  | 'VJSC_STYLE_IMPLICIT_ANCESTOR'
+  | 'VJSC_STYLE_UNOWNED_GROUP'
+  | 'VJSC_STYLE_SCOPE_ESCAPE'
+  | 'VJSC_STYLE_COMPLEX_SELECTOR';
+
+export interface StyleDiagnostic {
+  readonly code: StyleDiagnosticCode;
+  readonly kind: 'error' | 'complex-selector';
+  readonly rule: StyleManifestRule;
+  readonly utilities: readonly string[];
+}
+
+/** Diagnose relationships and structural selectors using only the imported local manifest. */
+export function diagnoseStyleManifest(
+  manifest: StyleManifest,
+  variants: readonly string[] = []
+): readonly StyleDiagnostic[] {
+  const owners = collectGroupOwners(manifest.rules, variants);
+  const diagnostics: StyleDiagnostic[] = [];
+
+  for (const rule of manifest.rules) {
+    const utilities = utilitiesForRule(rule, variants);
+    const peers = utilities.filter(usesPeerRelationship);
+    const implicitAncestors = utilities.filter(usesImplicitAncestor);
+    const unownedGroups = utilities.filter((utility) =>
+      candidateVariants(utility).some((variant) => {
+        const owner = groupOwnerForVariant(variant);
+        return owner !== undefined && !owners.has(owner);
+      })
+    );
+    const complex = utilities.filter(usesComplexSelector);
+
+    if (peers.length > 0) diagnostics.push(createDiagnostic('VJSC_STYLE_PEER_RELATIONSHIP', rule, peers));
+    if (implicitAncestors.length > 0) {
+      diagnostics.push(createDiagnostic('VJSC_STYLE_IMPLICIT_ANCESTOR', rule, implicitAncestors));
+    }
+    if (unownedGroups.length > 0) {
+      diagnostics.push(createDiagnostic('VJSC_STYLE_UNOWNED_GROUP', rule, unownedGroups));
+    }
+    if (complex.length > 0) diagnostics.push(createDiagnostic('VJSC_STYLE_COMPLEX_SELECTOR', rule, complex));
+  }
+
+  return diagnostics;
+}
+
+/** Inspect Tailwind-expanded CSS so custom utilities cannot conceal structural selectors. */
+export function diagnoseCompiledCandidate(
+  rule: StyleManifestRule,
+  candidate: string,
+  css: string,
+  groupOwners: ReadonlySet<string>
+): readonly StyleDiagnostic[] {
+  let hasRoot = false;
+  let scopeEscape = false;
+  let complex = false;
+
+  transform({
+    filename: 'candidate.css',
+    code: encoder.encode(css),
+    visitor: {
+      Rule: {
+        style(styleRule) {
+          for (const selector of styleRule.value.selectors) {
+            if (isCandidateRoot(selector, candidate)) {
+              hasRoot = true;
+              continue;
+            }
+
+            if (!selector.some((component) => component.type === 'nesting')) scopeEscape = true;
+            if (selectorIsComplex(selector, groupOwners)) complex = true;
+          }
+        },
+      },
+    },
+  });
+
+  const diagnostics: StyleDiagnostic[] = [];
+  if (!hasRoot || scopeEscape) diagnostics.push(createDiagnostic('VJSC_STYLE_SCOPE_ESCAPE', rule, [candidate]));
+  if (complex) diagnostics.push(createDiagnostic('VJSC_STYLE_COMPLEX_SELECTOR', rule, [candidate]));
+  return diagnostics;
+}
+
+/** Diagnose Tailwind-expanded candidates for the semantic rules referenced by one source module. */
+export function diagnoseCompiledStyles(
+  manifest: StyleManifest,
+  design: DesignSystem,
+  ruleClassNames: ReadonlySet<string>,
+  variants: readonly string[] = []
+): readonly StyleDiagnostic[] {
+  const groupOwners = collectGroupOwners(manifest.rules, variants);
+  const diagnostics: StyleDiagnostic[] = [];
+
+  for (const rule of manifest.rules) {
+    if (!ruleClassNames.has(rule.className)) continue;
+
+    for (const candidate of utilitiesForRule(rule, variants)) {
+      if (isGroupMarker(candidate)) continue;
+      const css = design.candidateCss(candidate);
+      if (css) diagnostics.push(...diagnoseCompiledCandidate(rule, candidate, css, groupOwners));
+    }
+  }
+
+  return diagnostics;
+}
+
+export function formatStyleDiagnostic(diagnostic: StyleDiagnostic): string {
+  const context = `Style rule \`${diagnostic.rule.tokenPath.join('.')}\` in \`${diagnostic.rule.modulePath}\``;
+  const utilities = diagnostic.utilities.map((utility) => `\`${utility}\``).join(', ');
+
+  switch (diagnostic.code) {
+    case 'VJSC_STYLE_PEER_RELATIONSHIP':
+      return `[${diagnostic.code}] ${context} uses peer relationship utilities: ${utilities}.\nReason: Peer relationships depend on sibling ownership that an isolated module cannot discover safely.\nRecommendation: Expose an explicit component part or backdrop, or put the relevant state on the styled component.`;
+    case 'VJSC_STYLE_IMPLICIT_ANCESTOR':
+      return `[${diagnostic.code}] ${context} uses implicit ancestor utilities: ${utilities}.\nReason: The ancestor owner is undeclared and cannot be validated by an isolated transform.\nRecommendation: Use a locally owned named group, a component state attribute, or a CSS custom property.`;
+    case 'VJSC_STYLE_UNOWNED_GROUP':
+      return `[${diagnostic.code}] ${context} uses group utilities without a local owner: ${utilities}.\nReason: Resolving the relationship would require knowledge from an unrelated module.\nRecommendation: Define the named group owner beside the consumer or expose the relationship through component anatomy or state.`;
+    case 'VJSC_STYLE_SCOPE_ESCAPE':
+      return `[${diagnostic.code}] ${context} emits selectors outside its semantic scope from: ${utilities}.\nReason: The compiled output is no longer owned by the component rule being transformed.\nRecommendation: Move the style to the target part or add a deliberate component-level hook.`;
+    case 'VJSC_STYLE_COMPLEX_SELECTOR':
+      return `[${diagnostic.code}] ${context} uses structural selector utilities: ${utilities}.\nReason: Descendant, sibling, ancestor, or :has() selectors couple the rule to markup outside its own styling hook.\nRecommendation: Prefer an explicit component part, a state attribute on the styled component, or a locally owned named group.`;
+  }
+}
+
+function createDiagnostic(
+  code: StyleDiagnosticCode,
+  rule: StyleManifestRule,
+  utilities: readonly string[]
+): StyleDiagnostic {
+  return {
+    code,
+    kind: code === 'VJSC_STYLE_COMPLEX_SELECTOR' ? 'complex-selector' : 'error',
+    rule,
+    utilities: [...new Set(utilities)],
+  };
+}
+
+function collectGroupOwners(rules: readonly StyleManifestRule[], variants: readonly string[]): ReadonlySet<string> {
+  const owners = new Set<string>();
+
+  for (const rule of rules) {
+    for (const utility of utilitiesForRule(rule, variants)) {
+      if (isGroupMarker(utility)) owners.add(utility);
+    }
+  }
+
+  return owners;
+}
+
+function usesPeerRelationship(candidate: string): boolean {
+  const { utility, variants } = splitCandidate(candidate);
+  return isPeerPart(utility) || variants.some(isPeerPart);
+}
+
+function isPeerPart(value: string): boolean {
+  return value === 'peer' || value.startsWith('peer/') || value.startsWith('peer-') || value.startsWith('peer[');
+}
+
+function usesImplicitAncestor(candidate: string): boolean {
+  return candidateVariants(candidate).some(
+    (variant) => variant === 'in' || variant.startsWith('in-') || variant.startsWith('in[')
+  );
+}
+
+function usesComplexSelector(candidate: string): boolean {
+  return candidateVariants(candidate).some((variant) => {
+    if (variant === '*' || variant === '**') return true;
+    if (variant.startsWith('has-') || variant.startsWith('group-has-')) return true;
+    if (!variant.startsWith('[') || !variant.endsWith(']')) return false;
+
+    const selector = variant.slice(1, -1);
+    return selector.includes('&') && (selector.includes('_') || selector.includes(':has(') || hasCombinator(selector));
+  });
+}
+
+function hasCombinator(selector: string): boolean {
+  let squareDepth = 0;
+  let parenthesisDepth = 0;
+  let escaped = false;
+
+  for (const character of selector) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character === '[') squareDepth++;
+    else if (character === ']') squareDepth--;
+    else if (character === '(') parenthesisDepth++;
+    else if (character === ')') parenthesisDepth--;
+    else if (
+      squareDepth === 0 &&
+      parenthesisDepth === 0 &&
+      (character === '>' || character === '+' || character === '~')
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function groupOwnerForVariant(variant: string): string | undefined {
+  if (!variant.startsWith('group-') && !variant.startsWith('group[')) return;
+
+  const slash = lastTopLevelSlash(variant);
+  return slash < 0 ? 'group' : `group/${variant.slice(slash + 1)}`;
+}
+
+function lastTopLevelSlash(value: string): number {
+  let squareDepth = 0;
+  let parenthesisDepth = 0;
+  let escaped = false;
+  let slash = -1;
+
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index]!;
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character === '[') squareDepth++;
+    else if (character === ']') squareDepth--;
+    else if (character === '(') parenthesisDepth++;
+    else if (character === ')') parenthesisDepth--;
+    else if (character === '/' && squareDepth === 0 && parenthesisDepth === 0) slash = index;
+  }
+
+  return slash;
+}
+
+function candidateVariants(candidate: string): readonly string[] {
+  return splitCandidate(candidate).variants;
+}
+
+function splitCandidate(candidate: string): { readonly variants: readonly string[]; readonly utility: string } {
+  const parts: string[] = [];
+  let start = 0;
+  let squareDepth = 0;
+  let parenthesisDepth = 0;
+  let escaped = false;
+
+  for (let index = 0; index < candidate.length; index++) {
+    const character = candidate[index]!;
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character === '[') squareDepth++;
+    else if (character === ']') squareDepth--;
+    else if (character === '(') parenthesisDepth++;
+    else if (character === ')') parenthesisDepth--;
+    else if (character === ':' && squareDepth === 0 && parenthesisDepth === 0) {
+      parts.push(candidate.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  parts.push(candidate.slice(start));
+  return { variants: parts.slice(0, -1), utility: parts.at(-1) ?? '' };
+}
+
+function isCandidateRoot(selector: Selector, candidate: string): boolean {
+  return selector.length === 1 && selector[0]?.type === 'class' && selector[0].name === candidate;
+}
+
+function selectorIsComplex(selector: Selector, groupOwners: ReadonlySet<string>): boolean {
+  return selector.some((component) => componentIsComplex(component, groupOwners));
+}
+
+function componentIsComplex(component: SelectorComponent, groupOwners: ReadonlySet<string>): boolean {
+  if (component.type === 'combinator') return true;
+  if (component.type !== 'pseudo-class') return false;
+  if (component.kind === 'has') return true;
+
+  const selectors = nestedSelectors(component);
+  if (selectors.length === 0) return false;
+  if (selectors.some((selector) => selectorContainsGroupOwner(selector, groupOwners))) return false;
+  return selectors.some((selector) => selectorIsComplex(selector, groupOwners));
+}
+
+function selectorContainsGroupOwner(selector: Selector, groupOwners: ReadonlySet<string>): boolean {
+  return selector.some((component) => {
+    if (component.type === 'class' && groupOwners.has(component.name)) return true;
+    if (component.type !== 'pseudo-class') return false;
+    return nestedSelectors(component).some((nested) => selectorContainsGroupOwner(nested, groupOwners));
+  });
+}
+
+function nestedSelectors(component: Extract<SelectorComponent, { type: 'pseudo-class' }>): readonly Selector[] {
+  switch (component.kind) {
+    case 'not':
+    case 'where':
+    case 'is':
+    case 'any':
+    case 'has':
+      return component.selectors;
+    case 'nth-child':
+    case 'nth-last-child':
+      return component.of ?? [];
+    case 'host':
+      return component.selectors ? [component.selectors] : [];
+    default:
+      return [];
+  }
+}

--- a/packages/vjsc/src/styles/tests/diagnostics.test.ts
+++ b/packages/vjsc/src/styles/tests/diagnostics.test.ts
@@ -1,0 +1,137 @@
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { loadDesignSystem } from '../design-system';
+import { diagnoseCompiledCandidate, diagnoseStyleManifest, formatStyleDiagnostic } from '../diagnostics';
+import type { StyleManifest, StyleManifestRule } from '../manifest';
+
+const designPath = resolve(import.meta.dirname, 'fixtures/diagnostics.css');
+
+describe('style diagnostics', () => {
+  it('rejects peers, implicit ancestors, and unowned groups with actionable messages', () => {
+    const diagnostics = diagnoseStyleManifest(
+      manifest([
+        rule('peer', ['peer/dialog', 'peer-data-open/dialog:hidden']),
+        rule('ancestor', ['in-data-open:hidden']),
+        rule('group', ['group-data-open/menu:block']),
+      ])
+    );
+
+    expect(diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'VJSC_STYLE_PEER_RELATIONSHIP',
+      'VJSC_STYLE_IMPLICIT_ANCESTOR',
+      'VJSC_STYLE_UNOWNED_GROUP',
+    ]);
+    expect(formatStyleDiagnostic(diagnostics[0]!)).toBe(
+      '[VJSC_STYLE_PEER_RELATIONSHIP] Style rule `peer` in `test.styles.ts` uses peer relationship utilities: `peer/dialog`, `peer-data-open/dialog:hidden`.\n' +
+        'Reason: Peer relationships depend on sibling ownership that an isolated module cannot discover safely.\n' +
+        'Recommendation: Expose an explicit component part or backdrop, or put the relevant state on the styled component.'
+    );
+  });
+
+  it('allows named groups whose owners and consumers are local', () => {
+    const diagnostics = diagnoseStyleManifest(
+      manifest([rule('owner', ['group/menu']), rule('consumer', ['group-data-open/menu:block'])])
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('ignores delimiters inside arbitrary group variant values', () => {
+    const diagnostics = diagnoseStyleManifest(
+      manifest([
+        rule('unnamed-owner', ['group']),
+        rule('unnamed-consumer', ['group-data-[url=https://example.com/video]:block']),
+        rule('named-owner', ['group/menu']),
+        rule('named-consumer', ['group-data-[url=https://example.com/video]/menu:block']),
+      ])
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('warns for structural selectors but not self state selectors', () => {
+    const diagnostics = diagnoseStyleManifest(
+      manifest([
+        rule('safe', ['data-open:block', '[&:fullscreen]:block', 'before:block']),
+        rule('complex', [
+          'has-[img]:hidden',
+          '[&_img]:block',
+          '[&>*]:flex-1',
+          '[&:fullscreen_video]:block',
+          '[.external_&]:block',
+          '[&+*]:block',
+          '*:block',
+          '**:hidden',
+        ]),
+      ])
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      code: 'VJSC_STYLE_COMPLEX_SELECTOR',
+      kind: 'complex-selector',
+      utilities: [
+        'has-[img]:hidden',
+        '[&_img]:block',
+        '[&>*]:flex-1',
+        '[&:fullscreen_video]:block',
+        '[.external_&]:block',
+        '[&+*]:block',
+        '*:block',
+        '**:hidden',
+      ],
+    });
+    expect(formatStyleDiagnostic(diagnostics[0]!)).toContain('\nReason: ');
+    expect(formatStyleDiagnostic(diagnostics[0]!)).toContain('\nRecommendation: ');
+  });
+
+  it('warns for :has() even when its named group owner is local', () => {
+    const diagnostics = diagnoseStyleManifest(
+      manifest([rule('owner', ['group/thumbnail']), rule('spinner', ['group-has-[img]/thumbnail:block'])])
+    );
+
+    expect(diagnostics).toMatchObject([{ code: 'VJSC_STYLE_COMPLEX_SELECTOR', kind: 'complex-selector' }]);
+  });
+
+  it('detects structural selectors concealed by a custom Tailwind utility', async () => {
+    const design = await loadDesignSystem(designPath);
+    const styleRule = rule('custom', ['child-target']);
+    const css = design.candidateCss('child-target');
+
+    expect(css).toBeDefined();
+    expect(diagnoseCompiledCandidate(styleRule, 'child-target', css!, new Set())).toMatchObject([
+      { code: 'VJSC_STYLE_COMPLEX_SELECTOR', utilities: ['child-target'] },
+    ]);
+  });
+
+  it('rejects compiled selectors that escape the candidate scope', () => {
+    const diagnostics = diagnoseCompiledCandidate(
+      rule('escape', ['escape']),
+      'escape',
+      '.escape { display: block; } .external { display: none; }',
+      new Set()
+    );
+
+    expect(diagnostics).toMatchObject([{ code: 'VJSC_STYLE_SCOPE_ESCAPE', kind: 'error' }]);
+  });
+});
+
+function rule(token: string, utilities: readonly string[]): StyleManifestRule {
+  return {
+    modulePath: 'test.styles.ts',
+    tokenPath: token.split('.'),
+    className: `media-${token}`,
+    file: 'test.css',
+    layer: 'videojs.components',
+    scopeRoot: false,
+    utilityGroups: utilities,
+    utilities,
+    variantGroups: {},
+    variants: {},
+  };
+}
+
+function manifest(rules: readonly StyleManifestRule[]): StyleManifest {
+  return { modules: new Map(), rules, watchFiles: [] };
+}

--- a/packages/vjsc/src/styles/tests/diagnostics.test.ts
+++ b/packages/vjsc/src/styles/tests/diagnostics.test.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
+
 import { loadDesignSystem } from '../design-system';
 import { diagnoseCompiledCandidate, diagnoseStyleManifest, formatStyleDiagnostic } from '../diagnostics';
 import type { StyleManifest, StyleManifestRule } from '../manifest';

--- a/packages/vjsc/src/styles/tests/fixtures/diagnostics.css
+++ b/packages/vjsc/src/styles/tests/fixtures/diagnostics.css
@@ -1,0 +1,7 @@
+@import "tailwindcss" theme(inline);
+
+@utility child-target {
+  & > * {
+    display: block;
+  }
+}

--- a/packages/vjsc/src/vite/index.ts
+++ b/packages/vjsc/src/vite/index.ts
@@ -2,6 +2,7 @@ import { createVjscPluginPipeline, type VjscPluginOptions } from '../plugins/vjs
 import { type ViteOxcPlugin, viteOxcPlugin } from './oxc';
 
 export type { VjscModule, VjscModuleConfig, VjscPluginOptions } from '../plugins/vjsc';
+export type { ComplexSelectorDiagnosticLevel, VjscDiagnosticsOptions } from '../styles/diagnostics';
 
 /** Create the Vite-adapted VJSC compiler pipeline. */
 export function vjscPlugin(options: VjscPluginOptions): ViteOxcPlugin[] {


### PR DESCRIPTION
Refs #2260

## Summary

Add explicit VJSC style-isolation errors and configurable complex-selector diagnostics so per-module transforms fail clearly when authored styles require unavailable structure.

## Changes

- Error on peer relationships, implicit ancestor variants, unowned named groups, and compiled selector scope escapes
- Add `warn`, `error`, and `off` levels for complex selectors while keeping hard isolation errors unsilenceable
- Inspect authored utilities in every mode and Tailwind-expanded candidates in CSS mode, including selectors concealed inside custom utilities
- Report stable, deduplicated diagnostics with the module, rule path, offending utilities, `Reason:`, and `Recommendation:`
- Preserve valid locally owned named groups while surfacing deferred structural style smells

## Configuration

```ts
vjscPlugin({
  diagnostics: {
    complexSelectors: 'warn', // 'warn' | 'error' | 'off'
  },
  configure,
});
```

## Stack

6 of 9. Base: #2344. Next: #2376.

Full stack: #2343 → #2347 → #2348 → #2355 → #2344 → #2345 → #2376 → #2378 → #2381.

## Testing

- `pnpm -F vjsc test`
- `pnpm -F vjsc build`
- `pnpm -F @videojs/skins test`
- `pnpm -F @videojs/skins build:shadcn`
- Vite serve/build/HMR integration, including logger delivery
- `pnpm typecheck`
- `pnpm check:workspace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large player UI and styling refactor with broad e2e coverage; user-visible skin behavior can shift, though documented gaps are explicitly scoped in tests and `gaps.md`.
> 
> **Overview**
> Adds a **VJSC skin parity gate** and reshapes how generated skins are authored and verified against legacy `packages/skins/src`.
> 
> **Playwright** gains a dedicated `vjsc-chromium` project and `vjsc-skin-styling.spec.ts`, which runs against the skins dev app on port 5190. Tests compare legacy vs VJSC layout contracts, CSS vs Tailwind output, and screenshots across default/minimal skins in React and HTML (controls, menus, buffering, errors, accessibility prefs, and more). Known minimal volume spacing is relaxed in assertions with a pointer to `packages/skins/vjsc/gaps.md`.
> 
> **VJSC styling** moves from monolithic `styles/components/*` modules into per-area files (`buttons/`, `popups/`, `menus/`, `sliders/`, `feedback/`, `surfaces/`, etc.). Default and minimal video skins extract **`controls.tsx` / `controls.styles.ts`**, drop the separate overlay wrapper, and wire controls through shared surface/popup primitives. CSS mode now uses `tailwind.compiler.css`; captions and base reset rules are tightened.
> 
> **Tooling & docs**: the skins dev preview supports `?source=legacy|vjsc`, captions, and HMR-safe React roots; icon Vite serving and AirPlay HTML name mapping are fixed; vitest disables file parallelism for skins integration tests. A new **`maintain-vjsc-skin-gaps`** agent skill and **`gaps.md`** document RTL control order and minimal volume tooltip gaps; SPF skill blurbs and `AGENTS.md` are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8220a4f652b6e5fa4a8b9063a305a202542af65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->