### PR TITLE
fix(sandbox): use fixed ports for sandbox and skins dev

### DIFF
--- a/apps/sandbox/vite.config.ts
+++ b/apps/sandbox/vite.config.ts
@@ -161,6 +161,10 @@ export default defineConfig({
     include: ['react', 'react-dom'],
     exclude: ['@videojs/core', '@videojs/html', '@videojs/react', '@videojs/spf', '@videojs/store', '@videojs/utils'],
   },
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
   build: {
     outDir: resolve(__dirname, 'dist'),
     emptyOutDir: true,

--- a/cspell.json
+++ b/cspell.json
@@ -19,7 +19,8 @@
     "shiki",
     "squircle",
     "videojs",
-    "vidstack"
+    "vidstack",
+    "vjsc"
   ],
   "ignoreWords": [],
   "import": []

--- a/packages/skins/vite.config.ts
+++ b/packages/skins/vite.config.ts
@@ -40,6 +40,10 @@ function createPreviewConfig() {
       include: ['react', 'react-dom'],
       exclude: ['vjsc', 'vjsc/styles', '@videojs/core', '@videojs/icons', '@videojs/react', '@videojs/utils'],
     },
+    server: {
+      port: 5174,
+      strictPort: true,
+    },
     build: {
       sourcemap: true,
       rolldownOptions: {


### PR DESCRIPTION
There's a race condition where the skins package vite server nicks port 5173 before the sandbox runs. I've got tabs open all over the place using 5173 for the sandbox and others may too so I'm fixing the ports. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-server port config only; no production, auth, or data-path changes.
> 
> **Overview**
> Pins local Vite dev servers so sandbox and skins no longer race for the default port.
> 
> Sandbox always uses **5173** and skins **5174**, both with `strictPort` so they fail instead of hopping to the next free port. Also adds `vjsc` to the spellcheck dictionary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c9ab44c37e451b2c98788f5975c1d7b1a2c40f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->