### PR TITLE
docs(site): update menu reference composition

### DIFF
--- a/site/src/content/docs/reference/menu.mdx
+++ b/site/src/content/docs/reference/menu.mdx
@@ -24,27 +24,24 @@ import basicUsageHtmlTs from "@/components/docs/demos/menu/html/css/BasicUsage.t
 
 ## Anatomy
 
-A submenu is a menu inside another menu. The submenu trigger lives in the parent list, and the submenu content is the next view.
+A submenu is a menu nested inside another menu's content. Its trigger participates in the parent menu, while its content becomes the submenu panel.
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx
   <Menu.Root>
     <Menu.Trigger />
     <Menu.Content>
-      <Menu.View>
+      <div>
         {/* Parent menu item that opens a submenu */}
         <Menu.Root>
-          {/* Submenu trigger */}
-          <Menu.Trigger>
-            <Menu.ItemValue />
-          </Menu.Trigger>
+          <Menu.Trigger>Quality</Menu.Trigger>
 
           {/* Submenu content */}
           <Menu.Content>
-            <Menu.Back />
-            <Menu.RadioGroup>
+            <Menu.Item>Back</Menu.Item>
+            <Menu.RadioGroup value={quality} onValueChange={setQuality}>
               <Menu.GroupLabel />
-              <Menu.RadioItem>
+              <Menu.RadioItem value="auto">
                 <Menu.ItemIndicator />
               </Menu.RadioItem>
             </Menu.RadioGroup>
@@ -60,7 +57,7 @@ A submenu is a menu inside another menu. The submenu trigger lives in the parent
         </Menu.Group>
         <Menu.Separator />
         <Menu.Item />
-      </Menu.View>
+      </div>
     </Menu.Content>
   </Menu.Root>
   ```
@@ -71,11 +68,9 @@ A submenu is a menu inside another menu. The submenu trigger lives in the parent
   <button type="button" commandfor="settings-menu">Settings</button>
 
   <media-menu id="settings-menu">
-    <media-menu-view>
+    <div>
       <!-- Parent menu item that opens a submenu -->
-      <media-menu-item commandfor="submenu">
-        <media-menu-item-value></media-menu-item-value>
-      </media-menu-item>
+      <media-menu-item commandfor="quality-menu">Quality</media-menu-item>
 
       <!-- Other parent menu items -->
       <media-menu-group>
@@ -86,14 +81,14 @@ A submenu is a menu inside another menu. The submenu trigger lives in the parent
       </media-menu-group>
       <media-menu-separator></media-menu-separator>
       <media-menu-item></media-menu-item>
-    </media-menu-view>
+    </div>
 
     <!-- Submenu content -->
-    <media-menu id="submenu">
-      <media-menu-back></media-menu-back>
-      <media-menu-radio-group>
+    <media-menu id="quality-menu">
+      <media-menu-item>Back</media-menu-item>
+      <media-menu-radio-group value="auto">
         <media-menu-group-label></media-menu-group-label>
-        <media-menu-radio-item>
+        <media-menu-radio-item value="auto">
           <media-menu-item-indicator></media-menu-item-indicator>
         </media-menu-radio-item>
       </media-menu-radio-group>
@@ -106,17 +101,19 @@ A submenu is a menu inside another menu. The submenu trigger lives in the parent
 
 Menus open from a trigger and close when you select an item, click outside, move focus away, or press <kbd>Escape</kbd>. Root menus use `side` and `align` as their preferred placement. When the preferred side overflows the positioning boundary, the menu uses the opposite side if it has more space.
 
-Create a submenu by putting another menu inside the root menu's content. Its trigger stays in the root list, and its content becomes the next view. In HTML, give the submenu a matching `id` and point the trigger at it with `commandfor`. Wrap the root list in `Menu.View` or `<media-menu-view>` when the root list and submenus share one animated viewport.
+Create a submenu by nesting another menu inside the parent menu's content. In React, the nested `Menu.Trigger` automatically acts as an item in the parent menu. In HTML, give the nested `<media-menu>` an `id` and point a `<media-menu-item>` at it with `commandfor`. Use an ordinary `Menu.Item` or `<media-menu-item>` for a back item; selecting an item in a submenu closes that submenu and returns to its parent.
 
-Set `type="playback-rate"`, `type="quality"`, `type="audio-track"`, or `type="captions"` on a submenu trigger when it represents a media setting. `Menu.ItemValue` and `<media-menu-item-value>` read that setting context and display the current value, such as `1.5x`, `Auto`, `English`, or `Off`. See <DocsLink slug="reference/playback-rate-radio-group">PlaybackRateRadioGroup</DocsLink>, <DocsLink slug="reference/quality-radio-group">QualityRadioGroup</DocsLink>, <DocsLink slug="reference/audio-track-radio-group">AudioTrackRadioGroup</DocsLink>, and <DocsLink slug="reference/captions-radio-group">CaptionsRadioGroup</DocsLink> for the generated option groups.
+When a submenu represents a media setting, render the current value from the corresponding option state. In React, the option hooks expose `selectedLabel` for the trigger. In HTML, add an element with `data-part="hint"` to the trigger; the setting-specific radio group fills it with the selected item's label. See <DocsLink slug="reference/playback-rate-radio-group">PlaybackRateRadioGroup</DocsLink>, <DocsLink slug="reference/quality-radio-group">QualityRadioGroup</DocsLink>, <DocsLink slug="reference/audio-track-radio-group">AudioTrackRadioGroup</DocsLink>, and <DocsLink slug="reference/captions-radio-group">CaptionsRadioGroup</DocsLink> for the generated option groups.
 
 ## Styling
 
-Use data attributes to style open state, highlighted items, selected radio items, and submenu views:
+Use data attributes to style open state, highlighted items, selected radio items, and submenu panels:
 
 `data-highlighted` is added to the current menu item. The highlighted item is the item that keyboard selection will act on. It changes when the menu opens, when the pointer moves over another item, when the user presses arrow keys, or when type-ahead search finds a match.
 
 On root menu content, `data-side` reflects the rendered side and can differ from the preferred `side` prop after collision handling. Submenus do not have `data-side`.
+
+`data-submenu` identifies submenu panels. Root content receives `data-submenu-expanded` while a submenu is active. Use `data-starting-style` and `data-ending-style` on submenu panels to style their open and close transitions.
 
 <FrameworkCase frameworks={["react"]}>
   ```css


### PR DESCRIPTION
Refs #2155

## Summary

Update the Menu reference to match the simplified menu composition introduced by #2029. The page no longer documents removed parts or the removed setting `type` prop.

## Changes

- Replace removed View, Back, and ItemValue parts in the React and HTML anatomy examples
- Document nested menus and ordinary items as the current submenu and back-navigation composition
- Explain current selected-label rendering through React option state and HTML hint parts
- Document the current submenu lifecycle data attributes

## Testing

- `pnpm -F site api-docs`
- `pnpm -F site astro check` (0 errors)
- `pnpm exec prettier --check site/src/content/docs/reference/menu.mdx`
- `pnpm dev:site` (React and HTML routes returned the updated reference markup; interactive inspection is blocked by the existing sizing loop tracked in #2337)
