### PR TITLE
docs(site): correct v10 guides after merge

### DIFF
--- a/packages/core/src/dom/store/selectors.ts
+++ b/packages/core/src/dom/store/selectors.ts
@@ -20,7 +20,7 @@ import { volumeFeature } from './features/volume';
 
 /** Select the audio track state (audioTrackList, selectAudioTrack). */
 export const selectAudioTrack = createSelector(audioTrackFeature);
-/** Select the buffer state (buffered ranges, percent buffered). */
+/** Select the buffer state (buffered and seekable ranges). */
 export const selectBuffer = createSelector(bufferFeature);
 /** Select the controls state (controls visible, user-active). */
 export const selectControls = createSelector(controlsFeature);

--- a/site/src/components/docs/demos/background-video/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/background-video/react/css/BasicUsage.css
@@ -1,5 +1,13 @@
-.container {
+.react-background-video-basic {
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+
+.react-background-video-basic > video {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }

--- a/site/src/components/docs/demos/background-video/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/background-video/react/css/BasicUsage.tsx
@@ -2,7 +2,7 @@ import { BackgroundVideo } from '@videojs/react/media/background-video';
 
 export default function BasicUsage() {
   return (
-    <div className="container">
+    <div className="react-background-video-basic">
       <BackgroundVideo src="{{VJS10_DEMO_BACKGROUND_VIDEO_MP4}}" />
     </div>
   );

--- a/site/src/content/docs/concepts/browser-support.mdx
+++ b/site/src/content/docs/concepts/browser-support.mdx
@@ -25,15 +25,19 @@ Video.js 10 builds directly on the web platform: custom elements, CSS custom pro
 
 ### Progressive enhancement
 
-When we use a platform feature that hasn't landed in all supported browsers yet, we provide a fallback. The player works either way; the experience may differ slightly in older browsers. For example, tooltips and popovers use CSS anchor positioning where available and fall back to absolute positioning where it isn't.
+When we use a platform feature that hasn't landed in all supported browsers yet, we provide a fallback. The player works either way; the experience may differ slightly in older browsers. For example, tooltips and popovers use CSS anchor positioning where available and fall back to JavaScript-computed positioning where it isn't.
 
 ## Rendering contexts
 
-### WebViews and PWAs
+### WebViews
 
-A [WebView](https://developer.mozilla.org/en-US/docs/Glossary/WebView) is a browser engine embedded inside a native app. WebViews on iOS (WKWebView) and Android (Android WebView) behave differently from the full browser; autoplay policies, fullscreen APIs, and hardware acceleration can vary. Progressive Web Apps (PWAs) installed via "Add to Homescreen" can exhibit similar quirks, since they also run in a limited browser context rather than a full browser tab.
+A [WebView](https://developer.mozilla.org/en-US/docs/Glossary/WebView) is a browser engine embedded inside a native app. WebViews on iOS (WKWebView) and Android (Android WebView) can behave differently from the full browser; autoplay policies, fullscreen APIs, and hardware acceleration can vary.
 
-Video.js 10 beta targets only standard browser environments. If you embed a player inside a native app or PWA, test thoroughly for your specific platform and runtime.
+Video.js 10 beta targets standard browser environments. If you embed a player inside a native app, test it on each platform and WebView version you support.
+
+### Progressive Web Apps
+
+Installed Progressive Web Apps (PWAs) use the browser engine, but their standalone display mode and platform policies can affect fullscreen, media sessions, and other browser integration. Test playback both in a browser tab and in the installed app.
 
 ### Smart TVs and set-top boxes
 

--- a/site/src/content/docs/concepts/bundlers.mdx
+++ b/site/src/content/docs/concepts/bundlers.mdx
@@ -13,9 +13,11 @@ If an older bundler reports that one of these paths is missing or not exported, 
 
 ## Vite compatibility
 
-Vite 3.2.8 can load Video.js JavaScript, but it cannot load the exported `@videojs/html/video/skin.css` file. Vite 5.4.19 can load both.
+Use a current Vite release. Testing confirmed that Vite 5.4.19 can load Video.js JavaScript and CSS package exports. Vite 3.2.8 can load the JavaScript, but it cannot load an exported stylesheet such as `@videojs/html/video/skin.css`.
 
-## Publish a wrapper library
+Packaged HTML skins import their own styles, so an HTML application using `@videojs/html/video/skin` doesn't need to import `skin.css` separately. The CSS limitation matters only when your application imports that stylesheet directly.
+
+## Externalize Video.js in a wrapper library
 
 You can skip this section when building an application.
 

--- a/site/src/content/docs/concepts/overview.mdx
+++ b/site/src/content/docs/concepts/overview.mdx
@@ -116,7 +116,7 @@ Media components are the components that actually display your media. They're es
 Media components can be format specific (HLS, DASH), service specific (YouTube, Vimeo, Mux), or use case specific (background video).
 
 <FrameworkCase frameworks={["html"]}>
-Media elements are discovered automatically. Plain `<video>` and `<audio>` elements are found via a `querySelector`, while custom media elements like `<hlsjs-video>` register themselves.
+Media elements are discovered automatically. Plain `<video>` and `<audio>` elements are found via a `querySelector`. Custom media elements like `<hlsjs-video>` register themselves after you import their registration entry point.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
@@ -150,37 +150,13 @@ The default presets are `@videojs/react/video` and `@videojs/react/audio`, cover
 The default presets are `@videojs/html/video` and `@videojs/html/audio`, covering the baseline set of controls you'd expect from the HTML `<video>` and `<audio>` tags. 
 </FrameworkCase>
 
-Beyond the defaults, presets target more specific use cases. For example, `/background` includes a media element with autoplay, mute, and loop built in, a skin with no controls, and just the features needed to power it:
+Beyond the defaults, presets target more specific use cases. The `/background` preset combines a media element with autoplay, mute, and loop built in, a skin with no controls, and only the features needed to power it.
 
 <FrameworkCase frameworks={["react"]}>
-```tsx
-import { BackgroundVideo, BackgroundVideoPlayer, BackgroundVideoSkin } from '@videojs/react/background';
-
-function Hero() {
-  return (
-    <BackgroundVideoPlayer>
-      <BackgroundVideoSkin>
-        <BackgroundVideo src="hero.mp4" />
-      </BackgroundVideoSkin>
-    </BackgroundVideoPlayer>
-  );
-}
-```
+You can use it from `@videojs/react/background`.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
-```html
-<script type="module">
-  import '@videojs/html/background/player';
-  import '@videojs/html/background/video';
-  import '@videojs/html/background/skin';
-</script>
-
-<background-video-player>
-  <background-video-skin>
-    <background-video src="hero.mp4"></background-video>
-  </background-video-skin>
-</background-video-player>
-```
+You can use it from the `@videojs/html/background/*` registration entry points.
 </FrameworkCase>
 
 <DocsLinkCard slug="concepts/presets">Learn more about presets</DocsLinkCard>

--- a/site/src/content/docs/concepts/presets.mdx
+++ b/site/src/content/docs/concepts/presets.mdx
@@ -5,7 +5,6 @@ description: Pre-packaged player configurations that bundle state management, sk
 
 import PresetReference from '@/components/docs/api-reference/PresetReference.astro';
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
-import Aside from '@/components/Aside.astro';
 import DocsLink from '@/components/docs/DocsLink.astro';
 
 A **preset** packages what you need for a specific player use case. It can include special <DocsLink slug="concepts/features">state management</DocsLink>, one or more <DocsLink slug="concepts/skins">skins</DocsLink> for UI, and specific media elements. Instead of assembling these pieces individually, you pick a preset that matches what you're building.
@@ -15,6 +14,7 @@ For example, the `@videojs/react/background` preset includes a media element wit
 
 ```tsx title="App.tsx"
 import { BackgroundVideo, BackgroundVideoPlayer, BackgroundVideoSkin } from '@videojs/react/background'; // [!code focus]
+import '@videojs/react/background/skin.css';
 
 function Hero() {
   return (
@@ -29,7 +29,7 @@ function Hero() {
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
 For example, the `@videojs/html/background` preset includes a media element with autoplay, mute, and loop built in, a skin with no controls, and just the features needed to power them:
-    
+
 ```html title="index.html"
 <script type="module">
   import '@videojs/html/background/player';
@@ -79,7 +79,7 @@ Add features to a preset's feature bundle to enable new functionality. For examp
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx title="App.tsx"
-import { Container, createPlayer, playbackFeature } from '@videojs/react';
+import { Container, createPlayer, playbackFeature, PlayButton } from '@videojs/react';
 import { backgroundFeatures, BackgroundVideo } from '@videojs/react/background';
 
 const { Player } = createPlayer({ // [!code focus]
@@ -103,6 +103,7 @@ function Hero() {
 <script type="module">
   import { createPlayer, playbackFeature, UIElement } from '@videojs/html';
   import { backgroundFeatures } from '@videojs/html/background';
+  import '@videojs/html/background/video';
   import '@videojs/html/ui/container';
   import '@videojs/html/ui/play-button';
 
@@ -111,7 +112,7 @@ function Hero() {
   }); // [!code focus]
 
   class MyPlayer extends ProviderMixin(UIElement) {
-    static readonly tagName = 'my-player';
+    static tagName = 'my-player';
   }
 
   customElements.define('my-player', MyPlayer);

--- a/site/src/content/docs/concepts/skins.mdx
+++ b/site/src/content/docs/concepts/skins.mdx
@@ -5,9 +5,6 @@ description: Packaged player designs that include both UI components and their s
 
 import PresetReference from '@/components/docs/api-reference/PresetReference.astro';
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
-import { FrostedSkinDemo } from '@/examples/react/FrostedSkin/FrostedSkinDemo';
-import { MinimalSkinDemo } from '@/examples/react/MinimalSkin/MinimalSkinDemo';
-import MinimalFrame from '@/components/frames/Minimal.astro';
 import DocsLink from '@/components/docs/DocsLink.astro';
 import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
 import Aside from '@/components/Aside.astro';
@@ -17,30 +14,9 @@ import EjectedSkin from '@/components/docs/EjectedSkin.astro';
 In prior versions of Video.js, skins were CSS-only themes applied to the same set of default controls. In version 10 the concept of skins has been expanded to include the UI components, so each skin can be completely unique and only include the UI components it needs.
 </Aside>
 
-<FrameworkCase frameworks={["html"]}>
+A skin wraps the media component and provides the player's complete interface. It combines a specific set of UI components with the styles that arrange and present them.
 
-```html
-<video-player>
-  <video-skin><!-- [!code focus] -->
-    <!-- wraps the media element --> <!-- [!code focus] -->
-    <video src="video.mp4"></video>
-  </video-skin><!-- [!code focus] -->
-</video-player>
-```
-
-</FrameworkCase>
-<FrameworkCase frameworks={["react"]}>
-```tsx
-<VideoPlayer>
-  <VideoSkin> {/* [!code focus] */}
-    {/* wraps the Media component */} {/* [!code focus] */}
-    <Video src="video.mp4"></Video>
-  </VideoSkin> {/* [!code focus] */}
-</VideoPlayer>
-```
-</FrameworkCase>
-
-## Packaged vs. ejected
+## Packaged and ejected skins
 
 When you choose a skin you have two options for how you use it: **packaged** or **ejected**. It's usually easiest to start with a packaged skin and later eject its internal components into your project when you need more customization.
 
@@ -52,36 +28,46 @@ Packaged skins cover common visual changes through documented CSS custom propert
 | Documented CSS custom properties | Components and styles you own |
 | Future design updates auto-applied by bumping the version | Future design updates manually applied, or intentionally ignored |
 
-Don't depend on elements, class names, or undocumented custom properties inside a packaged skin. They may change between releases. In an ejected skin, the markup and styles become app code that you own.
-
-<DocsLinkCard slug="how-to/customize-skins">Read more about ejecting skins</DocsLinkCard>
-<DocsLinkCard slug="concepts/ui-components">Read more about UI Components</DocsLinkCard>
-
-### Example of packaged
+### Packaged skin
 
 <FrameworkCase frameworks={["html"]}>
 
 ```html
-  <video-player>
-    <video-skin>
-      <!--...Media...-->
-    </video-skin>
-  </video-player>
+<script type="module">
+  import '@videojs/html/video/player';
+  import '@videojs/html/video/skin';
+</script>
 
+<video-player>
+  <video-skin>
+    <video src="video.mp4"></video>
+  </video-skin>
+</video-player>
 ```
 
 </FrameworkCase>
 <FrameworkCase frameworks={["react"]}>
-```tsx
-  <VideoPlayer>
-    <VideoSkin>
-      {/* ...Media... */}
-    </VideoSkin>
-  </VideoPlayer>
+```tsx title="Player.tsx"
+import { Video, VideoPlayer, VideoSkin } from '@videojs/react/video';
+import '@videojs/react/video/skin.css';
+
+export function Player() {
+  return (
+    <VideoPlayer>
+      <VideoSkin>
+        <Video src="video.mp4" />
+      </VideoSkin>
+    </VideoPlayer>
+  );
+}
 ```
 </FrameworkCase>
 
-### Example of ejected
+Don't depend on elements, class names, or undocumented custom properties inside a packaged skin. They may change between releases.
+
+### Ejected skin
+
+An ejected skin exposes its UI components and styles as app code that you own. You can add, remove, rearrange, or restyle any part of it.
 
 <FrameworkCase frameworks={["html"]}>
   <EjectedSkin id="default-video" />
@@ -91,6 +77,9 @@ Don't depend on elements, class names, or undocumented custom properties inside 
   <EjectedSkin id="default-video-react" />
 </FrameworkCase>
 
+<DocsLinkCard slug="how-to/customize-skins">Read more about ejecting skins</DocsLinkCard>
+<DocsLinkCard slug="concepts/ui-components">Read more about UI components</DocsLinkCard>
+
 ## Skins, features, and presets
 
 Each skin is built with specific <DocsLink slug="concepts/features">features</DocsLink> in mind. For example, a video skin renders fullscreen and picture-in-picture controls. An audio skin doesn't.
@@ -99,40 +88,36 @@ You'll find a preconfigured player, its typed hook, a skin, and the matching fea
 
 <PresetReference />
 
-Presets are a topic quite a bit bigger than just this guide. To learn more, check out the guide:
-
 <DocsLinkCard slug="concepts/presets">Read about presets</DocsLinkCard>
 
 ## Styling
 
-There are currently two options for styling:
+Packaged skins use vanilla CSS. Their documented CSS custom properties cover common visual changes.
 
 <FrameworkCase frameworks={["react"]}>
 
-- Vanilla CSS — import the stylesheet listed for each skin in the [preset table](#skins-features-and-presets). This is the default.
-- Tailwind where you [eject](../how-to/customize-skins#ejecting) the skin and use Tailwind classnames in your app.
+Import the stylesheet listed for each skin in the [preset table](#skins-features-and-presets).
 
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
 
-- Vanilla CSS that's automatically imported. This is the default.
-- Tailwind where you [eject](../how-to/customize-skins#ejecting) the skin and use Tailwind classnames in your app.
+The skin registration entry point imports its styles automatically.
 
 </FrameworkCase>
 
-### Current limitations
+To use Tailwind or change the underlying CSS, [eject the skin](../how-to/customize-skins#ejecting) and edit its styles in your app.
 
-- In both style systems we assume a 16px root font size and we use rem units for sizing.
-- The default font stack includes [`Inter`](https://rsms.me/inter/) (because it's awesome) but we do not load the webfonts for you. If they are not available then system fonts are used.
+### Shared limitations
 
-These only apply to ejected HTML and React skins:
+- Both style systems assume a 16px root font size and use rem units for sizing.
+- The default font stack includes [`Inter`](https://rsms.me/inter/), but we do not load the webfont for you. If Inter is unavailable, the skin uses system fonts.
 
-#### Vanilla CSS
+### Ejected vanilla CSS
 
 - We use a [BEM](https://en.bem.info/methodology/quick-start/) classname structure and every component classname is scoped with a `media-` prefix.
 
-#### Tailwind
+### Ejected Tailwind
 
-- Currently we're assuming you're using the default configuration and that's all that's supported. With the release of our CLI, this will change, allowing you to specify a custom prefix to the Tailwind classnames. For now, you'll need to edit the ejected skins yourself.
-- We're assuming the latest version, currently 4.2.x.
+- Ejected skins currently assume the default configuration. A future CLI eject command will support custom class prefixes. For now, edit the ejected skin to use your prefix.
+- Ejected skins currently support Tailwind 4.2.x.

--- a/site/src/content/docs/concepts/ui-components.mdx
+++ b/site/src/content/docs/concepts/ui-components.mdx
@@ -1,6 +1,6 @@
 ---
 title: UI components
-description: How Video.js UI components work — one element per component, data attributes for state, and compound composition.
+description: How Video.js UI components use focused elements, data attributes for state, and compound composition.
 ---
 
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
@@ -9,13 +9,14 @@ import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
 
 UI components are controls like buttons, sliders, and time displays.
 
-Every UI component renders exactly one HTML element, taking inspiration from projects like [shadcn/ui](https://ui.shadcn.com/) and [Base UI](https://base-ui.com/). This approach gives you control over styling and behavior while handling the complex interactions for you.
+Visible UI components render at most one HTML element, taking inspiration from projects like [shadcn/ui](https://ui.shadcn.com/) and [Base UI](https://base-ui.com/). This approach gives you control over styling and behavior while handling the complex interactions for you. State-only components render no markup, and controls can skip rendering when their feature is unavailable.
 
 Individual controls provide interaction, accessible names, and state. You add their visible text or icons and CSS. Sliders also need the child elements and styles shown on their reference pages.
 
 ## Where to put your components
+
 <FrameworkCase frameworks={["react"]}>
-UI Components can go anywhere inside a <DocsLink slug="reference/player-provider">`<Player>`</DocsLink>.
+UI components can go anywhere inside a <DocsLink slug="reference/player-provider">`<Player>`</DocsLink>.
 
 However, you should consider placing your components in `<Container>`. Components in `<Container>` will go fullscreen with the player, respond to user activity, and more.
 
@@ -23,7 +24,7 @@ However, you should consider placing your components in `<Container>`. Component
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-UI Components can go anywhere inside a <DocsLink slug="reference/player-provider">`<video-player>`</DocsLink>.
+UI components can go anywhere inside a <DocsLink slug="reference/player-provider">`<video-player>`</DocsLink>.
 
 However, you should consider placing your components in `<media-container>`. Components in `<media-container>` will go fullscreen with the player, respond to user activity, and more.
 
@@ -139,7 +140,7 @@ Some components also expose **CSS custom properties** for continuous values like
 
 ## Compound components
 
-Complex interactions are split into composable parts. A parent manages shared state while children consume it. Each part is still one element.
+Complex interactions are split into composable parts. A parent manages shared state while children consume it. Each visible part owns at most one element.
 
 <FrameworkCase frameworks={["react"]}>
 

--- a/site/src/content/docs/concepts/why-videojs.mdx
+++ b/site/src/content/docs/concepts/why-videojs.mdx
@@ -109,7 +109,7 @@ Of course, you don't have to think about every feature you're going to need if y
 
 ### Framework-native
 
-Many player libraries wrap a single web component for every framework. That works, until you reach the seams: refs you can't pass through, state that doesn't reconcile, prop names that aren't quite React or HTML. Video.js ships idiomatic APIs in each framework: React components and hooks for React, custom elements and controllers for HTML. We plan to support more frameworks in the future.
+Many player libraries wrap a single web component for every framework. That works, until you reach the seams: refs you can't pass through, state that doesn't reconcile, prop names that aren't quite React or HTML. Video.js ships idiomatic APIs for its supported frameworks: React components and hooks for React, and custom elements and controllers for HTML.
 
 The player feels like the rest of your app.
 

--- a/site/src/content/docs/concepts/why-videojs.mdx
+++ b/site/src/content/docs/concepts/why-videojs.mdx
@@ -14,7 +14,7 @@ import firefoxDefaultControls from '@/assets/docs/concepts/why-videojs/firefox-d
 
 Video.js is the open-source video player for the web. It makes web video easy, performant, accessible, and customizable. 
 
-Let's dig into when you'd want to use Video.js, starting with the the question we hear most...
+Let's dig into when you'd want to use Video.js, starting with the question we hear most...
 
 
 ## Why not `<video>`?
@@ -60,17 +60,17 @@ Chrome, Safari, and Firefox each render the default `<video>` controls different
 
 ### Video interactions
 
-Video often involves a lot more than an MP4 in `src`. Rich playback features (like thumbnail previews, adaptive bitrate, quality selection, chapters, audio track switching, control localization, error UI, live-streaming UI, analytics, ads, 360 video, Chromecast, AirPlay, DRM, and more) are _possible_ with the video element but require complex wiring and deep consideration for maintainabilty and <DocsLink slug="concepts/accessibility">accessibility</DocsLink>.
+Video often involves more than an MP4 in `src`. Features like thumbnail previews, adaptive bitrate, quality selection, chapters, audio track switching, localized controls, error UI, live-streaming UI, AirPlay, and DRM are _possible_ with the video element, but require complex wiring and careful work on maintainability and <DocsLink slug="concepts/accessibility">accessibility</DocsLink>.
 
-Video.js aims to handle this all out of the box. (Though some features are still under development. Stay tuned!)
+Video.js provides accessible, composable building blocks for these common playback and streaming features. Other integrations, including ads and emerging media formats, remain under development as version 10 matures.
 
 ### Streaming formats and sources
 
-Behind features like adaptive bitrate and quality selection are video formats like HLS or DASH -- videos broken into segments that can be selected according to bandwidth and preferences. Not every browser supports HLS, and DASH support is even more limited. Video.js closes the gap so the same `src` works everywhere.
+Behind features like adaptive bitrate and quality selection are streaming formats such as HLS and DASH. They split video into segments that a playback engine can select based on bandwidth and preferences. Choose the matching Video.js media component to play these formats across browsers while keeping the surrounding player state and UI consistent.
 
-Of course, your video might not be coming from a `src` like that. It might be provided by a service. However, services like YouTube, Vimeo, and Mux each speak their own API. Switching from a self-hosted file to a hosted service shouldn't mean switching players. Video.js abstracts the source so you can change where the video comes from without rewriting the surrounding code.
+Of course, your video might not be coming from a `src` like that. It might be provided by a service. However, services like YouTube, Vimeo, and Mux each speak their own API. Video.js gives their media components a consistent interface, so changing providers doesn't require rebuilding the player around them.
 
-Video.js even considers sources like canvas-based MoQ or animated GIFs, all with the same components.
+That boundary also gives us a path to future sources such as canvas-based MoQ playback and use cases such as animated GIF replacement without rebuilding the controls around them.
 
 ## Why Video.js?
 
@@ -109,7 +109,7 @@ Of course, you don't have to think about every feature you're going to need if y
 
 ### Framework-native
 
-Many player libraries wrap a single web component for every framework. That works, until you reach the seams: refs you can't pass through, state that doesn't reconcile, prop names that aren't quite React or HTML. Video.js ships idiomatic APIs in each framework: React components and hooks for React, custom elements and controllers for HTML. (And we plan on supporting more frameworks in the futrue!) 
+Many player libraries wrap a single web component for every framework. That works, until you reach the seams: refs you can't pass through, state that doesn't reconcile, prop names that aren't quite React or HTML. Video.js ships idiomatic APIs in each framework: React components and hooks for React, custom elements and controllers for HTML. We plan to support more frameworks in the future.
 
 The player feels like the rest of your app.
 
@@ -121,6 +121,7 @@ The player feels like the rest of your app.
   <TabsPanel client:idle value="react" initial>
     ```tsx
     import { VideoPlayer, Video, VideoSkin } from '@videojs/react/video';
+    import '@videojs/react/video/skin.css';
 
     function MyPlayer() {
       return (
@@ -135,7 +136,10 @@ The player feels like the rest of your app.
   </TabsPanel>
   <TabsPanel client:idle value="html">
     ```html
-    <script type="module" src="@videojs/html/video/player"></script>
+    <script type="module">
+      import '@videojs/html/video/player';
+      import '@videojs/html/video/skin';
+    </script>
 
     <video-player>
       <video-skin>
@@ -150,7 +154,7 @@ The player feels like the rest of your app.
 
 Most player libraries draw a line between "configurable through props" and "fork the source." Cross the line and you're on your own. Video.js lets you eject any skin and walk away with the source: components in your framework's language that you can read and change. The skin you ship is yours; the rest of the player keeps working underneath it.
 
-We don't want to cram every possible player into one configuration API. Packaged skins cover common visual changes. For everything else, eject early and compose the UI you need. Today that starts with copy and paste. Soon, a CLI will do the copying for you.
+We don't want to cram every possible player into one configuration API. Packaged skins cover common visual changes. For everything else, eject early and compose the UI you need. Today that starts with copy and paste. A future CLI eject command will automate the copying.
 
 <DocsLinkCard slug="how-to/customize-skins">Customize skins</DocsLinkCard>
 

--- a/site/src/content/docs/how-to/customize-skins.mdx
+++ b/site/src/content/docs/how-to/customize-skins.mdx
@@ -8,7 +8,7 @@ import StyleCase from '@/components/docs/StyleCase.astro';
 import EjectedSkin from '@/components/docs/EjectedSkin.astro';
 import DocsLink from '@/components/docs/DocsLink.astro';
 
-Video.js v10 comes with two pre-built skins; Default and Minimal. Basic customization is possible with CSS custom properties, but if you want more control over the design and functionality of your player, you can copy the skin's code into your project and modify it as needed. We call this "ejecting" the skin, since you're taking the internal code that makes up the skin and making it your own.
+Video.js v10 comes with two pre-built skins: Default and Minimal. Start with their public CSS custom properties. When you need to change controls, layout, or interactions, eject the closest skin by copying its code into your project and making it your own.
 
 ## Basic customization
 
@@ -76,7 +76,7 @@ Vanilla CSS skins use `--media-scale-unit` as the base for control spacing, icon
 
 </StyleCase>
 
-You can of course also add your own classnames to the skins themselves.
+You can also add your own class names to the skins.
 
 ## Where packaged customization stops
 
@@ -98,15 +98,19 @@ See <DocsLink slug="reference/poster">Poster</DocsLink>.
 
 For anything deeper, eject instead of reaching into the packaged skin. There are no packaged-skin options for adding, removing, or rearranging controls, or replacing its built-in feedback and interactions.
 
-## Ejecting
-
-If you'd like to customize them you can fully customize them by "ejecting" the code and making it your own.
+## Eject a skin
 
 Eject as soon as the packaged skin no longer matches the player you need. Once ejected, removing a control is removing a component, and changing an overlay or interaction is editing code you own.
 
-An ejected skin is app code, so its markup, classnames, and styles are yours to change. If none of the packaged skins is a useful starting point, build a custom UI from the player, container, and individual <DocsLink slug="concepts/ui-components">UI components</DocsLink> instead.
+An ejected skin is app code, so its markup, class names, and styles are yours to change. If none of the packaged skins is a useful starting point, build a custom UI from the player, container, and individual <DocsLink slug="concepts/ui-components">UI components</DocsLink> instead.
 
 Soon, we'll have a CLI that ejects skins in your preferred framework and style. For now, we invite you to try these copy-paste-ready implementations.
+
+To eject a skin:
+
+1. Choose the closest implementation below.
+2. Copy every file shown for your framework into your project.
+3. Replace the packaged skin with the copied component or player markup, then edit the files you own.
 
 {/*TODO: Add StyleCase for tailwind variants once tailwind is a supported style (see #840)*/}
 

--- a/site/src/content/docs/how-to/i18n-register-locale.mdx
+++ b/site/src/content/docs/how-to/i18n-register-locale.mdx
@@ -148,17 +148,21 @@ All keys are optional. Missing keys follow the <DocsLink slug="concepts/i18n">lo
 Load the player and a locale chunk. CDN locale modules call <DocsLink slug="reference/register-i18n">`registerI18n`</DocsLink> on import:
 
 ```html
-<script type="module" src="{{VJS10_HTML_CDN_BASE}}/video.js"></script>
-<script type="module" src="{{VJS10_HTML_CDN_BASE}}/locales/es.js"></script>
-
+<!doctype html>
 <html lang="es">
-  <media-i18n>
-    <video-player>
-      <video-skin>
-        <video src="..." playsinline></video>
-      </video-skin>
-    </video-player>
-  </media-i18n>
+  <head>
+    <script type="module" src="{{VJS10_HTML_CDN_BASE}}/locales/es.js"></script>
+    <script type="module" src="{{VJS10_HTML_CDN_BASE}}/video.js"></script>
+  </head>
+  <body>
+    <media-i18n>
+      <video-player>
+        <video-skin>
+          <video src="..." playsinline></video>
+        </video-skin>
+      </video-player>
+    </media-i18n>
+  </body>
 </html>
 ```
 
@@ -179,7 +183,7 @@ registerI18n('es', {
 });
 ```
 
-Load your module after the player script and before playback starts.
+Load your locale module before the player module so its strings are registered before the player upgrades.
 
 </FrameworkCase>
 

--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -89,7 +89,7 @@ Video.js aims to provide idiomatic development experiences in React components o
 </ContentWidth>
 
 <FrameworkCase frameworks={["html"]}>
-  Complete the installation steps below, then visit the guide for your framework for more detailed integration information. We're planning on adding official support in the future.
+  Complete the installation steps below, then visit the guide for your framework for more detailed integration information. These guides use the HTML custom elements until we add first-party Vue and Svelte packages.
 
   <DocsLinkCard slug="how-to/use-videojs-with-vue">Vue and Nuxt</DocsLinkCard>
 

--- a/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
+++ b/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
@@ -316,12 +316,6 @@ Chapters themselves do work. Add a default `<track kind="chapters">` and the pac
 
 Packaged skins don't expose an autohide switch. Eject the closest skin and remove its hidden-control styles. That's safer than overriding internal selectors in a skin you don't own.
 
-To change the *delay* rather than disable it, note that the idle timer is a constant inside `controlsFeature`. Fork that feature, swap it into a custom feature list, and pass that list to `createPlayer`:
-
-```ts
-const features = videoFeatures.map((f) => (f.name === 'controls' ? myControlsFeature : f));
-```
-
 ### Breakpoints
 
 The skin root is an inline-size container named `media-root`, so write responsive styles with container queries instead of `breakpoints` attributes. This is exactly how the built-in skins adapt:

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -68,7 +68,7 @@ Here's a typical Mux Player embed. A playback ID, a title and viewer ID for anal
 ></mux-player>
 ```
 
-A <DocsLink slug="concepts/presets">preset</DocsLink> is a player, a skin, and a media element that already fit together. Everything else is its own import. From the CDN, that's one script for the video preset, one for the Mux media, and one for analytics:
+From the CDN, load the video <DocsLink slug="concepts/presets">preset</DocsLink>, the Mux media, and analytics:
 
 ```html
 <script type="module" src="{{VJS10_HTML_CDN_BASE}}/video.js"></script>
@@ -128,7 +128,7 @@ export function MyPlayer() {
 npm install @videojs/react
 ```
 
-One new idea here. Instead of one component that does everything, you pick a <DocsLink slug="concepts/presets">preset</DocsLink> that matches what you're building. A preset is a player, a skin, and a media element that already fit together. `@videojs/react/video` is the general-purpose one, and it's what you want unless you're doing something unusual.
+Start with the general-purpose `@videojs/react/video` <DocsLink slug="concepts/presets">preset</DocsLink>, then add the Mux media and analytics components:
 
 ```tsx
 'use client';
@@ -567,6 +567,7 @@ import '@videojs/html/media/mux-video';
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
+import '@videojs/react/live-video/skin.css';
 import { LiveVideoPlayer, LiveVideoSkin } from '@videojs/react/live-video';
 import { MuxVideo } from '@videojs/react/media/mux-video';
 
@@ -580,7 +581,7 @@ import { MuxVideo } from '@videojs/react/media/mux-video';
 
 You get `targetLiveWindow` and `liveEdgeStart` in player state, plus a live button that jumps to the live edge. The live preset doesn't include `streamType` state and doesn't force a source to be live. The Mux media detects the manifest: `targetLiveWindow` is `NaN` for an on-demand or unknown source, `0` for a sliding live window, and `Infinity` for a live event with playback history. See <DocsLink slug="reference/feature-live">the live feature</DocsLink>.
 
-The live composition is narrower than the video one on purpose: it leaves out quality, audio-track, and playback-rate state, none of which apply cleanly to a stream with no fixed duration. So a live skin's settings menu holds captions and nothing else. If you need one of the others on a live player, build your own player from a feature list rather than taking the preset's.
+The live composition is narrower than the video one on purpose: it leaves out quality, audio-track, and playback-rate state. A live skin's settings menu therefore holds captions and nothing else. If you need one of the omitted features on a live player, build your own player from a feature list rather than taking the preset's.
 
 <FrameworkCase frameworks={["html"]}>
 Use <DocsLink slug="reference/html-create-player">`createPlayer`</DocsLink> to build a player element from that list.
@@ -618,7 +619,7 @@ Do not rebuild this behavior from `duration` or set `currentTime` to `Infinity`.
 
 #### An on-demand video shows live controls
 
-Video.js does not replace the preset after reading the HLS playlist. Render the video preset for on-demand content and the live preset for live content. If the same part of your app handles both, use `streamType` to choose the preset or controls.
+Video.js does not replace the preset after reading the HLS playlist. Render the video preset for on-demand content and the live preset for live content. If the same part of your app handles both, choose the preset from application or content metadata before rendering. If only the manifest can tell you, use a custom player with the stream type feature and choose the controls from that state.
 
 #### `selectStreamType` returns `undefined`
 

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -69,7 +69,7 @@ The easiest path is the CDN:
       <track kind="metadata" label="thumbnails" src="/path/to/storyboard.vtt" default />
     </video>
 
-    <img slot="poster" src="/path/to/poster.jpg" alt="Video poster" />
+    <img slot="poster" src="/path/to/poster.jpg" alt="" />
   </video-minimal-skin>
 </video-player>
 ```
@@ -133,7 +133,7 @@ export function AppVideoPlayer({ origin }: AppVideoPlayerProps) {
 
 </FrameworkCase>
 
-## Advanced migration
+## Map common features
 
 ### Streaming
 
@@ -388,11 +388,7 @@ Individual HTML buttons include no text, icon, or finished styling. Add your own
 Individual React buttons do not include visible content. Use their `render` props to add an icon or text and style the element you return. Eject a ready-made skin when you need to change its control set or layout.
 </FrameworkCase>
 
-## Dynamic sources
-
-In Video.js v10 you can swap out the `src` or the media component itself and the UI will update.
-
-## Imperative API
+## Use the imperative API
 
 Use the media element for standard playback operations:
 
@@ -406,6 +402,8 @@ Use the media element for standard playback operations:
 | `player.speed = 1.5` | `video.playbackRate = 1.5` |
 | `player.fullscreen.enter()` | Fullscreen feature or fullscreen control |
 | `player.toggleCaptions()` | Text-track feature or captions control |
+
+To change content without changing media type, set `src` on the media component. Replace the component when the media type changes, such as moving from `Video` to `HlsVideo`. The player UI follows the attached media.
 
 For custom UI, read and write through the Video.js player store.
 
@@ -477,7 +475,7 @@ video-player {
 
 `--media-accent-color` reaches the sliders, active buttons, and accent surfaces, so it's the closest match for Plyr's `--plyr-color-main`. Video.js picks a readable text color to sit on top of it; set `--media-accent-text-color` to choose that yourself. `--media-border-radius` and `--media-scale-unit` cover rounding and control sizing. See <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink> for the full list.
 
-## Ejecting
+## Eject a skin
 
 If you need extra customization of layout, styles, or icons, you can "eject" the skin into your application, much like a shadcn installation. Copy the skin and its CSS into your project, then modify the components and styles directly. <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink> has copy-paste-ready implementations for every packaged skin.
 

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -94,7 +94,7 @@ v10 ships web components, so the migration keeps its declarative feel. One scrip
 </video-player>
 ```
 
-With a bundler, the same thing is three imports:
+With a bundler, the same thing is two imports:
 
 ```js
 import '@videojs/html/video/player';
@@ -159,8 +159,8 @@ import { Video, VideoPlayer, VideoSkin } from '@videojs/react/video';
 
 export function MyPlayer() {
   return (
-    <VideoPlayer>
-      <VideoSkin className="aspect-video" poster="/poster.jpg">
+    <VideoPlayer poster="/poster.jpg">
+      <VideoSkin className="aspect-video">
         <Video src="/video.mp4" preload="auto" playsInline>
           <track kind="captions" src="/captions/en.vtt" srclang="en" label="English" default />
           <track kind="metadata" src="/storyboard.vtt" label="thumbnails" default />
@@ -177,7 +177,7 @@ Three differences worth understanding, because each one is a pattern you'll see 
 
 - **No `videojs()` call and no effect.** `VideoPlayer` owns the lifecycle.
 - **No `controls` prop.** The skin *is* the controls. Rendering a skin is how you ask for them, which is also how you opt out.
-- **The poster is a skin prop, not a media attribute.** That's what lets the skin control how it appears, rather than the browser.
+- **The poster is player metadata, not a media attribute.** Pass it to `VideoPlayer`, and the skin controls how it appears.
 
 The `'use client'` directive is there because the player owns browser state. There's also a minimal skin, closer to v8's control bar, if the default's frosted look is too much of a change.
 
@@ -188,7 +188,7 @@ The `'use client'` directive is there because the player owns browser state. The
 The v8 options object is gone, and its contents scattered in four directions. This is the biggest conceptual step, so it's worth understanding the four buckets before you go looking for a specific option.
 
 1. **Media attributes.** Anything the browser itself understands stays exactly where it was, on your media element.
-2. **Skin attributes.** The poster belongs to the skin, because the skin is what paints it.
+2. **Player metadata.** The title and poster belong to player state, which lets the skin or your custom UI render them.
 3. **Your CSS.** Sizing, aspect ratio, and responsive behavior are layout, and layout is yours.
 4. **Composition.** Which controls exist, which shortcuts fire, which language you're in. You express these by choosing components rather than by setting flags.
 
@@ -202,34 +202,37 @@ Port these across untouched. They're native attributes and always were.
 | `sources: [{ src, type }]` | `src`, or `<source>` children for progressive fallback |
 | `disablePictureInPicture` | `disablepictureinpicture` |
 
-### Skin attributes
+### Player metadata
 
 | Video.js 8 | Video.js v10 |
 |---|---|
-| `poster` | the skin's poster |
-| `posterImage: false` | leave the poster unset |
-| the title in `TitleBar` | `content-title` on the player, with no built-in UI yet |
+| `poster` | `poster` on `<video-player>` or `VideoPlayer` |
+| `posterImage: false` | leave the player's poster unset |
+| the title in `TitleBar` | `content-title` on `<video-player>` or `title` on `VideoPlayer`, rendered with the Title component |
 
-The poster belongs to the skin rather than the media, which is what lets the skin control how it appears:
+The poster belongs to player state rather than the media, which lets the skin control how it appears:
 
 <FrameworkCase frameworks={["html"]}>
 ```html
-<video-skin>
-  <video src="/video.mp4"></video>
-  <img slot="poster" src="/poster.jpg" alt="" />
-</video-skin>
+<video-player poster="/poster.jpg">
+  <video-skin>
+    <video src="/video.mp4"></video>
+  </video-skin>
+</video-player>
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
 ```jsx
-<VideoSkin poster="/poster.jpg">
-  <Video src="/video.mp4" />
-</VideoSkin>
+<VideoPlayer poster="/poster.jpg">
+  <VideoSkin>
+    <Video src="/video.mp4" />
+  </VideoSkin>
+</VideoPlayer>
 ```
 </FrameworkCase>
 
-`content-title` is the closest thing to v8's `TitleBar`, and it does reach player state, so your own UI can read it. No packaged skin draws it, so v8's `TitleBar` has no visual equivalent ([#1123](https://github.com/videojs/v10/issues/1123)). See the <DocsLink slug="reference/poster">Poster</DocsLink> reference for the poster component itself.
+The packaged skins do not place the title in their default layouts. Add the <DocsLink slug="reference/title">Title</DocsLink> component as a child of the skin, or place it in an ejected or custom layout. See the <DocsLink slug="reference/poster">Poster</DocsLink> reference for poster rendering options.
 
 ### Your CSS
 
@@ -491,7 +494,7 @@ class MyElapsed extends ReactiveElement {
 
 ### Player state
 
-There are **no `on*` props**. Read state through the preset's <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> hook, typed to that preset's features:
+Put standard media event props such as `onPlay`, `onTimeUpdate`, `onEnded`, and `onError` on `Video` or your chosen media component. Read player state through the preset's <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> hook, typed to that preset's features:
 
 ```tsx
 import { usePlayer } from '@videojs/react/video';
@@ -523,7 +526,7 @@ v8 used accessor methods for everything: `player.currentTime()` to read, `player
 | `player.audioTracks()` | `audioTracks` in player state |
 | `player.error()` | `error` in player state |
 | `player.dispose()` | remove the element, or unmount the component |
-| `player.tech()` | `.host.engine` on engine-backed media, where one exists |
+| `player.tech()` | the media component's public `engine` escape hatch, where one exists; in React, reach it through `useMedia()` |
 | `videojs.getPlayer(id)` | hold a reference to the element |
 
 Swapping sources is the change most likely to surprise you. There's no `player.src()`; you set `src` on the media element, or replace the media element entirely, and the UI follows. Changing formats is changing tags.
@@ -579,6 +582,7 @@ For audio, use the audio player with the audio skin, or the live audio pair. The
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
+import '@videojs/react/live-video/skin.css';
 import { HlsVideo } from '@videojs/react/media/hls-video';
 import { LiveVideoPlayer, LiveVideoSkin } from '@videojs/react/live-video';
 
@@ -592,9 +596,9 @@ import { LiveVideoPlayer, LiveVideoSkin } from '@videojs/react/live-video';
 For audio, use the audio preset, or the live audio one. There's also a background video preset for muted, chrome-free background video, which v8 had no answer for.
 </FrameworkCase>
 
-You get `streamType`, `targetLiveWindow`, and `liveEdgeStart` in state, plus a live button that jumps to the live edge. v8's `liveTracker` tuning has no equivalent ([#1730](https://github.com/videojs/v10/issues/1730)).
+You get `targetLiveWindow` and `liveEdgeStart` in state, plus a live button that jumps to the live edge. The live preset does not include `streamType`; add the stream type feature to a custom player when you need it. v8's `liveTracker` tuning has no equivalent ([#1730](https://github.com/videojs/v10/issues/1730)).
 
-The live composition is deliberately narrower than the video one. It leaves out playback rate, quality, and audio-track state, so those controls don't appear in a live skin's settings menu. If you need one of them on a live player, build your own player from a feature list rather than taking the preset's.
+The live composition is deliberately narrower than the video one. It leaves out playback rate, quality, and audio-track state, so those controls don't appear in a live skin's settings menu. If you need an omitted feature on a live player, build your own player from a feature list rather than taking the preset's.
 
 <FrameworkCase frameworks={["html"]}>
 That's what <DocsLink slug="reference/html-create-player">`createPlayer`</DocsLink> is for. Hand it a feature list and you get back the mixins to define your own player element.
@@ -611,7 +615,6 @@ Ordered roughly by how likely each is to block a v8 migration.
 - **No ads support.** v8's IMA and ad-plugin ecosystem has no v10 equivalent. This is the most common hard blocker.
 - **No playlist support.** No `videojs-playlist` equivalent.
 - **No plugin system**, by design. Budget for rebuilding UI plugins as components. See [Plugins](#plugins).
-- No skin draws `content-title`, so v8's `TitleBar` has no visual equivalent ([#1123](https://github.com/videojs/v10/issues/1123)).
 - Playback rates are a fixed set — `0.2`, `0.5`, `0.7`, `1`, `1.2`, `1.5`, `1.7`, `2` — so v8's `playbackRates` has no equivalent yet ([#1404](https://github.com/videojs/v10/issues/1404)).
 - No text-track settings dialog. v8's `textTrackSettings` let viewers restyle captions; v10 exposes only the positioning custom properties its skins define.
 - No spatial navigation. v8's `spatialNavigation` for TV and D-pad remotes has no equivalent.

--- a/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
+++ b/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
@@ -17,7 +17,7 @@ If your component needs to react to player state or call a player action, wait u
   import { onMount } from 'svelte';
 
   let player: VideoPlayerElement;
-  let paused = $state(true);
+  let paused = true;
 
   onMount(() => {
     const sync = () => (paused = player.store.paused);

--- a/site/src/content/docs/reference/background-video.mdx
+++ b/site/src/content/docs/reference/background-video.mdx
@@ -28,7 +28,15 @@ import basicUsageHtml from "@/components/docs/demos/background-video/html/css/Ba
 import basicUsageHtmlCss from "@/components/docs/demos/background-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/background-video/html/css/BasicUsage.ts?raw";
 
-Decorative background video for a source the browser can play natively. By default it's muted, looped, and autoplaying — use the opt-out attributes below to change that. It renders a `<video>` inside a shadow DOM and fills the box you give the component.
+Decorative background video for a source the browser can play natively. By default it's muted, looped, and autoplaying.
+
+<FrameworkCase frameworks={["react"]}>
+`BackgroundVideo` renders a native `<video>`. Override the defaults with native React props such as `muted={false}`, `loop={false}`, or `autoPlay={false}`, and size the video with `className` or `style`.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+`<background-video>` renders a `<video>` inside shadow DOM and fills the box you give the component. Use the opt-out attributes in the [API reference](#api-reference) to change its playback defaults.
+</FrameworkCase>
 
 An HLS URL only works where the browser has native HLS playback. See <DocsLink slug="how-to/add-a-background-video">Add a background video</DocsLink> to choose a cross-browser HLS or Mux path and set up layout, poster, and decorative semantics.
 
@@ -58,6 +66,8 @@ An HLS URL only works where the browser has native HLS playback. See <DocsLink s
     </Demo>
   </StyleCase>
 </FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
 
 ## API Reference
 
@@ -90,6 +100,18 @@ An HLS URL only works where the browser has native HLS playback. See <DocsLink s
   </Tbody>
 </Table>
 
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+
+## Styling
+
+`BackgroundVideo` is the native `<video>` element, so size and position it with regular CSS. Use `object-fit` and `object-position` to control how the video fills its box.
+
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+
 ### CSS Custom Properties
 
 <Table outerClass="my-6">
@@ -113,3 +135,5 @@ An HLS URL only works where the browser has native HLS playback. See <DocsLink s
     </Tr>
   </Tbody>
 </Table>
+
+</FrameworkCase>

--- a/site/src/content/docs/reference/feature-buffer.mdx
+++ b/site/src/content/docs/reference/feature-buffer.mdx
@@ -24,15 +24,19 @@ Pass `selectBuffer` to <DocsLink slug="reference/player-controller">`PlayerContr
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
-```tsx title="BufferBar.tsx"
+```tsx title="BufferedRanges.tsx"
 import { selectBuffer, usePlayer } from '@videojs/react';
 
-function BufferBar() {
+function BufferedRanges() {
   const buffer = usePlayer(selectBuffer);
   if (!buffer) return null;
 
   return (
-    <div style={{ width: `${buffer.percentBuffered * 100}%` }} />
+    <ul>
+      {buffer.buffered.map(([start, end]) => (
+        <li key={`${start}-${end}`}>{start.toFixed(1)}–{end.toFixed(1)} seconds</li>
+      ))}
+    </ul>
   );
 }
 ```

--- a/site/src/content/docs/reference/mux-video.mdx
+++ b/site/src/content/docs/reference/mux-video.mdx
@@ -48,7 +48,7 @@ If for some reason you need a bit more control, you can use the `src` param with
 />
 ```
 
-MuxVideo fires a `sourcechange` event when the source actually changes. Setting the same values again, like a fresh object on a React re-render, doesn't fire it.
+MuxVideo ignores the same source object when it is assigned again. A new object fires `sourcechange` even when its values are equal, although an equivalent playback source does not reload.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -70,7 +70,7 @@ video.source = {
 };
 ```
 
-MuxVideo fires a `sourcechange` event when the source actually changes. Setting the same values again doesn't fire it.
+MuxVideo ignores the same source object when it is assigned again. A new object fires `sourcechange` even when its values are equal, although an equivalent playback source does not reload.
 </FrameworkCase>
 
 ## Posters and storyboards
@@ -167,24 +167,41 @@ MuxVideo plays Mux streams. It doesn't monitor them or cast them — <DocsLink s
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
+import { createPlayer } from '@videojs/react';
 import { GoogleCast } from '@videojs/react/media/google-cast';
 import { MuxData } from '@videojs/react/media/mux-data';
 import { MuxVideo } from '@videojs/react/media/mux-video';
+import { videoFeatures } from '@videojs/react/video';
 
-<MuxVideo source={{ playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM' }} playsInline />
-<MuxData playerSoftwareName="mux-video" />
-<GoogleCast />
+const { Player } = createPlayer({ features: videoFeatures });
+
+export function MuxPlayer() {
+  return (
+    <Player>
+      <MuxVideo source={{ playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM' }} playsInline />
+      <MuxData playerSoftwareName="mux-video" />
+      <GoogleCast />
+    </Player>
+  );
+}
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
 ```html
-<mux-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" playsinline></mux-video>
-<mux-data player-software-name="mux-video"></mux-data>
-<google-cast></google-cast>
-```
+<script type="module">
+  import '@videojs/html/video/player';
+  import '@videojs/html/media/mux-video';
+  import '@videojs/html/media/mux-data';
+  import '@videojs/html/media/google-cast';
+</script>
 
-Register the elements by importing `@videojs/html/media/mux-data` and `@videojs/html/media/google-cast`.
+<video-player>
+  <mux-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" playsinline></mux-video>
+  <mux-data player-software-name="mux-video"></mux-data>
+  <google-cast></google-cast>
+</video-player>
+```
 </FrameworkCase>
 
 <DocsLinkCard slug="concepts/mux-data" description="Metadata, options, and configuration">Mux Data</DocsLinkCard>

--- a/site/src/content/docs/reference/player-container.mdx
+++ b/site/src/content/docs/reference/player-container.mdx
@@ -10,17 +10,17 @@ import DocsLink from '@/components/docs/DocsLink.astro';
 import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
 
 <FrameworkCase frameworks={["react"]}>
-The `Container` is the player's physical surface. It defines the visual boundary, attaches the media element, and detects user interaction like activity and (eventually) gestures and keyboard input. It lives inside a <DocsLink slug="reference/player-provider">`Player`</DocsLink>.
+The `Container` is the player's physical surface. It defines the visual boundary, registers the fullscreen and activity target, and gives gesture and hotkey components a shared interaction surface. It lives inside a <DocsLink slug="reference/player-provider">`Player`</DocsLink>.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
-The `<media-container>` is the player's physical surface. It defines the visual boundary, attaches the media element, and detects user interaction like activity and (eventually) gestures and keyboard input. It lives inside a <DocsLink slug="reference/player-provider">`<video-player>`</DocsLink>.
+The `<media-container>` is the player's physical surface. It defines the visual boundary, registers the fullscreen and activity target, and gives gesture and hotkey elements a shared interaction surface. It lives inside a <DocsLink slug="reference/player-provider">`<video-player>`</DocsLink>.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 <Player>
   <Container> {/* [!code focus] */}
-    <video src="video.mp4" />
+    <Video src="video.mp4" />
     <Controls.Root>
       {/* ... */}
     </Controls.Root>
@@ -46,7 +46,7 @@ Import `Container` from the main React package. It connects to whichever `Player
 
 ```tsx
 import { Container, createPlayer } from '@videojs/react';
-import { videoFeatures } from '@videojs/react/video';
+import { Video, videoFeatures } from '@videojs/react/video';
 
 const { Player } = createPlayer({ features: videoFeatures });
 ```
@@ -55,11 +55,10 @@ const { Player } = createPlayer({ features: videoFeatures });
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-Register the standard player and skin entry points for a complete video player. The skin supplies `<media-container>` and the UI elements it uses:
+Import the standard player entry point. It registers both `<video-player>` and `<media-container>`:
 
 ```ts
 import '@videojs/html/video/player';
-import '@videojs/html/video/skin';
 ```
 
 ```html
@@ -91,7 +90,7 @@ The container is the visual box around your media and controls. Put sizing, aspe
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 <Container style={{ position: 'relative', width: 640, aspectRatio: '16/9' }}>
-  <video src="video.mp4" />
+  <Video src="video.mp4" />
   <Controls.Root>
     {/* ... */}
   </Controls.Root>
@@ -165,7 +164,7 @@ If you omit `<video-skin>` to build custom UI, render and style `<media-containe
 ```tsx
 <Player>
   <Container>
-    <video src="video.mp4" />
+    <Video src="video.mp4" />
     <Controls.Root>          {/* fullscreen, activity detection, gestures */}
       {/* ... */}
     </Controls.Root>

--- a/site/src/content/docs/reference/player-provider.mdx
+++ b/site/src/content/docs/reference/player-provider.mdx
@@ -19,7 +19,7 @@ The `<video-player>` element is the state boundary of your player. It creates a 
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx title="App.tsx"
-import { videoFeatures } from '@videojs/react/video';
+import { Video, videoFeatures } from '@videojs/react/video';
 import { Container, createPlayer } from '@videojs/react';
 
 const { Player } = createPlayer({ features: videoFeatures });
@@ -29,7 +29,7 @@ function App() {
     <Player>
       {/* Everything inside can access the player store */}
       <Container>
-        <video src="video.mp4" />
+        <Video src="video.mp4" />
       </Container>
     </Player>
   );
@@ -141,13 +141,15 @@ If you omit `<video-skin>` and import only the player and media elements, those 
 Use `usePlayer` to read state or call actions from any component inside `Player`:
 
 ```tsx title="PlayPauseButton.tsx"
+import { selectPlayback, usePlayer } from '@videojs/react';
+
 function PlayPauseButton() {
-  const paused = usePlayer(selectPlayback).paused;
-  const store = usePlayer();
+  const playback = usePlayer(selectPlayback);
+  if (!playback) return null;
 
   return (
-    <button onClick={() => store.dispatch('toggle-playback')}>
-      {paused ? 'Play' : 'Pause'}
+    <button onClick={() => playback.togglePaused()}>
+      {playback.paused ? 'Play' : 'Pause'}
     </button>
   );
 }
@@ -159,18 +161,25 @@ function PlayPauseButton() {
 Use `PlayerController` to subscribe to store state from any custom element inside the provider:
 
 ```ts title="play-pause-button.ts"
-import { selectPlayback } from '@videojs/html';
+import { PlayerController, UIElement, playerContext, selectPlayback } from '@videojs/html';
 
 class PlayPauseButton extends UIElement {
-  #playback = new PlayerController(this, context, selectPlayback);
+  readonly #playback = new PlayerController(this, playerContext, selectPlayback);
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener('click', () => {
-      this.#playback.store?.dispatch('toggle-playback');
-    });
+    this.addEventListener('click', this.#togglePlayback);
   }
+
+  disconnectedCallback() {
+    this.removeEventListener('click', this.#togglePlayback);
+    super.disconnectedCallback();
+  }
+
+  readonly #togglePlayback = () => this.#playback.value?.togglePaused();
 }
+
+customElements.define('play-pause-button', PlayPauseButton);
 ```
 
 <DocsLinkCard slug="reference/player-controller">PlayerController reference</DocsLinkCard>
@@ -184,7 +193,7 @@ The player's scope can extend beyond the fullscreen target. Playlists, transcrip
 ```tsx
 <Player>
   <Container>
-    <video src="video.mp4" />
+    <Video src="video.mp4" />
     <Controls.Root>          {/* goes fullscreen with the video */}
       {/* ... */}
     </Controls.Root>

--- a/site/src/content/docs/reference/use-media.mdx
+++ b/site/src/content/docs/reference/use-media.mdx
@@ -14,7 +14,7 @@ import basicUsageReactCss from "@/components/docs/demos/use-media/react/css/Basi
 
 `useMedia` returns the media object attached to the current player. It returns `null` until the media mounts. Call it inside the matching `Player`.
 
-The media object may be an `HTMLVideoElement` or a Video.js media object that controls one. It always provides common media methods such as `play()` and `pause()`.
+The media object may be an `HTMLVideoElement` or a Video.js media object that controls one. It always provides `play()`. Check `isMediaPauseCapable(media)` before using `pause()` because lightweight media implementations do not have to provide it.
 
 With a packaged preset, import `useMedia` from `@videojs/react`. With a player made by <DocsLink slug="reference/create-player">`createPlayer`</DocsLink>, use the `useMedia` hook returned by that call. It is connected to the new player's context.
 

--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -25,13 +25,29 @@ import withPartsHtmlTs from "@/components/docs/demos/volume-slider/html/css/With
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <VolumeSlider.Root />
+  <VolumeSlider.Root>
+    <VolumeSlider.Track>
+      <VolumeSlider.Fill />
+    </VolumeSlider.Track>
+    <VolumeSlider.Thumb />
+    <VolumeSlider.Preview>
+      <VolumeSlider.Value type="pointer" />
+    </VolumeSlider.Preview>
+  </VolumeSlider.Root>
   ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
   ```html
-  <media-volume-slider></media-volume-slider>
+  <media-volume-slider>
+    <media-slider-track>
+      <media-slider-fill></media-slider-fill>
+    </media-slider-track>
+    <media-slider-thumb></media-slider-thumb>
+    <media-slider-preview>
+      <media-slider-value type="pointer"></media-slider-value>
+    </media-slider-preview>
+  </media-volume-slider>
   ```
 </FrameworkCase>
 


### PR DESCRIPTION
## Summary

Follow up on the merged Video.js 10 migration documentation with a source-backed editorial and correctness audit. This fixes examples that no longer match current APIs and smooths repetition introduced across the documentation batch.

## Changes

- Correct broken poster, event, live-state, player-attachment, state-action, buffer, and source-change examples.
- Separate React and HTML behavior where the APIs differ, especially background video and player composition.
- Make skin, preset, framework, i18n, and migration guidance lead readers through a complete supported path.
- Correct the `selectBuffer` JSDoc and the React background-video demo alongside the prose they own.

## Editorial choices

- Narrow current capability promises in Why Video.js while preserving future-facing architecture language.
- Remove repeated packaged-skin and background-preset walkthroughs, and separate packaged from ejected styling guidance.
- Turn skin ejection into a choose, copy, replace workflow; trim repeated Mux setup and the incomplete Media Chrome autohide fork recipe.
- Tighten Plyr section hierarchy, clarify first-party framework package language, and use broadly compatible Svelte state syntax.

## Testing

- `pnpm -F site api-docs`
- `pnpm -F site astro check` (0 errors)
- `pnpm -F site test` (611 tests passed)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to site docs, demo CSS, and a comment in core selectors; no runtime player behavior is modified.
> 
> **Overview**
> This PR is a **documentation and demo cleanup pass** after the v10 docs merge: examples and prose are brought in line with how presets, skins, player metadata, and buffer state actually work today.
> 
> **API-aligned fixes** include moving **poster/title to `VideoPlayer` / `<video-player>`** (not the skin), using **`selectPlayback` / `togglePaused()`** in player examples, showing **`buffer.buffered` ranges** instead of removed `percentBuffered`, clarifying **`MuxVideo` `sourcechange`** semantics, and noting **`useMedia` pause** requires `isMediaPauseCapable`. Core gets a small **`selectBuffer` JSDoc** update (buffered + seekable).
> 
> **Integration guidance** is tightened across concepts, skins/presets, bundlers, browser support (WebViews vs PWAs), and migration guides (v8, Plyr, Mux, Media Chrome): React examples add explicit **`skin.css` imports** where needed; HTML examples use **registration entry points**; **background video** docs split React (native `<video>`) from HTML (shadow DOM + opt-out attributes); the React background demo gets **cover-style layout CSS**; CDN **locale load order** is corrected; incomplete workarounds (e.g. Media Chrome autohide delay fork) are removed.
> 
> **Editorial** trims duplicate preset/background walkthroughs, narrows marketing claims in Why Video.js, and reframes skin customization (packaged vs ejected, eject workflow steps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 260db1eaeb36de8fad92d30638be45bd001fb958. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->