### PR TITLE
fix(packages): add audio playback rate tooltips

### DIFF
--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -126,7 +126,7 @@ function getTemplateHTML() {
               </media-volume-slider>
             </media-popover>
 
-            <media-playback-rate-button commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}">
+            <media-playback-rate-button id="playback-rate-trigger" commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}">
             </media-playback-rate-button>
             <media-menu id="playback-rate-menu" side="top" align="center" boundary="viewport" class="${cn(popup.popover, menu.root)}">
               <media-playback-rate-radio-group class="${menu.group}">
@@ -140,6 +140,10 @@ function getTemplateHTML() {
                 </template>
               </media-playback-rate-radio-group>
             </media-menu>
+            <media-tooltip trigger="playback-rate-trigger" side="top" boundary="viewport" class="${popup.tooltip}">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
+            </media-tooltip>
 
           </div>
         </media-tooltip-group>

--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -108,7 +108,7 @@ function getTemplateHTML() {
               </media-volume-slider>
             </media-popover>
 
-            <media-playback-rate-button commandfor="playback-rate-menu" class="media-button media-button--subtle media-button--icon media-button--playback-rate"></media-playback-rate-button>
+            <media-playback-rate-button id="playback-rate-trigger" commandfor="playback-rate-menu" class="media-button media-button--subtle media-button--icon media-button--playback-rate"></media-playback-rate-button>
             <media-menu id="playback-rate-menu" side="top" align="center" boundary="viewport" class="media-popover media-menu">
               <media-playback-rate-radio-group class="media-menu__group">
                 <template>
@@ -121,6 +121,10 @@ function getTemplateHTML() {
                 </template>
               </media-playback-rate-radio-group>
             </media-menu>
+            <media-tooltip trigger="playback-rate-trigger" side="top" boundary="viewport" class="media-tooltip">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
+            </media-tooltip>
 
           </div>
         </media-tooltip-group>

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -103,7 +103,7 @@ function getTemplateHTML() {
           </div>
 
           <div class="${buttonGroup}">
-            <media-playback-rate-button commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}"></media-playback-rate-button>
+            <media-playback-rate-button id="playback-rate-trigger" commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}"></media-playback-rate-button>
             <media-menu id="playback-rate-menu" side="top" align="center" boundary="viewport" class="${cn(popup.popover, menu.root)}">
               <media-playback-rate-radio-group class="${menu.group}">
                 <template>
@@ -116,6 +116,10 @@ function getTemplateHTML() {
                 </template>
               </media-playback-rate-radio-group>
             </media-menu>
+            <media-tooltip trigger="playback-rate-trigger" side="top" boundary="viewport" class="${popup.tooltip}">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
+            </media-tooltip>
 
             <media-mute-button commandfor="audio-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
               ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -85,7 +85,7 @@ function getTemplateHTML() {
           </div>
 
           <div class="media-button-group">
-            <media-playback-rate-button commandfor="playback-rate-menu" class="media-button media-button--subtle media-button--icon media-button--playback-rate"></media-playback-rate-button>
+            <media-playback-rate-button id="playback-rate-trigger" commandfor="playback-rate-menu" class="media-button media-button--subtle media-button--icon media-button--playback-rate"></media-playback-rate-button>
             <media-menu id="playback-rate-menu" side="top" align="center" boundary="viewport" class="media-surface media-popover media-menu">
               <media-playback-rate-radio-group class="media-menu__group">
                 <template>
@@ -98,6 +98,10 @@ function getTemplateHTML() {
                 </template>
               </media-playback-rate-radio-group>
             </media-menu>
+            <media-tooltip trigger="playback-rate-trigger" side="top" boundary="viewport" class="media-surface media-tooltip">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
+            </media-tooltip>
 
             <media-mute-button commandfor="audio-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
               ${renderIcon('volume-off', { class: 'media-icon media-icon--volume-off' })}

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -172,10 +172,20 @@ function PlaybackRateTrigger(): ReactNode {
   if (!state) return null;
 
   return (
-    <Menu.Trigger
-      disabled={state.disabled}
-      render={<PlaybackRateButton className={playbackRate.button} render={<Button />} />}
-    />
+    <Tooltip.Root side="top" boundary="viewport">
+      <Tooltip.Trigger
+        render={
+          <Menu.Trigger
+            disabled={state.disabled}
+            render={<PlaybackRateButton className={playbackRate.button} render={<Button />} />}
+          />
+        }
+      />
+      <Tooltip.Popup className={popup.tooltip}>
+        <Tooltip.Label />
+        <Tooltip.Shortcut className={popup.tooltipShortcut} />
+      </Tooltip.Popup>
+    </Tooltip.Root>
   );
 }
 

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -118,10 +118,20 @@ function PlaybackRateTrigger(): ReactNode {
   if (!state) return null;
 
   return (
-    <Menu.Trigger
-      disabled={state.disabled}
-      render={<PlaybackRateButton className="media-button--playback-rate" render={<Button />} />}
-    />
+    <Tooltip.Root side="top" boundary="viewport">
+      <Tooltip.Trigger
+        render={
+          <Menu.Trigger
+            disabled={state.disabled}
+            render={<PlaybackRateButton className="media-button--playback-rate" render={<Button />} />}
+          />
+        }
+      />
+      <Tooltip.Popup className="media-tooltip">
+        <Tooltip.Label />
+        <Tooltip.Shortcut className="media-tooltip__kbd" />
+      </Tooltip.Popup>
+    </Tooltip.Root>
   );
 }
 

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -156,10 +156,20 @@ function PlaybackRateTrigger(): ReactNode {
   if (!state) return null;
 
   return (
-    <Menu.Trigger
-      disabled={state.disabled}
-      render={<PlaybackRateButton className={playbackRate.button} render={<Button />} />}
-    />
+    <Tooltip.Root side="top" boundary="viewport">
+      <Tooltip.Trigger
+        render={
+          <Menu.Trigger
+            disabled={state.disabled}
+            render={<PlaybackRateButton className={playbackRate.button} render={<Button />} />}
+          />
+        }
+      />
+      <Tooltip.Popup className={popup.tooltip}>
+        <Tooltip.Label />
+        <Tooltip.Shortcut className={popup.tooltipShortcut} />
+      </Tooltip.Popup>
+    </Tooltip.Root>
   );
 }
 

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -102,10 +102,20 @@ function PlaybackRateTrigger(): ReactNode {
   if (!state) return null;
 
   return (
-    <Menu.Trigger
-      disabled={state.disabled}
-      render={<PlaybackRateButton className="media-button--playback-rate" render={<Button />} />}
-    />
+    <Tooltip.Root side="top" boundary="viewport">
+      <Tooltip.Trigger
+        render={
+          <Menu.Trigger
+            disabled={state.disabled}
+            render={<PlaybackRateButton className="media-button--playback-rate" render={<Button />} />}
+          />
+        }
+      />
+      <Tooltip.Popup className="media-surface media-tooltip">
+        <Tooltip.Label />
+        <Tooltip.Shortcut className="media-tooltip__kbd" />
+      </Tooltip.Popup>
+    </Tooltip.Root>
   );
 }
 


### PR DESCRIPTION
## Summary

Add the missing playback-rate tooltips to the Default and Minimal audio skins so the menu trigger has the same localized hover and focus label as other controls.

## Changes

- Add playback-rate tooltips to the HTML audio presets
- Wrap the React playback-rate menu triggers with the shared tooltip compound
- Keep CSS and Tailwind variants in parity

## Testing

- `pnpm exec biome check` on all eight changed files
- `pnpm -F @videojs/html build`
- `pnpm -F @videojs/react build`
- `git diff --check`
- `pnpm typecheck` *(fails on unrelated existing generated skin imports and SPF playlist metadata errors)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only skin template updates that follow existing tooltip patterns; no playback, auth, or data-path changes.
> 
> **Overview**
> Adds **hover/focus tooltips** on the playback-rate menu trigger for Default and Minimal **audio** skins so it matches play, seek, and mute controls (localized label + keyboard shortcut).
> 
> In the **HTML** presets, the playback-rate button gets `id="playback-rate-trigger"` and a sibling `media-tooltip` wired with `trigger="playback-rate-trigger"`, label, and shortcut slots. In **React**, `PlaybackRateTrigger` wraps the existing `Menu.Trigger` / `PlaybackRateButton` in the shared `Tooltip` compound (`Tooltip.Root`, `Tooltip.Popup`, `Label`, `Shortcut`). Changes are mirrored across CSS and Tailwind variants for both skin families.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e3b8353df7e3bf5ae076a71d40cf4d7e003d014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->