### PR TITLE
fix: set oxlint path in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
   },
 
   "editor.defaultFormatter": "oxc.oxc-vscode",
+  "oxc.path.oxlint": "./node_modules/vite-plus/bin/oxlint",
   "oxc.fmt.configPath": "./vite.config.ts",
   "npm.scriptRunner": "vp",
   "js/ts.tsdk.path": "node_modules/typescript/lib",

--- a/cspell.json
+++ b/cspell.json
@@ -12,6 +12,7 @@
     "noautohide",
     "noto",
     "nums",
+    "oxlint",
     "plyr",
     "prefs",
     "rahim",


### PR DESCRIPTION
This hooks up the oxc plugin with the correct location for oxlint so errors show up in vscode and get auto fixed. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor and spell-check config only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Configures the **oxc** VS Code extension to run **oxlint** from `./node_modules/vite-plus/bin/oxlint` via the new `oxc.path.oxlint` setting, so in-editor diagnostics and `source.fixAll.oxc` on save use the same binary as the Vite+ toolchain instead of a missing or wrong default path.
> 
> Adds **oxlint** to the **cspell** project word list so the new setting key/path does not trigger spelling warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d72862c3f9565a9c156fe49981950efe8aaaa4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->