### PR TITLE
feat(packages): add volume popover compound

### DIFF
--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -90,6 +90,8 @@ export * from './ui/volume-indicator/core';
 export * from './ui/volume-indicator/data';
 export * from './ui/volume-indicator/vars';
 export * from './ui/volume-indicator/volume-indicator-status';
+export * from './ui/volume-popover/core';
+export * from './ui/volume-popover/data';
 export * from './ui/volume-slider/core';
 export * from './ui/volume-slider/data';
 export * from './ui/volume-slider/vars';

--- a/packages/core/src/core/ui/tests/jsx-runtime.test-d.tsx
+++ b/packages/core/src/core/ui/tests/jsx-runtime.test-d.tsx
@@ -12,6 +12,7 @@ import {
   Time,
   TimeSlider,
   Tooltip,
+  VolumePopover,
   VolumeSlider,
 } from '@videojs/core/vjsc';
 import { describe, it } from 'vite-plus/test';
@@ -71,6 +72,17 @@ describe('constrained JSX', () => {
           </VolumeSlider.Root>
         </Popover.Popup>
       </Popover.Root>
+    );
+
+    void (
+      <VolumePopover.Root openOnHover>
+        <VolumePopover.Trigger>
+          <MuteButton />
+        </VolumePopover.Trigger>
+        <VolumePopover.Popup>
+          <VolumeSlider.Root orientation="vertical" />
+        </VolumePopover.Popup>
+      </VolumePopover.Root>
     );
 
     void (

--- a/packages/core/src/core/ui/volume-popover/core.ts
+++ b/packages/core/src/core/ui/volume-popover/core.ts
@@ -1,0 +1,38 @@
+import type { MediaFeatureAvailability, MediaVolumeState } from '@videojs/media';
+
+import { PopoverCore, type PopoverProps, type PopoverState } from '../popover/popover-core';
+
+export interface VolumePopoverProps extends PopoverProps {}
+
+export interface VolumePopoverState extends PopoverState {
+  /** Whether volume level controls are available. */
+  availability: MediaFeatureAvailability;
+  /** Whether the popup is hidden because volume level controls are unavailable. */
+  hidden: boolean;
+}
+
+/** A volume-aware popover that preserves its mute trigger when volume level controls are unavailable. */
+export class VolumePopoverCore extends PopoverCore {
+  static override readonly defaultProps = PopoverCore.defaultProps;
+
+  #media: MediaVolumeState | null = null;
+
+  setMedia(media: MediaVolumeState): void {
+    this.#media = media;
+  }
+
+  override getState(): VolumePopoverState {
+    const availability = this.#media!.volumeAvailability;
+
+    return {
+      ...super.getState(),
+      availability,
+      hidden: availability !== 'available',
+    };
+  }
+}
+
+export namespace VolumePopoverCore {
+  export type Props = VolumePopoverProps;
+  export type State = VolumePopoverState;
+}

--- a/packages/core/src/core/ui/volume-popover/core.ts
+++ b/packages/core/src/core/ui/volume-popover/core.ts
@@ -1,6 +1,6 @@
 import type { MediaFeatureAvailability, MediaVolumeState } from '@videojs/media';
 
-import { PopoverCore, type PopoverProps, type PopoverState } from '../popover/popover-core';
+import { PopoverCore, type PopoverProps, type PopoverState } from '../popover/core';
 
 export interface VolumePopoverProps extends PopoverProps {}
 

--- a/packages/core/src/core/ui/volume-popover/data.ts
+++ b/packages/core/src/core/ui/volume-popover/data.ts
@@ -1,0 +1,19 @@
+import type { StateAttrMap } from '../types';
+import type { VolumePopoverState } from './core';
+
+export const VolumePopoverDataAttrs = {
+  /** Present when the popover is open. */
+  open: 'data-open',
+  /** Indicates the rendered side after collision handling. */
+  side: 'data-side',
+  /** Indicates how the popup is aligned relative to its side. */
+  align: 'data-align',
+  /** Present during the open transition. */
+  transitionStarting: 'data-starting-style',
+  /** Present during the close transition. */
+  transitionEnding: 'data-ending-style',
+  /** Indicates volume control availability (`available`, `unavailable`, or `unsupported`). */
+  availability: 'data-availability',
+  /** Present when volume level controls are unavailable. */
+  hidden: 'data-hidden',
+} as const satisfies StateAttrMap<VolumePopoverState>;

--- a/packages/core/src/core/ui/volume-popover/tests/core.test.ts
+++ b/packages/core/src/core/ui/volume-popover/tests/core.test.ts
@@ -1,0 +1,23 @@
+import type { MediaVolumeState } from '@videojs/media';
+import { describe, expect, it } from 'vite-plus/test';
+
+import { VolumePopoverCore } from '../core';
+
+function createMediaState(volumeAvailability: MediaVolumeState['volumeAvailability']): MediaVolumeState {
+  return { volumeAvailability } as MediaVolumeState;
+}
+
+describe('VolumePopoverCore', () => {
+  it.each([
+    ['available', false],
+    ['unavailable', true],
+    ['unsupported', true],
+  ] as const)('maps %s volume controls to hidden=%s', (availability, hidden) => {
+    const core = new VolumePopoverCore();
+
+    core.setInput({ active: false, status: 'idle' });
+    core.setMedia(createMediaState(availability));
+
+    expect(core.getState()).toMatchObject({ availability, hidden });
+  });
+});

--- a/packages/core/src/core/ui/volume-popover/volume-popover-component.ts
+++ b/packages/core/src/core/ui/volume-popover/volume-popover-component.ts
@@ -1,0 +1,15 @@
+import { defineComponent } from 'vjsc/components';
+
+import type { VolumePopoverProps } from './core';
+import { VolumePopoverDataAttrs } from './data';
+
+export default defineComponent({
+  name: 'VolumePopover',
+  root: 'Root',
+  parts: {
+    Root: defineComponent<VolumePopoverProps>(),
+    Trigger: defineComponent(),
+    Popup: defineComponent(),
+  },
+  dataAttrs: VolumePopoverDataAttrs,
+});

--- a/packages/html/src/define/ui/volume-popover.ts
+++ b/packages/html/src/define/ui/volume-popover.ts
@@ -1,0 +1,10 @@
+import { VolumePopoverElement } from '../../ui/volume-popover/volume-popover-element';
+import { safeDefine } from '../safe-define';
+
+safeDefine(VolumePopoverElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [VolumePopoverElement.tagName]: VolumePopoverElement;
+  }
+}

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -158,4 +158,5 @@ export * from './ui/ui-element';
 export { VolumeIndicatorElement } from './ui/volume-indicator/volume-indicator-element';
 export { VolumeIndicatorFillElement } from './ui/volume-indicator/volume-indicator-fill-element';
 export { VolumeIndicatorValueElement } from './ui/volume-indicator/volume-indicator-value-element';
+export { VolumePopoverElement } from './ui/volume-popover/volume-popover-element';
 export { VolumeSliderElement } from './ui/volume-slider/volume-slider-element';

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -18,6 +18,7 @@ import { containerContext } from '../../player/context';
 import { popupGroupContext } from '../../player/popup-group-context';
 import { PositionController } from '../position-controller';
 import { UIElement } from '../ui-element';
+
 export class PopoverElement extends UIElement {
   static readonly tagName = 'media-popover';
 
@@ -122,6 +123,10 @@ export class PopoverElement extends UIElement {
 
   close(reason: PopoverOpenChangeReason = 'imperative-action'): void {
     this.#popover?.close(reason);
+  }
+
+  protected get triggerElement(): HTMLElement | null {
+    return this.#currentTrigger;
   }
 
   protected override willUpdate(changed: PropertyValues): void {

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -20,7 +20,7 @@ import { PositionController } from '../position-controller';
 import { UIElement } from '../ui-element';
 
 export class PopoverElement extends UIElement {
-  static readonly tagName = 'media-popover';
+  static readonly tagName: string = 'media-popover';
 
   static override properties = {
     open: { type: Boolean },

--- a/packages/html/src/ui/volume-popover/tests/volume-popover-element.test.ts
+++ b/packages/html/src/ui/volume-popover/tests/volume-popover-element.test.ts
@@ -2,9 +2,10 @@ import type { AnyPlayerStore } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaVolumeState } from '@videojs/media';
 import { createStore } from '@videojs/store';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
 import { playerContext } from '../../../player/context';
-import { MediaElement } from '../../media-element';
+import { UIElement } from '../../ui-element';
 import { VolumePopoverElement } from '../volume-popover-element';
 
 let tagCounter = 0;
@@ -23,7 +24,7 @@ function createVolumeStore(volumeAvailability: MediaVolumeState['volumeAvailabil
   }) as unknown as AnyPlayerStore;
 }
 
-class TestPlayerProviderElement extends MediaElement {
+class TestPlayerProviderElement extends UIElement {
   store: AnyPlayerStore = createVolumeStore('available');
   readonly #provider = new ContextProvider(this, { context: playerContext });
 

--- a/packages/html/src/ui/volume-popover/tests/volume-popover-element.test.ts
+++ b/packages/html/src/ui/volume-popover/tests/volume-popover-element.test.ts
@@ -40,6 +40,7 @@ if (!customElements.get('test-volume-popover-player')) {
 
 function createPopover(): VolumePopoverElement {
   const tag = `test-volume-popover-${tagCounter++}`;
+
   customElements.define(tag, class extends VolumePopoverElement {});
   return document.createElement(tag) as VolumePopoverElement;
 }
@@ -59,6 +60,7 @@ describe('VolumePopoverElement', () => {
     ['unsupported', true],
   ] as const)('reflects %s volume controls with hidden=%s', async (volumeAvailability, hidden) => {
     const provider = document.createElement('test-volume-popover-player') as TestPlayerProviderElement;
+
     provider.store = createVolumeStore(volumeAvailability);
     const trigger = document.createElement('button');
     const popover = createPopover();

--- a/packages/html/src/ui/volume-popover/tests/volume-popover-element.test.ts
+++ b/packages/html/src/ui/volume-popover/tests/volume-popover-element.test.ts
@@ -1,0 +1,77 @@
+import type { AnyPlayerStore } from '@videojs/core/dom';
+import { ContextProvider } from '@videojs/element/context';
+import type { MediaVolumeState } from '@videojs/media';
+import { createStore } from '@videojs/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { playerContext } from '../../../player/context';
+import { MediaElement } from '../../media-element';
+import { VolumePopoverElement } from '../volume-popover-element';
+
+let tagCounter = 0;
+
+function createVolumeStore(volumeAvailability: MediaVolumeState['volumeAvailability']): AnyPlayerStore {
+  return createStore<unknown>()<MediaVolumeState>({
+    name: 'volume',
+    state: () => ({
+      volume: 1,
+      muted: false,
+      volumeAvailability,
+      mutedAvailability: 'available',
+      setVolume: vi.fn(),
+      toggleMuted: vi.fn(),
+    }),
+  }) as unknown as AnyPlayerStore;
+}
+
+class TestPlayerProviderElement extends MediaElement {
+  store: AnyPlayerStore = createVolumeStore('available');
+  readonly #provider = new ContextProvider(this, { context: playerContext });
+
+  override connectedCallback(): void {
+    this.#provider.setValue(this.store);
+    super.connectedCallback();
+  }
+}
+
+if (!customElements.get('test-volume-popover-player')) {
+  customElements.define('test-volume-popover-player', TestPlayerProviderElement);
+}
+
+function createPopover(): VolumePopoverElement {
+  const tag = `test-volume-popover-${tagCounter++}`;
+  customElements.define(tag, class extends VolumePopoverElement {});
+  return document.createElement(tag) as VolumePopoverElement;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('VolumePopoverElement', () => {
+  it('has the correct tag name', () => {
+    expect(VolumePopoverElement.tagName).toBe('media-volume-popover');
+  });
+
+  it.each([
+    ['available', false],
+    ['unavailable', true],
+    ['unsupported', true],
+  ] as const)('reflects %s volume controls with hidden=%s', async (volumeAvailability, hidden) => {
+    const provider = document.createElement('test-volume-popover-player') as TestPlayerProviderElement;
+    provider.store = createVolumeStore(volumeAvailability);
+    const trigger = document.createElement('button');
+    const popover = createPopover();
+
+    document.body.append(provider);
+    provider.append(trigger, popover);
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(hidden);
+    expect(popover.hasAttribute('data-hidden')).toBe(hidden);
+    expect(popover.getAttribute('data-availability')).toBe(volumeAvailability);
+    expect(trigger.getAttribute('commandfor')).toBe(popover.id);
+    expect(trigger.hasAttribute('aria-expanded')).toBe(!hidden);
+    expect(trigger.hasAttribute('aria-haspopup')).toBe(!hidden);
+    expect(trigger.hasAttribute('aria-controls')).toBe(!hidden);
+  });
+});

--- a/packages/html/src/ui/volume-popover/volume-popover-element.ts
+++ b/packages/html/src/ui/volume-popover/volume-popover-element.ts
@@ -2,6 +2,7 @@ import { VolumePopoverCore, VolumePopoverDataAttrs } from '@videojs/core';
 import { applyElementProps, applyStateDataAttrs, selectVolume } from '@videojs/core/dom';
 import type { PropertyValues } from '@videojs/element';
 import type { MediaVolumeState } from '@videojs/media';
+
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { PopoverElement } from '../popover/popover-element';
@@ -37,10 +38,13 @@ export class VolumePopoverElement extends PopoverElement {
     this.#core.setMedia(this.#volume.value ?? unavailableVolume);
 
     const state = this.#core.getState();
+
     applyStateDataAttrs(this, state, VolumePopoverDataAttrs);
     this.hidden = state.hidden;
+
     if (state.hidden) {
       this.close();
+
       if (this.triggerElement) {
         applyElementProps(this.triggerElement, {
           'aria-expanded': undefined,

--- a/packages/html/src/ui/volume-popover/volume-popover-element.ts
+++ b/packages/html/src/ui/volume-popover/volume-popover-element.ts
@@ -1,0 +1,53 @@
+import { VolumePopoverCore, VolumePopoverDataAttrs } from '@videojs/core';
+import { applyElementProps, applyStateDataAttrs, selectVolume } from '@videojs/core/dom';
+import type { PropertyValues } from '@videojs/element';
+import type { MediaVolumeState } from '@videojs/media';
+import { playerContext } from '../../player/context';
+import { PlayerController } from '../../player/player-controller';
+import { PopoverElement } from '../popover/popover-element';
+
+const unavailableVolume: MediaVolumeState = {
+  volume: 0,
+  muted: false,
+  volumeAvailability: 'unsupported',
+  mutedAvailability: 'unsupported',
+  setVolume: () => 0,
+  toggleMuted: () => false,
+};
+
+/** A volume-aware popover that keeps its adjacent mute trigger available as a fallback. */
+export class VolumePopoverElement extends PopoverElement {
+  static override readonly tagName = 'media-volume-popover';
+
+  readonly #core = new VolumePopoverCore();
+  readonly #volume = new PlayerController(this, playerContext, selectVolume);
+
+  protected override update(changed: PropertyValues): void {
+    super.update(changed);
+
+    this.#core.setProps(this);
+    this.#core.setInput({
+      active: this.hasAttribute('data-open'),
+      status: this.hasAttribute('data-starting-style')
+        ? 'starting'
+        : this.hasAttribute('data-ending-style')
+          ? 'ending'
+          : 'idle',
+    });
+    this.#core.setMedia(this.#volume.value ?? unavailableVolume);
+
+    const state = this.#core.getState();
+    applyStateDataAttrs(this, state, VolumePopoverDataAttrs);
+    this.hidden = state.hidden;
+    if (state.hidden) {
+      this.close();
+      if (this.triggerElement) {
+        applyElementProps(this.triggerElement, {
+          'aria-expanded': undefined,
+          'aria-haspopup': undefined,
+          'aria-controls': undefined,
+        });
+      }
+    }
+  }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -181,6 +181,7 @@ export { VolumeIndicator } from './ui/volume-indicator';
 export type { VolumeIndicatorFillProps } from './ui/volume-indicator/volume-indicator-fill';
 export type { VolumeIndicatorRootProps } from './ui/volume-indicator/volume-indicator-root';
 export type { VolumeIndicatorValueProps } from './ui/volume-indicator/volume-indicator-value';
+export { VolumePopover } from './ui/volume-popover';
 export { VolumeSlider } from './ui/volume-slider';
 // Utilities
 export { mergeProps } from './utils/merge-props';

--- a/packages/react/src/ui/volume-popover/context.tsx
+++ b/packages/react/src/ui/volume-popover/context.tsx
@@ -11,7 +11,6 @@ export const VolumePopoverContextProvider = VolumePopoverContext.Provider;
 
 export function useVolumePopoverContext(): VolumePopoverContextValue {
   const context = useContext(VolumePopoverContext);
-
   if (!context) throw new Error('VolumePopover compound components must be used within a VolumePopover.Root');
 
   return context;

--- a/packages/react/src/ui/volume-popover/context.tsx
+++ b/packages/react/src/ui/volume-popover/context.tsx
@@ -11,6 +11,8 @@ export const VolumePopoverContextProvider = VolumePopoverContext.Provider;
 
 export function useVolumePopoverContext(): VolumePopoverContextValue {
   const context = useContext(VolumePopoverContext);
+
   if (!context) throw new Error('VolumePopover compound components must be used within a VolumePopover.Root');
+
   return context;
 }

--- a/packages/react/src/ui/volume-popover/context.tsx
+++ b/packages/react/src/ui/volume-popover/context.tsx
@@ -1,0 +1,16 @@
+import type { VolumePopoverCore } from '@videojs/core';
+import { createContext, useContext } from 'react';
+
+export interface VolumePopoverContextValue {
+  state: VolumePopoverCore.State;
+}
+
+const VolumePopoverContext = createContext<VolumePopoverContextValue | null>(null);
+
+export const VolumePopoverContextProvider = VolumePopoverContext.Provider;
+
+export function useVolumePopoverContext(): VolumePopoverContextValue {
+  const context = useContext(VolumePopoverContext);
+  if (!context) throw new Error('VolumePopover compound components must be used within a VolumePopover.Root');
+  return context;
+}

--- a/packages/react/src/ui/volume-popover/index.parts.ts
+++ b/packages/react/src/ui/volume-popover/index.parts.ts
@@ -1,0 +1,6 @@
+export { VolumePopoverPopup as Popup, type VolumePopoverPopupProps as PopupProps } from './volume-popover-popup';
+export { VolumePopoverRoot as Root, type VolumePopoverRootProps as RootProps } from './volume-popover-root';
+export {
+  VolumePopoverTrigger as Trigger,
+  type VolumePopoverTriggerProps as TriggerProps,
+} from './volume-popover-trigger';

--- a/packages/react/src/ui/volume-popover/index.ts
+++ b/packages/react/src/ui/volume-popover/index.ts
@@ -1,0 +1,1 @@
+export * as VolumePopover from './index.parts';

--- a/packages/react/src/ui/volume-popover/tests/volume-popover.test.tsx
+++ b/packages/react/src/ui/volume-popover/tests/volume-popover.test.tsx
@@ -1,0 +1,98 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+
+import { VolumePopover } from '..';
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { MuteButton } from '../../mute-button/mute-button';
+
+const availableVolume = {
+  volume: 1,
+  muted: false,
+  volumeAvailability: 'available',
+  mutedAvailability: 'available',
+  setVolume: () => 1,
+  toggleMuted: () => false,
+};
+
+afterEach(cleanup);
+
+describe('VolumePopover', () => {
+  it('opens its popup when volume level controls are available', async () => {
+    const { Wrapper } = createPlayerWrapper(availableVolume);
+
+    render(
+      <Wrapper>
+        <VolumePopover.Root>
+          <VolumePopover.Trigger
+            render={
+              <button type="button" data-testid="trigger">
+                Volume
+              </button>
+            }
+          />
+          <VolumePopover.Popup data-testid="popup">Slider</VolumePopover.Popup>
+        </VolumePopover.Root>
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('popup').getAttribute('data-availability')).toBe('available');
+      expect(screen.getByTestId('trigger').getAttribute('aria-expanded')).toBe('true');
+    });
+  });
+
+  it.each(['unavailable', 'unsupported'] as const)(
+    'keeps only its trigger when volume level controls are %s',
+    (volumeAvailability) => {
+      const { Wrapper } = createPlayerWrapper({ ...availableVolume, volumeAvailability });
+
+      render(
+        <Wrapper>
+          <VolumePopover.Root defaultOpen>
+            <VolumePopover.Trigger data-testid="trigger" render={<MuteButton>Mute</MuteButton>} />
+            <VolumePopover.Popup data-testid="popup">Slider</VolumePopover.Popup>
+          </VolumePopover.Root>
+        </Wrapper>
+      );
+
+      expect(screen.getByTestId('trigger').hasAttribute('aria-expanded')).toBe(false);
+      expect(screen.queryByTestId('popup')).toBeNull();
+    }
+  );
+
+  it('closes an open popup when volume level controls become unavailable', async () => {
+    const { Wrapper, store } = createPlayerWrapper(availableVolume);
+
+    render(
+      <Wrapper>
+        <VolumePopover.Root>
+          <VolumePopover.Trigger
+            render={
+              <button type="button" data-testid="trigger">
+                Volume
+              </button>
+            }
+          />
+          <VolumePopover.Popup data-testid="popup">Slider</VolumePopover.Popup>
+        </VolumePopover.Root>
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('trigger'));
+    await waitFor(() => expect(screen.queryByTestId('popup')).not.toBeNull());
+
+    act(() => {
+      store.state = { ...availableVolume, volumeAvailability: 'unsupported' };
+      const subscriptions = store.subscribe.mock.calls as unknown as Array<[() => void]>;
+
+      for (const [notify] of subscriptions) notify();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('popup')).toBeNull();
+      expect(screen.getByTestId('trigger').hasAttribute('aria-expanded')).toBe(false);
+    });
+  });
+});

--- a/packages/react/src/ui/volume-popover/volume-popover-popup.tsx
+++ b/packages/react/src/ui/volume-popover/volume-popover-popup.tsx
@@ -1,6 +1,7 @@
 import { VolumePopoverDataAttrs } from '@videojs/core';
 import { getStateDataAttrs } from '@videojs/core/dom';
 import { forwardRef } from 'react';
+
 import { PopoverPopup, type PopoverPopupProps } from '../popover/popover-popup';
 import { useVolumePopoverContext } from './context';
 
@@ -10,6 +11,7 @@ export interface VolumePopoverPopupProps extends PopoverPopupProps {}
 export const VolumePopoverPopup = forwardRef<HTMLDivElement, VolumePopoverPopupProps>(
   function VolumePopoverPopup(props, forwardedRef) {
     const { state } = useVolumePopoverContext();
+
     if (state.hidden) return null;
 
     return <PopoverPopup ref={forwardedRef} {...getStateDataAttrs(state, VolumePopoverDataAttrs)} {...props} />;

--- a/packages/react/src/ui/volume-popover/volume-popover-popup.tsx
+++ b/packages/react/src/ui/volume-popover/volume-popover-popup.tsx
@@ -1,0 +1,21 @@
+import { VolumePopoverDataAttrs } from '@videojs/core';
+import { getStateDataAttrs } from '@videojs/core/dom';
+import { forwardRef } from 'react';
+import { PopoverPopup, type PopoverPopupProps } from '../popover/popover-popup';
+import { useVolumePopoverContext } from './context';
+
+export interface VolumePopoverPopupProps extends PopoverPopupProps {}
+
+/** Positioned volume content. Omitted when volume level controls are unavailable. */
+export const VolumePopoverPopup = forwardRef<HTMLDivElement, VolumePopoverPopupProps>(
+  function VolumePopoverPopup(props, forwardedRef) {
+    const { state } = useVolumePopoverContext();
+    if (state.hidden) return null;
+
+    return <PopoverPopup ref={forwardedRef} {...getStateDataAttrs(state, VolumePopoverDataAttrs)} {...props} />;
+  }
+);
+
+export namespace VolumePopoverPopup {
+  export type Props = VolumePopoverPopupProps;
+}

--- a/packages/react/src/ui/volume-popover/volume-popover-popup.tsx
+++ b/packages/react/src/ui/volume-popover/volume-popover-popup.tsx
@@ -11,7 +11,6 @@ export interface VolumePopoverPopupProps extends PopoverPopupProps {}
 export const VolumePopoverPopup = forwardRef<HTMLDivElement, VolumePopoverPopupProps>(
   function VolumePopoverPopup(props, forwardedRef) {
     const { state } = useVolumePopoverContext();
-
     if (state.hidden) return null;
 
     return <PopoverPopup ref={forwardedRef} {...getStateDataAttrs(state, VolumePopoverDataAttrs)} {...props} />;

--- a/packages/react/src/ui/volume-popover/volume-popover-root.tsx
+++ b/packages/react/src/ui/volume-popover/volume-popover-root.tsx
@@ -1,0 +1,52 @@
+import { VolumePopoverCore } from '@videojs/core';
+import { selectVolume } from '@videojs/core/dom';
+import type { MediaVolumeState } from '@videojs/media';
+import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import { usePlayer } from '../../player/context';
+import { Popover } from '../popover';
+import { usePopoverContext } from '../popover/context';
+import type { PopoverRootProps } from '../popover/popover-root';
+import { VolumePopoverContextProvider } from './context';
+
+const unavailableVolume: MediaVolumeState = {
+  volume: 0,
+  muted: false,
+  volumeAvailability: 'unsupported',
+  mutedAvailability: 'unsupported',
+  setVolume: () => 0,
+  toggleMuted: () => false,
+};
+
+export interface VolumePopoverRootProps extends PopoverRootProps {}
+
+/** Owns volume availability and the popover interaction lifecycle. */
+export function VolumePopoverRoot({ children, ...props }: VolumePopoverRootProps): ReactNode {
+  const volume = usePlayer(selectVolume);
+  const [core] = useState(() => new VolumePopoverCore(props));
+  core.setProps(props);
+  core.setMedia(volume ?? unavailableVolume);
+
+  return (
+    <Popover.Root {...props}>
+      <VolumePopoverState core={core}>{children}</VolumePopoverState>
+    </Popover.Root>
+  );
+}
+
+function VolumePopoverState({ core, children }: { core: VolumePopoverCore; children?: ReactNode }): ReactNode {
+  const { popover } = usePopoverContext();
+  core.setInput(popover.input.current);
+  const state = core.getState();
+
+  useEffect(() => {
+    if (state.hidden) popover.close('imperative-action');
+  }, [popover, state.hidden]);
+
+  return <VolumePopoverContextProvider value={{ state }}>{children}</VolumePopoverContextProvider>;
+}
+
+export namespace VolumePopoverRoot {
+  export type Props = VolumePopoverRootProps;
+  export type State = VolumePopoverCore.State;
+}

--- a/packages/react/src/ui/volume-popover/volume-popover-root.tsx
+++ b/packages/react/src/ui/volume-popover/volume-popover-root.tsx
@@ -3,6 +3,7 @@ import { selectVolume } from '@videojs/core/dom';
 import type { MediaVolumeState } from '@videojs/media';
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
+
 import { usePlayer } from '../../player/context';
 import { Popover } from '../popover';
 import { usePopoverContext } from '../popover/context';
@@ -24,6 +25,7 @@ export interface VolumePopoverRootProps extends PopoverRootProps {}
 export function VolumePopoverRoot({ children, ...props }: VolumePopoverRootProps): ReactNode {
   const volume = usePlayer(selectVolume);
   const [core] = useState(() => new VolumePopoverCore(props));
+
   core.setProps(props);
   core.setMedia(volume ?? unavailableVolume);
 
@@ -36,6 +38,7 @@ export function VolumePopoverRoot({ children, ...props }: VolumePopoverRootProps
 
 function VolumePopoverState({ core, children }: { core: VolumePopoverCore; children?: ReactNode }): ReactNode {
   const { popover } = usePopoverContext();
+
   core.setInput(popover.input.current);
   const state = core.getState();
 

--- a/packages/react/src/ui/volume-popover/volume-popover-trigger.tsx
+++ b/packages/react/src/ui/volume-popover/volume-popover-trigger.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from 'react';
+
 import { renderElement } from '../../utils/use-render';
 import { usePopoverContext } from '../popover/context';
 import { PopoverTrigger, type PopoverTriggerProps } from '../popover/popover-trigger';

--- a/packages/react/src/ui/volume-popover/volume-popover-trigger.tsx
+++ b/packages/react/src/ui/volume-popover/volume-popover-trigger.tsx
@@ -1,0 +1,35 @@
+import { forwardRef } from 'react';
+import { renderElement } from '../../utils/use-render';
+import { usePopoverContext } from '../popover/context';
+import { PopoverTrigger, type PopoverTriggerProps } from '../popover/popover-trigger';
+import { useVolumePopoverContext } from './context';
+
+export interface VolumePopoverTriggerProps extends PopoverTriggerProps {}
+
+/** Opens the volume popup, or renders its mute-button fallback when volume level controls are unavailable. */
+export const VolumePopoverTrigger = forwardRef<HTMLButtonElement, VolumePopoverTriggerProps>(
+  function VolumePopoverTrigger({ render, className, style, ...elementProps }, forwardedRef) {
+    const { state: popoverState } = usePopoverContext();
+    const { state } = useVolumePopoverContext();
+
+    if (!state.hidden) {
+      return (
+        <PopoverTrigger ref={forwardedRef} render={render} className={className} style={style} {...elementProps} />
+      );
+    }
+
+    return renderElement(
+      'button',
+      { render, className, style },
+      {
+        state: popoverState,
+        ref: forwardedRef,
+        props: [{ type: 'button' as const }, elementProps],
+      }
+    );
+  }
+);
+
+export namespace VolumePopoverTrigger {
+  export type Props = VolumePopoverTriggerProps;
+}

--- a/packages/skins/vjsc/components/controls/volume-popover.tsx
+++ b/packages/skins/vjsc/components/controls/volume-popover.tsx
@@ -1,4 +1,4 @@
-import type { PopoverProps as CoreProps, VolumeSliderProps as CoreVolumeSliderProps } from '@videojs/core';
+import type { VolumePopoverProps as CoreProps, VolumeSliderProps as CoreVolumeSliderProps } from '@videojs/core';
 import * as $ from '@videojs/core/vjsc';
 import type { Props } from 'vjsc/components';
 
@@ -20,11 +20,11 @@ export function VolumePopover({
   }
 > = {}) {
   return (
-    <$.Popover.Root openOnHover delay={200} closeDelay={100} side={side} {...props}>
-      <$.Popover.Trigger>
+    <$.VolumePopover.Root openOnHover delay={200} closeDelay={100} side={side} {...props}>
+      <$.VolumePopover.Trigger>
         <MuteButton />
-      </$.Popover.Trigger>
-      <$.Popover.Popup
+      </$.VolumePopover.Trigger>
+      <$.VolumePopover.Popup
         className={[
           popupStyles.root,
           popupStyles.transition,
@@ -35,8 +35,8 @@ export function VolumePopover({
         ]}
       >
         <VolumeSlider orientation={orientation} />
-      </$.Popover.Popup>
-    </$.Popover.Root>
+      </$.VolumePopover.Popup>
+    </$.VolumePopover.Root>
   );
 }
 

--- a/packages/skins/vjsc/styles/popups/volume-popover.styles.ts
+++ b/packages/skins/vjsc/styles/popups/volume-popover.styles.ts
@@ -9,7 +9,6 @@ export default styles({
       utilities: [
         'rounded-media-control px-0 py-3',
         'data-[side=right]:rounded-none data-[side=right]:bg-transparent data-[side=right]:p-0 data-[side=right]:shadow-none data-[side=right]:ring-0 data-[side=right]:backdrop-filter-none data-[side=right]:after:hidden',
-        'has-[media-volume-slider[data-hidden]]:hidden',
       ],
     },
   },

--- a/packages/skins/vjsc/target/html.tsx
+++ b/packages/skins/vjsc/target/html.tsx
@@ -95,6 +95,11 @@ const componentParts: Readonly<Record<string, Readonly<Record<string, string>>>>
     Fill: 'VolumeIndicatorFill',
     Value: 'VolumeIndicatorValue',
   },
+  VolumePopover: {
+    Root: 'VolumePopover',
+    Trigger: 'VolumePopover',
+    Popup: 'VolumePopover',
+  },
   VolumeSlider: {
     Root: 'VolumeSlider',
     Track: 'SliderTrack',
@@ -186,6 +191,12 @@ export const htmlComponentTarget: ComponentTarget<CoreSchema> = defineComponentT
       Popover: ({ props, parts }) => [
         parts.Trigger.children,
         <target.Popover.Popup {...props.merge(parts.Popup.props)}>{parts.Popup.children}</target.Popover.Popup>,
+      ],
+      VolumePopover: ({ props, parts }) => [
+        parts.Trigger.children,
+        <target.VolumePopover.Popup {...props.merge(parts.Popup.props)}>
+          {parts.Popup.children}
+        </target.VolumePopover.Popup>,
       ],
       Poster: ({ props }) => (
         <target.Poster {...props}>

--- a/packages/skins/vjsc/target/react-transform.ts
+++ b/packages/skins/vjsc/target/react-transform.ts
@@ -19,7 +19,7 @@ const optionMenus = [
   { component: 'CaptionsMenu', binding: 'captions', hook: 'useCaptionsOptions' },
 ] as const;
 
-/** Add React player bindings and availability gates to skin controls and menus. */
+/** Add React player bindings and availability gates to skin menus. */
 export const reactComponentTransform: ComponentTargetTransform = {
   name: 'videojs:react-components',
   transform(context) {
@@ -49,36 +49,10 @@ function transformReactComponent(
   name: string,
   body: BlockBody
 ): boolean {
-  if (name === 'VolumePopover') return transformVolumePopover(context, imports, body);
-
   const menu = optionMenus.find((candidate) => candidate.component === name);
   if (menu) return transformOptionMenu(context, imports, body, menu);
 
   return name === 'VideoSettingsMenu' ? transformVideoSettingsMenu(context, imports, body) : false;
-}
-
-/**
- * Replace an unavailable volume popover with its mute-button fallback.
- *
- * ```diff
- * - <$.Popover.Root>...</$.Popover.Root>
- * + volumeAvailability === 'available' ? <$.Popover.Root>...</$.Popover.Root> : <MuteButton />
- * ```
- */
-function transformVolumePopover(
-  context: ComponentTargetTransformContext,
-  imports: ModuleImports,
-  body: BlockBody
-): true {
-  const usePlayer = imports.reference({ from: '@videojs/react', name: 'usePlayer' });
-
-  prependBlockBody(
-    context.magicString,
-    body,
-    `const volumeAvailability = ${usePlayer}(state => state.volumeAvailability);`
-  );
-  wrapElement(context, body, '$.Popover.Root', `volumeAvailability === 'available'`, '<MuteButton />');
-  return true;
 }
 
 /**

--- a/packages/skins/vjsc/target/react.tsx
+++ b/packages/skins/vjsc/target/react.tsx
@@ -54,6 +54,9 @@ export const reactComponentTarget: ComponentTarget<CoreSchema> = defineComponent
       Popover: {
         Trigger: ({ props, children }) => <target.Popover.Trigger render={children} {...props} />,
       },
+      VolumePopover: {
+        Trigger: ({ props, children }) => <target.VolumePopover.Trigger render={children} {...props} />,
+      },
       Poster: ({ props, children }) => <target.Poster render={children} {...props} />,
       Slider: {
         Thumbnail: {

--- a/packages/skins/vjsc/tests/__snapshots__/generated.tsx.snap
+++ b/packages/skins/vjsc/tests/__snapshots__/generated.tsx.snap
@@ -312,32 +312,28 @@ import { VolumeSlider } from '../sliders/volume-slider';
 import "virtual:vjsc/css/<hash>/base.css";
 import "virtual:vjsc/css/<hash>/common.css";
 import "virtual:vjsc/css/<hash>/popups.css";
-import { usePlayer } from "@videojs/react";
-import { Popover } from "@videojs/react";
+import { VolumePopover as VolumePopoverPrimitive } from "@videojs/react";
 import { cn, resolveClassName } from "@videojs/utils/style";
 
 
 
 
-
-export interface VolumePopoverProps extends Omit<Popover.Root.RootProps, "children"> {}
+export interface VolumePopoverProps extends Omit<VolumePopoverPrimitive.Root.RootProps, "children"> {}
 export function VolumePopover({
   className,
   side = 'top',
   orientation = 'vertical',
   ...props
 }: VolumePopoverProps = {}) {
-const volumeAvailability = usePlayer(state => state.volumeAvailability);
-
   return (
-    volumeAvailability === 'available' ? <Popover.Root openOnHover delay={200} closeDelay={100} side={side} {...props}>
-      <Popover.Trigger render={<MuteButton />} />
-      <Popover.Popup
+    <VolumePopoverPrimitive.Root openOnHover delay={200} closeDelay={100} side={side} {...props}>
+      <VolumePopoverPrimitive.Trigger render={<MuteButton />} />
+      <VolumePopoverPrimitive.Popup
         className={state => cn("media-popup", "media-popup-transition", "media-popup-safe-area", "media-surface", "media-volume-popover", resolveClassName(className, state))}
       >
         <VolumeSlider orientation={orientation} />
-      </Popover.Popup>
-    </Popover.Root> : <MuteButton />
+      </VolumePopoverPrimitive.Popup>
+    </VolumePopoverPrimitive.Root>
   );
 }
 
@@ -1566,31 +1562,27 @@ export function SeekButton({ className, seconds = 10, ...props }: SeekButtonProp
 
 import { MuteButton } from '../buttons/mute-button';
 import { VolumeSlider } from '../sliders/volume-slider';
-import { usePlayer } from "@videojs/react";
-import { Popover } from "@videojs/react";
+import { VolumePopover as VolumePopoverPrimitive } from "@videojs/react";
 import { cn, resolveClassName } from "@videojs/utils/style";
 
 
 
-
-export interface VolumePopoverProps extends Omit<Popover.Root.RootProps, "children"> {}
+export interface VolumePopoverProps extends Omit<VolumePopoverPrimitive.Root.RootProps, "children"> {}
 export function VolumePopover({
   className,
   side = 'top',
   orientation = 'vertical',
   ...props
 }: VolumePopoverProps = {}) {
-const volumeAvailability = usePlayer(state => state.volumeAvailability);
-
   return (
-    volumeAvailability === 'available' ? <Popover.Root openOnHover delay={200} closeDelay={100} side={side} {...props}>
-      <Popover.Trigger render={<MuteButton />} />
-      <Popover.Popup
-        className={state => cn("m-0 overflow-visible border-0 text-inherit", "data-starting-style:opacity-0 data-starting-style:scale-95", "data-[side=top]:data-starting-style:translate-y-(--media-popup-translate-distance)", "data-[side=bottom]:data-starting-style:-translate-y-(--media-popup-translate-distance)", "data-[side=left]:data-starting-style:translate-x-(--media-popup-translate-distance)", "data-[side=right]:data-starting-style:-translate-x-(--media-popup-translate-distance)", "data-ending-style:opacity-0 data-ending-style:blur-xs data-ending-style:scale-95 data-ending-style:transform-none", "data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left", "before:pointer-events-auto before:absolute", "data-[side=top]:before:inset-x-0 data-[side=top]:before:top-full", "data-[side=bottom]:before:inset-x-0 data-[side=bottom]:before:bottom-full", "data-[side=left]:before:inset-y-0 data-[side=left]:before:left-full", "data-[side=right]:before:inset-y-0 data-[side=right]:before:right-full", "[--media-popup-translate-distance:calc(var(--media-scale-unit,16px)*0.5)]", "data-starting-style:blur-xs", "transition-[opacity,filter,transform,scale] duration-100 ease-out motion-reduce:duration-0", "data-ending-style:duration-50 motion-reduce:data-ending-style:duration-0", "data-[side=top]:before:h-(--media-popover-side-offset) data-[side=bottom]:before:h-(--media-popover-side-offset)", "data-[side=left]:before:w-(--media-popover-side-offset) data-[side=right]:before:w-(--media-popover-side-offset)", "text-white backdrop-blur-lg backdrop-saturate-150", "after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]", "after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.1),inset_0_0_0_1px_rgb(255_255_255/0.05)]", "[@media(prefers-reduced-transparency:reduce)]:bg-black [@media(prefers-reduced-transparency:reduce)]:ring-1 [@media(prefers-reduced-transparency:reduce)]:ring-transparent", "[@media(prefers-reduced-transparency:reduce)]:backdrop-filter-none", "[@media(prefers-reduced-transparency:reduce)]:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "contrast-more:bg-black contrast-more:ring-1 contrast-more:ring-transparent contrast-more:backdrop-filter-none", "contrast-more:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "forced-colors:bg-[Canvas] forced-colors:ring-1 forced-colors:ring-[CanvasText]", "forced-colors:after:shadow-[inset_0_1px_0_0_CanvasText,inset_0_0_0_1px_CanvasText]", "shadow-sm shadow-black/15 ring-1 ring-black/10", "[@media(prefers-reduced-transparency:reduce)]:shadow-sm [@media(prefers-reduced-transparency:reduce)]:shadow-black/15", "contrast-more:shadow-sm contrast-more:shadow-black/15", "forced-colors:shadow-sm forced-colors:shadow-black/15", "bg-white/10", "rounded-media-control px-0 py-3", "data-[side=right]:rounded-none data-[side=right]:bg-transparent data-[side=right]:p-0 data-[side=right]:shadow-none data-[side=right]:ring-0 data-[side=right]:backdrop-filter-none data-[side=right]:after:hidden", "has-[media-volume-slider[data-hidden]]:hidden", resolveClassName(className, state))}
+    <VolumePopoverPrimitive.Root openOnHover delay={200} closeDelay={100} side={side} {...props}>
+      <VolumePopoverPrimitive.Trigger render={<MuteButton />} />
+      <VolumePopoverPrimitive.Popup
+        className={state => cn("m-0 overflow-visible border-0 text-inherit", "data-starting-style:opacity-0 data-starting-style:scale-95", "data-[side=top]:data-starting-style:translate-y-(--media-popup-translate-distance)", "data-[side=bottom]:data-starting-style:-translate-y-(--media-popup-translate-distance)", "data-[side=left]:data-starting-style:translate-x-(--media-popup-translate-distance)", "data-[side=right]:data-starting-style:-translate-x-(--media-popup-translate-distance)", "data-ending-style:opacity-0 data-ending-style:blur-xs data-ending-style:scale-95 data-ending-style:transform-none", "data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left", "before:pointer-events-auto before:absolute", "data-[side=top]:before:inset-x-0 data-[side=top]:before:top-full", "data-[side=bottom]:before:inset-x-0 data-[side=bottom]:before:bottom-full", "data-[side=left]:before:inset-y-0 data-[side=left]:before:left-full", "data-[side=right]:before:inset-y-0 data-[side=right]:before:right-full", "[--media-popup-translate-distance:calc(var(--media-scale-unit,16px)*0.5)]", "data-starting-style:blur-xs", "transition-[opacity,filter,transform,scale] duration-100 ease-out motion-reduce:duration-0", "data-ending-style:duration-50 motion-reduce:data-ending-style:duration-0", "data-[side=top]:before:h-(--media-popover-side-offset) data-[side=bottom]:before:h-(--media-popover-side-offset)", "data-[side=left]:before:w-(--media-popover-side-offset) data-[side=right]:before:w-(--media-popover-side-offset)", "text-white backdrop-blur-lg backdrop-saturate-150", "after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]", "after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.1),inset_0_0_0_1px_rgb(255_255_255/0.05)]", "[@media(prefers-reduced-transparency:reduce)]:bg-black [@media(prefers-reduced-transparency:reduce)]:ring-1 [@media(prefers-reduced-transparency:reduce)]:ring-transparent", "[@media(prefers-reduced-transparency:reduce)]:backdrop-filter-none", "[@media(prefers-reduced-transparency:reduce)]:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "contrast-more:bg-black contrast-more:ring-1 contrast-more:ring-transparent contrast-more:backdrop-filter-none", "contrast-more:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "forced-colors:bg-[Canvas] forced-colors:ring-1 forced-colors:ring-[CanvasText]", "forced-colors:after:shadow-[inset_0_1px_0_0_CanvasText,inset_0_0_0_1px_CanvasText]", "shadow-sm shadow-black/15 ring-1 ring-black/10", "[@media(prefers-reduced-transparency:reduce)]:shadow-sm [@media(prefers-reduced-transparency:reduce)]:shadow-black/15", "contrast-more:shadow-sm contrast-more:shadow-black/15", "forced-colors:shadow-sm forced-colors:shadow-black/15", "bg-white/10", "rounded-media-control px-0 py-3", "data-[side=right]:rounded-none data-[side=right]:bg-transparent data-[side=right]:p-0 data-[side=right]:shadow-none data-[side=right]:ring-0 data-[side=right]:backdrop-filter-none data-[side=right]:after:hidden", resolveClassName(className, state))}
       >
         <VolumeSlider orientation={orientation} />
-      </Popover.Popup>
-    </Popover.Root> : <MuteButton />
+      </VolumePopoverPrimitive.Popup>
+    </VolumePopoverPrimitive.Root>
   );
 }
 
@@ -2778,32 +2770,28 @@ import { VolumeSlider } from '../sliders/volume-slider';
 import "virtual:vjsc/css/<hash>/base.css";
 import "virtual:vjsc/css/<hash>/common.css";
 import "virtual:vjsc/css/<hash>/popups.css";
-import { usePlayer } from "@videojs/react";
-import { Popover } from "@videojs/react";
+import { VolumePopover as VolumePopoverPrimitive } from "@videojs/react";
 import { cn, resolveClassName } from "@videojs/utils/style";
 
 
 
 
-
-export interface VolumePopoverProps extends Omit<Popover.Root.RootProps, "children"> {}
+export interface VolumePopoverProps extends Omit<VolumePopoverPrimitive.Root.RootProps, "children"> {}
 export function VolumePopover({
   className,
   side = 'top',
   orientation = 'vertical',
   ...props
 }: VolumePopoverProps = {}) {
-const volumeAvailability = usePlayer(state => state.volumeAvailability);
-
   return (
-    volumeAvailability === 'available' ? <Popover.Root openOnHover delay={200} closeDelay={100} side={side} {...props}>
-      <Popover.Trigger render={<MuteButton />} />
-      <Popover.Popup
+    <VolumePopoverPrimitive.Root openOnHover delay={200} closeDelay={100} side={side} {...props}>
+      <VolumePopoverPrimitive.Trigger render={<MuteButton />} />
+      <VolumePopoverPrimitive.Popup
         className={state => cn("media-popup", "media-popup-transition", "media-popup-safe-area", "media-surface", "media-volume-popover", resolveClassName(className, state))}
       >
         <VolumeSlider orientation={orientation} />
-      </Popover.Popup>
-    </Popover.Root> : <MuteButton />
+      </VolumePopoverPrimitive.Popup>
+    </VolumePopoverPrimitive.Root>
   );
 }
 
@@ -4031,31 +4019,27 @@ export function SeekButton({ className, seconds = 10, ...props }: SeekButtonProp
 
 import { MuteButton } from '../buttons/mute-button';
 import { VolumeSlider } from '../sliders/volume-slider';
-import { usePlayer } from "@videojs/react";
-import { Popover } from "@videojs/react";
+import { VolumePopover as VolumePopoverPrimitive } from "@videojs/react";
 import { cn, resolveClassName } from "@videojs/utils/style";
 
 
 
-
-export interface VolumePopoverProps extends Omit<Popover.Root.RootProps, "children"> {}
+export interface VolumePopoverProps extends Omit<VolumePopoverPrimitive.Root.RootProps, "children"> {}
 export function VolumePopover({
   className,
   side = 'top',
   orientation = 'vertical',
   ...props
 }: VolumePopoverProps = {}) {
-const volumeAvailability = usePlayer(state => state.volumeAvailability);
-
   return (
-    volumeAvailability === 'available' ? <Popover.Root openOnHover delay={200} closeDelay={100} side={side} {...props}>
-      <Popover.Trigger render={<MuteButton />} />
-      <Popover.Popup
-        className={state => cn("m-0 overflow-visible border-0 text-inherit", "data-starting-style:opacity-0 data-starting-style:scale-95", "data-[side=top]:data-starting-style:translate-y-(--media-popup-translate-distance)", "data-[side=bottom]:data-starting-style:-translate-y-(--media-popup-translate-distance)", "data-[side=left]:data-starting-style:translate-x-(--media-popup-translate-distance)", "data-[side=right]:data-starting-style:-translate-x-(--media-popup-translate-distance)", "data-ending-style:opacity-0 data-ending-style:blur-xs data-ending-style:scale-95 data-ending-style:transform-none", "data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left", "before:pointer-events-auto before:absolute", "data-[side=top]:before:inset-x-0 data-[side=top]:before:top-full", "data-[side=bottom]:before:inset-x-0 data-[side=bottom]:before:bottom-full", "data-[side=left]:before:inset-y-0 data-[side=left]:before:left-full", "data-[side=right]:before:inset-y-0 data-[side=right]:before:right-full", "[--media-popup-translate-distance:--spacing(2)]", "transition-[opacity,filter,transform,scale] duration-100 ease-out motion-reduce:duration-0", "data-ending-style:duration-50 motion-reduce:data-ending-style:duration-0", "data-[side=top]:before:h-(--media-popover-side-offset) data-[side=bottom]:before:h-(--media-popover-side-offset)", "data-[side=left]:before:w-(--media-popover-side-offset) data-[side=right]:before:w-(--media-popover-side-offset)", "text-white backdrop-blur-lg backdrop-saturate-150", "after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]", "after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.1),inset_0_0_0_1px_rgb(255_255_255/0.05)]", "[@media(prefers-reduced-transparency:reduce)]:bg-black [@media(prefers-reduced-transparency:reduce)]:ring-1 [@media(prefers-reduced-transparency:reduce)]:ring-transparent", "[@media(prefers-reduced-transparency:reduce)]:backdrop-filter-none", "[@media(prefers-reduced-transparency:reduce)]:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "contrast-more:bg-black contrast-more:ring-1 contrast-more:ring-transparent contrast-more:backdrop-filter-none", "contrast-more:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "forced-colors:bg-[Canvas] forced-colors:ring-1 forced-colors:ring-[CanvasText]", "forced-colors:after:shadow-[inset_0_1px_0_0_CanvasText,inset_0_0_0_1px_CanvasText]", "shadow-sm shadow-black/20 ring-1 ring-white/10", "[@media(prefers-reduced-transparency:reduce)]:shadow-sm [@media(prefers-reduced-transparency:reduce)]:shadow-black/20", "contrast-more:shadow-sm contrast-more:shadow-black/20", "forced-colors:shadow-sm forced-colors:shadow-black/20", "bg-black/50", "rounded-media-control px-0 py-3", "data-[side=right]:rounded-none data-[side=right]:bg-transparent data-[side=right]:p-0 data-[side=right]:shadow-none data-[side=right]:ring-0 data-[side=right]:backdrop-filter-none data-[side=right]:after:hidden", "has-[media-volume-slider[data-hidden]]:hidden", resolveClassName(className, state))}
+    <VolumePopoverPrimitive.Root openOnHover delay={200} closeDelay={100} side={side} {...props}>
+      <VolumePopoverPrimitive.Trigger render={<MuteButton />} />
+      <VolumePopoverPrimitive.Popup
+        className={state => cn("m-0 overflow-visible border-0 text-inherit", "data-starting-style:opacity-0 data-starting-style:scale-95", "data-[side=top]:data-starting-style:translate-y-(--media-popup-translate-distance)", "data-[side=bottom]:data-starting-style:-translate-y-(--media-popup-translate-distance)", "data-[side=left]:data-starting-style:translate-x-(--media-popup-translate-distance)", "data-[side=right]:data-starting-style:-translate-x-(--media-popup-translate-distance)", "data-ending-style:opacity-0 data-ending-style:blur-xs data-ending-style:scale-95 data-ending-style:transform-none", "data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left", "before:pointer-events-auto before:absolute", "data-[side=top]:before:inset-x-0 data-[side=top]:before:top-full", "data-[side=bottom]:before:inset-x-0 data-[side=bottom]:before:bottom-full", "data-[side=left]:before:inset-y-0 data-[side=left]:before:left-full", "data-[side=right]:before:inset-y-0 data-[side=right]:before:right-full", "[--media-popup-translate-distance:--spacing(2)]", "transition-[opacity,filter,transform,scale] duration-100 ease-out motion-reduce:duration-0", "data-ending-style:duration-50 motion-reduce:data-ending-style:duration-0", "data-[side=top]:before:h-(--media-popover-side-offset) data-[side=bottom]:before:h-(--media-popover-side-offset)", "data-[side=left]:before:w-(--media-popover-side-offset) data-[side=right]:before:w-(--media-popover-side-offset)", "text-white backdrop-blur-lg backdrop-saturate-150", "after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]", "after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.1),inset_0_0_0_1px_rgb(255_255_255/0.05)]", "[@media(prefers-reduced-transparency:reduce)]:bg-black [@media(prefers-reduced-transparency:reduce)]:ring-1 [@media(prefers-reduced-transparency:reduce)]:ring-transparent", "[@media(prefers-reduced-transparency:reduce)]:backdrop-filter-none", "[@media(prefers-reduced-transparency:reduce)]:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "contrast-more:bg-black contrast-more:ring-1 contrast-more:ring-transparent contrast-more:backdrop-filter-none", "contrast-more:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "forced-colors:bg-[Canvas] forced-colors:ring-1 forced-colors:ring-[CanvasText]", "forced-colors:after:shadow-[inset_0_1px_0_0_CanvasText,inset_0_0_0_1px_CanvasText]", "shadow-sm shadow-black/20 ring-1 ring-white/10", "[@media(prefers-reduced-transparency:reduce)]:shadow-sm [@media(prefers-reduced-transparency:reduce)]:shadow-black/20", "contrast-more:shadow-sm contrast-more:shadow-black/20", "forced-colors:shadow-sm forced-colors:shadow-black/20", "bg-black/50", "rounded-media-control px-0 py-3", "data-[side=right]:rounded-none data-[side=right]:bg-transparent data-[side=right]:p-0 data-[side=right]:shadow-none data-[side=right]:ring-0 data-[side=right]:backdrop-filter-none data-[side=right]:after:hidden", resolveClassName(className, state))}
       >
         <VolumeSlider orientation={orientation} />
-      </Popover.Popup>
-    </Popover.Root> : <MuteButton />
+      </VolumePopoverPrimitive.Popup>
+    </VolumePopoverPrimitive.Root>
   );
 }
 
@@ -5192,7 +5176,7 @@ export function SeekButton({ className, seconds = 10, ...props }: Props<CoreProp
 
 // ===== html/default-video/css/components/controls/volume-popover.tsx =====
 /** @jsxImportSource vjsc/html-runtime */
-import type { PopoverProps as CoreProps, VolumeSliderProps as CoreVolumeSliderProps } from '@videojs/core';
+import type { VolumePopoverProps as CoreProps, VolumeSliderProps as CoreVolumeSliderProps } from '@videojs/core';
 
 import type { Props } from 'vjsc/components';
 
@@ -5205,7 +5189,7 @@ import { VolumeSlider } from '../sliders/volume-slider';
 import "virtual:vjsc/css/<hash>/base.css";
 import "virtual:vjsc/css/<hash>/common.css";
 import "virtual:vjsc/css/<hash>/popups.css";
-import "@videojs/html/ui/popover";
+import "@videojs/html/ui/volume-popover";
 
 
 
@@ -5222,7 +5206,7 @@ export function VolumePopover({
   return (
     <>
         <MuteButton />
-      <media-popover open-on-hover delay={200} close-delay={100} side={side} {...props} class={[
+      <media-volume-popover open-on-hover delay={200} close-delay={100} side={side} {...props} class={[
           "media-popup",
           "media-popup-transition",
           "media-popup-safe-area",
@@ -5231,7 +5215,7 @@ export function VolumePopover({
           className,
         ]}>
         <VolumeSlider orientation={orientation} />
-      </media-popover></>
+      </media-volume-popover></>
   );
 }
 
@@ -6327,7 +6311,7 @@ export function SeekButton({ className, seconds = 10, ...props }: Props<CoreProp
 
 // ===== html/default-video/tailwind/components/controls/volume-popover.tsx =====
 /** @jsxImportSource vjsc/html-runtime */
-import type { PopoverProps as CoreProps, VolumeSliderProps as CoreVolumeSliderProps } from '@videojs/core';
+import type { VolumePopoverProps as CoreProps, VolumeSliderProps as CoreVolumeSliderProps } from '@videojs/core';
 
 import type { Props } from 'vjsc/components';
 
@@ -6337,7 +6321,7 @@ import type { Props } from 'vjsc/components';
 
 import { MuteButton } from '../buttons/mute-button';
 import { VolumeSlider } from '../sliders/volume-slider';
-import "@videojs/html/ui/popover";
+import "@videojs/html/ui/volume-popover";
 
 
 export function VolumePopover({
@@ -6353,16 +6337,16 @@ export function VolumePopover({
   return (
     <>
         <MuteButton />
-      <media-popover open-on-hover delay={200} close-delay={100} side={side} {...props} class={[
+      <media-volume-popover open-on-hover delay={200} close-delay={100} side={side} {...props} class={[
           "m-0 overflow-visible border-0 text-inherit", "data-starting-style:opacity-0 data-starting-style:scale-95", "data-[side=top]:data-starting-style:translate-y-(--media-popup-translate-distance)", "data-[side=bottom]:data-starting-style:-translate-y-(--media-popup-translate-distance)", "data-[side=left]:data-starting-style:translate-x-(--media-popup-translate-distance)", "data-[side=right]:data-starting-style:-translate-x-(--media-popup-translate-distance)", "data-ending-style:opacity-0 data-ending-style:blur-xs data-ending-style:scale-95 data-ending-style:transform-none", "data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left", "before:pointer-events-auto before:absolute", "data-[side=top]:before:inset-x-0 data-[side=top]:before:top-full", "data-[side=bottom]:before:inset-x-0 data-[side=bottom]:before:bottom-full", "data-[side=left]:before:inset-y-0 data-[side=left]:before:left-full", "data-[side=right]:before:inset-y-0 data-[side=right]:before:right-full", "[--media-popup-translate-distance:calc(var(--media-scale-unit,16px)*0.5)]", "data-starting-style:blur-xs",
           "transition-[opacity,filter,transform,scale] duration-100 ease-out motion-reduce:duration-0", "data-ending-style:duration-50 motion-reduce:data-ending-style:duration-0",
           "data-[side=top]:before:h-(--media-popover-side-offset) data-[side=bottom]:before:h-(--media-popover-side-offset)", "data-[side=left]:before:w-(--media-popover-side-offset) data-[side=right]:before:w-(--media-popover-side-offset)",
           "text-white backdrop-blur-lg backdrop-saturate-150", "after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]", "after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.1),inset_0_0_0_1px_rgb(255_255_255/0.05)]", "[@media(prefers-reduced-transparency:reduce)]:bg-black [@media(prefers-reduced-transparency:reduce)]:ring-1 [@media(prefers-reduced-transparency:reduce)]:ring-transparent", "[@media(prefers-reduced-transparency:reduce)]:backdrop-filter-none", "[@media(prefers-reduced-transparency:reduce)]:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "contrast-more:bg-black contrast-more:ring-1 contrast-more:ring-transparent contrast-more:backdrop-filter-none", "contrast-more:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "forced-colors:bg-[Canvas] forced-colors:ring-1 forced-colors:ring-[CanvasText]", "forced-colors:after:shadow-[inset_0_1px_0_0_CanvasText,inset_0_0_0_1px_CanvasText]", "shadow-sm shadow-black/15 ring-1 ring-black/10", "[@media(prefers-reduced-transparency:reduce)]:shadow-sm [@media(prefers-reduced-transparency:reduce)]:shadow-black/15", "contrast-more:shadow-sm contrast-more:shadow-black/15", "forced-colors:shadow-sm forced-colors:shadow-black/15", "bg-white/10",
-          "rounded-media-control px-0 py-3", "data-[side=right]:rounded-none data-[side=right]:bg-transparent data-[side=right]:p-0 data-[side=right]:shadow-none data-[side=right]:ring-0 data-[side=right]:backdrop-filter-none data-[side=right]:after:hidden", "has-[media-volume-slider[data-hidden]]:hidden",
+          "rounded-media-control px-0 py-3", "data-[side=right]:rounded-none data-[side=right]:bg-transparent data-[side=right]:p-0 data-[side=right]:shadow-none data-[side=right]:ring-0 data-[side=right]:backdrop-filter-none data-[side=right]:after:hidden",
           className,
         ]}>
         <VolumeSlider orientation={orientation} />
-      </media-popover></>
+      </media-volume-popover></>
   );
 }
 
@@ -7414,7 +7398,7 @@ export function SeekButton({ className, seconds = 10, ...props }: Props<CoreProp
 
 // ===== html/minimal-video/css/components/controls/volume-popover.tsx =====
 /** @jsxImportSource vjsc/html-runtime */
-import type { PopoverProps as CoreProps, VolumeSliderProps as CoreVolumeSliderProps } from '@videojs/core';
+import type { VolumePopoverProps as CoreProps, VolumeSliderProps as CoreVolumeSliderProps } from '@videojs/core';
 
 import type { Props } from 'vjsc/components';
 
@@ -7427,7 +7411,7 @@ import { VolumeSlider } from '../sliders/volume-slider';
 import "virtual:vjsc/css/<hash>/base.css";
 import "virtual:vjsc/css/<hash>/common.css";
 import "virtual:vjsc/css/<hash>/popups.css";
-import "@videojs/html/ui/popover";
+import "@videojs/html/ui/volume-popover";
 
 
 
@@ -7444,7 +7428,7 @@ export function VolumePopover({
   return (
     <>
         <MuteButton />
-      <media-popover open-on-hover delay={200} close-delay={100} side={side} {...props} class={[
+      <media-volume-popover open-on-hover delay={200} close-delay={100} side={side} {...props} class={[
           "media-popup",
           "media-popup-transition",
           "media-popup-safe-area",
@@ -7453,7 +7437,7 @@ export function VolumePopover({
           className,
         ]}>
         <VolumeSlider orientation={orientation} />
-      </media-popover></>
+      </media-volume-popover></>
   );
 }
 
@@ -8550,7 +8534,7 @@ export function SeekButton({ className, seconds = 10, ...props }: Props<CoreProp
 
 // ===== html/minimal-video/tailwind/components/controls/volume-popover.tsx =====
 /** @jsxImportSource vjsc/html-runtime */
-import type { PopoverProps as CoreProps, VolumeSliderProps as CoreVolumeSliderProps } from '@videojs/core';
+import type { VolumePopoverProps as CoreProps, VolumeSliderProps as CoreVolumeSliderProps } from '@videojs/core';
 
 import type { Props } from 'vjsc/components';
 
@@ -8560,7 +8544,7 @@ import type { Props } from 'vjsc/components';
 
 import { MuteButton } from '../buttons/mute-button';
 import { VolumeSlider } from '../sliders/volume-slider';
-import "@videojs/html/ui/popover";
+import "@videojs/html/ui/volume-popover";
 
 
 export function VolumePopover({
@@ -8576,16 +8560,16 @@ export function VolumePopover({
   return (
     <>
         <MuteButton />
-      <media-popover open-on-hover delay={200} close-delay={100} side={side} {...props} class={[
+      <media-volume-popover open-on-hover delay={200} close-delay={100} side={side} {...props} class={[
           "m-0 overflow-visible border-0 text-inherit", "data-starting-style:opacity-0 data-starting-style:scale-95", "data-[side=top]:data-starting-style:translate-y-(--media-popup-translate-distance)", "data-[side=bottom]:data-starting-style:-translate-y-(--media-popup-translate-distance)", "data-[side=left]:data-starting-style:translate-x-(--media-popup-translate-distance)", "data-[side=right]:data-starting-style:-translate-x-(--media-popup-translate-distance)", "data-ending-style:opacity-0 data-ending-style:blur-xs data-ending-style:scale-95 data-ending-style:transform-none", "data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left", "before:pointer-events-auto before:absolute", "data-[side=top]:before:inset-x-0 data-[side=top]:before:top-full", "data-[side=bottom]:before:inset-x-0 data-[side=bottom]:before:bottom-full", "data-[side=left]:before:inset-y-0 data-[side=left]:before:left-full", "data-[side=right]:before:inset-y-0 data-[side=right]:before:right-full", "[--media-popup-translate-distance:--spacing(2)]",
           "transition-[opacity,filter,transform,scale] duration-100 ease-out motion-reduce:duration-0", "data-ending-style:duration-50 motion-reduce:data-ending-style:duration-0",
           "data-[side=top]:before:h-(--media-popover-side-offset) data-[side=bottom]:before:h-(--media-popover-side-offset)", "data-[side=left]:before:w-(--media-popover-side-offset) data-[side=right]:before:w-(--media-popover-side-offset)",
           "text-white backdrop-blur-lg backdrop-saturate-150", "after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]", "after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.1),inset_0_0_0_1px_rgb(255_255_255/0.05)]", "[@media(prefers-reduced-transparency:reduce)]:bg-black [@media(prefers-reduced-transparency:reduce)]:ring-1 [@media(prefers-reduced-transparency:reduce)]:ring-transparent", "[@media(prefers-reduced-transparency:reduce)]:backdrop-filter-none", "[@media(prefers-reduced-transparency:reduce)]:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "contrast-more:bg-black contrast-more:ring-1 contrast-more:ring-transparent contrast-more:backdrop-filter-none", "contrast-more:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "forced-colors:bg-[Canvas] forced-colors:ring-1 forced-colors:ring-[CanvasText]", "forced-colors:after:shadow-[inset_0_1px_0_0_CanvasText,inset_0_0_0_1px_CanvasText]", "shadow-sm shadow-black/20 ring-1 ring-white/10", "[@media(prefers-reduced-transparency:reduce)]:shadow-sm [@media(prefers-reduced-transparency:reduce)]:shadow-black/20", "contrast-more:shadow-sm contrast-more:shadow-black/20", "forced-colors:shadow-sm forced-colors:shadow-black/20", "bg-black/50",
-          "rounded-media-control px-0 py-3", "data-[side=right]:rounded-none data-[side=right]:bg-transparent data-[side=right]:p-0 data-[side=right]:shadow-none data-[side=right]:ring-0 data-[side=right]:backdrop-filter-none data-[side=right]:after:hidden", "has-[media-volume-slider[data-hidden]]:hidden",
+          "rounded-media-control px-0 py-3", "data-[side=right]:rounded-none data-[side=right]:bg-transparent data-[side=right]:p-0 data-[side=right]:shadow-none data-[side=right]:ring-0 data-[side=right]:backdrop-filter-none data-[side=right]:after:hidden",
           className,
         ]}>
         <VolumeSlider orientation={orientation} />
-      </media-popover></>
+      </media-volume-popover></>
   );
 }
 

--- a/packages/skins/vjsc/tests/shadcn.test.ts
+++ b/packages/skins/vjsc/tests/shadcn.test.ts
@@ -77,8 +77,9 @@ describe('Skins Shadcn registry', () => {
     expect(qualityMenuSource).toContain('available &&');
     expect(videoSettingsMenuSource).toContain('const hasSettings =');
     expect(videoSettingsMenuSource).toContain('hasSettings &&');
-    expect(volumePopoverSource).toContain('usePlayer');
-    expect(volumePopoverSource).toContain(`volumeAvailability === 'available' ?`);
+    expect(volumePopoverSource).toContain('VolumePopoverPrimitive.Root');
+    expect(volumePopoverSource).toContain('VolumePopoverPrimitive.Trigger');
+    expect(volumePopoverSource).not.toContain('usePlayer');
     expect(styles.files.map((file) => file.target)).toEqual([
       'components/videojs/styles/base.css',
       'components/videojs/styles/captions.css',

--- a/packages/skins/vjsc/tests/vite.test.ts
+++ b/packages/skins/vjsc/tests/vite.test.ts
@@ -122,7 +122,9 @@ describe('Skins Vite workflow', () => {
     const volumePopover = await server.transformRequest(volumePopoverUrl);
 
     expect(settingsMenu?.code).toContain('Tooltip.Trigger, { render: /* @__PURE__ */ _jsxDEV(Menu.Trigger');
-    expect(volumePopover?.code).toContain('Popover.Trigger, { render: /* @__PURE__ */ _jsxDEV(MuteButton');
+    expect(volumePopover?.code).toContain(
+      'VolumePopoverPrimitive.Trigger, { render: /* @__PURE__ */ _jsxDEV(MuteButton'
+    );
     expect([...warn.mock.calls, ...warnOnce.mock.calls].flat().join('\n')).not.toContain('emitFile() is not supported');
   }, 30_000);
 

--- a/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.css
@@ -1,0 +1,86 @@
+.html-volume-popover-basic,
+.html-volume-popover-basic media-container {
+  position: relative;
+  display: block;
+}
+
+.html-volume-popover-basic video {
+  width: 100%;
+}
+
+.html-volume-popover-basic__controls {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+}
+
+.html-volume-popover-basic__trigger {
+  padding: 8px 20px;
+  color: black;
+  cursor: pointer;
+  background: rgb(255 255 255 / 70%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+  backdrop-filter: blur(10px);
+}
+
+.html-volume-popover-basic__trigger .muted,
+.html-volume-popover-basic__trigger .unmuted {
+  display: none;
+}
+
+.html-volume-popover-basic__trigger[data-muted] .muted,
+.html-volume-popover-basic__trigger:not([data-muted]) .unmuted {
+  display: inline;
+}
+
+.html-volume-popover-basic__popup {
+  --media-popover-side-offset: 8px;
+  width: 40px;
+  height: 120px;
+  padding: 12px;
+  margin: 0;
+  background: rgb(0 0 0 / 85%);
+  border: 0;
+  border-radius: 8px;
+}
+
+.html-volume-popover-basic__slider {
+  position: relative;
+  display: block;
+  width: 16px;
+  height: 96px;
+  margin: auto;
+  cursor: pointer;
+}
+
+.html-volume-popover-basic__track {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 6px;
+  width: 4px;
+  background: rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+}
+
+.html-volume-popover-basic__fill {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: var(--media-slider-fill);
+  background: white;
+  border-radius: inherit;
+}
+
+.html-volume-popover-basic__thumb {
+  position: absolute;
+  bottom: var(--media-slider-fill);
+  left: 1px;
+  width: 14px;
+  height: 14px;
+  background: white;
+  border-radius: 50%;
+  transform: translateY(50%);
+}

--- a/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.html
@@ -1,33 +1,19 @@
 <video-player class="html-volume-popover-basic">
-    <media-container>
-        <video
-            src="{{VJS10_DEMO_VIDEO_MP4}}"
-            autoplay
-            muted
-            playsinline
-            loop
-        ></video>
-        <div class="html-volume-popover-basic__controls">
-            <media-mute-button
-                commandfor="volume-popover-demo"
-                class="html-volume-popover-basic__trigger"
-            >
-                <span class="muted">Unmute</span>
-                <span class="unmuted">Mute</span>
-            </media-mute-button>
-            <media-volume-popover
-                id="volume-popover-demo"
-                open-on-hover
-                side="top"
-                class="html-volume-popover-basic__popup"
-            >
-                <media-volume-slider orientation="vertical" class="html-volume-popover-basic__slider">
-                    <media-slider-track class="html-volume-popover-basic__track">
-                        <media-slider-fill class="html-volume-popover-basic__fill"></media-slider-fill>
-                    </media-slider-track>
-                    <media-slider-thumb class="html-volume-popover-basic__thumb"></media-slider-thumb>
-                </media-volume-slider>
-            </media-volume-popover>
-        </div>
-    </media-container>
+  <media-container>
+    <video src="{{VJS10_DEMO_VIDEO_MP4}}" autoplay muted playsinline loop></video>
+    <div class="html-volume-popover-basic__controls">
+      <media-mute-button commandfor="volume-popover-demo" class="html-volume-popover-basic__trigger">
+        <span class="muted">Unmute</span>
+        <span class="unmuted">Mute</span>
+      </media-mute-button>
+      <media-volume-popover id="volume-popover-demo" open-on-hover side="top" class="html-volume-popover-basic__popup">
+        <media-volume-slider orientation="vertical" class="html-volume-popover-basic__slider">
+          <media-slider-track class="html-volume-popover-basic__track">
+            <media-slider-fill class="html-volume-popover-basic__fill"></media-slider-fill>
+          </media-slider-track>
+          <media-slider-thumb class="html-volume-popover-basic__thumb"></media-slider-thumb>
+        </media-volume-slider>
+      </media-volume-popover>
+    </div>
+  </media-container>
 </video-player>

--- a/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.html
@@ -1,0 +1,33 @@
+<video-player class="html-volume-popover-basic">
+    <media-container>
+        <video
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <div class="html-volume-popover-basic__controls">
+            <media-mute-button
+                commandfor="volume-popover-demo"
+                class="html-volume-popover-basic__trigger"
+            >
+                <span class="muted">Unmute</span>
+                <span class="unmuted">Mute</span>
+            </media-mute-button>
+            <media-volume-popover
+                id="volume-popover-demo"
+                open-on-hover
+                side="top"
+                class="html-volume-popover-basic__popup"
+            >
+                <media-volume-slider orientation="vertical" class="html-volume-popover-basic__slider">
+                    <media-slider-track class="html-volume-popover-basic__track">
+                        <media-slider-fill class="html-volume-popover-basic__fill"></media-slider-fill>
+                    </media-slider-track>
+                    <media-slider-thumb class="html-volume-popover-basic__thumb"></media-slider-thumb>
+                </media-volume-slider>
+            </media-volume-popover>
+        </div>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.ts
@@ -1,0 +1,4 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/mute-button';
+import '@videojs/html/ui/volume-popover';
+import '@videojs/html/ui/volume-slider';

--- a/site/src/components/docs/demos/volume-popover/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/volume-popover/react/css/BasicUsage.css
@@ -1,0 +1,73 @@
+.react-volume-popover-basic {
+  position: relative;
+}
+
+.react-volume-popover-basic video {
+  width: 100%;
+}
+
+.react-volume-popover-basic__controls {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+}
+
+.react-volume-popover-basic__trigger {
+  padding: 8px 20px;
+  color: black;
+  cursor: pointer;
+  background: rgb(255 255 255 / 70%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+  backdrop-filter: blur(10px);
+}
+
+.react-volume-popover-basic__popup {
+  --media-popover-side-offset: 8px;
+  width: 40px;
+  height: 120px;
+  padding: 12px;
+  margin: 0;
+  background: rgb(0 0 0 / 85%);
+  border: 0;
+  border-radius: 8px;
+}
+
+.react-volume-popover-basic__slider {
+  position: relative;
+  width: 16px;
+  height: 96px;
+  margin: auto;
+  cursor: pointer;
+}
+
+.react-volume-popover-basic__track {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 6px;
+  width: 4px;
+  background: rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+}
+
+.react-volume-popover-basic__fill {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: var(--media-slider-fill);
+  background: white;
+  border-radius: inherit;
+}
+
+.react-volume-popover-basic__thumb {
+  position: absolute;
+  bottom: var(--media-slider-fill);
+  left: 1px;
+  width: 14px;
+  height: 14px;
+  background: white;
+  border-radius: 50%;
+  transform: translateY(50%);
+}

--- a/site/src/components/docs/demos/volume-popover/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/volume-popover/react/css/BasicUsage.tsx
@@ -1,0 +1,32 @@
+import { Container, createPlayer, MuteButton, VolumePopover, VolumeSlider } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="react-volume-popover-basic">
+        <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <div className="react-volume-popover-basic__controls">
+          <VolumePopover.Root openOnHover side="top">
+            <VolumePopover.Trigger
+              className="react-volume-popover-basic__trigger"
+              render={
+                <MuteButton render={(props, state) => <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>} />
+              }
+            />
+            <VolumePopover.Popup className="react-volume-popover-basic__popup">
+              <VolumeSlider.Root orientation="vertical" className="react-volume-popover-basic__slider">
+                <VolumeSlider.Track className="react-volume-popover-basic__track">
+                  <VolumeSlider.Fill className="react-volume-popover-basic__fill" />
+                </VolumeSlider.Track>
+                <VolumeSlider.Thumb className="react-volume-popover-basic__thumb" />
+              </VolumeSlider.Root>
+            </VolumePopover.Popup>
+          </VolumePopover.Root>
+        </div>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/content/docs/reference/volume-popover.mdx
+++ b/site/src/content/docs/reference/volume-popover.mdx
@@ -1,0 +1,110 @@
+---
+title: VolumePopover
+frameworkTitle:
+  html: media-volume-popover
+description: A volume-aware popover that keeps mute available when volume level controls are unavailable
+---
+
+import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+import StyleCase from "@/components/docs/StyleCase.astro";
+import Demo from "@/components/docs/demos/Demo.astro";
+
+{/* React demos */}
+import BasicUsageDemoReact from "@/components/docs/demos/volume-popover/react/css/BasicUsage";
+import basicUsageReactTsx from "@/components/docs/demos/volume-popover/react/css/BasicUsage.tsx?raw";
+import basicUsageReactCss from "@/components/docs/demos/volume-popover/react/css/BasicUsage.css?raw";
+
+{/* HTML demos */}
+import BasicUsageDemoHtml from "@/components/docs/demos/volume-popover/html/css/BasicUsage.astro";
+import basicUsageHtml from "@/components/docs/demos/volume-popover/html/css/BasicUsage.html?raw";
+import basicUsageHtmlCss from "@/components/docs/demos/volume-popover/html/css/BasicUsage.css?raw";
+import basicUsageHtmlTs from "@/components/docs/demos/volume-popover/html/css/BasicUsage.ts?raw";
+
+## Anatomy
+
+<FrameworkCase frameworks={["react"]}>
+  ```tsx
+  <VolumePopover.Root>
+    <VolumePopover.Trigger render={<MuteButton />} />
+    <VolumePopover.Popup>
+      <VolumeSlider.Root />
+    </VolumePopover.Popup>
+  </VolumePopover.Root>
+  ```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  ```html
+  <media-mute-button commandfor="volume-popup"></media-mute-button>
+  <media-volume-popover id="volume-popup">
+    <media-volume-slider></media-volume-slider>
+  </media-volume-popover>
+  ```
+</FrameworkCase>
+
+## Behavior
+
+`VolumePopover` combines <DocsLink slug="reference/popover">popover behavior</DocsLink> with volume availability. When volume level controls are unavailable, it closes and omits the popup while keeping the mute trigger rendered. This lets media with fixed volume keep mute control without exposing a nonfunctional slider.
+
+The HTML trigger can target the popup with `commandfor`. An immediately adjacent trigger is linked automatically when neither element has an authored ID.
+
+## Styling
+
+The popup reflects `data-availability="available"` while it can render volume controls. HTML also receives native `hidden` and `data-hidden` when it cannot.
+
+<FrameworkCase frameworks={["html"]}>
+```css
+media-volume-popover[data-open] {
+  opacity: 1;
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+React renders the popup as a standard `<div>`. Add a `className` to select it:
+
+```css
+.volume-popup[data-open] {
+  opacity: 1;
+}
+```
+</FrameworkCase>
+
+## Accessibility
+
+The trigger receives `aria-haspopup`, `aria-expanded`, and `aria-controls` while the volume popup is available. When only mute is available, the trigger keeps the mute button's own accessible name and behavior without popup ARIA.
+
+## Examples
+
+### Basic usage
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+        { title: "App.css", code: basicUsageReactCss, lang: "css" },
+      ]}
+    >
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: basicUsageHtml, lang: "html" },
+        { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+        { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+      ]}
+    >
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<ComponentReference component="VolumePopover" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -135,6 +135,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/time-slider' },
           { slug: 'reference/title' },
           { slug: 'reference/tooltip' },
+          { slug: 'reference/volume-popover' },
           { slug: 'reference/volume-slider' },
         ],
       },


### PR DESCRIPTION
Refs #2260

## Summary

Add a volume-aware popover compound that preserves mute behavior without structural style queries or target-specific transform gates.

## Changes

- Add `VolumePopover.Root`, `Trigger`, and `Popup` across Core, React, HTML, and VJSC targets
- Preserve the mute trigger while omitting unavailable volume-level controls
- Close an open popup when volume availability changes and remove popup ARIA from the fallback trigger
- Replace the React-only injected availability gate and HTML descendant selector with component-owned state
- Add generated API reference, React/HTML demos, transform snapshots, and runtime coverage

## Stack

8 of 9. Base: #2376. Next: #2381.

Full stack: #2343 → #2347 → #2348 → #2355 → #2344 → #2345 → #2376 → #2378 → #2381.

## Testing

- `pnpm -F @videojs/core test`
- `pnpm -F @videojs/react test`
- `pnpm -F @videojs/html test`
- `pnpm -F @videojs/skins test`
- `pnpm -F site api-docs`
- `pnpm -F site test`
- `pnpm -F site build`
- `pnpm typecheck`
- `pnpm check:workspace`
- `pnpm -F @videojs/e2e e2e vjsc-skin-styling.spec.ts --project=vjsc-chromium` (84 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches player controls, popover open/close, and accessibility attributes when volume availability changes at runtime; scope is bounded to the new compound and skin wiring with solid test coverage.
> 
> **Overview**
> Introduces a **VolumePopover** compound (`Root`, `Trigger`, `Popup`) across Core, React, HTML (`media-volume-popover`), and VJSC, so volume UI can follow **media volume availability** instead of ad hoc skin logic.
> 
> When level controls are not `available`, the component **hides/closes the popup**, **drops popover ARIA** on the trigger, and **keeps the mute trigger** as a plain button fallback; when availability returns or is present, behavior matches a normal popover with `data-availability` / `data-hidden` state.
> 
> Skins and codegen **swap generic `Popover` + `usePlayer` availability ternaries and CSS `has-[media-volume-slider[data-hidden]]`** for the new primitive; `PopoverElement` exposes a **`triggerElement` getter** for subclasses. Adds tests, reference docs, and React/HTML demos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e49854e8f0698bcaf34ffefaf14bf76ed2d8206f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->