### PR TITLE
fix(i18n): preserve registered translation overrides

### DIFF
--- a/packages/html/src/i18n/provider-mixin.ts
+++ b/packages/html/src/i18n/provider-mixin.ts
@@ -169,8 +169,8 @@ export function createI18nProviderMixin({ context, loader = defaultLoader }: I18
         }
         const registryLayer = getI18nTranslations(locale);
         const translations: FlatTranslations = {
-          ...registryLayer,
           ...this.#lazyLayer,
+          ...registryLayer,
         };
         const translator = createTranslator(translations, locale);
         this.#i18nValue = { translator, locale };

--- a/packages/html/src/i18n/tests/create-i18n.test.ts
+++ b/packages/html/src/i18n/tests/create-i18n.test.ts
@@ -382,6 +382,40 @@ describe('createI18n (HTML)', () => {
     });
   });
 
+  it('keeps regional registry overrides above lazy parent packs and refreshes them after mount', async () => {
+    registerI18n('de-DE', { 'buttons.play': 'CustomPlay' });
+    const { ProviderMixin, TextMixin } = createI18n({
+      loader: async (tag) =>
+        tag === 'de' ? { 'buttons.play': 'BuiltinPlay', 'buttons.pause': 'BuiltinPause' } : undefined,
+    });
+    class RegionalProvider extends ProviderMixin(ReactiveElement) {}
+    class RegionalText extends TextMixin(ReactiveElement) {}
+    customElements.define('i18n-regional-provider', RegionalProvider);
+    customElements.define('i18n-regional-text', RegionalText);
+
+    const provider = new RegionalProvider();
+    provider.lang = 'de-DE';
+    const play = new RegionalText();
+    play.setAttribute('token', 'buttons.play');
+    play.textContent = 'Play';
+    const pause = new RegionalText();
+    pause.setAttribute('token', 'buttons.pause');
+    pause.textContent = 'Pause';
+    provider.append(play, pause);
+    document.body.appendChild(provider);
+
+    await vi.waitFor(() => {
+      expect(play.textContent).toBe('CustomPlay');
+      expect(pause.textContent).toBe('BuiltinPause');
+    });
+
+    registerI18n('de-DE', { 'buttons.pause': 'CustomPause' });
+
+    await vi.waitFor(() => {
+      expect(pause.textContent).toBe('CustomPause');
+    });
+  });
+
   it('keeps media-text fallback English without a provider when the registry changes', async () => {
     const text = new MediaTextElement();
     text.textContent = 'Play';

--- a/packages/react/src/i18n/tests/create-i18n.test.tsx
+++ b/packages/react/src/i18n/tests/create-i18n.test.tsx
@@ -383,8 +383,39 @@ describe('createI18n', () => {
     });
   });
 
+  it('keeps regional registry overrides above lazy parent packs and refreshes them after mount', async () => {
+    registerI18n('de-DE', { Play: 'CustomPlay' });
+    const { I18nProvider, useTranslator } = createI18n({
+      loader: async (tag) => (tag === 'de' ? { Play: 'BuiltinPlay', Pause: 'BuiltinPause' } : undefined),
+    });
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return (
+        <span>
+          {t('Play')}:{t('Pause')}
+        </span>
+      );
+    }
+
+    render(
+      <I18nProvider locale="de-DE">
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('CustomPlay:BuiltinPause')).not.toBeNull();
+    });
+
+    registerI18n('de-DE', { Pause: 'CustomPause' });
+
+    await waitFor(() => {
+      expect(screen.queryByText('CustomPlay:CustomPause')).not.toBeNull();
+    });
+  });
+
   it('drops lazy builtin overlay from the prior locale while the next locale is loading', async () => {
-    registerI18n('en', { Play: 'EnReg' });
     registerI18n('fr', { Play: 'FrReg' });
 
     let unblockFr!: () => void;
@@ -434,7 +465,7 @@ describe('createI18n', () => {
     unblockFr();
 
     await waitFor(() => {
-      expect(screen.queryByText('FrLazy')).not.toBeNull();
+      expect(screen.queryByText('FrReg')).not.toBeNull();
     });
   });
 

--- a/packages/react/src/i18n/use-merged-translations.ts
+++ b/packages/react/src/i18n/use-merged-translations.ts
@@ -20,8 +20,8 @@ export function useMergedTranslations(
     void registryEpoch;
     const registryLayer = getI18nTranslations(resolvedLocale);
     return {
-      ...registryLayer,
       ...lazyLayer,
+      ...registryLayer,
       ...flattenTranslations(translationsProp ?? {}),
     } as FlatTranslations;
   }, [resolvedLocale, lazyLayer, translationsProp, registryEpoch]);


### PR DESCRIPTION
## Summary

Ensure translations registered by applications remain authoritative over lazy-loaded built-in locale packs. This keeps regional overrides such as `de-DE` effective and lets mounted providers reflect registry updates consistently.

## Changes

- Merge lazy built-in translations below registered locale layers in HTML and React
- Preserve provider-level React translations as the highest-priority layer
- Cover regional overrides inherited over a parent language pack
- Cover registry updates applied after providers mount

## Testing

- `pnpm -F @videojs/html test src/i18n/tests/create-i18n.test.ts`
- `pnpm -F @videojs/react test src/i18n/tests/create-i18n.test.tsx`
- `pnpm exec biome check packages/html/src/i18n/provider-mixin.ts packages/html/src/i18n/tests/create-i18n.test.ts packages/react/src/i18n/use-merged-translations.ts packages/react/src/i18n/tests/create-i18n.test.tsx`
- `git diff --check`
- `pnpm typecheck` *(blocked by existing SPF `MediaPlaylistMetadata` errors in `packages/spf`; no i18n type errors)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small merge-order fix in i18n layering only; no auth, data, or API surface changes. Behavior change is limited to which translation source wins on key collisions.
> 
> **Overview**
> Registered app translations now win over lazy-loaded built-in locale packs in both HTML and React i18n providers. Regional overrides such as `de-DE` stay effective when a parent pack like `de` loads later, and registry updates after mount still apply.
> 
> React still applies the provider `translations` prop last. Tests cover regional override precedence and a locale-switch case that now expects the registered string rather than the lazy overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0523b97a32be3876a3c0a4b43246fd8dd2693585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->