### PR TITLE
fix(core): prevent menu measurement cycles

### DIFF
--- a/packages/core/src/dom/ui/menu/menu-popup.ts
+++ b/packages/core/src/dom/ui/menu/menu-popup.ts
@@ -118,6 +118,7 @@ export function createMenuPopup(): MenuPopupApi {
           styles: {
             insetInlineStart: '0px',
             insetInlineEnd: 'auto',
+            insetBlockEnd: 'auto',
             width: width === undefined ? 'max-content' : `${width}px`,
             height: 'auto',
             minWidth: '0px',

--- a/packages/core/src/dom/ui/menu/tests/menu-popup.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/menu-popup.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { MenuCSSVars } from '../../../../core/ui/menu/vars';
+import { createMenuPopup } from '../menu-popup';
+import { createTestMenu } from './create-menu-helpers';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('createMenuPopup', () => {
+  it('keeps repeated measurements stable when a panel is pinned to both block edges', () => {
+    const popup = createMenuPopup();
+    const { menu } = createTestMenu();
+    const element = document.createElement('div');
+    const content = document.createElement('div');
+    const panel = document.createElement('div');
+    const naturalHeight = 180;
+
+    element.style.paddingBlockStart = '6px';
+    element.style.paddingBlockEnd = '6px';
+    panel.style.position = 'absolute';
+    panel.style.inset = '0px';
+    content.append(panel);
+    element.append(content);
+    document.body.append(element);
+
+    // A panel authored with `inset: 0` stretches to the Popup height written by the previous
+    // measurement unless its block-end inset is released while measuring.
+    const getMeasuredHeight = () => {
+      if (panel.style.insetBlockEnd === 'auto') return naturalHeight;
+
+      const popupHeight = Number.parseFloat(element.style.getPropertyValue(MenuCSSVars.height)) || 0;
+
+      return Math.max(naturalHeight, popupHeight);
+    };
+
+    Object.defineProperty(panel, 'scrollWidth', { configurable: true, value: 180 });
+    Object.defineProperty(panel, 'scrollHeight', { configurable: true, get: getMeasuredHeight });
+    // SAFETY: `getElementSize` reads only `width` and `height` from the rect.
+    vi.spyOn(panel, 'getBoundingClientRect').mockImplementation(
+      () => ({ width: 180, height: getMeasuredHeight() }) as DOMRect
+    );
+
+    popup.setElement(element);
+    const cleanup = popup.registerContent({ menu, parent: null, element: content });
+
+    popup.sync();
+    expect(element.style.getPropertyValue(MenuCSSVars.height)).toBe('192px');
+
+    popup.sync();
+    expect(element.style.getPropertyValue(MenuCSSVars.height)).toBe('192px');
+    expect(panel.style.inset).toBe('0px');
+    expect(panel.style.insetBlockEnd).toBe('');
+
+    cleanup();
+    popup.destroy();
+    menu.destroy();
+  });
+});


### PR DESCRIPTION
Refs #2372

Refs #2337

## Summary

Measure menu panels independently of a height previously written to the menu Popup. This prevents ResizeObserver feedback when authored CSS pins a panel to both block edges, such as `inset: 0`.

This PR was re-ported onto current `main`: the original change edited `menu-size.ts`, which b303dc79c deleted. Measurement now lives in `measureContent()` in `packages/core/src/dom/ui/menu/menu-popup.ts`, so the fix and its regression test were re-created there.

## Changes

- Temporarily set the measured panel's block-end inset to `auto` alongside the existing inline-inset, width, and height measurement overrides in `measureContent()`; `measureElement` snapshots and restores the authored inline values after each measurement
- Add `packages/core/src/dom/ui/menu/tests/menu-popup.test.ts`, a style-responsive regression test that measures twice with a panel pinned via `inset: 0` plus Popup block padding, asserting the second measurement equals the first and that the authored inline inset is restored

## Testing

- `pnpm -F @videojs/core test src/dom/ui/menu` (2 files, 81 passed)
- `pnpm -F @videojs/html test src/ui/menu` (2 files, 16 passed; includes the existing `--media-menu-height` assertions)
- `pnpm exec vp run @videojs/core#build`
- `pnpm lint:fix:file` on both touched files (no warnings)
- `pnpm typecheck` after `pnpm build:packages` (clean)
- Negative check without the override: the second measurement grows from `192px` to `204px`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to menu popup measurement overrides plus a DOM test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes unstable menu popup sizing when a child panel is absolutely positioned with **`inset: 0`**, which could stretch to the popup height from the prior sync and inflate the next measurement (ResizeObserver feedback).
> 
> During **`measureContent()`** child measurement, **`insetBlockEnd: 'auto'`** is now applied with the existing inline inset overrides so block-end pinning is released only for the measure pass; **`measureElement`** still restores authored styles afterward.
> 
> Adds a regression test in **`menu-popup.test.ts`** that runs **`sync()`** twice with a pinned panel and block padding, asserting height stays **`192px`** and authored **`inset`** is unchanged after measure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 754de7056b1acdebdb190394b175a07fe3f56d6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
