### PR TITLE
refactor(packages): reuse tooltip styles for audio previews

### DIFF
--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -83,7 +83,7 @@ function getTemplateHTML() {
               </media-slider-track>
               <media-slider-thumb class="media-slider__thumb"></media-slider-thumb>
               <media-slider-preview class="media-slider__preview">
-                <media-slider-value type="pointer" class="media-slider__value media-time"></media-slider-value>
+                <media-slider-value type="pointer" class="media-tooltip media-slider__value media-time"></media-slider-value>
               </media-slider-preview>
             </media-time-slider>
           </div>

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -78,7 +78,7 @@ function getTemplateHTML() {
               </media-slider-track>
               <media-slider-thumb class="media-slider__thumb"></media-slider-thumb>
               <media-slider-preview overflow="visible" class="media-slider__preview">
-                <media-slider-value type="pointer" class="media-slider__value media-time"></media-slider-value>
+                <media-slider-value type="pointer" class="media-surface media-tooltip media-slider__value media-time"></media-slider-value>
               </media-slider-preview>
             </media-time-slider>
             <media-time toggle type="remaining" class="media-time"></media-time>

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -223,7 +223,7 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
               </TimeSlider.Track>
               <TimeSlider.Thumb className="media-slider__thumb" />
               <TimeSlider.Preview className="media-slider__preview">
-                <TimeSlider.Value type="pointer" className="media-slider__value media-time" />
+                <TimeSlider.Value type="pointer" className="media-tooltip media-slider__value media-time" />
               </TimeSlider.Preview>
             </TimeSlider.Root>
           </div>

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -202,7 +202,10 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
               </TimeSlider.Track>
               <TimeSlider.Thumb className="media-slider__thumb" />
               <TimeSlider.Preview overflow="visible" className="media-slider__preview">
-                <TimeSlider.Value type="pointer" className="media-slider__value media-time" />
+                <TimeSlider.Value
+                  type="pointer"
+                  className="media-surface media-tooltip media-slider__value media-time"
+                />
               </TimeSlider.Preview>
             </TimeSlider.Root>
             <Time.Value toggle type="remaining" className="media-time" />

--- a/packages/skins/src/default/css/audio.css
+++ b/packages/skins/src/default/css/audio.css
@@ -124,3 +124,7 @@
   background-color: light-dark(oklch(0 0 0 / 0.1), oklch(1 0 0 / 0.2));
   box-shadow: 0 0 0 1px light-dark(transparent, oklch(0 0 0 / 0.05));
 }
+
+.media-default-skin--audio .media-slider .media-slider__preview .media-slider__value {
+  bottom: calc(var(--spacing) * 10);
+}

--- a/packages/skins/src/default/css/components/slider.css
+++ b/packages/skins/src/default/css/components/slider.css
@@ -318,7 +318,6 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      text-shadow: 0 1px 0 var(--shadow-current-color);
     }
 
     .media-slider__chapter-title {

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -163,6 +163,10 @@
   font-size: var(--font-size-medium);
 }
 
+.media-default-skin--video .media-slider__value {
+  text-shadow: 0 1px 0 var(--shadow-current-color);
+}
+
 /* Controls (hide/show behavior) */
 
 .media-default-skin--video .media-controls--root {

--- a/packages/skins/src/default/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/default/tailwind/audio.tailwind.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 import { container as baseContainer } from './components/container';
 import { controls as baseControls } from './components/controls';
 import { error as baseError } from './components/error';
-import { popup as basePopup } from './components/popup';
+import { popup as basePopup, tooltip } from './components/popup';
 import { slider as baseSlider } from './components/slider';
 import { surface } from './components/surface';
 import { time as baseTime } from './components/time';
@@ -73,6 +73,7 @@ export const slider = {
     '[background-color:light-dark(oklch(0_0_0/0.1),oklch(1_0_0/0.2))]',
     '[box-shadow:0_0_0_1px_light-dark(transparent,oklch(0_0_0/0.05))]'
   ),
+  value: cn(baseSlider.value, surface, tooltip, 'bottom-10'),
 };
 
 /* Popup (with audio surface) */

--- a/packages/skins/src/default/tailwind/components/popup.ts
+++ b/packages/skins/src/default/tailwind/components/popup.ts
@@ -23,6 +23,8 @@ const base = cn(
   'data-[side=right]:before:top-0 data-[side=right]:before:bottom-0 data-[side=right]:before:right-full'
 );
 
+export const tooltip = 'py-1 px-2.5 rounded-full text-(length:--font-size-base) whitespace-nowrap';
+
 export const popup = {
   popover: cn(
     base,
@@ -31,7 +33,7 @@ export const popup = {
   ),
   tooltip: cn(
     base,
-    'py-1 px-2.5 rounded-full text-(length:--font-size-base) whitespace-nowrap',
+    tooltip,
     'data-open:flex data-open:items-center data-open:gap-1',
     'data-[side=top]:before:h-(--media-tooltip-side-offset) data-[side=bottom]:before:h-(--media-tooltip-side-offset)',
     'data-[side=left]:before:w-(--media-tooltip-side-offset) data-[side=right]:before:w-(--media-tooltip-side-offset)'

--- a/packages/skins/src/default/tailwind/components/slider.ts
+++ b/packages/skins/src/default/tailwind/components/slider.ts
@@ -120,10 +120,6 @@ export const slider = {
     '[--thumbnail-max-width:var(--max-size)] [--thumbnail-max-height:var(--max-size)]',
     '[bottom:calc(100%+--spacing(9))]'
   ),
-  value: cn(
-    previewContent,
-    '[bottom:calc(100%+--spacing(10.5))] flex flex-col items-center tabular-nums',
-    'text-shadow-2xs text-shadow-(color:--shadow-current-color)'
-  ),
+  value: cn(previewContent, '[bottom:calc(100%+--spacing(10.5))] flex flex-col items-center tabular-nums'),
   chapterTitle: 'min-w-0 max-w-(--max-size) px-6 overflow-hidden text-ellipsis whitespace-nowrap empty:hidden',
 };

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -171,6 +171,7 @@ export const thumbnail = {
 export const slider = {
   ...baseSlider,
   track: cn(baseSlider.track, 'bg-white/20'),
+  value: cn(baseSlider.value, 'text-shadow-2xs text-shadow-(color:--shadow-current-color)'),
 };
 
 /* Popup (with video surface) */

--- a/packages/skins/src/minimal/css/components/slider.css
+++ b/packages/skins/src/minimal/css/components/slider.css
@@ -299,8 +299,6 @@
       flex-direction: row-reverse;
       gap: calc(var(--spacing) * 2);
       justify-content: center;
-      padding-inline: calc(var(--spacing) * 3);
-      text-shadow: 0 1px 0 var(--shadow-current-color);
     }
 
     .media-slider__chapter-title {

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -292,6 +292,11 @@
 
 /* Slider preview */
 
+.media-minimal-skin--video .media-slider__value {
+  padding-inline: calc(var(--spacing) * 3);
+  text-shadow: 0 1px 0 var(--shadow-current-color);
+}
+
 .media-minimal-skin--video .media-slider .media-slider__preview {
   --preview-end-inset: calc(100cqi - 100%);
   --preview-left: clamp(

--- a/packages/skins/src/minimal/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/audio.tailwind.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 import { container as baseContainer } from './components/container';
 import { controls as baseControls } from './components/controls';
 import { error as baseError } from './components/error';
-import { popup as basePopup } from './components/popup';
+import { popup as basePopup, tooltip } from './components/popup';
 import { slider as baseSlider } from './components/slider';
 
 /* Container */
@@ -77,7 +77,7 @@ export const popup = {
 
 export const slider = {
   ...baseSlider,
-  value: cn(baseSlider.value, 'bottom-10'),
+  value: cn(baseSlider.value, tooltip, 'bottom-10'),
 };
 
 /* Error */

--- a/packages/skins/src/minimal/tailwind/components/popup.ts
+++ b/packages/skins/src/minimal/tailwind/components/popup.ts
@@ -23,6 +23,13 @@ const base = cn(
   'data-[side=right]:before:top-0 data-[side=right]:before:bottom-0 data-[side=right]:before:right-full'
 );
 
+export const tooltip = cn(
+  'px-2 py-1 rounded-[--spacing(2)] text-(length:--font-size-base) whitespace-nowrap',
+  'bg-(--tooltip-background-color) [backdrop-filter:var(--tooltip-backdrop-filter)]',
+  'ring-1 ring-(color:--tooltip-border-color) shadow-md shadow-black/20',
+  'text-(--tooltip-text-color)'
+);
+
 export const popup = {
   base,
   popover: cn(
@@ -32,11 +39,8 @@ export const popup = {
   ),
   tooltip: cn(
     base,
-    'px-2 py-1 rounded-[--spacing(2)] text-(length:--font-size-base) whitespace-nowrap',
+    tooltip,
     'data-open:flex data-open:items-center data-open:gap-1',
-    'bg-(--tooltip-background-color) [backdrop-filter:var(--tooltip-backdrop-filter)]',
-    'ring-1 ring-(color:--tooltip-border-color) shadow-md shadow-black/20',
-    'text-(--tooltip-text-color)',
     'data-[side=top]:before:h-(--media-tooltip-side-offset) data-[side=bottom]:before:h-(--media-tooltip-side-offset)',
     'data-[side=left]:before:w-(--media-tooltip-side-offset) data-[side=right]:before:w-(--media-tooltip-side-offset)'
   ),

--- a/packages/skins/src/minimal/tailwind/components/slider.ts
+++ b/packages/skins/src/minimal/tailwind/components/slider.ts
@@ -114,10 +114,6 @@ export const slider = {
     '[--thumbnail-max-width:var(--max-size)] [--thumbnail-max-height:var(--max-size)]',
     '[bottom:calc(100%+--spacing(11))]'
   ),
-  value: cn(
-    previewContent,
-    '[bottom:calc(100%+--spacing(5))] flex flex-row-reverse justify-center gap-2 px-3 tabular-nums',
-    'text-shadow-2xs text-shadow-(color:--shadow-current-color)'
-  ),
+  value: cn(previewContent, '[bottom:calc(100%+--spacing(5))] flex flex-row-reverse justify-center gap-2 tabular-nums'),
   chapterTitle: 'min-w-0 overflow-hidden text-ellipsis whitespace-nowrap empty:hidden',
 };

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -168,6 +168,7 @@ export const thumbnail = baseThumbnail;
 export const slider = {
   ...baseSlider,
   track: cn(baseSlider.track, 'ring-1 ring-black/5'),
+  value: cn(baseSlider.value, 'px-3 text-shadow-2xs text-shadow-(color:--shadow-current-color)'),
   preview: cn(
     baseSlider.preview,
     '[--preview-end-inset:calc(100cqi-100%)]',


### PR DESCRIPTION
## Summary

Give audio time-slider previews the same visual treatment as tooltips across the Default and Minimal skins, with CSS and Tailwind parity.

## Changes

- Reuse tooltip and surface classes for HTML and React audio preview values
- Share tooltip appearance utilities with Tailwind audio previews
- Keep slider padding and text shadows scoped to video previews
- Match the Default audio preview offset to control tooltips

## Testing

- `pnpm -F @videojs/html test` (409 tests)
- `pnpm -F @videojs/react test` (502 tests)
- `pnpm -F @videojs/skins test` (12 tests)
- `pnpm -F @videojs/skins build`
- `pnpm exec biome check` on changed files
- `git diff --check`
- Manual browser verification of Default and Minimal audio previews in CSS and Tailwind modes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only styling refactor across audio/video slider previews with HTML, React, CSS, and Tailwind parity; no playback or API behavior changes.
> 
> **Overview**
> **Audio time-slider hover previews** now use the same **`media-tooltip`** (and **`media-surface`** on the default skin) classes as control tooltips, in HTML and React presets for both Default and Minimal audio skins.
> 
> **Styling is split by media type:** shared slider rules no longer apply tooltip padding or text-shadow to every preview. **Audio** picks up tooltip look-and-feel via those classes plus a **Default audio–specific vertical offset** (`bottom` / `bottom-10`) so previews line up with other tooltips. **Video** keeps **padding and text-shadow** on `.media-slider__value` in video-only CSS/Tailwind overrides.
> 
> **Tailwind** exports a reusable **`tooltip`** utility from popup components (default and minimal) and composes it into **audio** `slider.value` (with **surface** on default audio); base slider `value` styles shed duplicated tooltip-like rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aed910c67bca3c0dac686733d06eda09e49e6a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->