### PR TITLE
docs(site): refine Vue and Svelte integration examples

### DIFF
--- a/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
+++ b/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
@@ -30,7 +30,20 @@ If your component needs to react to player state or call a player action, wait u
 <p>{paused ? 'Paused' : 'Playing'}</p>
 ```
 
-Return the store's unsubscribe function from `onMount` so Svelte cleans up the subscription. Use the store for player state and actions. You can still listen for native media events on the `<video>`, `<audio>`, or media custom element when you need the event itself.
+Return the store's unsubscribe function from `onMount` so Svelte cleans up the subscription. Use the store for player state and actions.
+
+When you need the native event itself, attach a listener to the `<video>`, `<audio>`, or media custom element:
+
+```svelte
+<script lang="ts">
+  function handleLoadedMetadata(event: Event) {
+    const media = event.currentTarget as HTMLVideoElement;
+    console.log(`Duration: ${media.duration} seconds`);
+  }
+</script>
+
+<video onloadedmetadata={handleLoadedMetadata}><!-- sources and tracks --></video>
+```
 
 ## Keep runtime styles global
 
@@ -52,34 +65,28 @@ If a style depends on a Video.js `data-*` state, Svelte may remove its selector 
 
 ## Pass objects as properties
 
-If you need to pass structured data, such as a Mux source, an HTML attribute will not work because attributes contain text. Bind the element to a variable and assign the object to its JavaScript property from a Svelte effect:
+If you need to pass structured data, such as a Mux source, an HTML attribute will not work because attributes contain text. Pass the object directly, and Svelte assigns it to the custom element's JavaScript property:
 
 ```svelte
 <script lang="ts">
   import '@videojs/html/video/player';
   import '@videojs/html/video/skin';
   import '@videojs/html/media/mux-video';
-  import type { MuxVideoElement } from '@videojs/html/media/mux-video';
-
-  const source = {
-    playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
-    playback: { maxResolution: '1080p' },
-  } as const;
-  let muxVideo: MuxVideoElement | undefined;
-
-  $effect(() => {
-    if (muxVideo) muxVideo.source = source;
-  });
 </script>
 
 <video-player>
   <video-skin>
-    <mux-video bind:this={muxVideo}></mux-video>
+    <mux-video
+      source={{
+        playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
+        playback: { maxResolution: '1080p' },
+      }}
+    ></mux-video>
   </video-skin>
 </video-player>
 ```
 
-The effect runs in the browser, so Svelte does not turn the object into a text attribute during server rendering. Video.js also preserves properties assigned before the custom element finishes loading.
+Keep the static element import with the component so `<mux-video>` is registered before Svelte assigns the property.
 
 ## Use SvelteKit
 

--- a/site/src/content/docs/how-to/use-videojs-with-vue.mdx
+++ b/site/src/content/docs/how-to/use-videojs-with-vue.mdx
@@ -55,21 +55,20 @@ If your Vue component needs to react to player state or call a player action, wa
 ```vue
 <script setup lang="ts">
 import type { VideoPlayerElement } from '@videojs/html/video/player';
-import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { onMounted, onUnmounted, ref } from 'vue';
 
 const player = ref<VideoPlayerElement | null>(null);
 const paused = ref(true);
 let unsubscribe = () => {};
 
-onMounted(async () => {
-  await customElements.whenDefined('video-player');
+onMounted(() => {
   const store = player.value!.store;
   const sync = () => (paused.value = store.paused);
   sync();
   unsubscribe = store.subscribe(sync);
 });
 
-onBeforeUnmount(() => unsubscribe());
+onUnmounted(() => unsubscribe());
 </script>
 
 <template>
@@ -78,7 +77,22 @@ onBeforeUnmount(() => unsubscribe());
 </template>
 ```
 
-Use the store for player state and actions. You can still listen for native media events on the `<video>`, `<audio>`, or media custom element when you need the event itself.
+Use the store for player state and actions. Unsubscribe in `onUnmounted`.
+
+When you need the native event itself, attach a listener to the `<video>`, `<audio>`, or media custom element:
+
+```vue
+<script setup lang="ts">
+function handleLoadedMetadata(event: Event) {
+  const media = event.currentTarget as HTMLVideoElement;
+  console.log(`Duration: ${media.duration} seconds`);
+}
+</script>
+
+<template>
+  <video @loadedmetadata="handleLoadedMetadata"><!-- sources and tracks --></video>
+</template>
+```
 
 ## Style Vue components
 


### PR DESCRIPTION
Follow-up to #2333 based on Rahim's review feedback.

## Summary

- add compact native media event examples while keeping the player store as the primary integration path
- simplify the Svelte structured-property example to bind the object directly
- clean up the Vue store subscription with `onUnmounted`

## Validation

- compiled the revised examples in standalone Svelte and Vue validation apps
- `pnpm --filter @videojs/html run build`
- `pnpm --filter site run test` (611 tests)
- `env -u SENTRY_AUTH_TOKEN pnpm --filter site run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes to integration examples; no runtime, auth, or data-handling code is modified.
> 
> **Overview**
> Documentation-only updates to the **Svelte** and **Vue** how-to guides, aligned with review feedback on #2333.
> 
> The **player store** stays the recommended path; both pages now spell out **native media events** in separate snippets (`onloadedmetadata` / `@loadedmetadata`) instead of folding that into one sentence.
> 
> **Svelte:** the Mux `source` example drops `$effect`, `bind:this`, and the `MuxVideoElement` type in favor of passing the object inline on `<mux-video>`, with guidance to keep static element imports so the custom element is registered before property assignment.
> 
> **Vue:** the store subscription example uses **`onUnmounted`** for cleanup (replacing `onBeforeUnmount`), removes the **`customElements.whenDefined`** wait in `onMounted`, and calls out unsubscribing explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 601fa67231daacbbb5243271aaf93c70f76517c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->