### PR TITLE
fix(core): preserve anchored popovers while scrolling

### DIFF
--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -156,6 +156,24 @@ for (const { name, path } of UI_VIDEO_PAGES) {
       await expect.poll(() => getMediaVolume(page)).toBeLessThan(0.5);
     });
 
+    test('volume popover stays anchored after scrolling the page', async ({ page }) => {
+      await page.evaluate(() => {
+        document.body.style.minHeight = '300vh';
+        document.body.style.paddingTop = '150vh';
+        window.scrollTo(0, window.innerHeight * 1.5);
+      });
+      await player.showControls();
+      await player.muteButton.hover();
+      await expect(player.volumeSlider).toBeVisible();
+
+      const triggerBox = await player.muteButton.boundingBox();
+      const popupBox = await page.locator('.media-popover--volume').first().boundingBox();
+      if (!triggerBox || !popupBox) throw new Error('Volume popover not visible');
+
+      expect(popupBox.y + popupBox.height).toBeLessThanOrEqual(triggerBox.y);
+      expect(popupBox.y + popupBox.height).toBeGreaterThanOrEqual(triggerBox.y - 16);
+    });
+
     test('controls remain visible while the settings menu is open', async ({ page }) => {
       await player.showControls();
       await player.settingsButton.click();

--- a/packages/core/src/dom/ui/popover/popover-positioning.ts
+++ b/packages/core/src/dom/ui/popover/popover-positioning.ts
@@ -78,14 +78,19 @@ function getAnchorCrossAxisShift(
   boundaryEnd: number,
   align: PopoverAlign,
   alignOffset: number,
-  boundaryOffset: number
+  boundaryOffset: number,
+  axis: 'horizontal' | 'vertical',
+  alignOffsetVar: string
 ): { base: string; translate: string } {
   const base =
     align === 'start' ? start + alignOffset : align === 'end' ? end + alignOffset : start + size / 2 + alignOffset;
+  const startAnchor = axis === 'horizontal' ? 'left' : 'top';
+  const endAnchor = OPPOSITE_SIDE[startAnchor];
+  const anchor = align === 'start' ? startAnchor : align === 'end' ? endAnchor : 'center';
   const desiredTranslate = align === 'start' ? '0px' : align === 'end' ? '-100%' : '-50%';
 
   return {
-    base: `${base}px`,
+    base: `calc(anchor(${anchor}) + ${alignOffsetVar})`,
     translate: `clamp(${boundaryStart + boundaryOffset - base}px, ${desiredTranslate}, calc(${
       boundaryEnd - boundaryOffset - base
     }px - 100%))`,
@@ -185,7 +190,9 @@ function getAnchorPositionCSS(
         boundaryRect.right,
         horizontalAlign,
         offsets.alignOffset,
-        boundaryOffset
+        boundaryOffset,
+        'horizontal',
+        ALIGN_OFFSET_VAR
       );
 
       style.left = base;
@@ -215,7 +222,9 @@ function getAnchorPositionCSS(
         boundaryRect.bottom,
         align,
         offsets.alignOffset,
-        boundaryOffset
+        boundaryOffset,
+        'vertical',
+        ALIGN_OFFSET_VAR
       );
 
       style.top = base;

--- a/packages/core/src/dom/ui/popover/tests/popover-positioning.test.ts
+++ b/packages/core/src/dom/ui/popover/tests/popover-positioning.test.ts
@@ -416,7 +416,7 @@ describe('getAnchorPositionStyle (CSS Anchor Positioning)', () => {
     expect(style.position).toBe('fixed');
   });
 
-  it('uses CSS cross-axis shifting when boundary rects are available', async () => {
+  it('anchors the cross axis while shifting inside the boundary', async () => {
     const getStyle = await importWithAnchorSupport();
     const boundary = makeDOMRect(0, 0, 300, 200);
     const trigger = makeDOMRect(20, 100, 30, 20);
@@ -428,8 +428,23 @@ describe('getAnchorPositionStyle (CSS Anchor Positioning)', () => {
 
     expect(style.positionAnchor).toBe('--my-popover');
     expect(style.bottom).toBe('calc(anchor(top) + var(--media-popover-side-offset, 0px))');
-    expect(style.left).toBe('35px');
+    expect(style.left).toBe('calc(anchor(center) + var(--media-popover-align-offset, 0px))');
     expect(style.translate).toBe('clamp(-27px, -50%, calc(257px - 100%)) 0');
+  });
+
+  it('anchors the vertical cross axis while shifting inside the boundary', async () => {
+    const getStyle = await importWithAnchorSupport();
+    const boundary = makeDOMRect(0, 0, 300, 200);
+    const trigger = makeDOMRect(100, 20, 30, 40);
+    const style = getStyle('my-popover', { side: 'left', align: 'end' }, trigger, undefined, boundary, {
+      sideOffset: 0,
+      alignOffset: 4,
+      boundaryOffset: 8,
+    });
+
+    expect(style.right).toBe('calc(anchor(left) + var(--media-popover-side-offset, 0px))');
+    expect(style.top).toBe('calc(anchor(bottom) + var(--media-popover-align-offset, 0px))');
+    expect(style.translate).toBe('0 clamp(-56px, -100%, calc(128px - 100%))');
   });
 
   it('resolves horizontal start from RTL direction', async () => {


### PR DESCRIPTION
## Summary

Keep anchor-positioned popovers attached to their triggers while the document scrolls. The native path now uses CSS anchors on both axes instead of mixing an anchor-relative side with a viewport-relative cross-axis inset.

## Changes

- Position the cross-axis base with native anchor functions
- Preserve boundary clamping using relative distances from the anchor
- Cover horizontal and vertical anchoring plus the scrolled volume-popover regression

## Testing

- `pnpm -F @videojs/core test popover-positioning popup-positioner` — 48 tests passed
- `pnpm --dir apps/e2e exec playwright test tests/video-controls.spec.ts --project=vite-chromium --project=vite-firefox --grep " UI"` — 44 tests passed
- Scrolled-popover test repeated five times per renderer and browser — 20 tests passed
- Biome and `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core popover layout for all anchor-positioning browsers; boundary clamp math still depends on one-time rect snapshots for translate bounds, but side/cross-axis anchoring behavior is materially different.
> 
> **Overview**
> Fixes popovers (e.g. the volume slider) drifting away from their trigger after the page scrolls when CSS Anchor Positioning is enabled.
> 
> **Cross-axis positioning** in `getAnchorCrossAxisShift` no longer sets `left`/`top` to fixed viewport pixels derived from `getBoundingClientRect`. Those values are now `calc(anchor(left|right|center|top|bottom) + align-offset var)` so the popover stays tied to the trigger on scroll, matching the side axis. **Boundary clamping** is unchanged in spirit: `translate` still uses a `clamp()` built from boundary rects relative to the previous pixel base.
> 
> Unit expectations were updated for the anchor-based `left`/`top`, a **left-side vertical cross-axis** case was added, and an **e2e** test scrolls the page and asserts the volume popover stays aligned with the mute button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02667919a600d6f967bc59b1566ff4c1d0c68264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->