### PR TITLE
fix(packages): restore minimal volume controls

### DIFF
--- a/apps/e2e/tests/sandbox-skin-styling.spec.ts
+++ b/apps/e2e/tests/sandbox-skin-styling.spec.ts
@@ -69,11 +69,11 @@ for (const { platform, skin, styling } of CASES) {
   });
 }
 
-for (const { platform, styling } of CASES.filter(({ skin }) => skin === 'minimal')) {
-  test(`${platform} minimal ${styling} reveals the volume thumb on keyboard focus`, async ({ page }) => {
+for (const { platform, skin, styling } of CASES) {
+  test(`${platform} ${skin} ${styling} opens the volume popover`, async ({ page }) => {
     const query = new URLSearchParams({
       styling,
-      skin: 'minimal',
+      skin,
       source: 'mp4-1',
       autoplay: '0',
       muted: '1',
@@ -87,10 +87,20 @@ for (const { platform, styling } of CASES.filter(({ skin }) => skin === 'minimal
     await expect(root).toBeVisible({ timeout: 15_000 });
 
     const muteButton = page.getByRole('button', { name: 'Unmute' }).first();
+    await muteButton.hover();
+    const muteTooltip = page.locator('[popover="manual"]').filter({ hasText: 'Unmute' }).first();
+    if (skin === 'minimal') await expect(muteTooltip).toBeVisible();
+    else await expect(muteTooltip).toHaveCount(0);
+
+    const volumeThumb = page.getByRole('slider', { name: 'Volume' }).first();
+    await expect(volumeThumb).toBeVisible();
+    await expect(volumeThumb).toHaveCSS('opacity', '1');
+    await expect(volumeThumb).toHaveCSS('scale', '1');
+    if (skin === 'minimal') await expect(muteTooltip).toBeVisible();
+
     await muteButton.focus();
     await page.keyboard.press('Tab');
 
-    const volumeThumb = page.getByRole('slider', { name: 'Volume' }).first();
     await expect(volumeThumb).toBeFocused();
     await expect(volumeThumb).toHaveCSS('opacity', '1');
     await expect(volumeThumb).toHaveCSS('scale', '1');

--- a/packages/core/src/core/ui/tooltip/tooltip-core.ts
+++ b/packages/core/src/core/ui/tooltip/tooltip-core.ts
@@ -22,6 +22,8 @@ export interface TooltipProps {
   disableHoverablePopup?: boolean | undefined;
   /** When true, the tooltip is disabled and will not open. */
   disabled?: boolean | undefined;
+  /** Whether the tooltip stays open when another popup opens from its trigger. */
+  sticky?: boolean | undefined;
 }
 
 export interface TooltipInput extends TransitionState {}
@@ -47,6 +49,7 @@ export class TooltipCore {
     closeDelay: 0,
     disableHoverablePopup: true,
     disabled: false,
+    sticky: false,
   };
 
   #props = { ...TooltipCore.defaultProps };

--- a/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
+++ b/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
@@ -247,6 +247,25 @@ describe('createTooltip', () => {
         expect(onOpenChange).toHaveBeenCalledWith(false, { reason: 'imperative-action' });
       });
 
+      it('stays open with its trigger popup when requested', () => {
+        const group = createPopupGroup();
+        const owner = createTestPopover({ group: () => group });
+        const { tooltip, onOpenChange } = createTestTooltip({
+          popupGroup: () => group,
+          sticky: () => true,
+        });
+        const trigger = document.createElement('button');
+        owner.popover.setTriggerElement(trigger);
+        tooltip.setTriggerElement(trigger);
+        tooltip.open();
+        onOpenChange.mockClear();
+
+        owner.popover.open();
+
+        expect(onOpenChange).not.toHaveBeenCalled();
+        expect(tooltip.input.current.active).toBe(true);
+      });
+
       it('does not open via focus after pointer down (tap)', () => {
         const { tooltip, onOpenChange } = createTestTooltip();
         const pointerEvent = {

--- a/packages/core/src/dom/ui/tooltip/tooltip.ts
+++ b/packages/core/src/dom/ui/tooltip/tooltip.ts
@@ -27,6 +27,7 @@ export interface TooltipOptions {
   closeDelay?: () => number;
   disableHoverablePopup?: () => boolean;
   disabled?: () => boolean;
+  sticky?: () => boolean;
   group?: () => TooltipGroupCore | undefined;
   popupGroup?: () => PopupGroup | undefined;
 }
@@ -98,6 +99,10 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
     return popupGroup?.isOpenFor(popover.triggerElement) ?? false;
   }
 
+  function isSticky(): boolean {
+    return options.sticky?.() ?? false;
+  }
+
   function syncPopupGroup(): void {
     const next = options.popupGroup?.();
     if (next === popupGroup) return;
@@ -105,14 +110,14 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
     unsubscribe?.();
     popupGroup = next;
     unsubscribe = popupGroup?.subscribe(() => {
-      if (isTriggerPopupOpen()) popover.close('imperative-action');
+      if (isTriggerPopupOpen() && !isSticky()) popover.close('imperative-action');
     });
   }
 
   function setTriggerElement(el: HTMLElement | null): void {
     popover.setTriggerElement(el);
     syncPopupGroup();
-    if (isTriggerPopupOpen()) popover.close('imperative-action');
+    if (isTriggerPopupOpen() && !isSticky()) popover.close('imperative-action');
   }
 
   // Spread popover trigger props, omit onClick, guard disabled/touch on open handlers.
@@ -122,19 +127,19 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
     onPointerDown() {
       syncPopupGroup();
       isPointerDown = true;
-      popover.close('imperative-action');
+      if (!isSticky()) popover.close('imperative-action');
     },
     onPointerEnter(event) {
       syncPopupGroup();
       if (options.disabled?.()) return;
-      if (isTriggerPopupOpen()) return;
+      if (isTriggerPopupOpen() && !isSticky()) return;
       if (event.pointerType === 'touch') return;
       baseTriggerProps.onPointerEnter(event);
     },
     onFocusIn(event) {
       syncPopupGroup();
       if (options.disabled?.()) return;
-      if (isTriggerPopupOpen()) return;
+      if (isTriggerPopupOpen() && !isSticky()) return;
       if (isPointerDown) {
         isPointerDown = false;
         return;
@@ -162,7 +167,7 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
     setTriggerElement,
     open: () => {
       syncPopupGroup();
-      if (!isTriggerPopupOpen()) popover.open('hover');
+      if (!isTriggerPopupOpen() || isSticky()) popover.open('hover');
     },
     close: (reason: TooltipOpenChangeReason = 'hover') => popover.close(reason),
     destroy() {

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -107,18 +107,22 @@ function getTemplateHTML() {
           </div>
 
           <div class="${buttonGroup}">
-            <media-mute-button commandfor="audio-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
+            <media-mute-button id="audio-mute-trigger" commandfor="audio-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
               ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}
               ${renderIcon('volume-low', { class: cn(icon, iconState.mute.volumeLow) })}
               ${renderIcon('volume-high', { class: cn(icon, iconState.mute.volumeHigh) })}
             </media-mute-button>
+            <media-tooltip trigger="audio-mute-trigger" delay="0" sticky side="top" class="${cn(popup.tooltip)}">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
+            </media-tooltip>
 
             <media-popover id="audio-volume-popover" open-on-hover delay="200" close-delay="100" side="left" boundary="viewport" class="${cn(popup.volume)}">
               <media-volume-slider class="${slider.root}" orientation="horizontal" thumb-alignment="edge">
                 <media-slider-track class="${slider.track}">
                   <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
                 </media-slider-track>
-                <media-slider-thumb class="${slider.thumb.base}"></media-slider-thumb>
+                <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
               </media-volume-slider>
             </media-popover>
 

--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -89,11 +89,15 @@ function getTemplateHTML() {
           </div>
 
           <div class="media-button-group">
-            <media-mute-button commandfor="audio-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
+            <media-mute-button id="audio-mute-trigger" commandfor="audio-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
               ${renderIcon('volume-off', { class: 'media-icon media-icon--volume-off' })}
               ${renderIcon('volume-low', { class: 'media-icon media-icon--volume-low' })}
               ${renderIcon('volume-high', { class: 'media-icon media-icon--volume-high' })}
             </media-mute-button>
+            <media-tooltip trigger="audio-mute-trigger" delay="0" sticky side="top" class="media-tooltip">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
+            </media-tooltip>
 
             <media-popover id="audio-volume-popover" open-on-hover delay="200" close-delay="100" side="left" boundary="viewport" class="media-popover media-popover--volume">
               <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">

--- a/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
@@ -63,18 +63,22 @@ function getTemplateHTML() {
           <div class="${spacer}" aria-hidden="true"></div>
 
           <div class="${buttonGroup}">
-            <media-mute-button commandfor="live-audio-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
+            <media-mute-button id="live-audio-mute-trigger" commandfor="live-audio-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
               ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}
               ${renderIcon('volume-low', { class: cn(icon, iconState.mute.volumeLow) })}
               ${renderIcon('volume-high', { class: cn(icon, iconState.mute.volumeHigh) })}
             </media-mute-button>
+            <media-tooltip trigger="live-audio-mute-trigger" delay="0" sticky side="top" class="${cn(popup.tooltip)}">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
+            </media-tooltip>
 
             <media-popover id="live-audio-volume-popover" open-on-hover delay="200" close-delay="100" side="left" boundary="viewport" class="${cn(popup.volume)}">
               <media-volume-slider class="${slider.root}" orientation="horizontal" thumb-alignment="edge">
                 <media-slider-track class="${slider.track}">
                   <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
                 </media-slider-track>
-                <media-slider-thumb class="${slider.thumb.base}"></media-slider-thumb>
+                <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
               </media-volume-slider>
             </media-popover>
           </div>

--- a/packages/html/src/define/live-audio/minimal-skin.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.ts
@@ -50,11 +50,15 @@ function getTemplateHTML() {
           <div class="media-time-controls" aria-hidden="true"></div>
 
           <div class="media-button-group">
-            <media-mute-button commandfor="live-audio-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
+            <media-mute-button id="live-audio-mute-trigger" commandfor="live-audio-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
               ${renderIcon('volume-off', { class: 'media-icon media-icon--volume-off' })}
               ${renderIcon('volume-low', { class: 'media-icon media-icon--volume-low' })}
               ${renderIcon('volume-high', { class: 'media-icon media-icon--volume-high' })}
             </media-mute-button>
+            <media-tooltip trigger="live-audio-mute-trigger" delay="0" sticky side="top" class="media-tooltip">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
+            </media-tooltip>
 
             <media-popover id="live-audio-volume-popover" open-on-hover delay="200" close-delay="100" side="left" boundary="viewport" class="media-popover media-popover--volume">
               <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">

--- a/packages/html/src/define/live-video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-video/minimal-skin.tailwind.ts
@@ -71,18 +71,22 @@ function getTemplateHTML() {
 
               <media-live-button class="${cn(button.base, button.subtle, button.live)}"></media-live-button>
 
-              <media-mute-button commandfor="live-video-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
+              <media-mute-button id="live-video-mute-trigger" commandfor="live-video-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
                 ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}
                 ${renderIcon('volume-low', { class: cn(icon, iconState.mute.volumeLow) })}
                 ${renderIcon('volume-high', { class: cn(icon, iconState.mute.volumeHigh) })}
               </media-mute-button>
+              <media-tooltip trigger="live-video-mute-trigger" delay="0" sticky side="top" class="${cn(popup.tooltip)}">
+                <media-tooltip-label></media-tooltip-label>
+                <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
+              </media-tooltip>
 
               <media-popover id="live-video-volume-popover" open-on-hover delay="200" close-delay="100" side="right" class="${cn(popup.volume)}">
                 <media-volume-slider class="${slider.root}" orientation="horizontal" thumb-alignment="edge">
                   <media-slider-track class="${slider.track}">
                     <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
                   </media-slider-track>
-                  <media-slider-thumb class="${slider.thumb.base}"></media-slider-thumb>
+                  <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
                 </media-volume-slider>
               </media-popover>
           </div>

--- a/packages/html/src/define/live-video/minimal-skin.ts
+++ b/packages/html/src/define/live-video/minimal-skin.ts
@@ -51,11 +51,15 @@ function getTemplateHTML() {
 
             <media-live-button class="media-button media-button--subtle media-button--live"></media-live-button>
 
-            <media-mute-button commandfor="live-video-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
+            <media-mute-button id="live-video-mute-trigger" commandfor="live-video-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
               ${renderIcon('volume-off', { class: 'media-icon media-icon--volume-off' })}
               ${renderIcon('volume-low', { class: 'media-icon media-icon--volume-low' })}
               ${renderIcon('volume-high', { class: 'media-icon media-icon--volume-high' })}
             </media-mute-button>
+            <media-tooltip trigger="live-video-mute-trigger" delay="0" sticky side="top" class="media-tooltip">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
+            </media-tooltip>
 
             <media-popover id="live-video-volume-popover" open-on-hover delay="200" close-delay="100" side="right" class="media-popover media-popover--volume">
               <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -75,17 +75,21 @@ function getTemplateHTML() {
                 <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
               </media-tooltip>
 
-            <media-mute-button commandfor="video-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
+            <media-mute-button id="video-mute-trigger" commandfor="video-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
               ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}
               ${renderIcon('volume-low', { class: cn(icon, iconState.mute.volumeLow) })}
               ${renderIcon('volume-high', { class: cn(icon, iconState.mute.volumeHigh) })}
             </media-mute-button>
+            <media-tooltip trigger="video-mute-trigger" delay="0" sticky side="top" class="${cn(popup.tooltip)}">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
+            </media-tooltip>
             <media-popover id="video-volume-popover" open-on-hover delay="200" close-delay="100" side="right" class="${popup.volume}">
               <media-volume-slider class="${slider.root}" orientation="horizontal" thumb-alignment="edge">
                 <media-slider-track class="${slider.track}">
                   <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
                 </media-slider-track>
-                <media-slider-thumb class="${slider.thumb.base}"></media-slider-thumb>
+                <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
               </media-volume-slider>
             </media-popover>
           </div>

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -51,11 +51,15 @@ function getTemplateHTML() {
               <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
             </media-tooltip>
 
-            <media-mute-button commandfor="video-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
+            <media-mute-button id="video-mute-trigger" commandfor="video-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
               ${renderIcon('volume-off', { class: 'media-icon media-icon--volume-off' })}
               ${renderIcon('volume-low', { class: 'media-icon media-icon--volume-low' })}
               ${renderIcon('volume-high', { class: 'media-icon media-icon--volume-high' })}
             </media-mute-button>
+            <media-tooltip trigger="video-mute-trigger" delay="0" sticky side="top" class="media-tooltip">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
+            </media-tooltip>
 
             <media-popover id="video-volume-popover" open-on-hover delay="200" close-delay="100" side="right" class="media-popover media-popover--volume">
               <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">

--- a/packages/html/src/ui/tooltip/tooltip-element.ts
+++ b/packages/html/src/ui/tooltip/tooltip-element.ts
@@ -57,6 +57,7 @@ export class TooltipElement extends UIElement {
     closeDelay: { type: Number, attribute: 'close-delay' },
     disableHoverablePopup: { type: Boolean, attribute: 'disable-hoverable-popup' },
     disabled: { type: Boolean },
+    sticky: { type: Boolean },
     boundary: { type: String },
     trigger: { type: String },
   } satisfies PropertyDeclarationMap<keyof TooltipCore.Props | 'boundary' | 'trigger'>;
@@ -69,6 +70,7 @@ export class TooltipElement extends UIElement {
   closeDelay = TooltipCore.defaultProps.closeDelay;
   disableHoverablePopup = TooltipCore.defaultProps.disableHoverablePopup;
   disabled = TooltipCore.defaultProps.disabled;
+  sticky = false;
   boundary: PositioningBoundary = 'container';
   trigger = '';
 
@@ -104,6 +106,7 @@ export class TooltipElement extends UIElement {
       closeDelay: () => this.closeDelay,
       disableHoverablePopup: () => this.disableHoverablePopup,
       disabled: () => this.disabled,
+      sticky: () => this.sticky,
       // Lazy getter — group may arrive after connect via context.
       group: () => this.#groupConsumer.value,
       popupGroup: () => this.#popupGroupCtx.value,

--- a/packages/html/src/ui/tooltip/tooltip-element.ts
+++ b/packages/html/src/ui/tooltip/tooltip-element.ts
@@ -70,7 +70,7 @@ export class TooltipElement extends UIElement {
   closeDelay = TooltipCore.defaultProps.closeDelay;
   disableHoverablePopup = TooltipCore.defaultProps.disableHoverablePopup;
   disabled = TooltipCore.defaultProps.disabled;
-  sticky = false;
+  sticky = TooltipCore.defaultProps.sticky;
   boundary: PositioningBoundary = 'container';
   trigger = '';
 

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -98,7 +98,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
   return (
     <div
       ref={ref}
-      className={cn(slider.thumb.base, persistent ? undefined : slider.thumb.interactive, className)}
+      className={cn(slider.thumb.base, persistent ? slider.thumb.persistent : slider.thumb.interactive, className)}
       {...props}
     />
   );
@@ -115,11 +115,27 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnavailable) return muteButton;
+  if (volumeUnavailable) {
+    return (
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={muteButton} />
+        <Tooltip.Popup className={cn(popup.tooltip)}>
+          <Tooltip.Label />
+          <Tooltip.Shortcut className={popup.tooltipShortcut} />
+        </Tooltip.Popup>
+      </Tooltip.Root>
+    );
+  }
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="left" boundary="viewport">
-      <Popover.Trigger render={muteButton} />
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={<Popover.Trigger render={muteButton} />} />
+        <Tooltip.Popup className={cn(popup.tooltip)}>
+          <Tooltip.Label />
+          <Tooltip.Shortcut className={popup.tooltipShortcut} />
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Popover.Popup className={cn(popup.volume)}>
         <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -61,11 +61,27 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnavailable) return muteButton;
+  if (volumeUnavailable) {
+    return (
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={muteButton} />
+        <Tooltip.Popup className="media-tooltip">
+          <Tooltip.Label />
+          <Tooltip.Shortcut className="media-tooltip__kbd" />
+        </Tooltip.Popup>
+      </Tooltip.Root>
+    );
+  }
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="left" boundary="viewport">
-      <Popover.Trigger render={muteButton} />
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={<Popover.Trigger render={muteButton} />} />
+        <Tooltip.Popup className="media-tooltip">
+          <Tooltip.Label />
+          <Tooltip.Shortcut className="media-tooltip__kbd" />
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
         <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -75,7 +75,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
   return (
     <div
       ref={ref}
-      className={cn(slider.thumb.base, persistent ? undefined : slider.thumb.interactive, className)}
+      className={cn(slider.thumb.base, persistent ? slider.thumb.persistent : slider.thumb.interactive, className)}
       {...props}
     />
   );
@@ -92,11 +92,27 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnavailable) return muteButton;
+  if (volumeUnavailable) {
+    return (
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={muteButton} />
+        <Tooltip.Popup className={cn(popup.tooltip)}>
+          <Tooltip.Label />
+          <Tooltip.Shortcut className={popup.tooltipShortcut} />
+        </Tooltip.Popup>
+      </Tooltip.Root>
+    );
+  }
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="left" boundary="viewport">
-      <Popover.Trigger render={muteButton} />
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={<Popover.Trigger render={muteButton} />} />
+        <Tooltip.Popup className={cn(popup.tooltip)}>
+          <Tooltip.Label />
+          <Tooltip.Shortcut className={popup.tooltipShortcut} />
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Popover.Popup className={cn(popup.volume)}>
         <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -49,11 +49,27 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnavailable) return muteButton;
+  if (volumeUnavailable) {
+    return (
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={muteButton} />
+        <Tooltip.Popup className="media-tooltip">
+          <Tooltip.Label />
+          <Tooltip.Shortcut className="media-tooltip__kbd" />
+        </Tooltip.Popup>
+      </Tooltip.Root>
+    );
+  }
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="left" boundary="viewport">
-      <Popover.Trigger render={muteButton} />
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={<Popover.Trigger render={muteButton} />} />
+        <Tooltip.Popup className="media-tooltip">
+          <Tooltip.Label />
+          <Tooltip.Shortcut className="media-tooltip__kbd" />
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
         <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -110,7 +110,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
   return (
     <div
       ref={ref}
-      className={cn(slider.thumb.base, persistent ? undefined : slider.thumb.interactive, className)}
+      className={cn(slider.thumb.base, persistent ? slider.thumb.persistent : slider.thumb.interactive, className)}
       {...props}
     />
   );
@@ -127,11 +127,27 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnavailable) return muteButton;
+  if (volumeUnavailable) {
+    return (
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={muteButton} />
+        <Tooltip.Popup className={cn(popup.tooltip)}>
+          <Tooltip.Label />
+          <Tooltip.Shortcut className={popup.tooltipShortcut} />
+        </Tooltip.Popup>
+      </Tooltip.Root>
+    );
+  }
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="right">
-      <Popover.Trigger render={muteButton} />
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={<Popover.Trigger render={muteButton} />} />
+        <Tooltip.Popup className={cn(popup.tooltip)}>
+          <Tooltip.Label />
+          <Tooltip.Shortcut className={popup.tooltipShortcut} />
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Popover.Popup className={cn(popup.volume)}>
         <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -77,11 +77,27 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnavailable) return muteButton;
+  if (volumeUnavailable) {
+    return (
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={muteButton} />
+        <Tooltip.Popup className="media-tooltip">
+          <Tooltip.Label />
+          <Tooltip.Shortcut className="media-tooltip__kbd" />
+        </Tooltip.Popup>
+      </Tooltip.Root>
+    );
+  }
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="right">
-      <Popover.Trigger render={muteButton} />
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={<Popover.Trigger render={muteButton} />} />
+        <Tooltip.Popup className="media-tooltip">
+          <Tooltip.Label />
+          <Tooltip.Shortcut className="media-tooltip__kbd" />
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
         <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -138,7 +138,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
   return (
     <div
       ref={ref}
-      className={cn(slider.thumb.base, persistent ? undefined : slider.thumb.interactive, className)}
+      className={cn(slider.thumb.base, persistent ? slider.thumb.persistent : slider.thumb.interactive, className)}
       {...props}
     />
   );
@@ -155,11 +155,27 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnavailable) return muteButton;
+  if (volumeUnavailable) {
+    return (
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={muteButton} />
+        <Tooltip.Popup className={cn(popup.tooltip)}>
+          <Tooltip.Label />
+          <Tooltip.Shortcut className={popup.tooltipShortcut} />
+        </Tooltip.Popup>
+      </Tooltip.Root>
+    );
+  }
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="right">
-      <Popover.Trigger render={muteButton} />
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={<Popover.Trigger render={muteButton} />} />
+        <Tooltip.Popup className={cn(popup.tooltip)}>
+          <Tooltip.Label />
+          <Tooltip.Shortcut className={popup.tooltipShortcut} />
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Popover.Popup className={popup.volume}>
         <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -99,11 +99,27 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnavailable) return muteButton;
+  if (volumeUnavailable) {
+    return (
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={muteButton} />
+        <Tooltip.Popup className="media-tooltip">
+          <Tooltip.Label />
+          <Tooltip.Shortcut className="media-tooltip__kbd" />
+        </Tooltip.Popup>
+      </Tooltip.Root>
+    );
+  }
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="right">
-      <Popover.Trigger render={muteButton} />
+      <Tooltip.Root side="top" delay={0} sticky>
+        <Tooltip.Trigger render={<Popover.Trigger render={muteButton} />} />
+        <Tooltip.Popup className="media-tooltip">
+          <Tooltip.Label />
+          <Tooltip.Shortcut className="media-tooltip__kbd" />
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
         <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">

--- a/packages/react/src/ui/tooltip/tooltip-root.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-root.tsx
@@ -22,8 +22,6 @@ import { useTooltipGroup } from './group-context';
 export interface TooltipRootProps extends CoreTooltipProps {
   /** Boundary used to constrain the popup size. */
   boundary?: PositioningBoundary;
-  /** Whether the tooltip stays open when another popup opens from its trigger. */
-  sticky?: boolean;
   /** Called when the tooltip open state changes (fires immediately, before animations). */
   onOpenChange?: (open: boolean, details: TooltipChangeDetails) => void;
   /** Called after open/close animations complete. */
@@ -40,7 +38,7 @@ export function TooltipRoot({
   closeDelay = TooltipCore.defaultProps.closeDelay,
   disableHoverablePopup = TooltipCore.defaultProps.disableHoverablePopup,
   disabled = TooltipCore.defaultProps.disabled,
-  sticky = false,
+  sticky = TooltipCore.defaultProps.sticky,
   boundary = 'container',
   children,
   ...coreProps

--- a/packages/react/src/ui/tooltip/tooltip-root.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-root.tsx
@@ -22,6 +22,8 @@ import { useTooltipGroup } from './group-context';
 export interface TooltipRootProps extends CoreTooltipProps {
   /** Boundary used to constrain the popup size. */
   boundary?: PositioningBoundary;
+  /** Whether the tooltip stays open when another popup opens from its trigger. */
+  sticky?: boolean;
   /** Called when the tooltip open state changes (fires immediately, before animations). */
   onOpenChange?: (open: boolean, details: TooltipChangeDetails) => void;
   /** Called after open/close animations complete. */
@@ -38,6 +40,7 @@ export function TooltipRoot({
   closeDelay = TooltipCore.defaultProps.closeDelay,
   disableHoverablePopup = TooltipCore.defaultProps.disableHoverablePopup,
   disabled = TooltipCore.defaultProps.disabled,
+  sticky = false,
   boundary = 'container',
   children,
   ...coreProps
@@ -60,6 +63,7 @@ export function TooltipRoot({
   const closeDelayRef = useLatestRef(closeDelay);
   const disableHoverablePopupRef = useLatestRef(disableHoverablePopup);
   const disabledRef = useLatestRef(disabled);
+  const stickyRef = useLatestRef(sticky);
   const groupRef = useLatestRef(groupFromContext);
   const popupGroupRef = useLatestRef(popupGroup);
 
@@ -76,6 +80,7 @@ export function TooltipRoot({
       closeDelay: () => closeDelayRef.current,
       disableHoverablePopup: () => disableHoverablePopupRef.current,
       disabled: () => disabledRef.current,
+      sticky: () => stickyRef.current,
       group: () => groupRef.current,
       popupGroup: () => popupGroupRef.current,
     });

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -236,12 +236,6 @@
     transition: mask-position 50ms ease-out;
   }
 
-  @container media-root (width <= 42rem) {
-    .media-popover--volume {
-      --media-popover-side-offset: calc(var(--spacing) * 3);
-    }
-  }
-
   &:has(.media-button--mute[aria-expanded="true"]) {
     @container media-root (width <= 42rem) {
       .media-button-group:last-child {
@@ -291,7 +285,8 @@
 /* Popups & Animations */
 
 .media-minimal-skin--video .media-popover--volume {
-  padding: 0;
+  --media-popover-side-offset: 0rem;
+  padding: 0 calc(var(--spacing) * 3);
   background: transparent;
 }
 

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -180,7 +180,7 @@ export const slider = {
 
 export const popup = {
   ...basePopup,
-  volume: cn(basePopup.popover, 'p-0 bg-transparent', '@max-2xl/media-root:[--media-popover-side-offset:--spacing(3)]'),
+  volume: cn(basePopup.popover, 'p-0 px-3 bg-transparent [--media-popover-side-offset:0rem]'),
 };
 
 /* Menu */


### PR DESCRIPTION
## Summary

Restore the missing Minimal Tailwind volume thumb styles and add mute tooltips to Minimal skins without introducing the tooltip/popover clash in Default skins.

## Changes

- Apply the persistent thumb style to Minimal Tailwind volume sliders.
- Add mute tooltips across Minimal React and HTML audio, video, and live presets. I've deliberately omitted Default because it uses the same real estate as the volume popover. Open to ideas though if we want something else here. 
- Keep mute tooltips visible alongside their volume popover with the opt-in `sticky` behavior. Open to changing the name. It follows Floating UI’s `stickIfOpen` terminology, while Base UI’s `closeOnClick` is too specific because our popover can open on hover. ([Floating UI](https://floating-ui.com/docs/useclick), [Base UI](https://base-ui.com/react/components/tooltip))
- Expand sandbox coverage for tooltip, popover, thumb visibility, and keyboard focus behavior.

## Testing

- `pnpm -F @videojs/core test src/dom/ui/tooltip/tests/tooltip.test.ts` (28 passed)
- `pnpm -F @videojs/react build`
- `pnpm -F @videojs/html build`
- `pnpm exec biome check packages/core/src/dom/ui/tooltip/tooltip.ts packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts packages/react/src/ui/tooltip/tooltip-root.tsx packages/html/src/ui/tooltip/tooltip-element.ts packages/react/src/presets packages/html/src/define`
- Focused Playwright sandbox checks for React CSS/Tailwind and HTML CSS skin combinations (8 passed across the final verification runs)
- `git diff --check`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared tooltip/popup interaction logic used beyond skins; incorrect sticky behavior could leave tooltips open or break hover popovers on other triggers.
> 
> **Overview**
> Restores **minimal** skin volume UX: visible volume slider thumbs, mute **tooltips** that can stay open while the hover volume **popover** is open, and tighter volume popover spacing in minimal video CSS/Tailwind.
> 
> Adds an opt-in **`sticky`** flag on tooltips (core, DOM, `media-tooltip`, React `Tooltip.Root`). When enabled, a tooltip no longer auto-closes or blocks hover/focus opens just because its trigger also opened another popup in the same popup group—so mute label/shortcut can show alongside the volume slider without the old tooltip/popover fight. Default skins are unchanged (no mute tooltips).
> 
> Minimal **React** and **HTML** presets (audio, video, live) wrap the mute control in `sticky` tooltips (`delay={0}`), nest tooltip trigger around popover trigger where volume is available, and apply **persistent** thumb classes on volume sliders (including fixing Tailwind `SliderThumb` to use `slider.thumb.persistent`).
> 
> **E2E** expands sandbox coverage: all platform/skin/styling combos assert volume popover + thumb visibility and keyboard focus; minimal-only checks for the mute tooltip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e61e05665e777cdfd42c20ebcac63b780e129c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->