### PR TITLE
refactor(skin): prefix all internal css custom properties

### DIFF
--- a/.agents/skills/migrate-css-to-tailwind/references/migration.md
+++ b/.agents/skills/migrate-css-to-tailwind/references/migration.md
@@ -36,15 +36,19 @@ Legacy **`tailwind.config.js`** theme spreads are not the primary path here—ex
 - `border-radius: 8px` → prefer `rounded-lg` (or a theme radius key) if equivalent/acceptable
 - `font-size`, `spacing`, `colors`, `shadow`, `z-index`, `radius` should map to **`@theme` or default v4 scales** when acceptable
 
-### 3. Use Tailwind's `--spacing` scale
+### 3. Keep Tailwind and skin spacing distinct
 
-Tailwind v4 spacing utilities are based on the `--spacing` variable. Translate spacing calculations directly to native utilities:
+Tailwind v4 spacing utilities are based on its `--spacing` variable. Translate site spacing calculations directly to native utilities:
 
 - `padding: calc(var(--spacing) * 2)` → `p-2`
 - `margin-inline: calc(var(--spacing) * 3)` → `mx-3`
 - `gap: var(--spacing)` → `gap-1`
 
-Use built-in responsive or named container variants (`md:`, `@md:`, `@md/media-root:`) for media-query behavior. If a scoped design needs to scale all spacing, overriding `--spacing` at that scope is valid because native utilities inherit it. Ignore `--scale-unit` and `--size`; resolve font and icon sizes to rem values.
+Use built-in responsive or named container variants (`md:`, `@md:`, `@md/media-root:`) for media-query behavior.
+
+In `packages/skins/src`, treat the skin container as a Tailwind theme boundary. Calculate the skin-owned `--media-spacing` from `--media-scale-unit` and `--media-scale`, then set `--spacing: var(--media-spacing)` on the container so native utilities respond to skin scaling without depending on the host's Tailwind configuration. The VJSC stylesheet performs the equivalent mapping at its isolated `@theme inline` boundary.
+
+Ignore legacy `--scale-unit` and `--size`; use the current `--media-*` tokens or resolve site font and icon sizes to rem values.
 
 For arbitrary values, Tailwind v4 also provides the build-time `--spacing(N)` function. Use it for literal spacing multipliers that do not map cleanly to a native utility:
 
@@ -52,7 +56,7 @@ For arbitrary values, Tailwind v4 also provides the build-time `--spacing(N)` fu
 - `[--max-width:calc(var(--spacing)*44)]` → `[--max-width:--spacing(44)]`
 - `[bottom:calc(100% + var(--spacing) * 4.8)]` → `[bottom:calc(100%+--spacing(4.8))]`
 
-`rounded-(--spacing(7))` is not the equivalent syntax: the parenthesized form is for a custom-property utility and would look for `var(--spacing(7))`. Keep `calc(var(--spacing) * var(...))` when the multiplier is runtime-derived because `--spacing()` only replaces literal values.
+`rounded-(--spacing(7))` is not the equivalent syntax: the parenthesized form is for a custom-property utility and would look for `var(--spacing(7))`. Keep `calc(var(--spacing) * var(...))`, or `calc(var(--media-spacing) * var(...))` in skins, when the multiplier is runtime-derived because `--spacing()` only replaces literal values.
 
 ### 4. Handle site one-offs without arbitrary-value classes
 

--- a/packages/skins/src/default/css/audio.css
+++ b/packages/skins/src/default/css/audio.css
@@ -17,33 +17,33 @@
 /* Container */
 
 .media-default-skin--audio {
-  --default-accent-color: light-dark(oklch(0 0 0), oklch(1 0 0));
-  --text-color: light-dark(oklch(0 0 0), oklch(1 0 0));
-  --border-color: oklch(0 0 0 / 0.1);
-  --focus-ring-color: light-dark(oklch(0 0 0), oklch(1 0 0));
+  --media-default-accent-color: light-dark(oklch(0 0 0), oklch(1 0 0));
+  --media-text-color: light-dark(oklch(0 0 0), oklch(1 0 0));
+  --media-border-color: oklch(0 0 0 / 0.1);
+  --media-focus-ring-color: light-dark(oklch(0 0 0), oklch(1 0 0));
 
-  --surface-background-color: light-dark(oklch(1 0 0 / 0.5), oklch(0 0 0 / 0.4));
-  --surface-inner-border-color: oklch(1 0 0 / 0.1);
-  --surface-outer-border-color: oklch(0 0 0 / 0.05);
-  --surface-shadow-color: oklch(0 0 0 / 0.15);
-  --surface-backdrop-filter: blur(16px) saturate(1.5);
+  --media-surface-background-color: light-dark(oklch(1 0 0 / 0.5), oklch(0 0 0 / 0.4));
+  --media-surface-inner-border-color: oklch(1 0 0 / 0.1);
+  --media-surface-outer-border-color: oklch(0 0 0 / 0.05);
+  --media-surface-shadow-color: oklch(0 0 0 / 0.15);
+  --media-surface-backdrop-filter: blur(16px) saturate(1.5);
 
-  --error-dialog-transition-duration: 250ms;
-  --error-dialog-transition-delay: 100ms;
+  --media-error-dialog-transition-duration: 250ms;
+  --media-error-dialog-transition-delay: 100ms;
 
-  --popup-transition-duration: 100ms;
-  --popup-transition-timing-function: ease-out;
+  --media-popup-transition-duration: 100ms;
+  --media-popup-transition-timing-function: ease-out;
 
   @media (prefers-reduced-motion: reduce) {
-    --error-dialog-transition-duration: 50ms;
-    --error-dialog-transition-delay: 0ms;
-    --popup-transition-duration: 0ms;
+    --media-error-dialog-transition-duration: 50ms;
+    --media-error-dialog-transition-delay: 0ms;
+    --media-popup-transition-duration: 0ms;
   }
 
   @media (prefers-reduced-transparency: reduce) or (prefers-contrast: more) {
-    --surface-background-color: light-dark(oklch(1 0 0), oklch(0 0 0));
-    --surface-inner-border-color: light-dark(oklch(1 0 0 / 0.1), oklch(1 0 0 / 0.2));
-    --surface-outer-border-color: light-dark(oklch(0 0 0 / 0.05), transparent);
+    --media-surface-background-color: light-dark(oklch(1 0 0), oklch(0 0 0));
+    --media-surface-inner-border-color: light-dark(oklch(1 0 0 / 0.1), oklch(1 0 0 / 0.2));
+    --media-surface-outer-border-color: light-dark(oklch(0 0 0 / 0.05), transparent);
   }
 }
 
@@ -54,16 +54,16 @@
   inset: 0;
   z-index: 20;
   display: flex;
-  gap: calc(var(--spacing) * 3);
+  gap: calc(var(--media-spacing) * 3);
   align-items: center;
-  padding-inline: calc(var(--spacing) * 5) calc(var(--spacing) * 0.5);
-  color: var(--text-color);
-  background-color: var(--surface-background-color);
+  padding-inline: calc(var(--media-spacing) * 5) calc(var(--media-spacing) * 0.5);
+  color: var(--media-text-color);
+  background-color: var(--media-surface-background-color);
   border-radius: calc(infinity * 1px);
-  backdrop-filter: var(--surface-backdrop-filter);
-  transition-delay: var(--error-dialog-transition-delay);
+  backdrop-filter: var(--media-surface-backdrop-filter);
+  transition-delay: var(--media-error-dialog-transition-delay);
   transition-timing-function: ease-out;
-  transition-duration: var(--error-dialog-transition-duration);
+  transition-duration: var(--media-error-dialog-transition-duration);
   transition-property: opacity, filter;
 }
 
@@ -79,18 +79,18 @@
 .media-default-skin--audio .media-error__content {
   display: flex;
   flex: 1;
-  gap: calc(var(--spacing) * 2);
+  gap: calc(var(--media-spacing) * 2);
   align-items: center;
 }
 
 /* Controls */
 
 .media-default-skin--audio .media-controls {
-  --base-boundary-offset: 2;
-  color: var(--text-color);
+  --media-base-boundary-offset: 2;
+  color: var(--media-text-color);
 
   .media-time-controls {
-    padding-inline: calc(var(--spacing) * 3);
+    padding-inline: calc(var(--media-spacing) * 3);
   }
 
   .media-button--seek {
@@ -126,5 +126,5 @@
 }
 
 .media-default-skin--audio .media-slider .media-slider__preview .media-slider__value {
-  bottom: calc(var(--spacing) * 10);
+  bottom: calc(var(--media-spacing) * 10);
 }

--- a/packages/skins/src/default/css/components/badge.css
+++ b/packages/skins/src/default/css/components/badge.css
@@ -1,6 +1,6 @@
 .media-default-skin .media-badge {
-  padding: calc(var(--spacing) * 0.5) calc(var(--spacing) * 1.5);
-  font-size: var(--font-size-small);
+  padding: calc(var(--media-spacing) * 0.5) calc(var(--media-spacing) * 1.5);
+  font-size: var(--media-font-size-small);
   font-weight: 500;
   line-height: 1;
   color: oklch(from currentColor l c h / 0.85);

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -4,9 +4,9 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
-  height: calc(var(--spacing) * 9);
+  height: calc(var(--media-spacing) * 9);
   min-height: 0;
-  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4);
+  padding: calc(var(--media-spacing) * 2) calc(var(--media-spacing) * 4);
   text-align: center;
   touch-action: manipulation;
   cursor: pointer;
@@ -22,7 +22,7 @@
   will-change: scale;
 
   &:focus-visible {
-    outline-color: var(--focus-ring-color);
+    outline-color: var(--media-focus-ring-color);
     outline-offset: 2px;
   }
 
@@ -39,9 +39,9 @@
 /* Primary button variant */
 .media-default-skin .media-button--primary {
   font-weight: 500;
-  color: var(--accent-contrast-color);
+  color: var(--media-accent-contrast-color);
   text-shadow: none;
-  background: var(--accent-color);
+  background: var(--media-internal-accent-color);
 }
 
 /* Subtle button variant */
@@ -54,9 +54,9 @@
     &:hover,
     &:focus-visible,
     &[aria-expanded="true"] {
-      color: var(--accent-text-color);
+      color: var(--media-internal-accent-text-color);
       text-decoration: none;
-      background-color: var(--accent-background-color);
+      background-color: var(--media-accent-background-color);
     }
   }
 }
@@ -77,7 +77,7 @@
 
   .media-icon {
     grid-area: 1 / 1;
-    filter: drop-shadow(0 1px 0 var(--shadow-current-color));
+    filter: drop-shadow(0 1px 0 var(--media-shadow-current-color));
     transition-timing-function: ease-out;
     transition-duration: 150ms;
     transition-property: opacity, scale;
@@ -137,12 +137,12 @@
    text content. */
 .media-default-skin .media-button--live {
   display: inline-flex;
-  gap: calc(var(--spacing) * 1.5);
+  gap: calc(var(--media-spacing) * 1.5);
   align-items: center;
   width: auto;
   aspect-ratio: auto;
-  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 3);
-  font-size: var(--font-size-small);
+  padding: calc(var(--media-spacing) * 2) calc(var(--media-spacing) * 3);
+  font-size: var(--media-font-size-small);
   font-weight: 600;
   line-height: 1;
   text-transform: uppercase;
@@ -151,8 +151,8 @@
   &::before {
     display: inline-block;
     flex-shrink: 0;
-    width: calc(var(--spacing) * 2);
-    height: calc(var(--spacing) * 2);
+    width: calc(var(--media-spacing) * 2);
+    height: calc(var(--media-spacing) * 2);
     content: "";
     background-color: oklch(from currentColor l c h / 0.4);
     border-radius: 50%;

--- a/packages/skins/src/default/css/components/captions.css
+++ b/packages/skins/src/default/css/components/captions.css
@@ -1,10 +1,10 @@
 .media-default-skin {
-  --media-caption-track-duration: var(--controls-transition-duration);
+  --media-caption-track-duration: var(--media-controls-transition-duration);
   --media-caption-track-delay: 25ms;
-  --media-caption-track-y: calc(var(--spacing) * -2);
+  --media-caption-track-y: calc(var(--media-spacing) * -2);
 
   &:has(.media-controls[data-visible]) {
-    --media-caption-track-y: calc(var(--spacing) * -14);
+    --media-caption-track-y: calc(var(--media-spacing) * -14);
   }
 }
 

--- a/packages/skins/src/default/css/components/container.css
+++ b/packages/skins/src/default/css/components/container.css
@@ -1,33 +1,36 @@
 .media-default-skin {
   /* Colors */
-  --accent-color: var(--media-accent-color, var(--default-accent-color));
-  --accent-contrast-color: contrast-color(var(--accent-color));
-  --accent-background-color: var(
+  --media-internal-accent-color: var(--media-accent-color, var(--media-default-accent-color));
+  --media-accent-contrast-color: contrast-color(var(--media-internal-accent-color));
+  --media-accent-background-color: var(
     --media-accent-color,
-    oklch(from var(--default-accent-color) l c h / calc(alpha * 0.1))
+    oklch(from var(--media-default-accent-color) l c h / calc(alpha * 0.1))
   );
-  --accent-text-color: var(--media-accent-text-color, contrast-color(var(--media-accent-color, oklch(0 0 0))));
-  --shadow-current-color: oklch(from currentColor 0 0 0 / clamp(0, calc((l - 0.5) * 0.5), 0.15));
-  --shadow-subtle-current-color: oklch(from var(--shadow-current-color) l c h / calc(alpha * 0.4));
-  --scrollbar-thumb-color: oklch(from currentColor l c h / 0.3);
+  --media-internal-accent-text-color: var(
+    --media-accent-text-color,
+    contrast-color(var(--media-accent-color, oklch(0 0 0)))
+  );
+  --media-shadow-current-color: oklch(from currentColor 0 0 0 / clamp(0, calc((l - 0.5) * 0.5), 0.15));
+  --media-shadow-subtle-current-color: oklch(from var(--media-shadow-current-color) l c h / calc(alpha * 0.4));
+  --media-scrollbar-thumb-color: oklch(from currentColor l c h / 0.3);
 
   /* Scaling - used in video fullscreen to scale the UI. */
-  --scale: 1;
+  --media-scale: 1;
   /* Fixed scaling unit to avoid inheriting the document's root font size. This must be a CSS <length>. */
-  --scale-unit: var(--media-scale-unit, 16px);
-  --size: calc(var(--scale-unit) * var(--scale));
+  --media-internal-scale-unit: var(--media-scale-unit, 16px);
+  --media-size: calc(var(--media-internal-scale-unit) * var(--media-scale));
   /* Create a Tailwind-like spacing unit where 1 equals 4px with default scaling. */
-  --spacing: calc(var(--size) / 4);
+  --media-spacing: calc(var(--media-size) / 4);
 
   /* Font sizes */
-  --font-size-medium: calc(0.9375 * var(--size)); /* 15px */
-  --font-size-base: calc(0.8125 * var(--size)); /* 13px */
-  --font-size-small: calc(0.6875 * var(--size)); /* 11px */
-  --font-size-tiny: calc(0.5625 * var(--size)); /* 9px */
-  --media-icon-size: calc(1.125 * var(--size)); /* 18px */
+  --media-font-size-medium: calc(0.9375 * var(--media-size)); /* 15px */
+  --media-font-size-base: calc(0.8125 * var(--media-size)); /* 13px */
+  --media-font-size-small: calc(0.6875 * var(--media-size)); /* 11px */
+  --media-font-size-tiny: calc(0.5625 * var(--media-size)); /* 9px */
+  --media-icon-size: calc(1.125 * var(--media-size)); /* 18px */
 
   /* Radii */
-  --container-border-radius: var(--media-border-radius, 1.75rem);
+  --media-container-border-radius: var(--media-border-radius, 1.75rem);
 
   position: relative;
   display: block;
@@ -40,33 +43,33 @@
     ui-sans-serif,
     system-ui,
     sans-serif;
-  font-size: var(--font-size-base);
+  font-size: var(--media-font-size-base);
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
   line-height: 1.5;
   letter-spacing: normal;
   outline: 2px solid transparent;
   outline-offset: -4px;
-  scrollbar-color: var(--scrollbar-thumb-color) transparent;
+  scrollbar-color: var(--media-scrollbar-thumb-color) transparent;
   scrollbar-width: thin;
-  border-radius: var(--container-border-radius, 1.75rem);
+  border-radius: var(--media-container-border-radius, 1.75rem);
   isolation: isolate;
   transition-timing-function: ease-out;
   transition-duration: 100ms;
   transition-property: outline-offset, outline-color;
 
   &:focus-visible {
-    outline-color: var(--focus-ring-color);
+    outline-color: var(--media-focus-ring-color);
     outline-offset: 2px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: var(--scrollbar-thumb-color);
+    background: var(--media-scrollbar-thumb-color);
     border-radius: 9999px;
   }
 
   @media (prefers-reduced-transparency: reduce) or (prefers-contrast: more) {
-    --scrollbar-thumb-color: oklch(from currentColor l c h / 0.8);
+    --media-scrollbar-thumb-color: oklch(from currentColor l c h / 0.8);
     scrollbar-width: auto;
   }
 }

--- a/packages/skins/src/default/css/components/controls.css
+++ b/packages/skins/src/default/css/components/controls.css
@@ -1,14 +1,14 @@
 .media-default-skin .media-controls {
-  --media-popover-side-offset: calc(var(--spacing) * (var(--base-side-offset, 2) + 1));
+  --media-popover-side-offset: calc(var(--media-spacing) * (var(--media-base-side-offset, 2) + 1));
   --media-tooltip-side-offset: var(--media-popover-side-offset);
-  --media-popover-boundary-offset: calc(var(--spacing) * var(--base-boundary-offset, 2));
+  --media-popover-boundary-offset: calc(var(--media-spacing) * var(--media-base-boundary-offset, 2));
   --media-tooltip-boundary-offset: var(--media-popover-boundary-offset);
 
   display: flex;
   align-items: center;
-  padding: calc(var(--spacing) * 1);
+  padding: calc(var(--media-spacing) * 1);
   container: media-controls / inline-size;
-  text-shadow: 0 1px 0 var(--shadow-current-color);
+  text-shadow: 0 1px 0 var(--media-shadow-current-color);
   border-radius: calc(Infinity * 1px);
 
   &:dir(rtl) {

--- a/packages/skins/src/default/css/components/error.css
+++ b/packages/skins/src/default/css/components/error.css
@@ -18,7 +18,7 @@
 
 .media-default-skin .media-error__actions {
   display: flex;
-  gap: calc(var(--spacing) * 2);
+  gap: calc(var(--media-spacing) * 2);
 
   > * {
     flex: 1;

--- a/packages/skins/src/default/css/components/input-indicator.css
+++ b/packages/skins/src/default/css/components/input-indicator.css
@@ -1,9 +1,9 @@
 .media-default-skin {
   .media-volume-indicator,
   .media-status-indicator--state {
-    --surface-background-color: oklch(0 0 0 / 0.25);
+    --media-surface-background-color: oklch(0 0 0 / 0.25);
     position: absolute;
-    top: calc(var(--spacing) * 3);
+    top: calc(var(--media-spacing) * 3);
     font-weight: 500;
     color: inherit;
     pointer-events: none;
@@ -15,11 +15,11 @@
     .media-volume-indicator__content,
     .media-status-indicator__content {
       display: flex;
-      gap: calc(var(--spacing) * 2);
+      gap: calc(var(--media-spacing) * 2);
       align-items: center;
       justify-content: space-between;
       width: 100%;
-      padding: calc(var(--spacing) * 1) calc(var(--spacing) * 2.5);
+      padding: calc(var(--media-spacing) * 1) calc(var(--media-spacing) * 2.5);
 
       * {
         mix-blend-mode: difference;
@@ -47,7 +47,7 @@
     }
 
     @media (prefers-reduced-transparency: reduce) or (prefers-contrast: more) {
-      --surface-background-color: oklch(0 0 0);
+      --media-surface-background-color: oklch(0 0 0);
     }
 
     &[data-starting-style],
@@ -75,7 +75,7 @@
     grid-row: 1;
     grid-column: 2;
     place-content: center;
-    padding: calc(var(--spacing) * 4);
+    padding: calc(var(--media-spacing) * 4);
     text-align: center;
   }
 }

--- a/packages/skins/src/default/css/components/media.css
+++ b/packages/skins/src/default/css/components/media.css
@@ -7,7 +7,7 @@
   object-position: var(--media-object-position, center);
 }
 .media-default-skin ::slotted(video) {
-  border-radius: var(--container-border-radius);
+  border-radius: var(--media-container-border-radius);
 }
 .media-default-skin video {
   border-radius: inherit;

--- a/packages/skins/src/default/css/components/menus.css
+++ b/packages/skins/src/default/css/components/menus.css
@@ -1,53 +1,53 @@
 .media-default-skin .media-menu {
-  --menu-transition-duration: 250ms;
-  --menu-max-height: calc(var(--spacing) * 56);
-  --menu-padding: calc(var(--spacing) * 1);
-  --menu-border-radius: calc(var(--spacing) * 3);
-  --menu-item-border-radius: calc(var(--menu-border-radius) - var(--menu-padding));
+  --media-menu-transition-duration: 250ms;
+  --media-menu-max-height: calc(var(--media-spacing) * 56);
+  --media-menu-padding: calc(var(--media-spacing) * 1);
+  --media-menu-border-radius: calc(var(--media-spacing) * 3);
+  --media-menu-item-border-radius: calc(var(--media-menu-border-radius) - var(--media-menu-padding));
   box-sizing: border-box;
   min-width: max-content;
   max-width: var(--media-popover-available-width, none);
-  max-height: min(var(--media-popover-available-height, var(--menu-max-height)), var(--menu-max-height));
-  padding: var(--menu-padding);
+  max-height: min(var(--media-popover-available-height, var(--media-menu-max-height)), var(--media-menu-max-height));
+  padding: var(--media-menu-padding);
   overflow: auto;
   overscroll-behavior: none;
-  border-radius: var(--menu-border-radius);
+  border-radius: var(--media-menu-border-radius);
 
   @media (prefers-reduced-motion: reduce) {
-    --menu-transition-duration: 0ms;
+    --media-menu-transition-duration: 0ms;
   }
 
   & > .media-menu__panel {
-    --menu-content-enter-translate: 100%;
+    --media-menu-content-enter-translate: 100%;
 
     position: absolute;
     inset-inline: 0;
     top: 0;
     z-index: 10;
     max-height: inherit;
-    padding: var(--menu-padding);
+    padding: var(--media-menu-padding);
     overflow: auto;
     overscroll-behavior: none;
     outline: none;
     translate: 0 0;
     transition-timing-function: ease-out;
-    transition-duration: var(--menu-transition-duration);
+    transition-duration: var(--media-menu-transition-duration);
     transition-property: translate, filter;
 
     &:where([data-starting-style], [data-ending-style]) {
       overflow: hidden;
       pointer-events: none;
       filter: blur(8px);
-      translate: var(--menu-content-enter-translate) 0;
+      translate: var(--media-menu-content-enter-translate) 0;
     }
 
     &:dir(rtl):where([data-starting-style], [data-ending-style]) {
-      --menu-content-enter-translate: -100%;
+      --media-menu-content-enter-translate: -100%;
     }
   }
 
   .media-menu__separator {
-    margin-block: calc(var(--spacing) * 1);
+    margin-block: calc(var(--media-spacing) * 1);
     border-bottom: 1px solid oklch(0 0 0 / 0.1);
     box-shadow: 0 1px 0 0 oklch(1 0 0 / 0.075);
   }
@@ -57,7 +57,7 @@
     anchor-scope: --menu-item-highlight-anchor;
     display: flex;
     flex-direction: column;
-    gap: calc(var(--spacing) * 0.5);
+    gap: calc(var(--media-spacing) * 0.5);
 
     @supports (top: anchor(top)) {
       &::before {
@@ -69,8 +69,8 @@
         overflow-anchor: none;
         pointer-events: none;
         content: "";
-        background-color: var(--accent-background-color);
-        border-radius: var(--menu-item-border-radius);
+        background-color: var(--media-accent-background-color);
+        border-radius: var(--media-menu-item-border-radius);
         transition: inset 100ms ease-in-out;
       }
 
@@ -84,16 +84,16 @@
   .media-menu__back {
     position: relative;
     display: flex;
-    gap: calc(var(--spacing) * 1.5);
+    gap: calc(var(--media-spacing) * 1.5);
     align-items: center;
-    padding: calc(var(--spacing) * 1.5) calc(var(--spacing) * 2);
+    padding: calc(var(--media-spacing) * 1.5) calc(var(--media-spacing) * 2);
     text-align: start;
-    text-shadow: 0 1px 0 var(--shadow-current-color);
+    text-shadow: 0 1px 0 var(--media-shadow-current-color);
     cursor: pointer;
     user-select: none;
     outline: 2px solid transparent;
     outline-offset: -2px;
-    border-radius: var(--menu-item-border-radius);
+    border-radius: var(--media-menu-item-border-radius);
     transition: background-color, color;
     transition-timing-function: ease-in-out;
     transition-duration: 100ms;
@@ -101,18 +101,18 @@
     .media-icon {
       flex-shrink: 0;
       color: oklch(from currentColor l c h / 0.65);
-      filter: drop-shadow(0 1px 0 var(--shadow-current-color));
+      filter: drop-shadow(0 1px 0 var(--media-shadow-current-color));
     }
 
     &:focus-visible {
-      outline-color: var(--focus-ring-color);
+      outline-color: var(--media-focus-ring-color);
       outline-offset: 2px;
     }
 
     &:hover,
     &[data-highlighted] {
-      color: var(--accent-text-color);
-      background-color: var(--accent-background-color);
+      color: var(--media-internal-accent-text-color);
+      background-color: var(--media-accent-background-color);
 
       .media-icon {
         color: inherit;
@@ -131,11 +131,11 @@
 
   .media-menu__indicator {
     flex-shrink: 0;
-    margin-inline: auto calc(var(--spacing) * -1);
+    margin-inline: auto calc(var(--media-spacing) * -1);
     opacity: 0;
 
     .media-icon {
-      filter: drop-shadow(0 1px 0 var(--shadow-current-color));
+      filter: drop-shadow(0 1px 0 var(--media-shadow-current-color));
     }
   }
 
@@ -168,9 +168,9 @@
   }
 
   .media-menu__tier {
-    padding-inline-start: calc(var(--spacing) * 0.5);
+    padding-inline-start: calc(var(--media-spacing) * 0.5);
     padding-top: 1px;
-    font-size: var(--font-size-tiny);
+    font-size: var(--media-font-size-tiny);
     font-weight: 600;
     line-height: 1;
     color: oklch(from currentColor l c h / 0.7);
@@ -178,59 +178,59 @@
 
   .media-menu__back {
     width: 100%;
-    margin-bottom: calc(var(--spacing) * 0.5);
+    margin-bottom: calc(var(--media-spacing) * 0.5);
   }
 
   .media-menu__hint {
     display: inline-flex;
-    gap: calc(var(--spacing) * 1);
+    gap: calc(var(--media-spacing) * 1);
     align-items: center;
     min-width: 0;
-    padding-inline-start: calc(var(--spacing) * 2);
+    padding-inline-start: calc(var(--media-spacing) * 2);
     margin-inline-start: auto;
     color: oklch(from currentColor l c h / 0.65);
   }
 
   .media-menu__hint-label {
-    max-width: calc(var(--spacing) * 24);
+    max-width: calc(var(--media-spacing) * 24);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .media-menu__chevron {
-    width: calc(var(--spacing) * 3.5);
-    height: calc(var(--spacing) * 3.5);
+    width: calc(var(--media-spacing) * 3.5);
+    height: calc(var(--media-spacing) * 3.5);
   }
 
   /* Settings menu */
   &.media-menu--settings {
     width: var(--media-menu-width);
-    min-width: calc(var(--spacing) * 48);
+    min-width: calc(var(--media-spacing) * 48);
     height: var(--media-menu-height);
     overflow: hidden;
     /* Only the menu size changes between panels. */
     transition:
-      var(--popup-transition),
-      width var(--popup-transition-timing-function) var(--menu-transition-duration),
-      height var(--popup-transition-timing-function) var(--menu-transition-duration);
+      var(--media-popup-transition),
+      width var(--media-popup-transition-timing-function) var(--media-menu-transition-duration),
+      height var(--media-popup-transition-timing-function) var(--media-menu-transition-duration);
 
     & > .media-menu__content {
-      --menu-content-exit-translate: -100%;
+      --media-menu-content-exit-translate: -100%;
 
       translate: 0 0;
       transition:
-        translate var(--menu-transition-duration) ease-out,
-        filter var(--menu-transition-duration) ease-out;
+        translate var(--media-menu-transition-duration) ease-out,
+        filter var(--media-menu-transition-duration) ease-out;
 
       &:dir(rtl) {
-        --menu-content-exit-translate: 100%;
+        --media-menu-content-exit-translate: 100%;
       }
     }
 
     & > .media-menu__content[data-child-open] {
       filter: blur(8px);
-      translate: var(--menu-content-exit-translate) 0;
+      translate: var(--media-menu-content-exit-translate) 0;
     }
 
     /* WebKit can restart the parent Content transition while the
@@ -243,7 +243,7 @@
     /* Don't transition size on open/close. */
     &[data-starting-style],
     &[data-ending-style] {
-      transition: var(--popup-transition);
+      transition: var(--media-popup-transition);
     }
   }
 }

--- a/packages/skins/src/default/css/components/overlay.css
+++ b/packages/skins/src/default/css/components/overlay.css
@@ -7,13 +7,13 @@
   opacity: 0;
   backdrop-filter: blur(0) saturate(1);
   transition-timing-function: ease-out;
-  transition-duration: var(--controls-transition-duration);
+  transition-duration: var(--media-controls-transition-duration);
   transition-property: opacity, backdrop-filter;
 }
 
 .media-default-skin .media-error ~ .media-overlay {
-  transition-delay: var(--error-dialog-transition-delay);
-  transition-duration: var(--error-dialog-transition-duration);
+  transition-delay: var(--media-error-dialog-transition-delay);
+  transition-duration: var(--media-error-dialog-transition-duration);
 }
 
 .media-default-skin .media-controls[data-visible] ~ .media-overlay,

--- a/packages/skins/src/default/css/components/popup.css
+++ b/packages/skins/src/default/css/components/popup.css
@@ -1,49 +1,49 @@
 .media-default-skin {
-  --popup-transition:
-    opacity var(--popup-transition-timing-function) var(--popup-transition-duration),
-    filter var(--popup-transition-timing-function) var(--popup-transition-duration),
-    transform var(--popup-transition-timing-function) var(--popup-transition-duration),
-    scale var(--popup-transition-timing-function) var(--popup-transition-duration);
+  --media-popup-transition:
+    opacity var(--media-popup-transition-timing-function) var(--media-popup-transition-duration),
+    filter var(--media-popup-transition-timing-function) var(--media-popup-transition-duration),
+    transform var(--media-popup-transition-timing-function) var(--media-popup-transition-duration),
+    scale var(--media-popup-transition-timing-function) var(--media-popup-transition-duration);
 }
 
 .media-default-skin .media-popover,
 .media-default-skin .media-tooltip {
-  --popup-translate-distance: calc(0.5 * var(--scale-unit));
+  --media-popup-translate-distance: calc(0.5 * var(--media-internal-scale-unit));
   margin: 0;
   overflow: visible;
   color: inherit;
   border: 0;
-  transition: var(--popup-transition);
+  transition: var(--media-popup-transition);
 
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
     filter: blur(4px);
     /* We have to use transform here for translate as the translate property is used for positioning by core. */
-    transform: translate(var(--popup-translate-x-distance, 0), var(--popup-translate-y-distance, 0));
+    transform: translate(var(--media-popup-translate-x-distance, 0), var(--media-popup-translate-y-distance, 0));
     scale: 0.95;
   }
 
   &[data-ending-style] {
     transform: none;
     /* Speed up the exit transition. */
-    transition-duration: max(0ms, calc(var(--popup-transition-duration) - 50ms));
+    transition-duration: max(0ms, calc(var(--media-popup-transition-duration) - 50ms));
   }
 
   &[data-side="top"] {
-    --popup-translate-y-distance: var(--popup-translate-distance);
+    --media-popup-translate-y-distance: var(--media-popup-translate-distance);
     transform-origin: bottom;
   }
   &[data-side="bottom"] {
-    --popup-translate-y-distance: calc(var(--popup-translate-distance) * -1);
+    --media-popup-translate-y-distance: calc(var(--media-popup-translate-distance) * -1);
     transform-origin: top;
   }
   &[data-side="left"] {
-    --popup-translate-x-distance: var(--popup-translate-distance);
+    --media-popup-translate-x-distance: var(--media-popup-translate-distance);
     transform-origin: right;
   }
   &[data-side="right"] {
-    --popup-translate-x-distance: calc(var(--popup-translate-distance) * -1);
+    --media-popup-translate-x-distance: calc(var(--media-popup-translate-distance) * -1);
     transform-origin: left;
   }
 
@@ -90,7 +90,7 @@
   }
 }
 .media-default-skin .media-popover--volume {
-  padding: calc(var(--spacing) * 3) 0;
+  padding: calc(var(--media-spacing) * 3) 0;
   border-radius: calc(Infinity * 1px);
 
   &:has(media-volume-slider[data-hidden]) {
@@ -99,15 +99,15 @@
 }
 
 .media-default-skin .media-tooltip {
-  padding: calc(var(--spacing) * 1) calc(var(--spacing) * 2.5);
-  font-size: var(--font-size-base);
+  padding: calc(var(--media-spacing) * 1) calc(var(--media-spacing) * 2.5);
+  font-size: var(--media-font-size-base);
   white-space: nowrap;
   border-radius: calc(Infinity * 1px);
 
   /* `display: flex` must not apply while closed — it overrides UA `[popover]` hiding. */
   &[data-open] {
     display: flex;
-    column-gap: calc(var(--spacing) * 1);
+    column-gap: calc(var(--media-spacing) * 1);
     align-items: center;
   }
 
@@ -124,11 +124,11 @@
     min-width: 1.5em;
     padding: 0.1em;
     font-family: inherit;
-    font-size: var(--font-size-small);
+    font-size: var(--media-font-size-small);
     font-weight: 600;
     line-height: 1.25;
     text-align: center;
     background-color: oklch(from currentColor l c h / 0.3);
-    border-radius: calc(var(--spacing) * 1);
+    border-radius: calc(var(--media-spacing) * 1);
   }
 }

--- a/packages/skins/src/default/css/components/poster.css
+++ b/packages/skins/src/default/css/components/poster.css
@@ -19,7 +19,7 @@
   height: 100%;
   object-fit: var(--media-object-fit, contain);
   object-position: var(--media-object-position, center);
-  border-radius: var(--container-border-radius);
+  border-radius: var(--media-container-border-radius);
 }
 .media-default-skin > img {
   object-fit: var(--media-object-fit, contain);

--- a/packages/skins/src/default/css/components/seek-indicator.css
+++ b/packages/skins/src/default/css/components/seek-indicator.css
@@ -1,12 +1,12 @@
 .media-default-skin .media-seek-indicator {
-  gap: calc(var(--spacing) * 1);
+  gap: calc(var(--media-spacing) * 1);
 
   .media-seek-indicator__value {
     font-variant-numeric: tabular-nums;
   }
 
   @container media-root (width > 24rem) {
-    padding: calc(var(--spacing) * 6);
+    padding: calc(var(--media-spacing) * 6);
   }
 
   &[data-direction="backward"] {

--- a/packages/skins/src/default/css/components/slider.css
+++ b/packages/skins/src/default/css/components/slider.css
@@ -1,11 +1,11 @@
 .media-default-skin .media-slider {
-  --track-size: calc(var(--spacing) * 1);
-  --track-highlighted-size: calc(var(--spacing) * 1.75);
-  --track-border-radius: 99px;
-  --thumb-size: calc(var(--spacing) * 3);
-  --chapter-gap: calc(var(--spacing) * 1);
-  --chapter-inset-start: calc(var(--chapter-gap) / 2);
-  --chapter-inset-end: calc(var(--chapter-gap) / 2);
+  --media-track-size: calc(var(--media-spacing) * 1);
+  --media-track-highlighted-size: calc(var(--media-spacing) * 1.75);
+  --media-track-border-radius: 99px;
+  --media-thumb-size: calc(var(--media-spacing) * 3);
+  --media-chapter-gap: calc(var(--media-spacing) * 1);
+  --media-internal-chapter-inset-start: calc(var(--media-chapter-gap) / 2);
+  --media-internal-chapter-inset-end: calc(var(--media-chapter-gap) / 2);
 
   position: relative;
   display: flex;
@@ -16,13 +16,13 @@
   outline: none;
 
   &[data-orientation="horizontal"] {
-    width: var(--slider-width, 100%);
-    min-width: calc(var(--spacing) * 20);
-    height: var(--slider-height, calc(var(--spacing) * 8));
+    width: var(--media-slider-width, 100%);
+    min-width: calc(var(--media-spacing) * 20);
+    height: var(--media-slider-height, calc(var(--media-spacing) * 8));
   }
   &[data-orientation="vertical"] {
-    width: var(--slider-width, calc(var(--spacing) * 8));
-    height: var(--slider-height, calc(var(--spacing) * 20));
+    width: var(--media-slider-width, calc(var(--media-spacing) * 8));
+    height: var(--media-slider-height, calc(var(--media-spacing) * 20));
   }
 
   /* Track */
@@ -31,15 +31,15 @@
     overflow: hidden;
     user-select: none;
     background-color: oklch(from currentColor l c h / 0.2);
-    border-radius: var(--track-border-radius);
+    border-radius: var(--media-track-border-radius);
     isolation: isolate;
 
     &[data-orientation="horizontal"] {
       width: 100%;
-      height: var(--track-size);
+      height: var(--media-track-size);
     }
     &[data-orientation="vertical"] {
-      width: var(--track-size);
+      width: var(--media-track-size);
       height: 100%;
     }
   }
@@ -79,30 +79,30 @@
     background-color: oklch(from currentColor l c h / 0.2);
 
     &[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-buffer)) 0 0 round var(--track-border-radius));
+      clip-path: inset(0 calc(100% - var(--media-slider-buffer)) 0 0 round var(--media-track-border-radius));
     }
     &[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-buffer)) 0 0 0 round var(--track-border-radius));
+      clip-path: inset(calc(100% - var(--media-slider-buffer)) 0 0 0 round var(--media-track-border-radius));
     }
   }
 
   /* Fill */
   .media-slider__fill {
-    background-color: var(--accent-color);
+    background-color: var(--media-internal-accent-color);
 
     &[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round var(--track-border-radius));
+      clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round var(--media-track-border-radius));
     }
     &[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-fill)) 0 0 0 round var(--track-border-radius));
+      clip-path: inset(calc(100% - var(--media-slider-fill)) 0 0 0 round var(--media-track-border-radius));
     }
   }
   &[data-dragging] {
     .media-slider__fill[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round var(--track-border-radius));
+      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round var(--media-track-border-radius));
     }
     .media-slider__fill[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round var(--track-border-radius));
+      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round var(--media-track-border-radius));
     }
   }
 
@@ -138,10 +138,10 @@
     border-radius: inherit;
 
     &:first-child {
-      --chapter-inset-start: 0px;
+      --media-internal-chapter-inset-start: 0px;
     }
     &:last-child {
-      --chapter-inset-end: 0px;
+      --media-internal-chapter-inset-end: 0px;
     }
 
     .media-slider__chapter-track {
@@ -157,15 +157,16 @@
       clip-path: inset(0 calc(100% - var(--media-slider-chapter-end)) 0 var(--media-slider-chapter-start));
 
       .media-slider__chapter-track {
-        height: var(--track-size);
+        height: var(--media-track-size);
         clip-path: inset(
-          0 calc(100% - var(--media-slider-chapter-end) + var(--chapter-inset-end)) 0
-            calc(var(--media-slider-chapter-start) + var(--chapter-inset-start)) round var(--track-border-radius)
+          0 calc(100% - var(--media-slider-chapter-end) + var(--media-internal-chapter-inset-end)) 0
+            calc(var(--media-slider-chapter-start) + var(--media-internal-chapter-inset-start)) round
+            var(--media-track-border-radius)
         );
       }
 
       &[data-highlighted] .media-slider__chapter-track {
-        height: var(--track-highlighted-size);
+        height: var(--media-track-highlighted-size);
       }
     }
 
@@ -173,15 +174,16 @@
       clip-path: inset(calc(100% - var(--media-slider-chapter-end)) 0 var(--media-slider-chapter-start) 0);
 
       .media-slider__chapter-track {
-        width: var(--track-size);
+        width: var(--media-track-size);
         clip-path: inset(
-          calc(100% - var(--media-slider-chapter-end) + var(--chapter-inset-end)) 0
-            calc(var(--media-slider-chapter-start) + var(--chapter-inset-start)) 0 round var(--track-border-radius)
+          calc(100% - var(--media-slider-chapter-end) + var(--media-internal-chapter-inset-end)) 0
+            calc(var(--media-slider-chapter-start) + var(--media-internal-chapter-inset-start)) 0 round
+            var(--media-track-border-radius)
         );
       }
 
       &[data-highlighted] .media-slider__chapter-track {
-        width: var(--track-highlighted-size);
+        width: var(--media-track-highlighted-size);
       }
     }
   }
@@ -190,15 +192,15 @@
   .media-slider__thumb {
     position: absolute;
     z-index: 10;
-    width: var(--thumb-size);
-    height: var(--thumb-size);
+    width: var(--media-thumb-size);
+    height: var(--media-thumb-size);
     user-select: none;
     outline: 4px solid transparent;
     outline-offset: -4px;
     background-color: currentColor;
     border-radius: calc(Infinity * 1px);
     box-shadow:
-      0 0 0 1px var(--shadow-current-color, oklch(0 0 0 / 0.1)),
+      0 0 0 1px var(--media-shadow-current-color, oklch(0 0 0 / 0.1)),
       0 1px 3px 0 oklch(0 0 0 / 0.35),
       0 1px 2px -1px oklch(0 0 0 / 0.35);
     opacity: 0;
@@ -283,38 +285,38 @@
 
   /* Preview */
   .media-slider__preview {
-    --max-size-factor: 36;
-    --max-size: min(calc(var(--spacing) * var(--max-size-factor)), 100cqi);
+    --media-max-size-factor: 36;
+    --media-max-size: min(calc(var(--media-spacing) * var(--media-max-size-factor)), 100cqi);
 
-    min-width: var(--max-size);
-    height: calc(var(--spacing) * 1);
+    min-width: var(--media-max-size);
+    height: calc(var(--media-spacing) * 1);
 
     @container media-root (width > 42rem) {
-      --max-size-factor: 48;
+      --media-max-size-factor: 48;
     }
 
     .media-slider__thumbnail,
     .media-slider__value {
       position: absolute;
       left: 50%;
-      max-width: var(--max-size);
+      max-width: var(--media-max-size);
       opacity: 0;
       filter: blur(8px);
       transform-origin: bottom;
       scale: 0.8;
-      translate: -50% calc(var(--spacing) * 2);
+      translate: -50% calc(var(--media-spacing) * 2);
       transition-timing-function: ease-out;
       transition-duration: 150ms;
     }
 
     .media-slider__thumbnail {
-      --thumbnail-max-width: var(--max-size);
-      --thumbnail-max-height: var(--max-size);
-      bottom: calc(100% + (var(--spacing) * 9));
+      --media-thumbnail-max-width: var(--media-max-size);
+      --media-thumbnail-max-height: var(--media-max-size);
+      bottom: calc(100% + (var(--media-spacing) * 9));
     }
 
     .media-slider__value {
-      bottom: calc(100% + (var(--spacing) * 10.5));
+      bottom: calc(100% + (var(--media-spacing) * 10.5));
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -322,8 +324,8 @@
 
     .media-slider__chapter-title {
       min-width: 0;
-      max-width: var(--max-size);
-      padding-inline: calc(var(--spacing) * 6);
+      max-width: var(--media-max-size);
+      padding-inline: calc(var(--media-spacing) * 6);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -338,14 +340,14 @@
       top: 50%;
       left: 50%;
       z-index: 1;
-      width: calc(var(--spacing) * 1);
-      height: calc(var(--spacing) * 1);
+      width: calc(var(--media-spacing) * 1);
+      height: calc(var(--media-spacing) * 1);
       pointer-events: none;
       content: "";
       background-color: currentColor;
       border-radius: 100%;
       box-shadow:
-        0 0 0 1px var(--shadow-current-color, oklch(0 0 0 / 0.15)),
+        0 0 0 1px var(--media-shadow-current-color, oklch(0 0 0 / 0.15)),
         0 1px 2px 0 oklch(0 0 0 / 0.35);
       opacity: 0;
       scale: 0.5;

--- a/packages/skins/src/default/css/components/surface.css
+++ b/packages/skins/src/default/css/components/surface.css
@@ -1,10 +1,10 @@
 .media-default-skin .media-surface {
-  background-color: var(--surface-background-color);
+  background-color: var(--media-surface-background-color);
   box-shadow:
-    0 0 0 1px var(--surface-outer-border-color),
-    0 1px 3px 0 var(--surface-shadow-color),
-    0 1px 2px -1px var(--surface-shadow-color);
-  backdrop-filter: var(--surface-backdrop-filter);
+    0 0 0 1px var(--media-surface-outer-border-color),
+    0 1px 3px 0 var(--media-surface-shadow-color),
+    0 1px 2px -1px var(--media-surface-shadow-color);
+  backdrop-filter: var(--media-surface-backdrop-filter);
 
   /* Inner border ring */
   &::after {
@@ -15,7 +15,7 @@
     content: "";
     border-radius: inherit;
     box-shadow:
-      inset 0 1px 0 0 var(--surface-inner-border-color),
-      inset 0 0 0 1px oklch(from var(--surface-inner-border-color) l c h / calc(alpha * 0.5));
+      inset 0 1px 0 0 var(--media-surface-inner-border-color),
+      inset 0 0 0 1px oklch(from var(--media-surface-inner-border-color) l c h / calc(alpha * 0.5));
   }
 }

--- a/packages/skins/src/default/css/components/thumbnail.css
+++ b/packages/skins/src/default/css/components/thumbnail.css
@@ -2,13 +2,13 @@
   position: relative;
   pointer-events: none;
   background-color: oklch(0 0 0 / 0.9);
-  border-radius: calc(var(--spacing) * 3);
+  border-radius: calc(var(--media-spacing) * 3);
 
   .media-thumbnail__image {
     position: relative;
     display: block;
-    max-width: var(--thumbnail-max-width);
-    max-height: var(--thumbnail-max-height);
+    max-width: var(--media-thumbnail-max-width);
+    max-height: var(--media-thumbnail-max-height);
     overflow: clip;
     border-radius: inherit;
 
@@ -45,7 +45,7 @@
   }
 
   &:has(.media-thumbnail__image[data-loading]) {
-    width: var(--thumbnail-max-width);
+    width: var(--media-thumbnail-max-width);
     max-width: 100%;
     aspect-ratio: 16 / 9;
     overflow: hidden;

--- a/packages/skins/src/default/css/components/time.css
+++ b/packages/skins/src/default/css/components/time.css
@@ -1,7 +1,7 @@
 .media-default-skin .media-time-controls {
   display: flex;
   flex: 1;
-  gap: calc(var(--spacing) * 2.5);
+  gap: calc(var(--media-spacing) * 2.5);
   align-items: center;
   container: media-time-controls / inline-size;
 
@@ -24,13 +24,13 @@
   cursor: pointer;
   outline: 2px solid transparent;
   outline-offset: -2px;
-  border-radius: calc(var(--spacing) * 1);
+  border-radius: calc(var(--media-spacing) * 1);
   transition-timing-function: ease-out;
   transition-duration: 100ms;
   transition-property: outline-color, outline-offset;
 
   &:focus-visible {
-    outline-color: var(--focus-ring-color);
+    outline-color: var(--media-focus-ring-color);
     outline-offset: 2px;
   }
 }

--- a/packages/skins/src/default/css/components/volume-indicator.css
+++ b/packages/skins/src/default/css/components/volume-indicator.css
@@ -1,5 +1,5 @@
 .media-default-skin .media-volume-indicator {
-  width: min(80%, calc(var(--spacing) * 48));
+  width: min(80%, calc(var(--media-spacing) * 48));
   transform: translateX(0);
 
   .media-volume-indicator__content {

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -27,34 +27,34 @@
 /* Video-specific container styles */
 
 .media-default-skin--video {
-  --default-accent-color: oklch(1 0 0);
-  --border-color: light-dark(oklch(0 0 0 / 0.1), oklch(1 0 0 / 0.15));
-  --focus-ring-color: light-dark(oklch(0 0 0), oklch(1 0 0));
-  --media-video-border-radius: var(--container-border-radius);
+  --media-default-accent-color: oklch(1 0 0);
+  --media-border-color: light-dark(oklch(0 0 0 / 0.1), oklch(1 0 0 / 0.15));
+  --media-focus-ring-color: light-dark(oklch(0 0 0), oklch(1 0 0));
+  --media-video-border-radius: var(--media-container-border-radius);
 
-  --surface-background-color: oklch(1 0 0 / 0.1);
-  --surface-inner-border-color: oklch(1 0 0 / 0.1);
-  --surface-outer-border-color: oklch(0 0 0 / 0.1);
-  --surface-shadow-color: oklch(0 0 0 / 0.15);
-  --surface-backdrop-filter: blur(16px) saturate(1.5);
+  --media-surface-background-color: oklch(1 0 0 / 0.1);
+  --media-surface-inner-border-color: oklch(1 0 0 / 0.1);
+  --media-surface-outer-border-color: oklch(0 0 0 / 0.1);
+  --media-surface-shadow-color: oklch(0 0 0 / 0.15);
+  --media-surface-backdrop-filter: blur(16px) saturate(1.5);
 
-  --controls-transition-duration: 100ms;
-  --controls-transition-timing-function: ease-out;
+  --media-controls-transition-duration: 100ms;
+  --media-controls-transition-timing-function: ease-out;
 
-  --error-dialog-transition-duration: 350ms;
-  --error-dialog-transition-delay: 100ms;
-  --error-dialog-transition-timing-function: ease-out;
+  --media-error-dialog-transition-duration: 350ms;
+  --media-error-dialog-transition-delay: 100ms;
+  --media-error-dialog-transition-timing-function: ease-out;
 
-  --popup-transition-duration: 100ms;
-  --popup-transition-timing-function: ease-out;
+  --media-popup-transition-duration: 100ms;
+  --media-popup-transition-timing-function: ease-out;
 
   overflow: clip;
   background: oklch(0 0 0);
 
   @media (prefers-reduced-motion: reduce) {
-    --error-dialog-transition-duration: 50ms;
-    --error-dialog-transition-delay: 0ms;
-    --popup-transition-duration: 0ms;
+    --media-error-dialog-transition-duration: 50ms;
+    --media-error-dialog-transition-delay: 0ms;
+    --media-popup-transition-duration: 0ms;
 
     .media-error__dialog {
       scale: 1;
@@ -63,21 +63,21 @@
   }
 
   @media (prefers-reduced-transparency: reduce) or (prefers-contrast: more) {
-    --surface-background-color: oklch(0 0 0);
-    --surface-inner-border-color: oklch(1 0 0 / 0.25);
-    --surface-outer-border-color: transparent;
+    --media-surface-background-color: oklch(0 0 0);
+    --media-surface-inner-border-color: oklch(1 0 0 / 0.25);
+    --media-surface-outer-border-color: transparent;
   }
 
   &:has(.media-controls--root:not([data-visible])) {
     /* Slight delay to hide controls on non-touch devices after interaction */
     @media (pointer: fine) {
-      --controls-transition-duration: 300ms;
+      --media-controls-transition-duration: 300ms;
     }
     @media (pointer: coarse) {
-      --controls-transition-duration: 150ms;
+      --media-controls-transition-duration: 150ms;
     }
     @media (prefers-reduced-motion: reduce) {
-      --controls-transition-duration: 50ms;
+      --media-controls-transition-duration: 50ms;
     }
   }
 
@@ -89,29 +89,29 @@
     pointer-events: none;
     content: "";
     border-radius: inherit;
-    box-shadow: inset 0 0 0 1px var(--border-color);
+    box-shadow: inset 0 0 0 1px var(--media-border-color);
   }
 
   &:fullscreen {
-    --container-border-radius: 0;
+    --media-container-border-radius: 0;
 
     &::after {
       display: none;
     }
 
     @media (width >= 1280px) {
-      --scale: 1.25;
+      --media-scale: 1.25;
     }
     @media (width >= 1536px) {
-      --scale: 1.5;
+      --media-scale: 1.5;
     }
     @media (width >= 1920px) {
-      --scale: 1.75;
+      --media-scale: 1.75;
     }
   }
 
   * {
-    --focus-ring-color: oklch(1 0 0);
+    --media-focus-ring-color: oklch(1 0 0);
   }
 }
 
@@ -129,16 +129,16 @@
 .media-default-skin--video .media-error__dialog {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--spacing) * 3);
+  gap: calc(var(--media-spacing) * 3);
   width: 100%;
-  max-width: calc(var(--spacing) * 72);
-  padding: calc(var(--spacing) * 3);
+  max-width: calc(var(--media-spacing) * 72);
+  padding: calc(var(--media-spacing) * 3);
   color: oklch(1 0 0);
   text-shadow: 0 1px 0 oklch(0 0 0 / 0.25);
-  border-radius: calc(var(--spacing) * 7);
-  transition-delay: var(--error-dialog-transition-delay);
-  transition-timing-function: var(--error-dialog-transition-timing-function);
-  transition-duration: var(--error-dialog-transition-duration);
+  border-radius: calc(var(--media-spacing) * 7);
+  transition-delay: var(--media-error-dialog-transition-delay);
+  transition-timing-function: var(--media-error-dialog-transition-timing-function);
+  transition-duration: var(--media-error-dialog-transition-duration);
   transition-property: opacity, scale;
 }
 
@@ -154,32 +154,32 @@
 .media-default-skin--video .media-error__content {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--spacing) * 2);
-  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 2) calc(var(--spacing) * 1.5);
+  gap: calc(var(--media-spacing) * 2);
+  padding: calc(var(--media-spacing) * 2) calc(var(--media-spacing) * 2) calc(var(--media-spacing) * 1.5);
   text-shadow: inherit;
 }
 
 .media-default-skin--video .media-error__title {
-  font-size: var(--font-size-medium);
+  font-size: var(--media-font-size-medium);
 }
 
 .media-default-skin--video .media-slider__value {
-  text-shadow: 0 1px 0 var(--shadow-current-color);
+  text-shadow: 0 1px 0 var(--media-shadow-current-color);
 }
 
 /* Controls (hide/show behavior) */
 
 .media-default-skin--video .media-controls--root {
-  --inset-factor: 2;
-  --inset: calc(var(--spacing) * var(--inset-factor));
-  --base-boundary-offset: var(--inset-factor);
+  --media-inset-factor: 2;
+  --media-inset: calc(var(--media-spacing) * var(--media-inset-factor));
+  --media-base-boundary-offset: var(--media-inset-factor);
 
   z-index: 10;
   display: contents;
   color: oklch(1 0 0);
-  transition-timing-function: var(--controls-transition-timing-function);
+  transition-timing-function: var(--media-controls-transition-timing-function);
   /* Speed up the entry transition */
-  transition-duration: calc(var(--controls-transition-duration) / 2);
+  transition-duration: calc(var(--media-controls-transition-duration) / 2);
 
   .media-controls--primary,
   .media-controls--secondary {
@@ -194,21 +194,21 @@
   }
 
   .media-controls--primary {
-    inset-inline: var(--inset);
-    bottom: var(--inset);
+    inset-inline: var(--media-inset);
+    bottom: var(--media-inset);
     transform-origin: bottom;
   }
 
   .media-controls--secondary {
-    top: var(--inset);
-    right: var(--inset);
+    top: var(--media-inset);
+    right: var(--media-inset);
     container-type: normal;
     transform-origin: top;
   }
 
   .media-time-controls {
     flex: 1;
-    padding-inline: calc(var(--spacing) * 2);
+    padding-inline: calc(var(--media-spacing) * 2);
   }
 
   @container media-root (width < 32rem) {
@@ -236,7 +236,7 @@
         pointer-events: none;
         opacity: 0;
         scale: 0.95;
-        transition-duration: var(--controls-transition-duration);
+        transition-duration: var(--media-controls-transition-duration);
 
         @media (pointer: fine) and (prefers-reduced-motion: no-preference) {
           filter: blur(8px);
@@ -267,8 +267,8 @@
 
   @container media-root (width >= 32rem) {
     position: absolute;
-    inset-inline: var(--inset);
-    bottom: var(--inset);
+    inset-inline: var(--media-inset);
+    bottom: var(--media-inset);
     display: flex;
     transform-origin: bottom;
 
@@ -285,7 +285,7 @@
       pointer-events: none;
       opacity: 0;
       scale: 0.95;
-      transition-duration: var(--controls-transition-duration);
+      transition-duration: var(--media-controls-transition-duration);
 
       @media (pointer: fine) and (prefers-reduced-motion: no-preference) {
         filter: blur(8px);
@@ -301,7 +301,7 @@
     }
 
     .media-time-controls {
-      padding-inline: calc(var(--spacing) * 3);
+      padding-inline: calc(var(--media-spacing) * 3);
     }
   }
 
@@ -314,7 +314,7 @@
   }
 
   @container media-root (width > 42rem) {
-    --inset-factor: 3;
+    --media-inset-factor: 3;
   }
 }
 

--- a/packages/skins/src/default/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/default/tailwind/audio.tailwind.ts
@@ -12,28 +12,28 @@ import { time as baseTime } from './components/time';
 
 export const container = cn(
   baseContainer,
-  '[--default-accent-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
-  '[--border-color:oklch(0_0_0/0.1)]',
-  '[--focus-ring-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
-  '[--text-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
-  '[--surface-background-color:light-dark(oklch(1_0_0/0.5),oklch(0_0_0/0.4))]',
-  '[--surface-inner-border-color:oklch(1_0_0/0.1)]',
-  '[--surface-outer-border-color:oklch(0_0_0/0.05)]',
-  '[--surface-shadow-color:oklch(0_0_0/0.15)]',
-  '[--surface-backdrop-filter:blur(16px)_saturate(1.5)]',
-  '[--error-dialog-transition-duration:250ms]',
-  '[--error-dialog-transition-delay:100ms]',
-  '[--popup-transition-duration:100ms]',
-  '[--popup-transition-timing-function:ease-out]',
-  'motion-reduce:[--error-dialog-transition-duration:50ms]',
-  'motion-reduce:[--error-dialog-transition-delay:0ms]',
-  'motion-reduce:[--popup-transition-duration:0ms]',
-  '[@media(prefers-reduced-transparency:reduce)]:[--surface-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]',
-  'contrast-more:[--surface-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]',
-  '[@media(prefers-reduced-transparency:reduce)]:[--surface-inner-border-color:light-dark(oklch(1_0_0/0.1),oklch(1_0_0/0.2))]',
-  'contrast-more:[--surface-inner-border-color:light-dark(oklch(1_0_0/0.1),oklch(1_0_0/0.2))]',
-  '[@media(prefers-reduced-transparency:reduce)]:[--surface-outer-border-color:light-dark(oklch(0_0_0/0.05),transparent)]',
-  'contrast-more:[--surface-outer-border-color:light-dark(oklch(0_0_0/0.05),transparent)]'
+  '[--media-default-accent-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
+  '[--media-border-color:oklch(0_0_0/0.1)]',
+  '[--media-focus-ring-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
+  '[--media-text-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
+  '[--media-surface-background-color:light-dark(oklch(1_0_0/0.5),oklch(0_0_0/0.4))]',
+  '[--media-surface-inner-border-color:oklch(1_0_0/0.1)]',
+  '[--media-surface-outer-border-color:oklch(0_0_0/0.05)]',
+  '[--media-surface-shadow-color:oklch(0_0_0/0.15)]',
+  '[--media-surface-backdrop-filter:blur(16px)_saturate(1.5)]',
+  '[--media-error-dialog-transition-duration:250ms]',
+  '[--media-error-dialog-transition-delay:100ms]',
+  '[--media-popup-transition-duration:100ms]',
+  '[--media-popup-transition-timing-function:ease-out]',
+  'motion-reduce:[--media-error-dialog-transition-duration:50ms]',
+  'motion-reduce:[--media-error-dialog-transition-delay:0ms]',
+  'motion-reduce:[--media-popup-transition-duration:0ms]',
+  '[@media(prefers-reduced-transparency:reduce)]:[--media-surface-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]',
+  'contrast-more:[--media-surface-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]',
+  '[@media(prefers-reduced-transparency:reduce)]:[--media-surface-inner-border-color:light-dark(oklch(1_0_0/0.1),oklch(1_0_0/0.2))]',
+  'contrast-more:[--media-surface-inner-border-color:light-dark(oklch(1_0_0/0.1),oklch(1_0_0/0.2))]',
+  '[@media(prefers-reduced-transparency:reduce)]:[--media-surface-outer-border-color:light-dark(oklch(0_0_0/0.05),transparent)]',
+  'contrast-more:[--media-surface-outer-border-color:light-dark(oklch(0_0_0/0.05),transparent)]'
 );
 
 /* Controls */
@@ -41,8 +41,8 @@ export const container = cn(
 export const controls = cn(
   baseControls,
   surface,
-  '[--base-boundary-offset:2]',
-  'text-(--text-color)',
+  '[--media-base-boundary-offset:2]',
+  'text-(--media-text-color)',
   'peer-data-open/error:**:invisible'
 );
 
@@ -91,11 +91,11 @@ export const error = {
   ...baseError,
   dialog: cn(
     'absolute inset-0 z-20 flex items-center gap-3 rounded-full px-5 pr-0.5',
-    'bg-(--surface-background-color) text-(--text-color)',
+    'bg-(--media-surface-background-color) text-(--media-text-color)',
     'backdrop-blur-lg backdrop-saturate-150',
     'transition-[opacity,filter] ease-out',
-    'duration-(--error-dialog-transition-duration)',
-    'delay-(--error-dialog-transition-delay)',
+    'duration-(--media-error-dialog-transition-duration)',
+    'delay-(--media-error-dialog-transition-delay)',
     'group-data-starting-style/error:opacity-0 group-data-starting-style/error:blur-xs',
     'group-data-ending-style/error:opacity-0 group-data-ending-style/error:blur-xs',
     'group-data-ending-style/error:delay-0'

--- a/packages/skins/src/default/tailwind/components/badge.ts
+++ b/packages/skins/src/default/tailwind/components/badge.ts
@@ -1,2 +1,2 @@
 export const badge =
-  'rounded-full bg-current/10 px-1.5 py-0.5 text-(length:--font-size-small) font-medium leading-none text-current/70';
+  'rounded-full bg-current/10 px-1.5 py-0.5 text-(length:--media-font-size-small) font-medium leading-none text-current/70';

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -11,14 +11,14 @@ export const button = {
     'not-aria-disabled:active:scale-[0.97]',
     'motion-reduce:scale-100 motion-reduce:transition-[background-color,color] motion-reduce:will-change-auto',
     'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
-    'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2'
+    'focus-visible:outline-(--media-focus-ring-color) focus-visible:outline-offset-2'
   ),
-  primary: 'bg-(--accent-color) text-(--accent-contrast-color) font-medium text-shadow-none',
+  primary: 'bg-(--media-internal-accent-color) text-(--media-accent-contrast-color) font-medium text-shadow-none',
   subtle: cn(
     'bg-transparent text-inherit text-shadow-inherit',
-    'not-aria-disabled:hover:bg-(--accent-background-color) not-aria-disabled:hover:text-(--accent-text-color) not-aria-disabled:hover:no-underline',
-    'not-aria-disabled:focus-visible:bg-(--accent-background-color) not-aria-disabled:focus-visible:text-(--accent-text-color)',
-    'not-aria-disabled:aria-expanded:bg-(--accent-background-color) not-aria-disabled:aria-expanded:text-(--accent-text-color)'
+    'not-aria-disabled:hover:bg-(--media-accent-background-color) not-aria-disabled:hover:text-(--media-internal-accent-text-color) not-aria-disabled:hover:no-underline',
+    'not-aria-disabled:focus-visible:bg-(--media-accent-background-color) not-aria-disabled:focus-visible:text-(--media-internal-accent-text-color)',
+    'not-aria-disabled:aria-expanded:bg-(--media-accent-background-color) not-aria-disabled:aria-expanded:text-(--media-internal-accent-text-color)'
   ),
   icon: cn('grid aspect-square p-0!', 'not-aria-disabled:active:scale-[0.97]'),
   seek: hideAtSmall,
@@ -30,7 +30,7 @@ export const button = {
   live: cn(
     'inline-flex items-center gap-1.5',
     'aspect-auto w-auto px-3 py-2',
-    'text-(length:--font-size-small) font-semibold uppercase tracking-wider leading-none',
+    'text-(length:--media-font-size-small) font-semibold uppercase tracking-wider leading-none',
     'before:inline-block before:size-2 before:shrink-0 before:rounded-full',
     'before:bg-current/40 before:transition-colors before:duration-150 before:ease-out',
     'data-[live-edge]:before:bg-red-500'

--- a/packages/skins/src/default/tailwind/components/container.ts
+++ b/packages/skins/src/default/tailwind/components/container.ts
@@ -7,32 +7,31 @@ export const container = cn(
   // Layout & containment
   'block relative isolate h-full w-full @container/media-root',
   // Appearance
-  'rounded-(--container-border-radius,1.75rem)',
-  'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] text-(length:--font-size-base) leading-normal subpixel-antialiased',
-  '[--accent-color:var(--media-accent-color,var(--default-accent-color))]',
-  '[--accent-contrast-color:contrast-color(var(--accent-color))]',
-  '[--accent-background-color:var(--media-accent-color,oklch(from_var(--default-accent-color)_l_c_h/calc(alpha*0.1)))]',
-  '[--accent-text-color:var(--media-accent-text-color,contrast-color(var(--media-accent-color,oklch(0_0_0))))]',
-  '[--container-border-radius:var(--media-border-radius,1.75rem)]',
+  'rounded-(--media-container-border-radius,1.75rem)',
+  'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] text-(length:--media-font-size-base) leading-normal subpixel-antialiased',
+  '[--media-internal-accent-color:var(--media-accent-color,var(--media-default-accent-color))]',
+  '[--media-accent-contrast-color:contrast-color(var(--media-internal-accent-color))]',
+  '[--media-accent-background-color:var(--media-accent-color,oklch(from_var(--media-default-accent-color)_l_c_h/calc(alpha*0.1)))]',
+  '[--media-internal-accent-text-color:var(--media-accent-text-color,contrast-color(var(--media-accent-color,oklch(0_0_0))))]',
+  '[--media-container-border-radius:var(--media-border-radius,1.75rem)]',
   // Focus ring
   'outline-2 outline-transparent -outline-offset-4',
   'transition-[outline-offset,outline-color] duration-100 ease-out',
-  'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',
+  'focus-visible:outline-(--media-focus-ring-color) focus-visible:outline-offset-2',
   // Scrollbars
   'scrollbar-thin scrollbar-thumb-current/30',
   '[@media_(prefers-reduced-transparency:reduce)_or_(prefers-contrast:more)]:scrollbar-auto',
   '[@media_(prefers-reduced-transparency:reduce)_or_(prefers-contrast:more)]:scrollbar-thumb-current/80',
   // Shadow color variables (derived from currentColor lightness)
-  '[--shadow-current-color:oklch(from_currentColor_0_0_0/clamp(0,calc((l-0.5)*0.5),0.15))]',
-  '[--shadow-subtle-current-color:oklch(from_var(--shadow-current-color)_l_c_h/calc(alpha*0.4))]',
+  '[--media-shadow-current-color:oklch(from_currentColor_0_0_0/clamp(0,calc((l-0.5)*0.5),0.15))]',
+  '[--media-shadow-subtle-current-color:oklch(from_var(--media-shadow-current-color)_l_c_h/calc(alpha*0.4))]',
   // Font and icon sizing
-  '[--scale:1]',
-  '[--font-size-base:calc(0.8125rem*var(--scale))]',
-  '[--font-size-small:calc(0.6875rem*var(--scale))]',
-  '[--font-size-medium:calc(0.9375rem*var(--scale))]',
-  '[--font-size-tiny:calc(0.5625rem*var(--scale))]',
-  '[--media-icon-size:calc(--spacing(4.5)*var(--scale))]',
-  // Preserve the container's Tailwind spacing value and scale descendants from it.
-  '[--spacing-proxy:var(--spacing)]',
-  '[&>*]:[--spacing:calc(var(--spacing-proxy)*var(--scale))]'
+  '[--media-scale:1]',
+  '[--media-font-size-base:calc(0.8125rem*var(--media-scale))]',
+  '[--media-font-size-small:calc(0.6875rem*var(--media-scale))]',
+  '[--media-font-size-medium:calc(0.9375rem*var(--media-scale))]',
+  '[--media-font-size-tiny:calc(0.5625rem*var(--media-scale))]',
+  '[--media-spacing:calc(var(--media-scale-unit,16px)*var(--media-scale)/4)]',
+  '[--spacing:var(--media-spacing)]',
+  '[--media-icon-size:calc(var(--media-spacing)*4.5)]'
 );

--- a/packages/skins/src/default/tailwind/components/controls.ts
+++ b/packages/skins/src/default/tailwind/components/controls.ts
@@ -5,12 +5,12 @@ export const controls = cn(
   'peer/controls',
   // Layout
   '@container/media-controls',
-  '[--media-popover-side-offset:calc(var(--spacing)*(var(--base-side-offset,2)+var(--controls-padding,1)))]',
+  '[--media-popover-side-offset:calc(var(--media-spacing)*(var(--media-base-side-offset,2)+var(--media-controls-padding,1)))]',
   '[--media-tooltip-side-offset:var(--media-popover-side-offset)]',
-  '[--media-popover-boundary-offset:calc(var(--spacing)*var(--base-boundary-offset,2))]',
+  '[--media-popover-boundary-offset:calc(var(--media-spacing)*var(--media-base-boundary-offset,2))]',
   '[--media-tooltip-boundary-offset:var(--media-popover-boundary-offset)]',
-  '[padding:calc(var(--spacing)*var(--controls-padding,1))] flex items-center [&:dir(rtl)]:flex-row-reverse',
+  '[padding:calc(var(--media-spacing)*var(--media-controls-padding,1))] flex items-center [&:dir(rtl)]:flex-row-reverse',
   'rounded-full',
   // Text shadow
-  'text-shadow-2xs text-shadow-(color:--shadow-current-color)'
+  'text-shadow-2xs text-shadow-(color:--media-shadow-current-color)'
 );

--- a/packages/skins/src/default/tailwind/components/error.ts
+++ b/packages/skins/src/default/tailwind/components/error.ts
@@ -6,9 +6,9 @@ export const error = {
     'flex flex-col gap-3 max-w-72 p-3 rounded-[--spacing(7)] text-white',
     // Animation
     'transition-[opacity,scale,transform]',
-    'duration-(--error-dialog-transition-duration)',
-    'delay-(--error-dialog-transition-delay)',
-    'ease-(--error-dialog-transition-timing-function)',
+    'duration-(--media-error-dialog-transition-duration)',
+    'delay-(--media-error-dialog-transition-delay)',
+    'ease-(--media-error-dialog-transition-timing-function)',
     'group-data-starting-style/error:opacity-0 group-data-starting-style/error:scale-95',
     'group-data-ending-style/error:opacity-0 group-data-ending-style/error:scale-95',
     'motion-reduce:scale-100 motion-reduce:transition-opacity',

--- a/packages/skins/src/default/tailwind/components/icon.ts
+++ b/packages/skins/src/default/tailwind/components/icon.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const icon = cn(
   'block [grid-area:1/1] size-(--media-icon-size) shrink-0',
-  'drop-shadow-[0_1px_0_var(--shadow-current-color)]',
+  'drop-shadow-[0_1px_0_var(--media-shadow-current-color)]',
   'transition-[opacity,scale] duration-150 ease-out'
 );
 

--- a/packages/skins/src/default/tailwind/components/input-indicator.ts
+++ b/packages/skins/src/default/tailwind/components/input-indicator.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const topIndicatorRoot = cn(
   'group/input-indicator',
-  '[--surface-background-color:oklch(0_0_0/0.25)]',
+  '[--media-surface-background-color:oklch(0_0_0/0.25)]',
   'absolute top-3 rounded-full origin-top pointer-events-none',
   'text-inherit font-medium',
   'duration-100 ease-out',
@@ -21,8 +21,8 @@ export const topIndicatorRoot = cn(
   'pointer-fine:motion-safe:data-ending-style:blur-sm',
   'pointer-fine:motion-safe:data-ending-style:scale-90',
   'motion-safe:data-ending-style:-translate-y-1/4',
-  '[@media(prefers-reduced-transparency:reduce)]:[--surface-background-color:oklch(0_0_0)]',
-  'contrast-more:[--surface-background-color:oklch(0_0_0)]'
+  '[@media(prefers-reduced-transparency:reduce)]:[--media-surface-background-color:oklch(0_0_0)]',
+  'contrast-more:[--media-surface-background-color:oklch(0_0_0)]'
 );
 
 export const topIndicatorContent = cn(

--- a/packages/skins/src/default/tailwind/components/menu.ts
+++ b/packages/skins/src/default/tailwind/components/menu.ts
@@ -4,37 +4,37 @@ import { popup } from './popup';
 import { surface } from './surface';
 
 const submenuPanel = cn(
-  '[--menu-content-enter-translate:100%] [&:dir(rtl)]:[--menu-content-enter-translate:-100%]',
-  'absolute inset-x-0 top-0 [max-height:inherit] overflow-auto overscroll-none p-(--menu-padding) outline-none',
+  '[--media-menu-content-enter-translate:100%] [&:dir(rtl)]:[--media-menu-content-enter-translate:-100%]',
+  'absolute inset-x-0 top-0 [max-height:inherit] overflow-auto overscroll-none p-(--media-menu-padding) outline-none',
   'z-10',
-  'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out',
+  'translate-none transition-[translate,filter] duration-(--media-menu-transition-duration) ease-out',
   'data-starting-style:pointer-events-none data-ending-style:pointer-events-none',
   'data-starting-style:overflow-hidden data-ending-style:overflow-hidden',
-  'data-starting-style:[translate:var(--menu-content-enter-translate)_0] data-ending-style:[translate:var(--menu-content-enter-translate)_0]',
+  'data-starting-style:[translate:var(--media-menu-content-enter-translate)_0] data-ending-style:[translate:var(--media-menu-content-enter-translate)_0]',
   'data-starting-style:blur data-ending-style:blur'
 );
 
 const itemBase = cn(
-  'group/menu-item relative flex cursor-pointer select-none items-center gap-1.5 rounded-(--menu-item-border-radius) py-1.5 px-2',
+  'group/menu-item relative flex cursor-pointer select-none items-center gap-1.5 rounded-(--media-menu-item-border-radius) py-1.5 px-2',
   'text-start',
-  'text-shadow-2xs text-shadow-(color:--shadow-current-color)',
+  'text-shadow-2xs text-shadow-(color:--media-shadow-current-color)',
   'outline-2 -outline-offset-2 outline-transparent',
   'transition-colors duration-100 ease-in-out',
   'supports-[top:anchor(top)]:duration-50',
   'supports-[top:anchor(top)]:hover:duration-200',
   'supports-[top:anchor(top)]:data-highlighted:duration-200',
-  'hover:bg-(--accent-background-color) hover:text-(--accent-text-color)',
-  'data-highlighted:bg-(--accent-background-color) data-highlighted:text-(--accent-text-color)',
-  'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2'
+  'hover:bg-(--media-accent-background-color) hover:text-(--media-internal-accent-text-color)',
+  'data-highlighted:bg-(--media-accent-background-color) data-highlighted:text-(--media-internal-accent-text-color)',
+  'focus-visible:outline-(--media-focus-ring-color) focus-visible:outline-offset-2'
 );
 
 const menuTokens = cn(
-  '[--menu-transition-duration:250ms]',
-  '[--menu-max-height:--spacing(56)]',
-  '[--menu-padding:--spacing(1)]',
-  '[--menu-border-radius:--spacing(3)]',
-  '[--menu-item-border-radius:calc(var(--menu-border-radius)_-_var(--menu-padding))]',
-  'motion-reduce:[--menu-transition-duration:0ms]'
+  '[--media-menu-transition-duration:250ms]',
+  '[--media-menu-max-height:--spacing(56)]',
+  '[--media-menu-padding:--spacing(1)]',
+  '[--media-menu-border-radius:--spacing(3)]',
+  '[--media-menu-item-border-radius:calc(var(--media-menu-border-radius)_-_var(--media-menu-padding))]',
+  'motion-reduce:[--media-menu-transition-duration:0ms]'
 );
 
 const group = cn(
@@ -47,8 +47,8 @@ const group = cn(
   // menu while hovering. Exclude it from scroll anchoring.
   'supports-[top:anchor(top)]:before:[overflow-anchor:none]',
   'supports-[top:anchor(top)]:before:pointer-events-none',
-  'supports-[top:anchor(top)]:before:bg-(--accent-background-color)',
-  'supports-[top:anchor(top)]:before:rounded-(--menu-item-border-radius)',
+  'supports-[top:anchor(top)]:before:bg-(--media-accent-background-color)',
+  'supports-[top:anchor(top)]:before:rounded-(--media-menu-item-border-radius)',
   'supports-[top:anchor(top)]:before:transition-[inset]',
   'supports-[top:anchor(top)]:before:duration-100',
   'supports-[top:anchor(top)]:before:ease-in-out',
@@ -59,8 +59,8 @@ const menuHostShell = cn(
   popup.popover,
   surface,
   menuTokens,
-  'min-w-max max-w-(--media-popover-available-width,none) max-h-[min(var(--media-popover-available-height,var(--menu-max-height)),var(--menu-max-height))]',
-  'box-border rounded-(--menu-border-radius) p-(--menu-padding) overscroll-none'
+  'min-w-max max-w-(--media-popover-available-width,none) max-h-[min(var(--media-popover-available-height,var(--media-menu-max-height)),var(--media-menu-max-height))]',
+  'box-border rounded-(--media-menu-border-radius) p-(--media-menu-padding) overscroll-none'
 );
 
 export const menu = {
@@ -73,19 +73,19 @@ export const menu = {
     menuHostShell,
     'group/menu-popup',
     // Only the menu size changes between panels.
-    '[--popup-transition:var(--popup-base-transition),width_var(--popup-transition-timing-function)_var(--menu-transition-duration),height_var(--popup-transition-timing-function)_var(--menu-transition-duration)]',
+    '[--media-popup-transition:var(--media-popup-base-transition),width_var(--media-popup-transition-timing-function)_var(--media-menu-transition-duration),height_var(--media-popup-transition-timing-function)_var(--media-menu-transition-duration)]',
     // Don't transition size on open/close.
-    'data-starting-style:[--popup-transition:var(--popup-base-transition)]',
-    'data-ending-style:[--popup-transition:var(--popup-base-transition)]',
+    'data-starting-style:[--media-popup-transition:var(--media-popup-base-transition)]',
+    'data-ending-style:[--media-popup-transition:var(--media-popup-base-transition)]',
     'min-w-48! w-(--media-menu-width) h-(--media-menu-height)',
     'overflow-hidden!'
   ),
   /** Root settings Content that exits when a nested Content opens. */
   settingsContent: cn(
     group,
-    'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out',
-    '[--menu-content-exit-translate:-100%] [&:dir(rtl)]:[--menu-content-exit-translate:100%]',
-    'data-[child-open]:[translate:var(--menu-content-exit-translate)_0]',
+    'translate-none transition-[translate,filter] duration-(--media-menu-transition-duration) ease-out',
+    '[--media-menu-content-exit-translate:-100%] [&:dir(rtl)]:[--media-menu-content-exit-translate:100%]',
+    'data-[child-open]:[translate:var(--media-menu-content-exit-translate)_0]',
     'data-[child-open]:blur',
     // Avoid restarting the parent Content transition in WebKit while the
     // anchor-positioned highlight is active.
@@ -102,9 +102,9 @@ export const menu = {
     'aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50'
   ),
   separator: 'my-1 border-b border-[oklch(0_0_0/0.1)] shadow-[0_1px_0_0_oklch(1_0_0/0.075)]',
-  tier: 'ps-0.5 pt-px text-(length:--font-size-tiny) font-semibold leading-none text-current/70',
+  tier: 'ps-0.5 pt-px text-(length:--media-font-size-tiny) font-semibold leading-none text-current/70',
   indicator: 'ms-auto -me-1 shrink-0 opacity-0 group-aria-checked/menu-item:opacity-100',
-  icon: 'shrink-0 text-current/65 drop-shadow-[0_1px_0_var(--shadow-current-color)] group-hover/menu-item:text-inherit group-data-highlighted/menu-item:text-inherit',
+  icon: 'shrink-0 text-current/65 drop-shadow-[0_1px_0_var(--media-shadow-current-color)] group-hover/menu-item:text-inherit group-data-highlighted/menu-item:text-inherit',
   /** Nested submenu panel. */
   submenuPanel,
   back: cn(itemBase, 'mb-0.5 w-full'),

--- a/packages/skins/src/default/tailwind/components/overlay.ts
+++ b/packages/skins/src/default/tailwind/components/overlay.ts
@@ -10,7 +10,7 @@ export const overlay = cn(
   'backdrop-blur-none backdrop-saturate-100',
   // Transitions
   'transition-[opacity,backdrop-filter]',
-  'duration-(--controls-transition-duration)',
+  'duration-(--media-controls-transition-duration)',
   'ease-out',
   // Shown when controls visible
   'peer-data-visible/controls:opacity-100',
@@ -21,7 +21,7 @@ export const overlay = cn(
   // Shown when error visible (+ blur)
   // Light DOM: peer/error is a direct sibling (React)
   'peer-data-open/error:opacity-100',
-  'peer-data-open/error:duration-(--error-dialog-transition-duration)',
-  'peer-data-open/error:delay-(--error-dialog-transition-delay)',
+  'peer-data-open/error:duration-(--media-error-dialog-transition-duration)',
+  'peer-data-open/error:delay-(--media-error-dialog-transition-delay)',
   'peer-data-open/error:backdrop-blur-lg peer-data-open/error:backdrop-saturate-150'
 );

--- a/packages/skins/src/default/tailwind/components/popup.ts
+++ b/packages/skins/src/default/tailwind/components/popup.ts
@@ -2,19 +2,19 @@ import { cn } from '@videojs/utils/style';
 
 const base = cn(
   // Reset default popover styles
-  '[--popup-base-transition:opacity_var(--popup-transition-timing-function)_var(--popup-transition-duration),filter_var(--popup-transition-timing-function)_var(--popup-transition-duration),transform_var(--popup-transition-timing-function)_var(--popup-transition-duration),scale_var(--popup-transition-timing-function)_var(--popup-transition-duration)]',
-  '[--popup-translate-distance:0.5rem] m-0 border-0 text-inherit overflow-visible',
+  '[--media-popup-base-transition:opacity_var(--media-popup-transition-timing-function)_var(--media-popup-transition-duration),filter_var(--media-popup-transition-timing-function)_var(--media-popup-transition-duration),transform_var(--media-popup-transition-timing-function)_var(--media-popup-transition-duration),scale_var(--media-popup-transition-timing-function)_var(--media-popup-transition-duration)]',
+  '[--media-popup-translate-distance:0.5rem] m-0 border-0 text-inherit overflow-visible',
   // Animation
-  '[transition:var(--popup-transition,var(--popup-base-transition))]',
+  '[transition:var(--media-popup-transition,var(--media-popup-base-transition))]',
   // We have to use transform here for translate as the translate property is used for positioning by core.
-  'data-starting-style:opacity-0 data-starting-style:blur-xs data-starting-style:scale-95 data-starting-style:[transform:translate(var(--popup-translate-x-distance,0),var(--popup-translate-y-distance,0))]',
+  'data-starting-style:opacity-0 data-starting-style:blur-xs data-starting-style:scale-95 data-starting-style:[transform:translate(var(--media-popup-translate-x-distance,0),var(--media-popup-translate-y-distance,0))]',
   'data-ending-style:opacity-0 data-ending-style:blur-xs data-ending-style:scale-95 data-ending-style:transform-none',
   // Speed up the exit transition.
-  'data-ending-style:[transition-duration:max(0ms,calc(var(--popup-transition-duration)-50ms))]',
+  'data-ending-style:[transition-duration:max(0ms,calc(var(--media-popup-transition-duration)-50ms))]',
   // Ensure we animate from the correct origin based on the side the popover is on
   'data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left',
-  'data-[side=top]:[--popup-translate-y-distance:var(--popup-translate-distance)] data-[side=bottom]:[--popup-translate-y-distance:calc(var(--popup-translate-distance)*-1)]',
-  'data-[side=left]:[--popup-translate-x-distance:var(--popup-translate-distance)] data-[side=right]:[--popup-translate-x-distance:calc(var(--popup-translate-distance)*-1)]',
+  'data-[side=top]:[--media-popup-translate-y-distance:var(--media-popup-translate-distance)] data-[side=bottom]:[--media-popup-translate-y-distance:calc(var(--media-popup-translate-distance)*-1)]',
+  'data-[side=left]:[--media-popup-translate-x-distance:var(--media-popup-translate-distance)] data-[side=right]:[--media-popup-translate-x-distance:calc(var(--media-popup-translate-distance)*-1)]',
   // Safe area between trigger and popup
   'before:absolute before:pointer-events-[inherit]',
   'data-[side=top]:before:left-0 data-[side=top]:before:right-0 data-[side=top]:before:top-full',
@@ -23,7 +23,7 @@ const base = cn(
   'data-[side=right]:before:top-0 data-[side=right]:before:bottom-0 data-[side=right]:before:right-full'
 );
 
-export const tooltip = 'py-1 px-2.5 rounded-full text-(length:--font-size-base) whitespace-nowrap';
+export const tooltip = 'py-1 px-2.5 rounded-full text-(length:--media-font-size-base) whitespace-nowrap';
 
 export const popup = {
   popover: cn(
@@ -40,6 +40,6 @@ export const popup = {
   ),
   volume: 'py-3 px-0 rounded-full',
   tooltipShortcut: cn(
-    'min-w-[1.5em] p-[0.1em] bg-current/30 text-(length:--font-size-small) font-semibold font-[inherit] leading-[1.25] text-center rounded-[--spacing(1)]'
+    'min-w-[1.5em] p-[0.1em] bg-current/30 text-(length:--media-font-size-small) font-semibold font-[inherit] leading-[1.25] text-center rounded-[--spacing(1)]'
   ),
 };

--- a/packages/skins/src/default/tailwind/components/poster.ts
+++ b/packages/skins/src/default/tailwind/components/poster.ts
@@ -15,7 +15,7 @@ export const poster = (isShadowDOM: boolean) =>
           '[&_::slotted(img)]:h-full',
           '[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]',
           '[&_::slotted(img)]:[object-position:var(--media-object-position,center)]',
-          '[&_::slotted(img)]:rounded-(--container-border-radius)',
+          '[&_::slotted(img)]:rounded-(--media-container-border-radius)',
           // The image this skin carries as slot fallback content, which `::slotted` cannot reach.
           '[&_img]:absolute',
           '[&_img]:inset-0',
@@ -23,7 +23,7 @@ export const poster = (isShadowDOM: boolean) =>
           '[&_img]:h-full',
           '[&_img]:[object-fit:var(--media-object-fit,contain)]',
           '[&_img]:[object-position:var(--media-object-position,center)]',
-          '[&_img]:rounded-(--container-border-radius)',
+          '[&_img]:rounded-(--media-container-border-radius)',
         ]
       : 'rounded-[inherit] [object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]'
   );

--- a/packages/skins/src/default/tailwind/components/slider.ts
+++ b/packages/skins/src/default/tailwind/components/slider.ts
@@ -1,7 +1,7 @@
 import { cn } from '@videojs/utils/style';
 
 const previewContent = cn(
-  'absolute left-1/2 max-w-(--max-size)',
+  'absolute left-1/2 max-w-(--media-max-size)',
   '-translate-x-1/2 translate-y-2 scale-80 opacity-0 blur-lg origin-bottom',
   'transition-[filter,opacity,scale] duration-150 ease-out',
   'group-data-pointing/slider:scale-100 group-data-pointing/slider:opacity-100',
@@ -12,16 +12,16 @@ const previewContent = cn(
 
 export const slider = {
   root: cn(
-    'group/slider relative flex flex-1 items-center justify-center rounded-(--track-border-radius) outline-none cursor-pointer',
-    '[--track-border-radius:99px]',
-    '[--chapter-gap:calc(var(--spacing)*1)] [--chapter-inset-start:calc(var(--chapter-gap)/2)] [--chapter-inset-end:calc(var(--chapter-gap)/2)]',
+    'group/slider relative flex flex-1 items-center justify-center rounded-(--media-track-border-radius) outline-none cursor-pointer',
+    '[--media-track-border-radius:99px]',
+    '[--media-chapter-gap:calc(var(--media-spacing)*1)] [--media-internal-chapter-inset-start:calc(var(--media-chapter-gap)/2)] [--media-internal-chapter-inset-end:calc(var(--media-chapter-gap)/2)]',
     // Horizontal
-    'data-[orientation=horizontal]:min-w-20 data-[orientation=horizontal]:w-(--slider-width,100%) data-[orientation=horizontal]:h-(--slider-height,--spacing(8))',
+    'data-[orientation=horizontal]:min-w-20 data-[orientation=horizontal]:w-(--media-slider-width,100%) data-[orientation=horizontal]:h-(--media-slider-height,--spacing(8))',
     // Vertical
-    'data-[orientation=vertical]:w-(--slider-width,--spacing(8)) data-[orientation=vertical]:h-(--slider-height,--spacing(20))'
+    'data-[orientation=vertical]:w-(--media-slider-width,--spacing(8)) data-[orientation=vertical]:h-(--media-slider-height,--spacing(20))'
   ),
   track: cn(
-    'relative isolate overflow-hidden bg-current/20 rounded-(--track-border-radius) select-none',
+    'relative isolate overflow-hidden bg-current/20 rounded-(--media-track-border-radius) select-none',
     // Horizontal
     'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-1',
     // Vertical
@@ -31,19 +31,19 @@ export const slider = {
   chapter: {
     base: cn(
       'group/chapter absolute inset-0 flex items-center justify-center min-w-0 min-h-0',
-      'first:[--chapter-inset-start:0px] last:[--chapter-inset-end:0px]',
+      'first:[--media-internal-chapter-inset-start:0px] last:[--media-internal-chapter-inset-end:0px]',
       'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start))]',
       'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start)_0)]'
     ),
     track: cn(
-      'relative isolate overflow-hidden bg-current/20 rounded-(--track-border-radius) select-none',
+      'relative isolate overflow-hidden bg-current/20 rounded-(--media-track-border-radius) select-none',
       'motion-safe:transition-[height,width] motion-safe:duration-200 motion-safe:ease-out',
       'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-1',
       'group-data-highlighted/chapter:data-[orientation=horizontal]:h-1.75',
-      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-inset-start))_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--media-internal-chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--media-internal-chapter-inset-start))_round_var(--media-track-border-radius))]',
       'data-[orientation=vertical]:w-1 data-[orientation=vertical]:h-full',
       'group-data-highlighted/chapter:data-[orientation=vertical]:w-1.75',
-      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-inset-start))_0_round_var(--track-border-radius))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--media-internal-chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--media-internal-chapter-inset-start))_0_round_var(--media-track-border-radius))]'
     ),
   },
   fill: {
@@ -53,24 +53,24 @@ export const slider = {
       'data-dragging:duration-0 data-seeking:duration-0'
     ),
     fill: cn(
-      'bg-(--accent-color)',
+      'bg-(--media-internal-accent-color)',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_var(--track-border-radius))]',
-      'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_var(--media-track-border-radius))]',
+      'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_var(--media-track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_var(--track-border-radius))]',
-      'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_var(--track-border-radius))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_var(--media-track-border-radius))]',
+      'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_var(--media-track-border-radius))]'
     ),
     buffer: cn(
       'bg-current/20',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_var(--media-track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_var(--track-border-radius))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_var(--media-track-border-radius))]'
     ),
   },
   thumb: {
@@ -78,7 +78,7 @@ export const slider = {
       'z-10 absolute size-2.5 -translate-x-1/2 -translate-y-1/2',
       'bg-current rounded-full',
       'opacity-0 scale-80',
-      'shadow-[0_0_0_1px_var(--shadow-current-color,oklch(0_0_0/0.1)),0_1px_3px_0_oklch(0_0_0/0.35),0_1px_2px_-1px_oklch(0_0_0/0.35)]',
+      'shadow-[0_0_0_1px_var(--media-shadow-current-color,oklch(0_0_0/0.1)),0_1px_3px_0_oklch(0_0_0/0.35),0_1px_2px_-1px_oklch(0_0_0/0.35)]',
       'transition-none motion-safe:transition-[opacity,height,width,outline-offset,left,top,scale] duration-150 ease-out select-none',
       'data-dragging:duration-0 data-seeking:duration-0',
       'group-active/slider:size-3',
@@ -105,21 +105,21 @@ export const slider = {
     ),
   },
   preview: cn(
-    '[--max-size-factor:36]',
-    '[--max-size:min(calc(var(--spacing)*var(--max-size-factor)),100cqi)]',
-    '@2xl/media-root:[--max-size-factor:48]',
-    'min-w-(--max-size) h-1',
+    '[--media-max-size-factor:36]',
+    '[--media-max-size:min(calc(var(--media-spacing)*var(--media-max-size-factor)),100cqi)]',
+    '@2xl/media-root:[--media-max-size-factor:48]',
+    'min-w-(--media-max-size) h-1',
     'before:absolute before:z-1 before:top-1/2 before:left-1/2 before:size-1 before:bg-current before:rounded-full before:pointer-events-none',
-    'before:shadow-[0_0_0_1px_var(--shadow-current-color,oklch(0_0_0/0.15)),0_1px_2px_0_oklch(0_0_0/0.35)]',
+    'before:shadow-[0_0_0_1px_var(--media-shadow-current-color,oklch(0_0_0/0.15)),0_1px_2px_0_oklch(0_0_0/0.35)]',
     'before:-translate-1/2 before:opacity-0 before:scale-50',
     'before:transition-[opacity,scale] before:duration-200 before:ease-out',
     'data-pointing:not-data-dragging:before:opacity-100 data-pointing:not-data-dragging:before:scale-100'
   ),
   thumbnail: cn(
     previewContent,
-    '[--thumbnail-max-width:var(--max-size)] [--thumbnail-max-height:var(--max-size)]',
+    '[--media-thumbnail-max-width:var(--media-max-size)] [--media-thumbnail-max-height:var(--media-max-size)]',
     '[bottom:calc(100%+--spacing(9))]'
   ),
   value: cn(previewContent, '[bottom:calc(100%+--spacing(10.5))] flex flex-col items-center tabular-nums'),
-  chapterTitle: 'min-w-0 max-w-(--max-size) px-6 overflow-hidden text-ellipsis whitespace-nowrap empty:hidden',
+  chapterTitle: 'min-w-0 max-w-(--media-max-size) px-6 overflow-hidden text-ellipsis whitespace-nowrap empty:hidden',
 };

--- a/packages/skins/src/default/tailwind/components/surface.ts
+++ b/packages/skins/src/default/tailwind/components/surface.ts
@@ -1,8 +1,8 @@
 import { cn } from '@videojs/utils/style';
 
 export const surface = cn(
-  'bg-(--surface-background-color)',
-  '[backdrop-filter:var(--surface-backdrop-filter)]',
-  '[box-shadow:0_0_0_1px_var(--surface-outer-border-color),0_1px_3px_0_var(--surface-shadow-color),0_1px_2px_-1px_var(--surface-shadow-color)]',
-  'after:absolute after:inset-0 after:[box-shadow:inset_0_1px_0_0_var(--surface-inner-border-color),inset_0_0_0_1px_oklch(from_var(--surface-inner-border-color)_l_c_h/calc(alpha*0.5))] after:rounded-[inherit] after:pointer-events-none after:z-10'
+  'bg-(--media-surface-background-color)',
+  '[backdrop-filter:var(--media-surface-backdrop-filter)]',
+  '[box-shadow:0_0_0_1px_var(--media-surface-outer-border-color),0_1px_3px_0_var(--media-surface-shadow-color),0_1px_2px_-1px_var(--media-surface-shadow-color)]',
+  'after:absolute after:inset-0 after:[box-shadow:inset_0_1px_0_0_var(--media-surface-inner-border-color),inset_0_0_0_1px_oklch(from_var(--media-surface-inner-border-color)_l_c_h/calc(alpha*0.5))] after:rounded-[inherit] after:pointer-events-none after:z-10'
 );

--- a/packages/skins/src/default/tailwind/components/thumbnail.ts
+++ b/packages/skins/src/default/tailwind/components/thumbnail.ts
@@ -3,11 +3,11 @@ import { cn } from '@videojs/utils/style';
 export const thumbnail = {
   root: cn(
     'group/thumbnail pointer-events-none bg-black/90 rounded-[--spacing(3)]',
-    'has-data-loading:w-(--thumbnail-max-width) has-data-loading:max-w-full',
+    'has-data-loading:w-(--media-thumbnail-max-width) has-data-loading:max-w-full',
     'has-data-loading:aspect-video has-data-loading:overflow-hidden'
   ),
   image: cn(
-    'relative block max-w-(--thumbnail-max-width) max-h-(--thumbnail-max-height) overflow-clip rounded-[inherit]',
+    'relative block max-w-(--media-thumbnail-max-width) max-h-(--media-thumbnail-max-height) overflow-clip rounded-[inherit]',
     'transition-opacity duration-150 ease-out',
     'after:absolute after:inset-0 after:rounded-[inherit]',
     'after:bg-linear-to-t after:from-black/50 after:via-black/10 after:to-black/0',

--- a/packages/skins/src/default/tailwind/components/time.ts
+++ b/packages/skins/src/default/tailwind/components/time.ts
@@ -3,5 +3,5 @@ export const time = {
     '@container/media-time flex items-center flex-1 gap-2.5 [&:dir(rtl)]:flex-row-reverse @max-[16rem]/media-time:[&>*:last-child]:hidden',
   current: 'tabular-nums',
   duration:
-    'tabular-nums cursor-pointer rounded-[--spacing(1)] outline-2 outline-transparent -outline-offset-2 transition-[outline-color,outline-offset] duration-100 ease-out focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',
+    'tabular-nums cursor-pointer rounded-[--spacing(1)] outline-2 outline-transparent -outline-offset-2 transition-[outline-color,outline-offset] duration-100 ease-out focus-visible:outline-(--media-focus-ring-color) focus-visible:outline-offset-2',
 };

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -24,53 +24,53 @@ export const container = (isShadowDOM: boolean) =>
     // Inner border ring
     'after:absolute after:pointer-events-none after:rounded-[inherit] after:z-10',
     '[&:fullscreen]:after:hidden',
-    'after:inset-0 after:ring-1 after:ring-inset after:ring-(color:--border-color)',
+    'after:inset-0 after:ring-1 after:ring-inset after:ring-(color:--media-border-color)',
     // Video element
     {
-      '[&_::slotted(video)]:block [&_::slotted(video)]:w-full [&_::slotted(video)]:h-full [&_::slotted(video)]:rounded-(--container-border-radius) [&_::slotted(video)]:[object-fit:var(--media-object-fit,contain)] [&_::slotted(video)]:[object-position:var(--media-object-position,center)]':
+      '[&_::slotted(video)]:block [&_::slotted(video)]:w-full [&_::slotted(video)]:h-full [&_::slotted(video)]:rounded-(--media-container-border-radius) [&_::slotted(video)]:[object-fit:var(--media-object-fit,contain)] [&_::slotted(video)]:[object-position:var(--media-object-position,center)]':
         isShadowDOM,
       '[&_video]:block [&_video]:w-full [&_video]:h-full [&_video]:rounded-[inherit] [&_video]:[object-fit:var(--media-object-fit,contain)] [&_video]:[object-position:var(--media-object-position,center)]':
         !isShadowDOM,
     },
-    '[--default-accent-color:oklch(1_0_0)]',
-    '[--border-color:light-dark(oklch(0_0_0/0.1),oklch(1_0_0/0.15))]',
-    '[--focus-ring-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
-    '**:[--focus-ring-color:oklch(1_0_0)]',
-    '[--container-border-radius:var(--media-border-radius,1.75rem)]',
-    '[--media-video-border-radius:var(--container-border-radius)]',
-    '[--controls-transition-duration:100ms]',
-    '[--controls-transition-timing-function:ease-out]',
-    '[--error-dialog-transition-duration:350ms]',
-    '[--error-dialog-transition-delay:100ms]',
-    '[--error-dialog-transition-timing-function:ease-out]',
-    '[--popup-transition-duration:100ms]',
-    '[--popup-transition-timing-function:ease-out]',
-    '[--surface-background-color:oklch(1_0_0/0.1)]',
-    '[--surface-inner-border-color:oklch(1_0_0/0.1)]',
-    '[--surface-outer-border-color:oklch(0_0_0/0.1)]',
-    '[--surface-shadow-color:oklch(0_0_0/0.15)]',
-    '[--surface-backdrop-filter:blur(16px)_saturate(1.5)]',
+    '[--media-default-accent-color:oklch(1_0_0)]',
+    '[--media-border-color:light-dark(oklch(0_0_0/0.1),oklch(1_0_0/0.15))]',
+    '[--media-focus-ring-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
+    '**:[--media-focus-ring-color:oklch(1_0_0)]',
+    '[--media-container-border-radius:var(--media-border-radius,1.75rem)]',
+    '[--media-video-border-radius:var(--media-container-border-radius)]',
+    '[--media-controls-transition-duration:100ms]',
+    '[--media-controls-transition-timing-function:ease-out]',
+    '[--media-error-dialog-transition-duration:350ms]',
+    '[--media-error-dialog-transition-delay:100ms]',
+    '[--media-error-dialog-transition-timing-function:ease-out]',
+    '[--media-popup-transition-duration:100ms]',
+    '[--media-popup-transition-timing-function:ease-out]',
+    '[--media-surface-background-color:oklch(1_0_0/0.1)]',
+    '[--media-surface-inner-border-color:oklch(1_0_0/0.1)]',
+    '[--media-surface-outer-border-color:oklch(0_0_0/0.1)]',
+    '[--media-surface-shadow-color:oklch(0_0_0/0.15)]',
+    '[--media-surface-backdrop-filter:blur(16px)_saturate(1.5)]',
     // Fullscreen scale
-    'min-[1280px]:[&:fullscreen]:[--scale:1.25]',
-    'min-[1536px]:[&:fullscreen]:[--scale:1.5]',
-    'min-[1920px]:[&:fullscreen]:[--scale:1.75]',
-    'motion-reduce:[--error-dialog-transition-duration:50ms]',
-    'motion-reduce:[--error-dialog-transition-delay:0ms]',
-    'motion-reduce:[--error-dialog-transition-timing-function:ease-out]',
-    'motion-reduce:[--popup-transition-duration:0ms]',
-    '[@media(prefers-reduced-transparency:reduce)]:[--surface-background-color:oklch(0_0_0)]',
-    'contrast-more:[--surface-background-color:oklch(0_0_0)]',
-    '[@media(prefers-reduced-transparency:reduce)]:[--surface-inner-border-color:oklch(1_0_0/0.25)]',
-    'contrast-more:[--surface-inner-border-color:oklch(1_0_0/0.25)]',
-    '[@media(prefers-reduced-transparency:reduce)]:[--surface-outer-border-color:transparent]',
-    'contrast-more:[--surface-outer-border-color:transparent]',
-    'pointer-fine:has-[[data-controls]:not([data-visible])]:[--controls-transition-duration:300ms]',
-    'pointer-coarse:has-[[data-controls]:not([data-visible])]:[--controls-transition-duration:150ms]',
-    'motion-reduce:has-[[data-controls]:not([data-visible])]:[--controls-transition-duration:50ms]',
+    'min-[1280px]:[&:fullscreen]:[--media-scale:1.25]',
+    'min-[1536px]:[&:fullscreen]:[--media-scale:1.5]',
+    'min-[1920px]:[&:fullscreen]:[--media-scale:1.75]',
+    'motion-reduce:[--media-error-dialog-transition-duration:50ms]',
+    'motion-reduce:[--media-error-dialog-transition-delay:0ms]',
+    'motion-reduce:[--media-error-dialog-transition-timing-function:ease-out]',
+    'motion-reduce:[--media-popup-transition-duration:0ms]',
+    '[@media(prefers-reduced-transparency:reduce)]:[--media-surface-background-color:oklch(0_0_0)]',
+    'contrast-more:[--media-surface-background-color:oklch(0_0_0)]',
+    '[@media(prefers-reduced-transparency:reduce)]:[--media-surface-inner-border-color:oklch(1_0_0/0.25)]',
+    'contrast-more:[--media-surface-inner-border-color:oklch(1_0_0/0.25)]',
+    '[@media(prefers-reduced-transparency:reduce)]:[--media-surface-outer-border-color:transparent]',
+    'contrast-more:[--media-surface-outer-border-color:transparent]',
+    'pointer-fine:has-[[data-controls]:not([data-visible])]:[--media-controls-transition-duration:300ms]',
+    'pointer-coarse:has-[[data-controls]:not([data-visible])]:[--media-controls-transition-duration:150ms]',
+    'motion-reduce:has-[[data-controls]:not([data-visible])]:[--media-controls-transition-duration:50ms]',
     // Caption track CSS variables (consumed by the native caption bridge in light DOM)
     '[--media-caption-track-y:--spacing(-2)]',
     '[--media-caption-track-delay:25ms]',
-    '[--media-caption-track-duration:var(--controls-transition-duration)]',
+    '[--media-caption-track-duration:var(--media-controls-transition-duration)]',
     'has-[[data-controls][data-visible]]:[--media-caption-track-y:--spacing(-14)]',
     // Native caption track container
     !isShadowDOM
@@ -86,7 +86,7 @@ export const container = (isShadowDOM: boolean) =>
         ]
       : [],
     // Fullscreen
-    '[&:fullscreen]:[--container-border-radius:0]',
+    '[&:fullscreen]:[--media-container-border-radius:0]',
     {
       '[&:fullscreen_video]:object-contain': !isShadowDOM,
       '[&:fullscreen_::slotted(video)]:object-contain': isShadowDOM,
@@ -100,11 +100,11 @@ const controlsBase = cn(
   surface,
   'text-white z-10',
   'peer-data-open/error:hidden!',
-  'ease-(--controls-transition-timing-function)',
-  'duration-[calc(var(--controls-transition-duration)/2)]',
+  'ease-(--media-controls-transition-timing-function)',
+  'duration-[calc(var(--media-controls-transition-duration)/2)]',
   'pointer-fine:transition-[filter,opacity,scale,translate]',
   'pointer-coarse:transition-[opacity,scale,translate]',
-  '@2xl/media-root:[--base-boundary-offset:3]'
+  '@2xl/media-root:[--media-base-boundary-offset:3]'
 );
 
 export const controls = cn(
@@ -117,7 +117,7 @@ export const controls = cn(
   // Hidden state (large)
   '@lg/media-root:not-data-visible:pointer-events-none',
   '@lg/media-root:not-data-visible:opacity-0',
-  '@lg/media-root:not-data-visible:duration-(--controls-transition-duration)',
+  '@lg/media-root:not-data-visible:duration-(--media-controls-transition-duration)',
   '@lg/media-root:motion-safe:not-data-visible:scale-95',
   '@lg/media-root:pointer-fine:motion-safe:not-data-visible:blur-sm',
   '@lg/media-root:motion-safe:not-data-visible:translate-y-1'
@@ -129,7 +129,7 @@ const splitControls = cn(
   '@lg/media-root:contents! @lg/media-root:after:hidden',
   '@max-lg/media-root:group-[:not([data-visible])]/controls:pointer-events-none',
   '@max-lg/media-root:group-[:not([data-visible])]/controls:opacity-0',
-  '@max-lg/media-root:group-[:not([data-visible])]/controls:duration-(--controls-transition-duration)',
+  '@max-lg/media-root:group-[:not([data-visible])]/controls:duration-(--media-controls-transition-duration)',
   '@max-lg/media-root:motion-safe:group-[:not([data-visible])]/controls:scale-95',
   '@max-lg/media-root:pointer-fine:motion-safe:group-[:not([data-visible])]/controls:blur-sm'
 );
@@ -172,7 +172,7 @@ export const thumbnail = {
 export const slider = {
   ...baseSlider,
   track: cn(baseSlider.track, 'bg-white/20'),
-  value: cn(baseSlider.value, 'text-shadow-2xs text-shadow-(color:--shadow-current-color)'),
+  value: cn(baseSlider.value, 'text-shadow-2xs text-shadow-(color:--media-shadow-current-color)'),
 };
 
 /* Popup (with video surface) */
@@ -201,7 +201,7 @@ export const error = {
   ...baseError,
   dialog: cn(baseError.dialog, surface, 'w-full text-shadow-2xs text-shadow-black/25'),
   content: cn(baseError.content, 'text-shadow-inherit'),
-  title: cn(baseError.title, 'text-(length:--font-size-medium)'),
+  title: cn(baseError.title, 'text-(length:--media-font-size-medium)'),
 };
 
 /* Input indicators (top indicators use video surface) */

--- a/packages/skins/src/minimal/css/audio.css
+++ b/packages/skins/src/minimal/css/audio.css
@@ -16,38 +16,38 @@
 /* Container */
 
 .media-minimal-skin--audio {
-  --default-accent-color: light-dark(oklch(0 0 0), oklch(1 0 0));
-  --focus-ring-color: light-dark(oklch(0 0 0), oklch(1 0 0));
+  --media-default-accent-color: light-dark(oklch(0 0 0), oklch(1 0 0));
+  --media-focus-ring-color: light-dark(oklch(0 0 0), oklch(1 0 0));
 
-  --controls-background-color: light-dark(oklch(1 0 0), oklch(0 0 0));
-  --controls-backdrop-filter: blur(16px) saturate(1.5);
-  --controls-border-color: light-dark(oklch(0 0 0 / 0.1), oklch(1 0 0 / 0.1));
-  --controls-text-color: light-dark(oklch(0 0 0), oklch(1 0 0));
+  --media-controls-background-color: light-dark(oklch(1 0 0), oklch(0 0 0));
+  --media-controls-backdrop-filter: blur(16px) saturate(1.5);
+  --media-controls-border-color: light-dark(oklch(0 0 0 / 0.1), oklch(1 0 0 / 0.1));
+  --media-controls-text-color: light-dark(oklch(0 0 0), oklch(1 0 0));
 
-  --error-dialog-transition-duration: 250ms;
-  --error-dialog-transition-delay: 100ms;
+  --media-error-dialog-transition-duration: 250ms;
+  --media-error-dialog-transition-delay: 100ms;
 
-  --popup-transition-duration: 100ms;
-  --popup-transition-timing-function: ease-out;
+  --media-popup-transition-duration: 100ms;
+  --media-popup-transition-timing-function: ease-out;
 
-  --popover-backdrop-filter: blur(16px) saturate(1.5);
-  --popover-background-color: light-dark(oklch(1 0 0), oklch(0 0 0));
-  --popover-border-color: oklch(0 0 0 / 0.1);
+  --media-popover-backdrop-filter: blur(16px) saturate(1.5);
+  --media-popover-background-color: light-dark(oklch(1 0 0), oklch(0 0 0));
+  --media-popover-border-color: oklch(0 0 0 / 0.1);
 
-  --tooltip-backdrop-filter: var(--popover-backdrop-filter);
-  --tooltip-background-color: var(--popover-background-color);
-  --tooltip-border-color: var(--popover-border-color);
+  --media-tooltip-backdrop-filter: var(--media-popover-backdrop-filter);
+  --media-tooltip-background-color: var(--media-popover-background-color);
+  --media-tooltip-border-color: var(--media-popover-border-color);
 
-  --tooltip-text-color: currentColor;
+  --media-tooltip-text-color: currentColor;
 
   @media (prefers-reduced-motion: reduce) {
-    --error-dialog-transition-duration: 50ms;
-    --error-dialog-transition-delay: 0ms;
-    --popup-transition-duration: 0ms;
+    --media-error-dialog-transition-duration: 50ms;
+    --media-error-dialog-transition-delay: 0ms;
+    --media-popup-transition-duration: 0ms;
   }
 
   @media (prefers-reduced-transparency: reduce) or (prefers-contrast: more) {
-    --tooltip-background-color: light-dark(oklch(1 0 0), oklch(0 0 0));
+    --media-tooltip-background-color: light-dark(oklch(1 0 0), oklch(0 0 0));
   }
 }
 
@@ -58,14 +58,14 @@
   inset: 0;
   z-index: 20;
   display: flex;
-  gap: calc(var(--spacing) * 4);
+  gap: calc(var(--media-spacing) * 4);
   align-items: center;
-  padding-inline: calc(var(--spacing) * 5) calc(var(--spacing) * 2);
-  background-color: oklch(from var(--controls-background-color) l c h / 1);
+  padding-inline: calc(var(--media-spacing) * 5) calc(var(--media-spacing) * 2);
+  background-color: oklch(from var(--media-controls-background-color) l c h / 1);
   border-radius: calc(Infinity * 1px);
-  transition-delay: var(--error-dialog-transition-delay);
+  transition-delay: var(--media-error-dialog-transition-delay);
   transition-timing-function: ease-out;
-  transition-duration: var(--error-dialog-transition-duration);
+  transition-duration: var(--media-error-dialog-transition-duration);
   transition-property: opacity, filter, scale;
 }
 
@@ -82,20 +82,20 @@
 .media-minimal-skin--audio .media-error__content {
   display: flex;
   flex: 1;
-  gap: calc(var(--spacing) * 2);
+  gap: calc(var(--media-spacing) * 2);
   align-items: center;
 }
 
 /* Controls */
 
 .media-minimal-skin--audio .media-controls {
-  --base-side-offset: 2;
-  --base-boundary-offset: 2;
+  --media-base-side-offset: 2;
+  --media-base-boundary-offset: 2;
 
-  gap: calc(var(--spacing) * 2);
-  color: var(--controls-text-color);
-  border-radius: var(--media-border-radius, calc(var(--spacing) * 3.5));
-  box-shadow: 0 0 0 1px var(--controls-border-color);
+  gap: calc(var(--media-spacing) * 2);
+  color: var(--media-controls-text-color);
+  border-radius: var(--media-border-radius, calc(var(--media-spacing) * 3.5));
+  box-shadow: 0 0 0 1px var(--media-controls-border-color);
 }
 
 /* Buffering (spinner over play button — overlay only, no layout change) */
@@ -120,10 +120,10 @@
 
 .media-minimal-skin--audio .media-popover--volume {
   --media-popover-side-offset: 0rem;
-  padding: 0 calc(var(--spacing) * 2) 0 calc(var(--spacing) * 16);
-  background: linear-gradient(to left, var(--controls-background-color) 80%, transparent 100%);
+  padding: 0 calc(var(--media-spacing) * 2) 0 calc(var(--media-spacing) * 16);
+  background: linear-gradient(to left, var(--media-controls-background-color) 80%, transparent 100%);
 }
 
 .media-minimal-skin--audio .media-slider .media-slider__preview .media-slider__value {
-  bottom: calc(var(--spacing) * 10);
+  bottom: calc(var(--media-spacing) * 10);
 }

--- a/packages/skins/src/minimal/css/components/badge.css
+++ b/packages/skins/src/minimal/css/components/badge.css
@@ -1,10 +1,10 @@
 .media-minimal-skin .media-badge {
-  padding: calc(var(--spacing) * 1) calc(var(--spacing) * 1.5);
-  font-size: var(--font-size-small);
+  padding: calc(var(--media-spacing) * 1) calc(var(--media-spacing) * 1.5);
+  font-size: var(--media-font-size-small);
   font-weight: 500;
   line-height: 1;
   color: oklch(from currentColor l c h / 0.85);
   white-space: nowrap;
   background-color: oklch(from currentColor l c h / 0.1);
-  border-radius: calc(var(--spacing) * 1);
+  border-radius: calc(var(--media-spacing) * 1);
 }

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -4,9 +4,9 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
-  height: calc(var(--spacing) * 9.5);
+  height: calc(var(--media-spacing) * 9.5);
   min-height: 0;
-  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4);
+  padding: calc(var(--media-spacing) * 2) calc(var(--media-spacing) * 4);
   text-align: center;
   touch-action: manipulation;
   cursor: pointer;
@@ -14,7 +14,7 @@
   outline: 2px solid transparent;
   outline-offset: -2px;
   border: none;
-  border-radius: calc(var(--spacing) * 2);
+  border-radius: calc(var(--media-spacing) * 2);
   transition-timing-function: ease-out;
   transition-duration: 150ms;
   transition-property: background-color, outline-offset, scale;
@@ -22,7 +22,7 @@
   will-change: scale;
 
   &:focus-visible {
-    outline-color: var(--focus-ring-color);
+    outline-color: var(--media-focus-ring-color);
     outline-offset: 2px;
   }
 
@@ -38,7 +38,7 @@
 
 @supports (corner-shape: squircle) {
   .media-minimal-skin .media-button {
-    border-radius: calc(var(--spacing) * 4);
+    border-radius: calc(var(--media-spacing) * 4);
     corner-shape: squircle;
   }
 }
@@ -46,9 +46,9 @@
 /* Primary button variant */
 .media-minimal-skin .media-button--primary {
   font-weight: 500;
-  color: var(--accent-contrast-color);
+  color: var(--media-accent-contrast-color);
   text-shadow: none;
-  background: var(--accent-color);
+  background: var(--media-internal-accent-color);
 }
 
 /* Subtle button variant */
@@ -61,9 +61,9 @@
     &:hover,
     &:focus-visible,
     &[aria-expanded="true"] {
-      color: var(--accent-text-color);
+      color: var(--media-internal-accent-text-color);
       text-decoration: none;
-      background-color: var(--accent-background-color);
+      background-color: var(--media-accent-background-color);
     }
   }
 }
@@ -84,7 +84,7 @@
 
   .media-icon {
     grid-area: 1 / 1;
-    filter: drop-shadow(0 1px 0 var(--shadow-current-color));
+    filter: drop-shadow(0 1px 0 var(--media-shadow-current-color));
     transition-timing-function: ease-out;
     transition-duration: 150ms;
     transition-property: opacity, scale;
@@ -144,12 +144,12 @@
    text content. */
 .media-minimal-skin .media-button--live {
   display: inline-flex;
-  gap: calc(var(--spacing) * 1.5);
+  gap: calc(var(--media-spacing) * 1.5);
   align-items: center;
   width: auto;
   aspect-ratio: auto;
-  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 3);
-  font-size: var(--font-size-small);
+  padding: calc(var(--media-spacing) * 2) calc(var(--media-spacing) * 3);
+  font-size: var(--media-font-size-small);
   font-weight: 600;
   line-height: 1;
   text-transform: uppercase;
@@ -158,8 +158,8 @@
   &::before {
     display: inline-block;
     flex-shrink: 0;
-    width: calc(var(--spacing) * 2);
-    height: calc(var(--spacing) * 2);
+    width: calc(var(--media-spacing) * 2);
+    height: calc(var(--media-spacing) * 2);
     content: "";
     background-color: oklch(from currentColor l c h / 0.4);
     border-radius: 50%;

--- a/packages/skins/src/minimal/css/components/captions.css
+++ b/packages/skins/src/minimal/css/components/captions.css
@@ -1,15 +1,15 @@
 .media-minimal-skin {
-  --media-caption-track-duration: var(--controls-transition-duration);
+  --media-caption-track-duration: var(--media-controls-transition-duration);
   --media-caption-track-delay: 25ms;
-  --media-caption-track-y: calc(var(--spacing) * -2);
+  --media-caption-track-y: calc(var(--media-spacing) * -2);
 
   &:has(.media-controls[data-visible]) {
-    --media-caption-track-y: calc(var(--spacing) * -18);
+    --media-caption-track-y: calc(var(--media-spacing) * -18);
   }
 
   @container media-root (width > 42rem) {
     &:has(.media-controls[data-visible]) > * {
-      --media-caption-track-y: calc(var(--spacing) * -12);
+      --media-caption-track-y: calc(var(--media-spacing) * -12);
     }
   }
 }

--- a/packages/skins/src/minimal/css/components/container.css
+++ b/packages/skins/src/minimal/css/components/container.css
@@ -1,33 +1,36 @@
 .media-minimal-skin {
   /* Colors */
-  --accent-color: var(--media-accent-color, var(--default-accent-color));
-  --accent-contrast-color: contrast-color(var(--accent-color));
-  --accent-background-color: var(
+  --media-internal-accent-color: var(--media-accent-color, var(--media-default-accent-color));
+  --media-accent-contrast-color: contrast-color(var(--media-internal-accent-color));
+  --media-accent-background-color: var(
     --media-accent-color,
-    oklch(from var(--default-accent-color) l c h / calc(alpha * 0.1))
+    oklch(from var(--media-default-accent-color) l c h / calc(alpha * 0.1))
   );
-  --accent-text-color: var(--media-accent-text-color, contrast-color(var(--media-accent-color, oklch(0 0 0))));
-  --shadow-current-color: oklch(from currentColor 0 0 0 / clamp(0, calc((l - 0.5) * 0.5), 0.15));
-  --shadow-subtle-current-color: oklch(from var(--shadow-current-color) l c h / calc(alpha * 0.4));
-  --scrollbar-thumb-color: oklch(from currentColor l c h / 0.3);
+  --media-internal-accent-text-color: var(
+    --media-accent-text-color,
+    contrast-color(var(--media-accent-color, oklch(0 0 0)))
+  );
+  --media-shadow-current-color: oklch(from currentColor 0 0 0 / clamp(0, calc((l - 0.5) * 0.5), 0.15));
+  --media-shadow-subtle-current-color: oklch(from var(--media-shadow-current-color) l c h / calc(alpha * 0.4));
+  --media-scrollbar-thumb-color: oklch(from currentColor l c h / 0.3);
 
   /* Scaling - used in video fullscreen to scale the UI. */
-  --scale: 1;
+  --media-scale: 1;
   /* Fixed scaling unit to avoid inheriting the document's root font size. This must be a CSS <length>. */
-  --scale-unit: var(--media-scale-unit, 16px);
-  --size: calc(var(--scale-unit) * var(--scale));
+  --media-internal-scale-unit: var(--media-scale-unit, 16px);
+  --media-size: calc(var(--media-internal-scale-unit) * var(--media-scale));
   /* Create a Tailwind-like spacing unit where 1 equals 4px with default scaling. */
-  --spacing: calc(var(--size) / 4);
+  --media-spacing: calc(var(--media-size) / 4);
 
   /* Font sizes */
-  --font-size-medium: calc(0.9375 * var(--size)); /* 15px */
-  --font-size-base: calc(0.8125 * var(--size)); /* 13px */
-  --font-size-small: calc(0.6875 * var(--size)); /* 11px */
-  --font-size-tiny: calc(0.5625 * var(--size)); /* 9px */
-  --media-icon-size: calc(1.125 * var(--size)); /* 18px */
+  --media-font-size-medium: calc(0.9375 * var(--media-size)); /* 15px */
+  --media-font-size-base: calc(0.8125 * var(--media-size)); /* 13px */
+  --media-font-size-small: calc(0.6875 * var(--media-size)); /* 11px */
+  --media-font-size-tiny: calc(0.5625 * var(--media-size)); /* 9px */
+  --media-icon-size: calc(1.125 * var(--media-size)); /* 18px */
 
   /* Radii */
-  --container-border-radius: var(--media-border-radius, 0.75rem);
+  --media-container-border-radius: var(--media-border-radius, 0.75rem);
 
   position: relative;
   display: block;
@@ -40,33 +43,33 @@
     ui-sans-serif,
     system-ui,
     sans-serif;
-  font-size: var(--font-size-base);
+  font-size: var(--media-font-size-base);
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
   line-height: 1.5;
   letter-spacing: normal;
   outline: 2px solid transparent;
   outline-offset: -4px;
-  scrollbar-color: var(--scrollbar-thumb-color) transparent;
+  scrollbar-color: var(--media-scrollbar-thumb-color) transparent;
   scrollbar-width: thin;
-  border-radius: var(--container-border-radius);
+  border-radius: var(--media-container-border-radius);
   isolation: isolate;
   transition-timing-function: ease-out;
   transition-duration: 100ms;
   transition-property: outline-offset, outline-color;
 
   &:focus-visible {
-    outline-color: var(--focus-ring-color);
+    outline-color: var(--media-focus-ring-color);
     outline-offset: 2px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: var(--scrollbar-thumb-color);
+    background: var(--media-scrollbar-thumb-color);
     border-radius: 9999px;
   }
 
   @media (prefers-reduced-transparency: reduce) or (prefers-contrast: more) {
-    --scrollbar-thumb-color: oklch(from currentColor l c h / 0.8);
+    --media-scrollbar-thumb-color: oklch(from currentColor l c h / 0.8);
     scrollbar-width: auto;
   }
 }

--- a/packages/skins/src/minimal/css/components/controls.css
+++ b/packages/skins/src/minimal/css/components/controls.css
@@ -1,16 +1,16 @@
 .media-minimal-skin .media-controls {
-  --media-popover-side-offset: calc(var(--spacing) * (var(--base-side-offset, 2) + 1));
+  --media-popover-side-offset: calc(var(--media-spacing) * (var(--media-base-side-offset, 2) + 1));
   --media-tooltip-side-offset: var(--media-popover-side-offset);
-  --media-popover-boundary-offset: calc(var(--spacing) * (var(--base-boundary-offset, 0) + 1));
+  --media-popover-boundary-offset: calc(var(--media-spacing) * (var(--media-base-boundary-offset, 0) + 1));
   --media-tooltip-boundary-offset: var(--media-popover-boundary-offset);
 
   display: flex;
   align-items: center;
-  padding: calc(var(--spacing) * 1);
+  padding: calc(var(--media-spacing) * 1);
   container: media-controls / inline-size;
-  text-shadow: 0 1px 0 var(--shadow-current-color);
-  background-color: var(--controls-background-color);
-  backdrop-filter: var(--controls-backdrop-filter);
+  text-shadow: 0 1px 0 var(--media-shadow-current-color);
+  background-color: var(--media-controls-background-color);
+  backdrop-filter: var(--media-controls-backdrop-filter);
 
   &:dir(rtl) {
     flex-direction: row-reverse;

--- a/packages/skins/src/minimal/css/components/error.css
+++ b/packages/skins/src/minimal/css/components/error.css
@@ -14,7 +14,7 @@
 
 .media-minimal-skin .media-error__actions {
   display: flex;
-  gap: calc(var(--spacing) * 2);
+  gap: calc(var(--media-spacing) * 2);
 
   > * {
     flex: 1;

--- a/packages/skins/src/minimal/css/components/input-indicator.css
+++ b/packages/skins/src/minimal/css/components/input-indicator.css
@@ -6,15 +6,15 @@
     top: 0;
     display: flex;
     justify-content: center;
-    padding-top: calc(var(--spacing) * 3);
-    padding-bottom: calc(var(--spacing) * 32);
+    padding-top: calc(var(--media-spacing) * 3);
+    padding-bottom: calc(var(--media-spacing) * 32);
     color: inherit;
-    text-shadow: 0 1px 0 var(--shadow-current-color);
+    text-shadow: 0 1px 0 var(--media-shadow-current-color);
     pointer-events: none;
     background-image: linear-gradient(
       to bottom,
       oklch(0 0 0 / 0.35),
-      oklch(0 0 0 / 0.2) calc(var(--spacing) * 12),
+      oklch(0 0 0 / 0.2) calc(var(--media-spacing) * 12),
       oklch(0 0 0 / 0)
     );
     transform-origin: top center;
@@ -24,16 +24,16 @@
     .media-volume-indicator__content,
     .media-status-indicator__content {
       display: flex;
-      gap: calc(var(--spacing) * 2);
+      gap: calc(var(--media-spacing) * 2);
       align-items: center;
       justify-content: space-between;
-      padding: calc(var(--spacing) * 1) calc(var(--spacing) * 2.5);
+      padding: calc(var(--media-spacing) * 1) calc(var(--media-spacing) * 2.5);
     }
 
     .media-icon {
       display: none;
       flex-shrink: 0;
-      filter: drop-shadow(0 1px 0 var(--shadow-current-color));
+      filter: drop-shadow(0 1px 0 var(--media-shadow-current-color));
     }
 
     .media-volume-indicator__value,
@@ -58,8 +58,8 @@
     @media (prefers-reduced-transparency: reduce) or (prefers-contrast: more) {
       .media-volume-indicator__content,
       .media-status-indicator__content {
-        background: var(--controls-background-color);
-        border-radius: calc(var(--spacing) * 2);
+        background: var(--media-controls-background-color);
+        border-radius: calc(var(--media-spacing) * 2);
       }
     }
 
@@ -87,7 +87,7 @@
     grid-row: 1;
     grid-column: 2;
     place-content: center;
-    padding: calc(var(--spacing) * 4);
+    padding: calc(var(--media-spacing) * 4);
     text-align: center;
   }
 }

--- a/packages/skins/src/minimal/css/components/media.css
+++ b/packages/skins/src/minimal/css/components/media.css
@@ -7,7 +7,7 @@
   object-position: var(--media-object-position, center);
 }
 .media-minimal-skin ::slotted(video) {
-  border-radius: var(--container-border-radius);
+  border-radius: var(--media-container-border-radius);
 }
 .media-minimal-skin video {
   border-radius: inherit;

--- a/packages/skins/src/minimal/css/components/menus.css
+++ b/packages/skins/src/minimal/css/components/menus.css
@@ -1,59 +1,59 @@
 .media-minimal-skin .media-menu {
-  --menu-transition-duration: 250ms;
-  --menu-max-height: calc(var(--spacing) * 56);
-  --menu-padding: calc(var(--spacing) * 1);
-  --menu-border-radius: calc(var(--spacing) * 2.5);
-  --menu-item-border-radius: calc(var(--menu-border-radius) - var(--menu-padding));
+  --media-menu-transition-duration: 250ms;
+  --media-menu-max-height: calc(var(--media-spacing) * 56);
+  --media-menu-padding: calc(var(--media-spacing) * 1);
+  --media-menu-border-radius: calc(var(--media-spacing) * 2.5);
+  --media-menu-item-border-radius: calc(var(--media-menu-border-radius) - var(--media-menu-padding));
   box-sizing: border-box;
   min-width: max-content;
   max-width: var(--media-popover-available-width, none);
-  max-height: min(var(--media-popover-available-height, var(--menu-max-height)), var(--menu-max-height));
-  padding: var(--menu-padding);
+  max-height: min(var(--media-popover-available-height, var(--media-menu-max-height)), var(--media-menu-max-height));
+  padding: var(--media-menu-padding);
   overflow: auto;
   overscroll-behavior: none;
-  background-color: var(--popover-background-color);
-  border-radius: var(--menu-border-radius);
+  background-color: var(--media-popover-background-color);
+  border-radius: var(--media-menu-border-radius);
   box-shadow:
-    0 0 0 1px var(--popover-border-color),
+    0 0 0 1px var(--media-popover-border-color),
     0 4px 6px -1px oklch(0 0 0 / 0.1),
     0 2px 4px -2px oklch(0 0 0 / 0.1);
-  backdrop-filter: var(--popover-backdrop-filter);
+  backdrop-filter: var(--media-popover-backdrop-filter);
 
   @media (prefers-reduced-motion: reduce) {
-    --menu-transition-duration: 0ms;
+    --media-menu-transition-duration: 0ms;
   }
 
   & > .media-menu__panel {
-    --menu-content-enter-translate: 100%;
+    --media-menu-content-enter-translate: 100%;
 
     position: absolute;
     inset-inline: 0;
     top: 0;
     z-index: 10;
     max-height: inherit;
-    padding: var(--menu-padding);
+    padding: var(--media-menu-padding);
     overflow: auto;
     overscroll-behavior: none;
     outline: none;
     translate: 0 0;
     transition-timing-function: ease-out;
-    transition-duration: var(--menu-transition-duration);
+    transition-duration: var(--media-menu-transition-duration);
     transition-property: translate, filter;
 
     &:where([data-starting-style], [data-ending-style]) {
       overflow: hidden;
       pointer-events: none;
       filter: blur(8px);
-      translate: var(--menu-content-enter-translate) 0;
+      translate: var(--media-menu-content-enter-translate) 0;
     }
 
     &:dir(rtl):where([data-starting-style], [data-ending-style]) {
-      --menu-content-enter-translate: -100%;
+      --media-menu-content-enter-translate: -100%;
     }
   }
 
   .media-menu__separator {
-    margin: calc(var(--spacing) * 1) 0;
+    margin: calc(var(--media-spacing) * 1) 0;
     border-bottom: 1px solid oklch(1 0 0 / 0.1);
   }
 
@@ -62,7 +62,7 @@
     anchor-scope: --menu-item-highlight-anchor;
     display: flex;
     flex-direction: column;
-    gap: calc(var(--spacing) * 0.5);
+    gap: calc(var(--media-spacing) * 0.5);
 
     @supports (top: anchor(top)) {
       &::before {
@@ -74,8 +74,8 @@
         overflow-anchor: none;
         pointer-events: none;
         content: "";
-        background-color: var(--accent-background-color);
-        border-radius: var(--menu-item-border-radius);
+        background-color: var(--media-accent-background-color);
+        border-radius: var(--media-menu-item-border-radius);
         transition: inset 100ms ease-in-out;
       }
 
@@ -89,16 +89,16 @@
   .media-menu__back {
     position: relative;
     display: flex;
-    gap: calc(var(--spacing) * 1.5);
+    gap: calc(var(--media-spacing) * 1.5);
     align-items: center;
-    padding: calc(var(--spacing) * 1.5) calc(var(--spacing) * 2);
+    padding: calc(var(--media-spacing) * 1.5) calc(var(--media-spacing) * 2);
     text-align: start;
-    text-shadow: 0 1px 0 var(--shadow-current-color);
+    text-shadow: 0 1px 0 var(--media-shadow-current-color);
     cursor: pointer;
     user-select: none;
     outline: 2px solid transparent;
     outline-offset: -2px;
-    border-radius: var(--menu-item-border-radius);
+    border-radius: var(--media-menu-item-border-radius);
     transition: background-color, color;
     transition-timing-function: ease-in-out;
     transition-duration: 100ms;
@@ -106,18 +106,18 @@
     .media-icon {
       flex-shrink: 0;
       color: oklch(from currentColor l c h / 0.5);
-      filter: drop-shadow(0 1px 0 var(--shadow-current-color));
+      filter: drop-shadow(0 1px 0 var(--media-shadow-current-color));
     }
 
     &:focus-visible {
-      outline-color: var(--focus-ring-color);
+      outline-color: var(--media-focus-ring-color);
       outline-offset: 2px;
     }
 
     &:hover,
     &[data-highlighted] {
-      color: var(--accent-text-color);
-      background-color: var(--accent-background-color);
+      color: var(--media-internal-accent-text-color);
+      background-color: var(--media-accent-background-color);
 
       .media-icon {
         color: inherit;
@@ -136,7 +136,7 @@
 
   .media-menu__indicator {
     flex-shrink: 0;
-    margin-inline: auto calc(var(--spacing) * -1);
+    margin-inline: auto calc(var(--media-spacing) * -1);
     opacity: 0;
   }
 
@@ -169,9 +169,9 @@
   }
 
   .media-menu__tier {
-    padding-inline-start: calc(var(--spacing) * 0.5);
+    padding-inline-start: calc(var(--media-spacing) * 0.5);
     padding-top: 1px;
-    font-size: var(--font-size-tiny);
+    font-size: var(--media-font-size-tiny);
     font-weight: 600;
     line-height: 1;
     color: oklch(from currentColor l c h / 0.7);
@@ -179,59 +179,59 @@
 
   .media-menu__back {
     width: 100%;
-    margin-bottom: calc(var(--spacing) * 0.5);
+    margin-bottom: calc(var(--media-spacing) * 0.5);
   }
 
   .media-menu__hint {
     display: inline-flex;
-    gap: calc(var(--spacing) * 1);
+    gap: calc(var(--media-spacing) * 1);
     align-items: center;
     min-width: 0;
-    padding-inline-start: calc(var(--spacing) * 2);
+    padding-inline-start: calc(var(--media-spacing) * 2);
     margin-inline-start: auto;
     color: oklch(from currentColor l c h / 0.65);
   }
 
   .media-menu__hint-label {
-    max-width: calc(var(--spacing) * 24);
+    max-width: calc(var(--media-spacing) * 24);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .media-menu__chevron {
-    width: calc(var(--spacing) * 3.5);
-    height: calc(var(--spacing) * 3.5);
+    width: calc(var(--media-spacing) * 3.5);
+    height: calc(var(--media-spacing) * 3.5);
   }
 
   /* Settings menu */
   &.media-menu--settings {
     width: var(--media-menu-width);
-    min-width: calc(var(--spacing) * 48);
+    min-width: calc(var(--media-spacing) * 48);
     height: var(--media-menu-height);
     overflow: hidden;
     /* Only the menu size changes between panels. */
     transition:
-      var(--popup-transition),
-      width var(--popup-transition-timing-function) var(--menu-transition-duration),
-      height var(--popup-transition-timing-function) var(--menu-transition-duration);
+      var(--media-popup-transition),
+      width var(--media-popup-transition-timing-function) var(--media-menu-transition-duration),
+      height var(--media-popup-transition-timing-function) var(--media-menu-transition-duration);
 
     & > .media-menu__content {
-      --menu-content-exit-translate: -100%;
+      --media-menu-content-exit-translate: -100%;
 
       translate: 0 0;
       transition:
-        translate var(--menu-transition-duration) ease-out,
-        filter var(--menu-transition-duration) ease-out;
+        translate var(--media-menu-transition-duration) ease-out,
+        filter var(--media-menu-transition-duration) ease-out;
 
       &:dir(rtl) {
-        --menu-content-exit-translate: 100%;
+        --media-menu-content-exit-translate: 100%;
       }
     }
 
     & > .media-menu__content[data-child-open] {
       filter: blur(8px);
-      translate: var(--menu-content-exit-translate) 0;
+      translate: var(--media-menu-content-exit-translate) 0;
     }
 
     /* WebKit can restart the parent Content transition while the
@@ -244,7 +244,7 @@
     /* Don't transition size on open/close. */
     &[data-starting-style],
     &[data-ending-style] {
-      transition: var(--popup-transition);
+      transition: var(--media-popup-transition);
     }
   }
 }

--- a/packages/skins/src/minimal/css/components/overlay.css
+++ b/packages/skins/src/minimal/css/components/overlay.css
@@ -5,20 +5,20 @@
   background-image: linear-gradient(
     to top,
     oklch(0 0 0 / 0.7),
-    oklch(0 0 0 / 0.5) calc(var(--spacing) * 30),
+    oklch(0 0 0 / 0.5) calc(var(--media-spacing) * 30),
     oklch(0 0 0 / 0)
   );
   border-radius: inherit;
   opacity: 0;
   backdrop-filter: blur(0) saturate(1);
   transition-timing-function: ease-out;
-  transition-duration: var(--controls-transition-duration);
+  transition-duration: var(--media-controls-transition-duration);
   transition-property: opacity, backdrop-filter;
 }
 
 .media-minimal-skin .media-error ~ .media-overlay {
-  transition-delay: var(--error-dialog-transition-delay);
-  transition-duration: var(--error-dialog-transition-duration);
+  transition-delay: var(--media-error-dialog-transition-delay);
+  transition-duration: var(--media-error-dialog-transition-duration);
 }
 
 .media-minimal-skin .media-controls[data-visible] ~ .media-overlay,

--- a/packages/skins/src/minimal/css/components/popup.css
+++ b/packages/skins/src/minimal/css/components/popup.css
@@ -1,25 +1,25 @@
 .media-minimal-skin {
-  --popup-transition:
-    opacity var(--popup-transition-timing-function) var(--popup-transition-duration),
-    filter var(--popup-transition-timing-function) var(--popup-transition-duration),
-    transform var(--popup-transition-timing-function) var(--popup-transition-duration),
-    scale var(--popup-transition-timing-function) var(--popup-transition-duration);
+  --media-popup-transition:
+    opacity var(--media-popup-transition-timing-function) var(--media-popup-transition-duration),
+    filter var(--media-popup-transition-timing-function) var(--media-popup-transition-duration),
+    transform var(--media-popup-transition-timing-function) var(--media-popup-transition-duration),
+    scale var(--media-popup-transition-timing-function) var(--media-popup-transition-duration);
 }
 
 .media-minimal-skin .media-popover,
 .media-minimal-skin .media-tooltip {
-  --popup-translate-distance: calc(var(--spacing) * 2);
+  --media-popup-translate-distance: calc(var(--media-spacing) * 2);
   margin: 0;
   overflow: visible;
   color: inherit;
   border: 0;
-  transition: var(--popup-transition);
+  transition: var(--media-popup-transition);
 
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
     /* We have to use transform here for translate as the translate property is used for positioning by core. */
-    transform: translate(var(--popup-translate-x-distance, 0), var(--popup-translate-y-distance, 0));
+    transform: translate(var(--media-popup-translate-x-distance, 0), var(--media-popup-translate-y-distance, 0));
     scale: 0.95;
   }
 
@@ -27,23 +27,23 @@
     filter: blur(4px);
     transform: none;
     /* Speed up the exit transition. */
-    transition-duration: max(0ms, calc(var(--popup-transition-duration) - 50ms));
+    transition-duration: max(0ms, calc(var(--media-popup-transition-duration) - 50ms));
   }
 
   &[data-side="top"] {
-    --popup-translate-y-distance: var(--popup-translate-distance);
+    --media-popup-translate-y-distance: var(--media-popup-translate-distance);
     transform-origin: bottom;
   }
   &[data-side="bottom"] {
-    --popup-translate-y-distance: calc(var(--popup-translate-distance) * -1);
+    --media-popup-translate-y-distance: calc(var(--media-popup-translate-distance) * -1);
     transform-origin: top;
   }
   &[data-side="left"] {
-    --popup-translate-x-distance: var(--popup-translate-distance);
+    --media-popup-translate-x-distance: var(--media-popup-translate-distance);
     transform-origin: right;
   }
   &[data-side="right"] {
-    --popup-translate-x-distance: calc(var(--popup-translate-distance) * -1);
+    --media-popup-translate-x-distance: calc(var(--media-popup-translate-distance) * -1);
     transform-origin: left;
   }
 
@@ -91,22 +91,22 @@
 }
 
 .media-minimal-skin .media-tooltip {
-  padding: calc(var(--spacing) * 1) calc(var(--spacing) * 2);
-  font-size: var(--font-size-base);
-  color: var(--tooltip-text-color);
+  padding: calc(var(--media-spacing) * 1) calc(var(--media-spacing) * 2);
+  font-size: var(--media-font-size-base);
+  color: var(--media-tooltip-text-color);
   white-space: nowrap;
-  background-color: var(--tooltip-background-color);
-  border-radius: calc(var(--spacing) * 2);
+  background-color: var(--media-tooltip-background-color);
+  border-radius: calc(var(--media-spacing) * 2);
   box-shadow:
-    0 0 0 1px var(--tooltip-border-color),
+    0 0 0 1px var(--media-tooltip-border-color),
     0 4px 6px -1px oklch(0 0 0 / 0.2),
     0 2px 4px -2px oklch(0 0 0 / 0.2);
-  backdrop-filter: var(--tooltip-backdrop-filter);
+  backdrop-filter: var(--media-tooltip-backdrop-filter);
 
   /* `display: flex` must not apply while closed — it overrides UA `[popover]` hiding. */
   &[data-open] {
     display: flex;
-    column-gap: calc(var(--spacing) * 1);
+    column-gap: calc(var(--media-spacing) * 1);
     align-items: center;
   }
 
@@ -122,14 +122,14 @@
   .media-tooltip__kbd {
     min-width: 1.5em;
     padding: 0.1em;
-    margin-right: calc(var(--spacing) * -1);
+    margin-right: calc(var(--media-spacing) * -1);
     font-family: inherit;
-    font-size: var(--font-size-small);
+    font-size: var(--media-font-size-small);
     font-weight: 600;
     line-height: 1.25;
     text-align: center;
     background-color: oklch(from currentColor l c h / 0.15);
-    border-radius: calc(var(--spacing) * 1);
+    border-radius: calc(var(--media-spacing) * 1);
   }
 }
 

--- a/packages/skins/src/minimal/css/components/poster.css
+++ b/packages/skins/src/minimal/css/components/poster.css
@@ -19,7 +19,7 @@
   height: 100%;
   object-fit: var(--media-object-fit, contain);
   object-position: var(--media-object-position, center);
-  border-radius: var(--container-border-radius);
+  border-radius: var(--media-container-border-radius);
 }
 .media-minimal-skin > img {
   object-fit: var(--media-object-fit, contain);

--- a/packages/skins/src/minimal/css/components/seek-indicator.css
+++ b/packages/skins/src/minimal/css/components/seek-indicator.css
@@ -1,12 +1,12 @@
 .media-minimal-skin .media-seek-indicator {
-  gap: calc(var(--spacing) * 1);
+  gap: calc(var(--media-spacing) * 1);
 
   .media-seek-indicator__value {
     font-variant-numeric: tabular-nums;
   }
 
   @container media-root (width > 24rem) {
-    padding: calc(var(--spacing) * 6);
+    padding: calc(var(--media-spacing) * 6);
   }
 
   &[data-direction="backward"] {

--- a/packages/skins/src/minimal/css/components/slider.css
+++ b/packages/skins/src/minimal/css/components/slider.css
@@ -1,11 +1,11 @@
 .media-minimal-skin .media-slider {
-  --track-size: calc(var(--spacing) * 1);
-  --track-highlighted-size: calc(var(--spacing) * 1.75);
-  --track-border-radius: 99px;
-  --thumb-size: calc(var(--spacing) * 3);
-  --chapter-gap: calc(var(--spacing) * 1);
-  --chapter-inset-start: calc(var(--chapter-gap) / 2);
-  --chapter-inset-end: calc(var(--chapter-gap) / 2);
+  --media-track-size: calc(var(--media-spacing) * 1);
+  --media-track-highlighted-size: calc(var(--media-spacing) * 1.75);
+  --media-track-border-radius: 99px;
+  --media-thumb-size: calc(var(--media-spacing) * 3);
+  --media-chapter-gap: calc(var(--media-spacing) * 1);
+  --media-internal-chapter-inset-start: calc(var(--media-chapter-gap) / 2);
+  --media-internal-chapter-inset-end: calc(var(--media-chapter-gap) / 2);
 
   position: relative;
   display: flex;
@@ -14,16 +14,16 @@
   justify-content: center;
   cursor: pointer;
   outline: none;
-  border-radius: var(--track-border-radius);
+  border-radius: var(--media-track-border-radius);
 
   &[data-orientation="horizontal"] {
-    width: var(--slider-width, 100%);
-    min-width: calc(var(--spacing) * 20);
-    height: var(--slider-height, calc(var(--spacing) * 8));
+    width: var(--media-slider-width, 100%);
+    min-width: calc(var(--media-spacing) * 20);
+    height: var(--media-slider-height, calc(var(--media-spacing) * 8));
   }
   &[data-orientation="vertical"] {
-    width: var(--slider-width, calc(var(--spacing) * 8));
-    height: var(--slider-height, calc(var(--spacing) * 20));
+    width: var(--media-slider-width, calc(var(--media-spacing) * 8));
+    height: var(--media-slider-height, calc(var(--media-spacing) * 20));
   }
 
   /* Track */
@@ -37,10 +37,10 @@
 
     &[data-orientation="horizontal"] {
       width: 100%;
-      height: var(--track-size);
+      height: var(--media-track-size);
     }
     &[data-orientation="vertical"] {
-      width: var(--track-size);
+      width: var(--media-track-size);
       height: 100%;
     }
   }
@@ -80,30 +80,30 @@
     background-color: oklch(from currentColor l c h / 0.2);
 
     &[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-buffer)) 0 0 round var(--track-border-radius));
+      clip-path: inset(0 calc(100% - var(--media-slider-buffer)) 0 0 round var(--media-track-border-radius));
     }
     &[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-buffer)) 0 0 0 round var(--track-border-radius));
+      clip-path: inset(calc(100% - var(--media-slider-buffer)) 0 0 0 round var(--media-track-border-radius));
     }
   }
 
   /* Fill */
   .media-slider__fill {
-    background-color: var(--accent-color);
+    background-color: var(--media-internal-accent-color);
 
     &[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round var(--track-border-radius));
+      clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round var(--media-track-border-radius));
     }
     &[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-fill)) 0 0 0 round var(--track-border-radius));
+      clip-path: inset(calc(100% - var(--media-slider-fill)) 0 0 0 round var(--media-track-border-radius));
     }
   }
   &[data-dragging] {
     .media-slider__fill[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round var(--track-border-radius));
+      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round var(--media-track-border-radius));
     }
     .media-slider__fill[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round var(--track-border-radius));
+      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round var(--media-track-border-radius));
     }
   }
 
@@ -138,14 +138,14 @@
     min-height: 0;
 
     &:first-child {
-      --chapter-inset-start: 0px;
+      --media-internal-chapter-inset-start: 0px;
     }
     &:last-child {
-      --chapter-inset-end: 0px;
+      --media-internal-chapter-inset-end: 0px;
     }
 
     .media-slider__chapter-track {
-      border-radius: var(--track-border-radius);
+      border-radius: var(--media-track-border-radius);
 
       @media (prefers-reduced-motion: no-preference) {
         transition: 200ms ease-out;
@@ -157,15 +157,16 @@
       clip-path: inset(0 calc(100% - var(--media-slider-chapter-end)) 0 var(--media-slider-chapter-start));
 
       .media-slider__chapter-track {
-        height: var(--track-size);
+        height: var(--media-track-size);
         clip-path: inset(
-          0 calc(100% - var(--media-slider-chapter-end) + var(--chapter-inset-end)) 0
-            calc(var(--media-slider-chapter-start) + var(--chapter-inset-start)) round var(--track-border-radius)
+          0 calc(100% - var(--media-slider-chapter-end) + var(--media-internal-chapter-inset-end)) 0
+            calc(var(--media-slider-chapter-start) + var(--media-internal-chapter-inset-start)) round
+            var(--media-track-border-radius)
         );
       }
 
       &[data-highlighted] .media-slider__chapter-track {
-        height: var(--track-highlighted-size);
+        height: var(--media-track-highlighted-size);
       }
     }
 
@@ -173,15 +174,16 @@
       clip-path: inset(calc(100% - var(--media-slider-chapter-end)) 0 var(--media-slider-chapter-start) 0);
 
       .media-slider__chapter-track {
-        width: var(--track-size);
+        width: var(--media-track-size);
         clip-path: inset(
-          calc(100% - var(--media-slider-chapter-end) + var(--chapter-inset-end)) 0
-            calc(var(--media-slider-chapter-start) + var(--chapter-inset-start)) 0 round var(--track-border-radius)
+          calc(100% - var(--media-slider-chapter-end) + var(--media-internal-chapter-inset-end)) 0
+            calc(var(--media-slider-chapter-start) + var(--media-internal-chapter-inset-start)) 0 round
+            var(--media-track-border-radius)
         );
       }
 
       &[data-highlighted] .media-slider__chapter-track {
-        width: var(--track-highlighted-size);
+        width: var(--media-track-highlighted-size);
       }
     }
   }
@@ -190,15 +192,15 @@
   .media-slider__thumb {
     position: absolute;
     z-index: 10;
-    width: var(--thumb-size);
-    height: var(--thumb-size);
+    width: var(--media-thumb-size);
+    height: var(--media-thumb-size);
     user-select: none;
     outline: 2px solid transparent;
     outline-offset: -2px;
     background-color: currentColor;
     border-radius: calc(Infinity * 1px);
     box-shadow:
-      0 0 0 1px var(--shadow-current-color, oklch(0 0 0 / 0.15)),
+      0 0 0 1px var(--media-shadow-current-color, oklch(0 0 0 / 0.15)),
       0 1px 3px 0 oklch(0 0 0 / 0.15),
       0 1px 2px -1px oklch(0 0 0 / 0.15);
     opacity: 0;
@@ -216,7 +218,7 @@
     }
 
     &:focus-visible {
-      outline-color: var(--focus-ring-color);
+      outline-color: var(--media-focus-ring-color);
       outline-offset: 2px;
     }
 
@@ -258,46 +260,46 @@
 
   /* Preview */
   .media-slider__preview {
-    --max-size-factor: 28;
-    --max-size: min(calc(var(--spacing) * var(--max-size-factor)), 100cqi);
+    --media-max-size-factor: 28;
+    --media-max-size: min(calc(var(--media-spacing) * var(--media-max-size-factor)), 100cqi);
 
     min-width: 100%;
-    height: calc(var(--spacing) * 1);
+    height: calc(var(--media-spacing) * 1);
 
     @container media-root (width > 32rem) {
-      --max-size-factor: 36;
+      --media-max-size-factor: 36;
     }
 
     @container media-root (width > 42rem) {
-      --max-size-factor: 48;
+      --media-max-size-factor: 48;
     }
 
     .media-slider__thumbnail,
     .media-slider__value {
       position: absolute;
-      left: var(--preview-left, var(--media-slider-pointer));
-      max-width: var(--max-size);
+      left: var(--media-preview-left, var(--media-slider-pointer));
+      max-width: var(--media-max-size);
       opacity: 0;
       filter: blur(8px);
       transform-origin: bottom;
       scale: 0.8;
-      translate: -50% calc(var(--spacing) * 2);
+      translate: -50% calc(var(--media-spacing) * 2);
       transition-timing-function: ease-out;
       transition-duration: 150ms;
       transition-property: filter, opacity, scale;
     }
 
     .media-slider__thumbnail {
-      --thumbnail-max-width: var(--max-size);
-      --thumbnail-max-height: var(--max-size);
-      bottom: calc(100% + (var(--spacing) * 11));
+      --media-thumbnail-max-width: var(--media-max-size);
+      --media-thumbnail-max-height: var(--media-max-size);
+      bottom: calc(100% + (var(--media-spacing) * 11));
     }
 
     .media-slider__value {
-      bottom: calc(100% + (var(--spacing) * 5));
+      bottom: calc(100% + (var(--media-spacing) * 5));
       display: flex;
       flex-direction: row-reverse;
-      gap: calc(var(--spacing) * 2);
+      gap: calc(var(--media-spacing) * 2);
       justify-content: center;
     }
 
@@ -330,12 +332,12 @@
       top: 50%;
       left: var(--media-slider-pointer);
       width: 1px;
-      height: calc(var(--spacing) * 5);
+      height: calc(var(--media-spacing) * 5);
     }
     &[data-orientation="vertical"]::before {
       top: calc(100% - var(--media-slider-pointer));
       left: 50%;
-      width: calc(var(--spacing) * 5);
+      width: calc(var(--media-spacing) * 5);
       height: 1px;
     }
 

--- a/packages/skins/src/minimal/css/components/thumbnail.css
+++ b/packages/skins/src/minimal/css/components/thumbnail.css
@@ -2,7 +2,7 @@
   position: relative;
   pointer-events: none;
   background-color: oklch(0 0 0 / 0.9);
-  border-radius: calc(var(--spacing) * 2);
+  border-radius: calc(var(--media-spacing) * 2);
 
   &::after {
     position: absolute;
@@ -18,8 +18,8 @@
   .media-thumbnail__image {
     position: relative;
     display: block;
-    max-width: var(--thumbnail-max-width);
-    max-height: var(--thumbnail-max-height);
+    max-width: var(--media-thumbnail-max-width);
+    max-height: var(--media-thumbnail-max-height);
     overflow: clip;
     border-radius: inherit;
   }
@@ -48,7 +48,7 @@
   }
 
   &:has(.media-thumbnail__image[data-loading]) {
-    width: var(--thumbnail-max-width);
+    width: var(--media-thumbnail-max-width);
     max-width: 100%;
     aspect-ratio: 16 / 9;
     overflow: hidden;

--- a/packages/skins/src/minimal/css/components/time.css
+++ b/packages/skins/src/minimal/css/components/time.css
@@ -2,7 +2,7 @@
   display: flex;
   flex: 1;
   flex-direction: row-reverse;
-  gap: calc(var(--spacing) * 3);
+  gap: calc(var(--media-spacing) * 3);
   align-items: center;
   container: media-time-controls / inline-size;
 
@@ -13,7 +13,7 @@
 
 .media-minimal-skin .media-time-group {
   display: flex;
-  gap: calc(var(--spacing) * 1);
+  gap: calc(var(--media-spacing) * 1);
   align-items: center;
 
   &:dir(rtl) {
@@ -29,18 +29,18 @@
   cursor: pointer;
   outline: 2px solid transparent;
   outline-offset: -2px;
-  border-radius: calc(var(--spacing) * 1);
+  border-radius: calc(var(--media-spacing) * 1);
   transition-timing-function: ease-out;
   transition-duration: 100ms;
   transition-property: outline-color, outline-offset;
 
   @supports (corner-shape: squircle) {
-    border-radius: calc(var(--spacing) * 4);
+    border-radius: calc(var(--media-spacing) * 4);
     corner-shape: squircle;
   }
 
   &:focus-visible {
-    outline-color: var(--focus-ring-color);
+    outline-color: var(--media-focus-ring-color);
     outline-offset: 2px;
   }
 }

--- a/packages/skins/src/minimal/css/components/volume-indicator.css
+++ b/packages/skins/src/minimal/css/components/volume-indicator.css
@@ -1,16 +1,16 @@
 .media-minimal-skin .media-volume-indicator {
   .media-volume-indicator__content {
-    width: min(80%, calc(var(--spacing) * 56));
+    width: min(80%, calc(var(--media-spacing) * 56));
     transform: translateX(0);
   }
 
   .media-volume-indicator__progress {
     position: relative;
     width: 100%;
-    height: calc(var(--spacing) * 0.75);
+    height: calc(var(--media-spacing) * 0.75);
     background: oklch(from currentColor l c h / 0.2);
     border-radius: calc(Infinity * 1px);
-    box-shadow: 0 1px 0 var(--shadow-subtle-current-color);
+    box-shadow: 0 1px 0 var(--media-shadow-subtle-current-color);
 
     &::before {
       position: absolute;
@@ -18,7 +18,7 @@
       left: 0;
       width: var(--media-volume-fill, 0%);
       content: "";
-      background: var(--accent-color);
+      background: var(--media-internal-accent-color);
       border-radius: inherit;
       transition: width 200ms linear;
     }

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -26,39 +26,39 @@
 /* Container */
 
 .media-minimal-skin--video {
-  --default-accent-color: oklch(1 0 0);
-  --border-color: light-dark(oklch(0 0 0 / 0.15), oklch(1 0 0 / 0.15));
-  --focus-ring-color: light-dark(oklch(0 0 0), oklch(1 0 0));
-  --media-video-border-radius: var(--container-border-radius);
+  --media-default-accent-color: oklch(1 0 0);
+  --media-border-color: light-dark(oklch(0 0 0 / 0.15), oklch(1 0 0 / 0.15));
+  --media-focus-ring-color: light-dark(oklch(0 0 0), oklch(1 0 0));
+  --media-video-border-radius: var(--media-container-border-radius);
 
-  --controls-background-color: transparent;
-  --controls-transition-duration: 100ms;
-  --controls-transition-timing-function: ease-out;
+  --media-controls-background-color: transparent;
+  --media-controls-transition-duration: 100ms;
+  --media-controls-transition-timing-function: ease-out;
 
-  --error-dialog-transition-duration: 150ms;
-  --error-dialog-transition-delay: 100ms;
-  --error-dialog-transition-timing-function: ease-out;
+  --media-error-dialog-transition-duration: 150ms;
+  --media-error-dialog-transition-delay: 100ms;
+  --media-error-dialog-transition-timing-function: ease-out;
 
-  --popup-transition-duration: 100ms;
-  --popup-transition-timing-function: ease-out;
+  --media-popup-transition-duration: 100ms;
+  --media-popup-transition-timing-function: ease-out;
 
-  --popover-backdrop-filter: blur(16px) saturate(1.5);
-  --popover-background-color: oklch(0 0 0 / 0.5);
-  --popover-border-color: oklch(1 0 0 / 0.1);
+  --media-popover-backdrop-filter: blur(16px) saturate(1.5);
+  --media-popover-background-color: oklch(0 0 0 / 0.5);
+  --media-popover-border-color: oklch(1 0 0 / 0.1);
 
-  --tooltip-backdrop-filter: var(--popover-backdrop-filter);
-  --tooltip-background-color: var(--popover-background-color);
-  --tooltip-border-color: var(--popover-border-color);
+  --media-tooltip-backdrop-filter: var(--media-popover-backdrop-filter);
+  --media-tooltip-background-color: var(--media-popover-background-color);
+  --media-tooltip-border-color: var(--media-popover-border-color);
 
-  --tooltip-text-color: currentColor;
+  --media-tooltip-text-color: currentColor;
 
   overflow: clip;
   background: oklch(0 0 0);
 
   @media (prefers-reduced-motion: reduce) {
-    --error-dialog-transition-duration: 50ms;
-    --error-dialog-transition-delay: 0ms;
-    --popup-transition-duration: 0ms;
+    --media-error-dialog-transition-duration: 50ms;
+    --media-error-dialog-transition-delay: 0ms;
+    --media-popup-transition-duration: 0ms;
 
     .media-error__dialog {
       scale: 1;
@@ -67,20 +67,20 @@
   }
 
   @media (prefers-reduced-transparency: reduce) or (prefers-contrast: more) {
-    --controls-background-color: oklch(0 0 0);
-    --tooltip-background-color: oklch(0 0 0);
+    --media-controls-background-color: oklch(0 0 0);
+    --media-tooltip-background-color: oklch(0 0 0);
   }
 
   &:has(.media-controls:not([data-visible])) {
     /* Slight delay to hide controls on non-touch devices after interaction */
     @media (pointer: fine) {
-      --controls-transition-duration: 300ms;
+      --media-controls-transition-duration: 300ms;
     }
     @media (pointer: coarse) {
-      --controls-transition-duration: 150ms;
+      --media-controls-transition-duration: 150ms;
     }
     @media (prefers-reduced-motion: reduce) {
-      --controls-transition-duration: 50ms;
+      --media-controls-transition-duration: 50ms;
     }
   }
 
@@ -92,29 +92,29 @@
     pointer-events: none;
     content: "";
     border-radius: inherit;
-    box-shadow: inset 0 0 0 1px var(--border-color);
+    box-shadow: inset 0 0 0 1px var(--media-border-color);
   }
 
   &:fullscreen {
-    --container-border-radius: 0;
+    --media-container-border-radius: 0;
 
     &::after {
       display: none;
     }
 
     @media (width >= 1280px) {
-      --scale: 1.25;
+      --media-scale: 1.25;
     }
     @media (width >= 1536px) {
-      --scale: 1.5;
+      --media-scale: 1.5;
     }
     @media (width >= 1920px) {
-      --scale: 1.75;
+      --media-scale: 1.75;
     }
   }
 
   * {
-    --focus-ring-color: oklch(1 0 0);
+    --media-focus-ring-color: oklch(1 0 0);
   }
 }
 
@@ -134,28 +134,28 @@
 .media-minimal-skin--video .media-error__dialog {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--spacing) * 3);
+  gap: calc(var(--media-spacing) * 3);
   width: 100%;
-  max-width: calc(var(--spacing) * 64);
-  padding: calc(var(--spacing) * 4);
+  max-width: calc(var(--media-spacing) * 64);
+  padding: calc(var(--media-spacing) * 4);
   color: oklch(1 0 0);
   text-shadow: 0 1px 0 oklch(0 0 0 / 0.5);
   pointer-events: auto;
-  transition-delay: var(--error-dialog-transition-delay);
-  transition-timing-function: var(--error-dialog-transition-timing-function);
-  transition-duration: var(--error-dialog-transition-duration);
+  transition-delay: var(--media-error-dialog-transition-delay);
+  transition-timing-function: var(--media-error-dialog-transition-timing-function);
+  transition-duration: var(--media-error-dialog-transition-duration);
   transition-property: opacity, scale;
 }
 
 .media-minimal-skin--video .media-error__content {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--spacing) * 2);
-  padding: calc(var(--spacing) * 1.5) 0;
+  gap: calc(var(--media-spacing) * 2);
+  padding: calc(var(--media-spacing) * 1.5) 0;
 }
 
 .media-minimal-skin--video .media-error__title {
-  font-size: var(--font-size-medium);
+  font-size: var(--media-font-size-medium);
 }
 
 .media-minimal-skin--video .media-error[data-starting-style] .media-error__dialog,
@@ -170,23 +170,23 @@
 /* Controls (hide/show behavior) */
 
 .media-minimal-skin--video .media-controls {
-  --base-side-offset: 5;
-  --base-boundary-offset: 1;
-  --inset-factor: 1;
-  --inset: calc(var(--spacing) * var(--inset-factor));
-  --volume-mask: linear-gradient(to right, transparent 10%, #000 25%, #000 100%);
+  --media-base-side-offset: 5;
+  --media-base-boundary-offset: 1;
+  --media-inset-factor: 1;
+  --media-inset: calc(var(--media-spacing) * var(--media-inset-factor));
+  --media-volume-mask: linear-gradient(to right, transparent 10%, #000 25%, #000 100%);
 
   position: absolute;
-  inset-inline: var(--inset);
-  bottom: var(--inset);
+  inset-inline: var(--media-inset);
+  bottom: var(--media-inset);
   z-index: 10;
   flex-wrap: wrap;
-  column-gap: calc(var(--spacing) * 2);
+  column-gap: calc(var(--media-spacing) * 2);
   color: oklch(1 0 0);
-  border-radius: calc(var(--spacing) * 3);
-  transition-timing-function: var(--controls-transition-timing-function);
+  border-radius: calc(var(--media-spacing) * 3);
+  transition-timing-function: var(--media-controls-transition-timing-function);
   /* Speed up the entry transition */
-  transition-duration: calc(var(--controls-transition-duration) / 2);
+  transition-duration: calc(var(--media-controls-transition-duration) / 2);
 
   @media (pointer: fine) {
     transition-property: translate, filter, opacity;
@@ -199,7 +199,7 @@
   &:not([data-visible]) {
     pointer-events: none;
     opacity: 0;
-    transition-duration: var(--controls-transition-duration);
+    transition-duration: var(--media-controls-transition-duration);
 
     @media (pointer: fine) and (prefers-reduced-motion: no-preference) {
       filter: blur(8px);
@@ -211,11 +211,11 @@
   }
 
   .media-time-controls {
-    --slider-height: calc(var(--spacing) * 5);
+    --media-slider-height: calc(var(--media-spacing) * 5);
 
     flex: 0 0 100%;
     order: -1;
-    padding-inline: calc(var(--spacing) * 1.5);
+    padding-inline: calc(var(--media-spacing) * 1.5);
   }
 
   .media-button-group:first-child {
@@ -229,38 +229,38 @@
   }
 
   :is(.media-time-controls, .media-button-group:last-child) {
-    mask-image: var(--volume-mask-image, none);
+    mask-image: var(--media-volume-mask-image, none);
     mask-repeat: no-repeat;
-    mask-position: var(--volume-mask-position, 100% 0);
-    mask-size: var(--volume-mask-size, 200% 100%);
+    mask-position: var(--media-volume-mask-position, 100% 0);
+    mask-size: var(--media-volume-mask-size, 200% 100%);
     transition: mask-position 50ms ease-out;
   }
 
   &:has(.media-button--mute[aria-expanded="true"]) {
     @container media-root (width <= 42rem) {
       .media-button-group:last-child {
-        --volume-mask-image: var(--volume-mask);
-        --volume-mask-position: 0 0;
-        --volume-mask-size: 400% 100%;
+        --media-volume-mask-image: var(--media-volume-mask);
+        --media-volume-mask-position: 0 0;
+        --media-volume-mask-size: 400% 100%;
       }
     }
 
     @container media-root (width > 42rem) {
       .media-time-controls {
-        --volume-mask-image: var(--volume-mask);
-        --volume-mask-position: 0 0;
+        --media-volume-mask-image: var(--media-volume-mask);
+        --media-volume-mask-position: 0 0;
       }
     }
   }
 
   @container media-root (width > 42rem) {
-    --inset-factor: 2;
-    --base-side-offset: 2;
+    --media-inset-factor: 2;
+    --media-base-side-offset: 2;
 
     flex-wrap: nowrap;
 
     .media-time-controls {
-      --slider-height: calc(var(--spacing) * 8);
+      --media-slider-height: calc(var(--media-spacing) * 8);
 
       flex: 1;
       order: unset;
@@ -286,26 +286,26 @@
 
 .media-minimal-skin--video .media-popover--volume {
   --media-popover-side-offset: 0rem;
-  padding: 0 calc(var(--spacing) * 3);
+  padding: 0 calc(var(--media-spacing) * 3);
   background: transparent;
 }
 
 /* Slider preview */
 
 .media-minimal-skin--video .media-slider__value {
-  padding-inline: calc(var(--spacing) * 3);
-  text-shadow: 0 1px 0 var(--shadow-current-color);
+  padding-inline: calc(var(--media-spacing) * 3);
+  text-shadow: 0 1px 0 var(--media-shadow-current-color);
 }
 
 .media-minimal-skin--video .media-slider .media-slider__preview {
-  --preview-end-inset: calc(100cqi - 100%);
-  --preview-left: clamp(
-    calc(var(--max-size) / 2),
+  --media-preview-end-inset: calc(100cqi - 100%);
+  --media-preview-left: clamp(
+    calc(var(--media-max-size) / 2),
     var(--media-slider-pointer),
-    calc(100% - var(--max-size) / 2 + var(--preview-end-inset))
+    calc(100% - var(--media-max-size) / 2 + var(--media-preview-end-inset))
   );
 
   @container media-root (width > 42rem) {
-    --preview-left: var(--media-slider-pointer);
+    --media-preview-left: var(--media-slider-pointer);
   }
 }

--- a/packages/skins/src/minimal/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/audio.tailwind.ts
@@ -10,28 +10,28 @@ import { slider as baseSlider } from './components/slider';
 
 export const container = cn(
   baseContainer,
-  '[--default-accent-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
-  '[--focus-ring-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
-  '[--controls-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]',
-  '[--controls-backdrop-filter:blur(16px)_saturate(1.5)]',
-  '[--controls-border-color:light-dark(oklch(0_0_0/0.1),oklch(1_0_0/0.1))]',
-  '[--controls-text-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
-  '[--error-dialog-transition-duration:250ms]',
-  '[--error-dialog-transition-delay:100ms]',
-  '[--popup-transition-duration:100ms]',
-  '[--popup-transition-timing-function:ease-out]',
-  '[--popover-backdrop-filter:blur(16px)_saturate(1.5)]',
-  '[--popover-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]',
-  '[--popover-border-color:oklch(0_0_0/0.1)]',
-  '[--tooltip-backdrop-filter:var(--popover-backdrop-filter)]',
-  '[--tooltip-background-color:var(--popover-background-color)]',
-  '[--tooltip-border-color:var(--popover-border-color)]',
-  '[--tooltip-text-color:currentColor]',
-  'motion-reduce:[--error-dialog-transition-duration:50ms]',
-  'motion-reduce:[--error-dialog-transition-delay:0ms]',
-  'motion-reduce:[--popup-transition-duration:0ms]',
-  '[@media(prefers-reduced-transparency:reduce)]:[--tooltip-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]',
-  'contrast-more:[--tooltip-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]'
+  '[--media-default-accent-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
+  '[--media-focus-ring-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
+  '[--media-controls-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]',
+  '[--media-controls-backdrop-filter:blur(16px)_saturate(1.5)]',
+  '[--media-controls-border-color:light-dark(oklch(0_0_0/0.1),oklch(1_0_0/0.1))]',
+  '[--media-controls-text-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
+  '[--media-error-dialog-transition-duration:250ms]',
+  '[--media-error-dialog-transition-delay:100ms]',
+  '[--media-popup-transition-duration:100ms]',
+  '[--media-popup-transition-timing-function:ease-out]',
+  '[--media-popover-backdrop-filter:blur(16px)_saturate(1.5)]',
+  '[--media-popover-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]',
+  '[--media-popover-border-color:oklch(0_0_0/0.1)]',
+  '[--media-tooltip-backdrop-filter:var(--media-popover-backdrop-filter)]',
+  '[--media-tooltip-background-color:var(--media-popover-background-color)]',
+  '[--media-tooltip-border-color:var(--media-popover-border-color)]',
+  '[--media-tooltip-text-color:currentColor]',
+  'motion-reduce:[--media-error-dialog-transition-duration:50ms]',
+  'motion-reduce:[--media-error-dialog-transition-delay:0ms]',
+  'motion-reduce:[--media-popup-transition-duration:0ms]',
+  '[@media(prefers-reduced-transparency:reduce)]:[--media-tooltip-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]',
+  'contrast-more:[--media-tooltip-background-color:light-dark(oklch(1_0_0),oklch(0_0_0))]'
 );
 
 /* Controls */
@@ -41,12 +41,12 @@ export const controls = cn(
   // Layout
   'p-1 gap-2',
   'rounded-(--media-border-radius,0.875rem)',
-  '[--base-side-offset:2] [--base-boundary-offset:2]',
+  '[--media-base-side-offset:2] [--media-base-boundary-offset:2]',
   'peer-data-open/error:**:invisible',
   // Appearance
-  'text-(--controls-text-color)',
+  'text-(--media-controls-text-color)',
   // Border
-  'ring-1 ring-(color:--controls-border-color)'
+  'ring-1 ring-(color:--media-controls-border-color)'
 );
 
 export const spacer = 'grow';
@@ -70,7 +70,7 @@ export const popup = {
   volume: cn(
     basePopup.popover,
     'p-0 pr-2 pl-16 [--media-popover-side-offset:0rem]',
-    'bg-transparent bg-gradient-to-l from-(--controls-background-color) from-80% to-transparent'
+    'bg-transparent bg-gradient-to-l from-(--media-controls-background-color) from-80% to-transparent'
   ),
 };
 
@@ -87,10 +87,10 @@ export const error = {
   ...baseError,
   dialog: cn(
     'absolute inset-0 z-20 flex items-center gap-4 rounded-full px-5 pr-2',
-    'bg-(--controls-background-color)',
+    'bg-(--media-controls-background-color)',
     'transition-[opacity,filter,scale] ease-out',
-    'duration-(--error-dialog-transition-duration)',
-    'delay-(--error-dialog-transition-delay)',
+    'duration-(--media-error-dialog-transition-duration)',
+    'delay-(--media-error-dialog-transition-delay)',
     'group-data-starting-style/error:opacity-0 group-data-starting-style/error:blur-xs group-data-starting-style/error:scale-95',
     'group-data-ending-style/error:opacity-0 group-data-ending-style/error:blur-xs group-data-ending-style/error:scale-95',
     'group-data-ending-style/error:delay-0'

--- a/packages/skins/src/minimal/tailwind/components/badge.ts
+++ b/packages/skins/src/minimal/tailwind/components/badge.ts
@@ -1,2 +1,2 @@
 export const badge =
-  'rounded-[--spacing(1)] bg-current/10 px-1.5 py-1 text-(length:--font-size-small) font-medium leading-none text-current/70';
+  'rounded-[--spacing(1)] bg-current/10 px-1.5 py-1 text-(length:--media-font-size-small) font-medium leading-none text-current/70';

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -8,19 +8,19 @@ export const button = {
     'py-2 px-4 rounded-[--spacing(2)]',
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
-    'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',
+    'focus-visible:outline-(--media-focus-ring-color) focus-visible:outline-offset-2',
     'not-aria-disabled:active:scale-[0.97]',
     'motion-reduce:scale-100 motion-reduce:transition-[background-color] motion-reduce:will-change-auto',
     'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]'
   ),
-  primary: 'bg-(--accent-color) text-(--accent-contrast-color) font-medium text-shadow-none',
+  primary: 'bg-(--media-internal-accent-color) text-(--media-accent-contrast-color) font-medium text-shadow-none',
   subtle: cn(
     'bg-transparent text-inherit text-shadow-inherit',
-    'not-aria-disabled:hover:bg-(--accent-background-color) not-aria-disabled:hover:text-(--accent-text-color) not-aria-disabled:hover:no-underline',
-    'not-aria-disabled:focus-visible:bg-(--accent-background-color) not-aria-disabled:focus-visible:text-(--accent-text-color)',
-    'not-aria-disabled:aria-expanded:bg-(--accent-background-color) not-aria-disabled:aria-expanded:text-(--accent-text-color)'
+    'not-aria-disabled:hover:bg-(--media-accent-background-color) not-aria-disabled:hover:text-(--media-internal-accent-text-color) not-aria-disabled:hover:no-underline',
+    'not-aria-disabled:focus-visible:bg-(--media-accent-background-color) not-aria-disabled:focus-visible:text-(--media-internal-accent-text-color)',
+    'not-aria-disabled:aria-expanded:bg-(--media-accent-background-color) not-aria-disabled:aria-expanded:text-(--media-internal-accent-text-color)'
   ),
   icon: cn('grid aspect-square p-0!', 'not-aria-disabled:active:scale-[0.97]'),
   seek: hideAtSmall,
@@ -35,7 +35,7 @@ export const button = {
   live: cn(
     'inline-flex items-center gap-1.5',
     'aspect-auto w-auto px-3 py-2',
-    'text-(length:--font-size-small) font-semibold uppercase tracking-wider leading-none',
+    'text-(length:--media-font-size-small) font-semibold uppercase tracking-wider leading-none',
     'before:inline-block before:size-2 before:shrink-0 before:rounded-full',
     'before:bg-current/40 before:transition-colors before:duration-150 before:ease-out',
     'data-[live-edge]:before:bg-red-500'

--- a/packages/skins/src/minimal/tailwind/components/container.ts
+++ b/packages/skins/src/minimal/tailwind/components/container.ts
@@ -7,32 +7,31 @@ export const container = cn(
   // Layout & containment
   'block relative isolate h-full w-full @container/media-root',
   // Appearance
-  'rounded-(--container-border-radius)',
-  'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] text-(length:--font-size-base) leading-normal subpixel-antialiased',
-  '[--accent-color:var(--media-accent-color,var(--default-accent-color))]',
-  '[--accent-contrast-color:contrast-color(var(--accent-color))]',
-  '[--accent-background-color:var(--media-accent-color,oklch(from_var(--default-accent-color)_l_c_h/calc(alpha*0.1)))]',
-  '[--accent-text-color:var(--media-accent-text-color,contrast-color(var(--media-accent-color,oklch(0_0_0))))]',
-  '[--container-border-radius:var(--media-border-radius,0.75rem)]',
+  'rounded-(--media-container-border-radius)',
+  'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] text-(length:--media-font-size-base) leading-normal subpixel-antialiased',
+  '[--media-internal-accent-color:var(--media-accent-color,var(--media-default-accent-color))]',
+  '[--media-accent-contrast-color:contrast-color(var(--media-internal-accent-color))]',
+  '[--media-accent-background-color:var(--media-accent-color,oklch(from_var(--media-default-accent-color)_l_c_h/calc(alpha*0.1)))]',
+  '[--media-internal-accent-text-color:var(--media-accent-text-color,contrast-color(var(--media-accent-color,oklch(0_0_0))))]',
+  '[--media-container-border-radius:var(--media-border-radius,0.75rem)]',
   // Focus ring
   'outline-2 outline-transparent -outline-offset-4',
   'transition-[outline-offset,outline-color] duration-100 ease-out',
-  'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',
+  'focus-visible:outline-(--media-focus-ring-color) focus-visible:outline-offset-2',
   // Scrollbars
   'scrollbar-thin scrollbar-thumb-current/30',
   '[@media_(prefers-reduced-transparency:reduce)_or_(prefers-contrast:more)]:scrollbar-auto',
   '[@media_(prefers-reduced-transparency:reduce)_or_(prefers-contrast:more)]:scrollbar-thumb-current/80',
   // Shadow color variables (derived from currentColor lightness)
-  '[--shadow-current-color:oklch(from_currentColor_0_0_0/clamp(0,calc((l-0.5)*0.5),0.15))]',
-  '[--shadow-subtle-current-color:oklch(from_var(--shadow-current-color)_l_c_h/calc(alpha*0.4))]',
+  '[--media-shadow-current-color:oklch(from_currentColor_0_0_0/clamp(0,calc((l-0.5)*0.5),0.15))]',
+  '[--media-shadow-subtle-current-color:oklch(from_var(--media-shadow-current-color)_l_c_h/calc(alpha*0.4))]',
   // Font and icon sizing
-  '[--scale:1]',
-  '[--font-size-base:calc(0.8125rem*var(--scale))]',
-  '[--font-size-small:calc(0.6875rem*var(--scale))]',
-  '[--font-size-medium:calc(0.9375rem*var(--scale))]',
-  '[--font-size-tiny:calc(0.5625rem*var(--scale))]',
-  '[--media-icon-size:calc(--spacing(4.5)*var(--scale))]',
-  // Preserve the container's Tailwind spacing value and scale descendants from it.
-  '[--spacing-proxy:var(--spacing)]',
-  '[&>*]:[--spacing:calc(var(--spacing-proxy)*var(--scale))]'
+  '[--media-scale:1]',
+  '[--media-font-size-base:calc(0.8125rem*var(--media-scale))]',
+  '[--media-font-size-small:calc(0.6875rem*var(--media-scale))]',
+  '[--media-font-size-medium:calc(0.9375rem*var(--media-scale))]',
+  '[--media-font-size-tiny:calc(0.5625rem*var(--media-scale))]',
+  '[--media-spacing:calc(var(--media-scale-unit,16px)*var(--media-scale)/4)]',
+  '[--spacing:var(--media-spacing)]',
+  '[--media-icon-size:calc(var(--media-spacing)*4.5)]'
 );

--- a/packages/skins/src/minimal/tailwind/components/controls.ts
+++ b/packages/skins/src/minimal/tailwind/components/controls.ts
@@ -5,14 +5,14 @@ export const controls = cn(
   'peer/controls',
   // Layout
   '@container/media-controls',
-  '[--media-popover-side-offset:calc(var(--spacing)*(var(--base-side-offset,0)+var(--controls-padding,1)))]',
+  '[--media-popover-side-offset:calc(var(--media-spacing)*(var(--media-base-side-offset,0)+var(--media-controls-padding,1)))]',
   '[--media-tooltip-side-offset:var(--media-popover-side-offset)]',
-  '[--media-popover-boundary-offset:calc(var(--spacing)*(var(--base-boundary-offset,0)+var(--controls-padding,1)))]',
+  '[--media-popover-boundary-offset:calc(var(--media-spacing)*(var(--media-base-boundary-offset,0)+var(--media-controls-padding,1)))]',
   '[--media-tooltip-boundary-offset:var(--media-popover-boundary-offset)]',
-  '[padding:calc(var(--spacing)*var(--controls-padding,1))] flex items-center [&:dir(rtl)]:flex-row-reverse',
+  '[padding:calc(var(--media-spacing)*var(--media-controls-padding,1))] flex items-center [&:dir(rtl)]:flex-row-reverse',
   // Appearance (driven by CSS variables set on the root)
-  'bg-(--controls-background-color)',
-  '[backdrop-filter:var(--controls-backdrop-filter)]',
+  'bg-(--media-controls-background-color)',
+  '[backdrop-filter:var(--media-controls-backdrop-filter)]',
   // Text shadow
-  'text-shadow-2xs text-shadow-(color:--shadow-current-color)'
+  'text-shadow-2xs text-shadow-(color:--media-shadow-current-color)'
 );

--- a/packages/skins/src/minimal/tailwind/components/error.ts
+++ b/packages/skins/src/minimal/tailwind/components/error.ts
@@ -7,9 +7,9 @@ export const error = {
     'text-shadow-2xs text-shadow-black/50',
     // Animation
     'transition-[opacity,scale,transform]',
-    'duration-(--error-dialog-transition-duration)',
-    'delay-(--error-dialog-transition-delay)',
-    'ease-(--error-dialog-transition-timing-function)',
+    'duration-(--media-error-dialog-transition-duration)',
+    'delay-(--media-error-dialog-transition-delay)',
+    'ease-(--media-error-dialog-transition-timing-function)',
     'group-data-starting-style/error:opacity-0 group-data-starting-style/error:scale-95',
     'group-data-ending-style/error:opacity-0 group-data-ending-style/error:scale-95',
     'motion-reduce:scale-100 motion-reduce:transition-opacity',

--- a/packages/skins/src/minimal/tailwind/components/icon.ts
+++ b/packages/skins/src/minimal/tailwind/components/icon.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const icon = cn(
   'block [grid-area:1/1] size-(--media-icon-size)',
-  'drop-shadow-[0_1px_0_var(--shadow-current-color)]',
+  'drop-shadow-[0_1px_0_var(--media-shadow-current-color)]',
   'transition-[opacity,scale] duration-150 ease-out'
 );
 

--- a/packages/skins/src/minimal/tailwind/components/input-indicator.ts
+++ b/packages/skins/src/minimal/tailwind/components/input-indicator.ts
@@ -15,7 +15,7 @@ export const topIndicatorRoot = cn(
   'data-ending-style:duration-400',
   'data-ending-style:ease-in',
   '[background-image:linear-gradient(to_bottom,oklch(0_0_0/0.35),oklch(0_0_0/0.2)_--spacing(12),oklch(0_0_0/0))]',
-  'text-shadow-2xs text-shadow-(color:--shadow-current-color)',
+  'text-shadow-2xs text-shadow-(color:--media-shadow-current-color)',
   'pointer-fine:will-change-[translate,filter,opacity]',
   'pointer-fine:transition-[translate,filter,opacity]',
   'pointer-coarse:will-change-[translate,opacity]',
@@ -28,12 +28,12 @@ export const topIndicatorRoot = cn(
 export const topIndicatorContent = cn(
   'flex justify-between items-center gap-2 px-2.5 py-1',
   '*:last:ml-auto',
-  '[@media(prefers-reduced-transparency:reduce)]:bg-(--controls-background-color)',
+  '[@media(prefers-reduced-transparency:reduce)]:bg-(--media-controls-background-color)',
   '[@media(prefers-reduced-transparency:reduce)]:rounded-[--spacing(2)]',
-  'contrast-more:bg-(--controls-background-color) contrast-more:rounded-[--spacing(2)]'
+  'contrast-more:bg-(--media-controls-background-color) contrast-more:rounded-[--spacing(2)]'
 );
 
-export const topIndicatorIcon = cn('hidden shrink-0', 'drop-shadow-[0_1px_0_var(--shadow-current-color)]');
+export const topIndicatorIcon = cn('hidden shrink-0', 'drop-shadow-[0_1px_0_var(--media-shadow-current-color)]');
 
 export const centeredIndicatorRoot = cn(
   'group/input-indicator',

--- a/packages/skins/src/minimal/tailwind/components/menu.ts
+++ b/packages/skins/src/minimal/tailwind/components/menu.ts
@@ -3,37 +3,37 @@ import { cn } from '@videojs/utils/style';
 import { popup } from './popup';
 
 const submenuPanel = cn(
-  '[--menu-content-enter-translate:100%] [&:dir(rtl)]:[--menu-content-enter-translate:-100%]',
-  'absolute inset-x-0 top-0 [max-height:inherit] overflow-auto overscroll-none p-(--menu-padding) outline-none',
+  '[--media-menu-content-enter-translate:100%] [&:dir(rtl)]:[--media-menu-content-enter-translate:-100%]',
+  'absolute inset-x-0 top-0 [max-height:inherit] overflow-auto overscroll-none p-(--media-menu-padding) outline-none',
   'z-10',
-  'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out',
+  'translate-none transition-[translate,filter] duration-(--media-menu-transition-duration) ease-out',
   'data-starting-style:pointer-events-none data-ending-style:pointer-events-none',
   'data-starting-style:overflow-hidden data-ending-style:overflow-hidden',
-  'data-starting-style:[translate:var(--menu-content-enter-translate)_0] data-ending-style:[translate:var(--menu-content-enter-translate)_0]',
+  'data-starting-style:[translate:var(--media-menu-content-enter-translate)_0] data-ending-style:[translate:var(--media-menu-content-enter-translate)_0]',
   'data-starting-style:blur data-ending-style:blur'
 );
 
 const itemBase = cn(
-  'group/menu-item relative flex cursor-pointer select-none items-center gap-1.5 rounded-(--menu-item-border-radius) py-1.5 px-2',
+  'group/menu-item relative flex cursor-pointer select-none items-center gap-1.5 rounded-(--media-menu-item-border-radius) py-1.5 px-2',
   'text-start',
-  'text-shadow-2xs text-shadow-(color:--shadow-current-color)',
+  'text-shadow-2xs text-shadow-(color:--media-shadow-current-color)',
   'outline-2 -outline-offset-2 outline-transparent',
   'transition-colors duration-100 ease-in-out',
   'supports-[top:anchor(top)]:duration-50',
   'supports-[top:anchor(top)]:hover:duration-200',
   'supports-[top:anchor(top)]:data-highlighted:duration-200',
-  'hover:bg-(--accent-background-color) hover:text-(--accent-text-color)',
-  'data-highlighted:bg-(--accent-background-color) data-highlighted:text-(--accent-text-color)',
-  'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2'
+  'hover:bg-(--media-accent-background-color) hover:text-(--media-internal-accent-text-color)',
+  'data-highlighted:bg-(--media-accent-background-color) data-highlighted:text-(--media-internal-accent-text-color)',
+  'focus-visible:outline-(--media-focus-ring-color) focus-visible:outline-offset-2'
 );
 
 const menuTokens = cn(
-  '[--menu-transition-duration:250ms]',
-  '[--menu-max-height:--spacing(56)]',
-  '[--menu-padding:--spacing(1)]',
-  '[--menu-border-radius:--spacing(2.5)]',
-  '[--menu-item-border-radius:calc(var(--menu-border-radius)_-_var(--menu-padding))]',
-  'motion-reduce:[--menu-transition-duration:0ms]'
+  '[--media-menu-transition-duration:250ms]',
+  '[--media-menu-max-height:--spacing(56)]',
+  '[--media-menu-padding:--spacing(1)]',
+  '[--media-menu-border-radius:--spacing(2.5)]',
+  '[--media-menu-item-border-radius:calc(var(--media-menu-border-radius)_-_var(--media-menu-padding))]',
+  'motion-reduce:[--media-menu-transition-duration:0ms]'
 );
 
 const group = cn(
@@ -46,8 +46,8 @@ const group = cn(
   // menu while hovering. Exclude it from scroll anchoring.
   'supports-[top:anchor(top)]:before:[overflow-anchor:none]',
   'supports-[top:anchor(top)]:before:pointer-events-none',
-  'supports-[top:anchor(top)]:before:bg-(--accent-background-color)',
-  'supports-[top:anchor(top)]:before:rounded-(--menu-item-border-radius)',
+  'supports-[top:anchor(top)]:before:bg-(--media-accent-background-color)',
+  'supports-[top:anchor(top)]:before:rounded-(--media-menu-item-border-radius)',
   'supports-[top:anchor(top)]:before:transition-[inset]',
   'supports-[top:anchor(top)]:before:duration-100',
   'supports-[top:anchor(top)]:before:ease-in-out',
@@ -57,10 +57,10 @@ const group = cn(
 const menuHostShell = cn(
   popup.popover,
   menuTokens,
-  'min-w-max max-w-(--media-popover-available-width,none) max-h-[min(var(--media-popover-available-height,var(--menu-max-height)),var(--menu-max-height))]',
-  'bg-(--popover-background-color) [backdrop-filter:var(--popover-backdrop-filter)]',
-  'shadow-[0_0_0_1px_var(--popover-border-color),0_4px_6px_-1px_oklch(0_0_0/0.1),0_2px_4px_-2px_oklch(0_0_0/0.1)]',
-  'box-border rounded-(--menu-border-radius) p-(--menu-padding) overscroll-none'
+  'min-w-max max-w-(--media-popover-available-width,none) max-h-[min(var(--media-popover-available-height,var(--media-menu-max-height)),var(--media-menu-max-height))]',
+  'bg-(--media-popover-background-color) [backdrop-filter:var(--media-popover-backdrop-filter)]',
+  'shadow-[0_0_0_1px_var(--media-popover-border-color),0_4px_6px_-1px_oklch(0_0_0/0.1),0_2px_4px_-2px_oklch(0_0_0/0.1)]',
+  'box-border rounded-(--media-menu-border-radius) p-(--media-menu-padding) overscroll-none'
 );
 
 export const menu = {
@@ -73,19 +73,19 @@ export const menu = {
     menuHostShell,
     'group/menu-popup',
     // Only the menu size changes between panels.
-    '[--popup-transition:var(--popup-base-transition),width_var(--popup-transition-timing-function)_var(--menu-transition-duration),height_var(--popup-transition-timing-function)_var(--menu-transition-duration)]',
+    '[--media-popup-transition:var(--media-popup-base-transition),width_var(--media-popup-transition-timing-function)_var(--media-menu-transition-duration),height_var(--media-popup-transition-timing-function)_var(--media-menu-transition-duration)]',
     // Don't transition size on open/close.
-    'data-starting-style:[--popup-transition:var(--popup-base-transition)]',
-    'data-ending-style:[--popup-transition:var(--popup-base-transition)]',
+    'data-starting-style:[--media-popup-transition:var(--media-popup-base-transition)]',
+    'data-ending-style:[--media-popup-transition:var(--media-popup-base-transition)]',
     'min-w-48! w-(--media-menu-width) h-(--media-menu-height)',
     'overflow-hidden!'
   ),
   /** Root settings Content that exits when a nested Content opens. */
   settingsContent: cn(
     group,
-    'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out',
-    '[--menu-content-exit-translate:-100%] [&:dir(rtl)]:[--menu-content-exit-translate:100%]',
-    'data-[child-open]:[translate:var(--menu-content-exit-translate)_0]',
+    'translate-none transition-[translate,filter] duration-(--media-menu-transition-duration) ease-out',
+    '[--media-menu-content-exit-translate:-100%] [&:dir(rtl)]:[--media-menu-content-exit-translate:100%]',
+    'data-[child-open]:[translate:var(--media-menu-content-exit-translate)_0]',
     'data-[child-open]:blur',
     // Avoid restarting the parent Content transition in WebKit while the
     // anchor-positioned highlight is active.
@@ -102,9 +102,9 @@ export const menu = {
     'aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50'
   ),
   separator: 'my-1 border-b border-[oklch(1_0_0/0.1)]',
-  tier: 'ps-0.5 pt-px text-(length:--font-size-tiny) font-semibold leading-none text-current/70',
+  tier: 'ps-0.5 pt-px text-(length:--media-font-size-tiny) font-semibold leading-none text-current/70',
   indicator: 'ms-auto -me-1 shrink-0 opacity-0 group-aria-checked/menu-item:opacity-100',
-  icon: 'shrink-0 text-current/50 drop-shadow-[0_1px_0_var(--shadow-current-color)] group-hover/menu-item:text-inherit group-data-highlighted/menu-item:text-inherit',
+  icon: 'shrink-0 text-current/50 drop-shadow-[0_1px_0_var(--media-shadow-current-color)] group-hover/menu-item:text-inherit group-data-highlighted/menu-item:text-inherit',
   /** Nested submenu panel. */
   submenuPanel,
   back: cn(itemBase, 'mb-0.5 w-full'),

--- a/packages/skins/src/minimal/tailwind/components/overlay.ts
+++ b/packages/skins/src/minimal/tailwind/components/overlay.ts
@@ -10,7 +10,7 @@ export const overlay = cn(
   'backdrop-blur-none backdrop-saturate-100',
   // Transitions
   'transition-[opacity,backdrop-filter]',
-  'duration-(--controls-transition-duration)',
+  'duration-(--media-controls-transition-duration)',
   'ease-out',
   // Shown when controls visible
   'peer-data-visible/controls:opacity-100',
@@ -21,7 +21,7 @@ export const overlay = cn(
   // Shown when error visible (+ blur)
   // Light DOM: peer/error is a direct sibling (React)
   'peer-data-open/error:opacity-100',
-  'peer-data-open/error:duration-(--error-dialog-transition-duration)',
-  'peer-data-open/error:delay-(--error-dialog-transition-delay)',
+  'peer-data-open/error:duration-(--media-error-dialog-transition-duration)',
+  'peer-data-open/error:delay-(--media-error-dialog-transition-delay)',
   'peer-data-open/error:backdrop-blur-lg peer-data-open/error:backdrop-saturate-120'
 );

--- a/packages/skins/src/minimal/tailwind/components/popup.ts
+++ b/packages/skins/src/minimal/tailwind/components/popup.ts
@@ -2,19 +2,19 @@ import { cn } from '@videojs/utils/style';
 
 const base = cn(
   // Reset default popover styles
-  '[--popup-base-transition:opacity_var(--popup-transition-timing-function)_var(--popup-transition-duration),filter_var(--popup-transition-timing-function)_var(--popup-transition-duration),transform_var(--popup-transition-timing-function)_var(--popup-transition-duration),scale_var(--popup-transition-timing-function)_var(--popup-transition-duration)]',
-  '[--popup-translate-distance:--spacing(2)] m-0 border-0 text-inherit overflow-visible',
+  '[--media-popup-base-transition:opacity_var(--media-popup-transition-timing-function)_var(--media-popup-transition-duration),filter_var(--media-popup-transition-timing-function)_var(--media-popup-transition-duration),transform_var(--media-popup-transition-timing-function)_var(--media-popup-transition-duration),scale_var(--media-popup-transition-timing-function)_var(--media-popup-transition-duration)]',
+  '[--media-popup-translate-distance:--spacing(2)] m-0 border-0 text-inherit overflow-visible',
   // Animation
-  '[transition:var(--popup-transition,var(--popup-base-transition))]',
+  '[transition:var(--media-popup-transition,var(--media-popup-base-transition))]',
   // We have to use transform here for translate as the translate property is used for positioning by core.
-  'data-starting-style:opacity-0 data-starting-style:scale-95 data-starting-style:[transform:translate(var(--popup-translate-x-distance,0),var(--popup-translate-y-distance,0))]',
+  'data-starting-style:opacity-0 data-starting-style:scale-95 data-starting-style:[transform:translate(var(--media-popup-translate-x-distance,0),var(--media-popup-translate-y-distance,0))]',
   'data-ending-style:opacity-0 data-ending-style:blur-xs data-ending-style:scale-95 data-ending-style:transform-none',
   // Speed up the exit transition.
-  'data-ending-style:[transition-duration:max(0ms,calc(var(--popup-transition-duration)-50ms))]',
+  'data-ending-style:[transition-duration:max(0ms,calc(var(--media-popup-transition-duration)-50ms))]',
   // Ensure we animate from the correct origin based on the side the popover is on
   'data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left',
-  'data-[side=top]:[--popup-translate-y-distance:var(--popup-translate-distance)] data-[side=bottom]:[--popup-translate-y-distance:calc(var(--popup-translate-distance)*-1)]',
-  'data-[side=left]:[--popup-translate-x-distance:var(--popup-translate-distance)] data-[side=right]:[--popup-translate-x-distance:calc(var(--popup-translate-distance)*-1)]',
+  'data-[side=top]:[--media-popup-translate-y-distance:var(--media-popup-translate-distance)] data-[side=bottom]:[--media-popup-translate-y-distance:calc(var(--media-popup-translate-distance)*-1)]',
+  'data-[side=left]:[--media-popup-translate-x-distance:var(--media-popup-translate-distance)] data-[side=right]:[--media-popup-translate-x-distance:calc(var(--media-popup-translate-distance)*-1)]',
   // Safe area between trigger and popup
   'before:absolute before:pointer-events-[inherit]',
   'data-[side=top]:before:left-0 data-[side=top]:before:right-0 data-[side=top]:before:top-full',
@@ -24,10 +24,10 @@ const base = cn(
 );
 
 export const tooltip = cn(
-  'px-2 py-1 rounded-[--spacing(2)] text-(length:--font-size-base) whitespace-nowrap',
-  'bg-(--tooltip-background-color) [backdrop-filter:var(--tooltip-backdrop-filter)]',
-  'ring-1 ring-(color:--tooltip-border-color) shadow-md shadow-black/20',
-  'text-(--tooltip-text-color)'
+  'px-2 py-1 rounded-[--spacing(2)] text-(length:--media-font-size-base) whitespace-nowrap',
+  'bg-(--media-tooltip-background-color) [backdrop-filter:var(--media-tooltip-backdrop-filter)]',
+  'ring-1 ring-(color:--media-tooltip-border-color) shadow-md shadow-black/20',
+  'text-(--media-tooltip-text-color)'
 );
 
 export const popup = {
@@ -45,6 +45,6 @@ export const popup = {
     'data-[side=left]:before:w-(--media-tooltip-side-offset) data-[side=right]:before:w-(--media-tooltip-side-offset)'
   ),
   tooltipShortcut: cn(
-    'min-w-[1.5em] -mr-1 p-[0.1em] bg-current/15 text-(length:--font-size-small) font-semibold font-[inherit] leading-[1.25] text-center rounded-[--spacing(1)]'
+    'min-w-[1.5em] -mr-1 p-[0.1em] bg-current/15 text-(length:--media-font-size-small) font-semibold font-[inherit] leading-[1.25] text-center rounded-[--spacing(1)]'
   ),
 };

--- a/packages/skins/src/minimal/tailwind/components/poster.ts
+++ b/packages/skins/src/minimal/tailwind/components/poster.ts
@@ -15,7 +15,7 @@ export const poster = (isShadowDOM: boolean) =>
           '[&_::slotted(img)]:h-full',
           '[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]',
           '[&_::slotted(img)]:[object-position:var(--media-object-position,center)]',
-          '[&_::slotted(img)]:rounded-(--container-border-radius)',
+          '[&_::slotted(img)]:rounded-(--media-container-border-radius)',
           // The image this skin carries as slot fallback content, which `::slotted` cannot reach.
           '[&_img]:absolute',
           '[&_img]:inset-0',
@@ -23,7 +23,7 @@ export const poster = (isShadowDOM: boolean) =>
           '[&_img]:h-full',
           '[&_img]:[object-fit:var(--media-object-fit,contain)]',
           '[&_img]:[object-position:var(--media-object-position,center)]',
-          '[&_img]:rounded-(--container-border-radius)',
+          '[&_img]:rounded-(--media-container-border-radius)',
         ]
       : 'rounded-[inherit] [object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]'
   );

--- a/packages/skins/src/minimal/tailwind/components/slider.ts
+++ b/packages/skins/src/minimal/tailwind/components/slider.ts
@@ -1,7 +1,7 @@
 import { cn } from '@videojs/utils/style';
 
 const previewContent = cn(
-  'absolute [left:var(--preview-left,var(--media-slider-pointer))] max-w-(--max-size)',
+  'absolute [left:var(--media-preview-left,var(--media-slider-pointer))] max-w-(--media-max-size)',
   '-translate-x-1/2 translate-y-2 scale-80 opacity-0 blur-lg origin-bottom',
   'transition-[filter,opacity,scale] duration-150 ease-out',
   'group-data-pointing/slider:scale-100 group-data-pointing/slider:opacity-100',
@@ -12,16 +12,16 @@ const previewContent = cn(
 
 export const slider = {
   root: cn(
-    'group/slider relative flex flex-1 items-center justify-center rounded-(--track-border-radius) outline-none cursor-pointer',
-    '[--track-border-radius:99px]',
-    '[--chapter-gap:calc(var(--spacing)*1)] [--chapter-inset-start:calc(var(--chapter-gap)/2)] [--chapter-inset-end:calc(var(--chapter-gap)/2)]',
+    'group/slider relative flex flex-1 items-center justify-center rounded-(--media-track-border-radius) outline-none cursor-pointer',
+    '[--media-track-border-radius:99px]',
+    '[--media-chapter-gap:calc(var(--media-spacing)*1)] [--media-internal-chapter-inset-start:calc(var(--media-chapter-gap)/2)] [--media-internal-chapter-inset-end:calc(var(--media-chapter-gap)/2)]',
     // Horizontal
-    'data-[orientation=horizontal]:min-w-20 data-[orientation=horizontal]:w-(--slider-width,100%) data-[orientation=horizontal]:h-(--slider-height,--spacing(8))',
+    'data-[orientation=horizontal]:min-w-20 data-[orientation=horizontal]:w-(--media-slider-width,100%) data-[orientation=horizontal]:h-(--media-slider-height,--spacing(8))',
     // Vertical
-    'data-[orientation=vertical]:w-(--slider-width,--spacing(8)) data-[orientation=vertical]:h-(--slider-height,--spacing(20))'
+    'data-[orientation=vertical]:w-(--media-slider-width,--spacing(8)) data-[orientation=vertical]:h-(--media-slider-height,--spacing(20))'
   ),
   track: cn(
-    'relative isolate overflow-hidden bg-current/20 rounded-(--track-border-radius) select-none',
+    'relative isolate overflow-hidden bg-current/20 rounded-(--media-track-border-radius) select-none',
     // Horizontal
     'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-1',
     // Vertical
@@ -31,19 +31,19 @@ export const slider = {
   chapter: {
     base: cn(
       'group/chapter absolute inset-0 flex items-center justify-center min-w-0 min-h-0',
-      'first:[--chapter-inset-start:0px] last:[--chapter-inset-end:0px]',
+      'first:[--media-internal-chapter-inset-start:0px] last:[--media-internal-chapter-inset-end:0px]',
       'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start))]',
       'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start)_0)]'
     ),
     track: cn(
-      'relative isolate overflow-hidden bg-current/20 rounded-(--track-border-radius) select-none',
+      'relative isolate overflow-hidden bg-current/20 rounded-(--media-track-border-radius) select-none',
       'motion-safe:transition-[height,width] motion-safe:duration-200 motion-safe:ease-out',
       'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-1',
       'group-data-highlighted/chapter:data-[orientation=horizontal]:h-1.75',
-      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-inset-start))_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--media-internal-chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--media-internal-chapter-inset-start))_round_var(--media-track-border-radius))]',
       'data-[orientation=vertical]:w-1 data-[orientation=vertical]:h-full',
       'group-data-highlighted/chapter:data-[orientation=vertical]:w-1.75',
-      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-inset-start))_0_round_var(--track-border-radius))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--media-internal-chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--media-internal-chapter-inset-start))_0_round_var(--media-track-border-radius))]'
     ),
   },
   fill: {
@@ -53,24 +53,24 @@ export const slider = {
       'data-dragging:duration-0 data-seeking:duration-0'
     ),
     fill: cn(
-      'bg-(--accent-color)',
+      'bg-(--media-internal-accent-color)',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_var(--track-border-radius))]',
-      'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_var(--media-track-border-radius))]',
+      'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_var(--media-track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_var(--track-border-radius))]',
-      'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_var(--track-border-radius))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_var(--media-track-border-radius))]',
+      'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_var(--media-track-border-radius))]'
     ),
     buffer: cn(
       'bg-current/20',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_var(--media-track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_var(--track-border-radius))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_var(--media-track-border-radius))]'
     ),
   },
   thumb: {
@@ -78,12 +78,12 @@ export const slider = {
       'z-10 absolute size-3 -translate-x-1/2 -translate-y-1/2',
       'bg-current rounded-full',
       'opacity-0 scale-70 origin-center',
-      'shadow-[0_0_0_1px_var(--shadow-current-color,oklch(0_0_0/0.15)),0_1px_3px_0_oklch(0_0_0/0.15),0_1px_2px_-1px_oklch(0_0_0/0.15)]',
+      'shadow-[0_0_0_1px_var(--media-shadow-current-color,oklch(0_0_0/0.15)),0_1px_3px_0_oklch(0_0_0/0.15),0_1px_2px_-1px_oklch(0_0_0/0.15)]',
       'transition-none motion-safe:transition-[opacity,height,width,outline-offset,left,top,scale] duration-150 ease-out select-none',
       'data-dragging:duration-0 data-seeking:duration-0',
       'group-active/slider:size-3.5',
       'outline-2 outline-transparent -outline-offset-2',
-      'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',
+      'focus-visible:outline-(--media-focus-ring-color) focus-visible:outline-offset-2',
       'focus-visible:opacity-100 focus-visible:scale-100',
       // Horizontal
       'data-[orientation=horizontal]:top-1/2 data-[orientation=horizontal]:left-(--media-slider-fill,0)',
@@ -96,9 +96,9 @@ export const slider = {
     interactive: cn('pointer-fine:group-hover/slider:opacity-100 pointer-fine:group-hover/slider:scale-100'),
   },
   preview: cn(
-    '[--max-size-factor:28]',
-    '[--max-size:min(calc(var(--spacing)*var(--max-size-factor)),100cqi)]',
-    '@lg/media-root:[--max-size-factor:36] @2xl/media-root:[--max-size-factor:48]',
+    '[--media-max-size-factor:28]',
+    '[--media-max-size:min(calc(var(--media-spacing)*var(--media-max-size-factor)),100cqi)]',
+    '@lg/media-root:[--media-max-size-factor:36] @2xl/media-root:[--media-max-size-factor:48]',
     'min-w-full h-1',
     'before:absolute before:z-1 before:bg-current/35 before:pointer-events-none',
     'before:-translate-1/2 before:opacity-0 before:scale-50',
@@ -111,7 +111,7 @@ export const slider = {
   ),
   thumbnail: cn(
     previewContent,
-    '[--thumbnail-max-width:var(--max-size)] [--thumbnail-max-height:var(--max-size)]',
+    '[--media-thumbnail-max-width:var(--media-max-size)] [--media-thumbnail-max-height:var(--media-max-size)]',
     '[bottom:calc(100%+--spacing(11))]'
   ),
   value: cn(previewContent, '[bottom:calc(100%+--spacing(5))] flex flex-row-reverse justify-center gap-2 tabular-nums'),

--- a/packages/skins/src/minimal/tailwind/components/thumbnail.ts
+++ b/packages/skins/src/minimal/tailwind/components/thumbnail.ts
@@ -5,11 +5,11 @@ export const thumbnail = {
     'group/thumbnail pointer-events-none bg-black/90 rounded-[--spacing(2)]',
     'after:absolute after:inset-0 after:rounded-[inherit]',
     'after:ring-1 after:ring-black/5 after:shadow-sm after:shadow-black/20',
-    'has-data-loading:w-(--thumbnail-max-width) has-data-loading:max-w-full',
+    'has-data-loading:w-(--media-thumbnail-max-width) has-data-loading:max-w-full',
     'has-data-loading:aspect-video has-data-loading:overflow-hidden'
   ),
   image: cn(
-    'relative block max-w-(--thumbnail-max-width) max-h-(--thumbnail-max-height) overflow-clip rounded-[inherit]',
+    'relative block max-w-(--media-thumbnail-max-width) max-h-(--media-thumbnail-max-height) overflow-clip rounded-[inherit]',
     'transition-opacity duration-150 ease-out data-loading:opacity-0'
   ),
   spinner: cn(

--- a/packages/skins/src/minimal/tailwind/components/time.ts
+++ b/packages/skins/src/minimal/tailwind/components/time.ts
@@ -7,7 +7,7 @@ export const time = {
     'transition-[outline-color,outline-offset] duration-100 ease-out',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]',
-    'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',
+    'focus-visible:outline-(--media-focus-ring-color) focus-visible:outline-offset-2',
     '@2xl/media-root:inline'
   ),
   separator: cn('hidden', '@2xl/media-root:inline @2xl/media-root:text-current/60'),

--- a/packages/skins/src/minimal/tailwind/components/volume-indicator.ts
+++ b/packages/skins/src/minimal/tailwind/components/volume-indicator.ts
@@ -14,9 +14,9 @@ export const volumeIndicator = {
   progress: cn(
     'relative w-full h-0.75 rounded-full bg-current/20',
     'before:absolute before:inset-y-0 before:left-0 before:w-(--media-volume-fill,0%) before:content-[""]',
-    'before:bg-(--accent-color) before:rounded-[inherit]',
+    'before:bg-(--media-internal-accent-color) before:rounded-[inherit]',
     'before:transition-[width] before:duration-200 before:ease-linear',
-    'shadow-[0_1px_0_var(--shadow-subtle-current-color)]'
+    'shadow-[0_1px_0_var(--media-shadow-subtle-current-color)]'
   ),
   value: 'ml-auto',
   icon: {

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -20,53 +20,53 @@ export const container = (isShadowDOM: boolean) =>
     // Border ring (::after)
     'after:absolute after:pointer-events-none after:rounded-[inherit] after:z-10',
     '[&:fullscreen]:after:hidden',
-    'after:inset-0 after:ring-1 after:ring-inset after:ring-(color:--border-color)',
+    'after:inset-0 after:ring-1 after:ring-inset after:ring-(color:--media-border-color)',
     // Video element
     {
-      '[&_::slotted(video)]:block [&_::slotted(video)]:w-full [&_::slotted(video)]:h-full [&_::slotted(video)]:rounded-(--container-border-radius) [&_::slotted(video)]:[object-fit:var(--media-object-fit,cover)] [&_::slotted(video)]:[object-position:var(--media-object-position,center)]':
+      '[&_::slotted(video)]:block [&_::slotted(video)]:w-full [&_::slotted(video)]:h-full [&_::slotted(video)]:rounded-(--media-container-border-radius) [&_::slotted(video)]:[object-fit:var(--media-object-fit,cover)] [&_::slotted(video)]:[object-position:var(--media-object-position,center)]':
         isShadowDOM,
       '[&_video]:block [&_video]:w-full [&_video]:h-full [&_video]:rounded-[inherit] [&_video]:[object-fit:var(--media-object-fit,contain)] [&_video]:[object-position:var(--media-object-position,center)]':
         !isShadowDOM,
     },
-    '[--default-accent-color:oklch(1_0_0)]',
-    '[--border-color:light-dark(oklch(0_0_0/0.15),oklch(1_0_0/0.15))]',
-    '[--focus-ring-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
-    '**:[--focus-ring-color:oklch(1_0_0)]',
-    '[--container-border-radius:var(--media-border-radius,0.75rem)]',
-    '[--media-video-border-radius:var(--container-border-radius)]',
-    '[--controls-background-color:transparent]',
-    '[--controls-transition-duration:100ms]',
-    '[--controls-transition-timing-function:ease-out]',
-    '[--error-dialog-transition-duration:150ms]',
-    '[--error-dialog-transition-delay:100ms]',
-    '[--error-dialog-transition-timing-function:ease-out]',
-    '[--popup-transition-duration:100ms]',
-    '[--popup-transition-timing-function:ease-out]',
-    '[--popover-backdrop-filter:blur(16px)_saturate(1.5)]',
-    '[--popover-background-color:oklch(0_0_0/0.5)]',
-    '[--popover-border-color:oklch(1_0_0/0.1)]',
-    '[--tooltip-backdrop-filter:var(--popover-backdrop-filter)]',
-    '[--tooltip-background-color:var(--popover-background-color)]',
-    '[--tooltip-border-color:var(--popover-border-color)]',
-    '[--tooltip-text-color:currentColor]',
+    '[--media-default-accent-color:oklch(1_0_0)]',
+    '[--media-border-color:light-dark(oklch(0_0_0/0.15),oklch(1_0_0/0.15))]',
+    '[--media-focus-ring-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
+    '**:[--media-focus-ring-color:oklch(1_0_0)]',
+    '[--media-container-border-radius:var(--media-border-radius,0.75rem)]',
+    '[--media-video-border-radius:var(--media-container-border-radius)]',
+    '[--media-controls-background-color:transparent]',
+    '[--media-controls-transition-duration:100ms]',
+    '[--media-controls-transition-timing-function:ease-out]',
+    '[--media-error-dialog-transition-duration:150ms]',
+    '[--media-error-dialog-transition-delay:100ms]',
+    '[--media-error-dialog-transition-timing-function:ease-out]',
+    '[--media-popup-transition-duration:100ms]',
+    '[--media-popup-transition-timing-function:ease-out]',
+    '[--media-popover-backdrop-filter:blur(16px)_saturate(1.5)]',
+    '[--media-popover-background-color:oklch(0_0_0/0.5)]',
+    '[--media-popover-border-color:oklch(1_0_0/0.1)]',
+    '[--media-tooltip-backdrop-filter:var(--media-popover-backdrop-filter)]',
+    '[--media-tooltip-background-color:var(--media-popover-background-color)]',
+    '[--media-tooltip-border-color:var(--media-popover-border-color)]',
+    '[--media-tooltip-text-color:currentColor]',
     // Fullscreen scale
-    'min-[1280px]:[&:fullscreen]:[--scale:1.25]',
-    'min-[1536px]:[&:fullscreen]:[--scale:1.5]',
-    'min-[1920px]:[&:fullscreen]:[--scale:1.75]',
-    'motion-reduce:[--error-dialog-transition-duration:50ms]',
-    'motion-reduce:[--error-dialog-transition-delay:0ms]',
-    'motion-reduce:[--popup-transition-duration:0ms]',
-    '[@media(prefers-reduced-transparency:reduce)]:[--controls-background-color:oklch(0_0_0)]',
-    'contrast-more:[--controls-background-color:oklch(0_0_0)]',
-    '[@media(prefers-reduced-transparency:reduce)]:[--tooltip-background-color:oklch(0_0_0)]',
-    'contrast-more:[--tooltip-background-color:oklch(0_0_0)]',
-    'pointer-fine:has-[[data-controls]:not([data-visible])]:[--controls-transition-duration:300ms]',
-    'pointer-coarse:has-[[data-controls]:not([data-visible])]:[--controls-transition-duration:150ms]',
-    'motion-reduce:has-[[data-controls]:not([data-visible])]:[--controls-transition-duration:50ms]',
+    'min-[1280px]:[&:fullscreen]:[--media-scale:1.25]',
+    'min-[1536px]:[&:fullscreen]:[--media-scale:1.5]',
+    'min-[1920px]:[&:fullscreen]:[--media-scale:1.75]',
+    'motion-reduce:[--media-error-dialog-transition-duration:50ms]',
+    'motion-reduce:[--media-error-dialog-transition-delay:0ms]',
+    'motion-reduce:[--media-popup-transition-duration:0ms]',
+    '[@media(prefers-reduced-transparency:reduce)]:[--media-controls-background-color:oklch(0_0_0)]',
+    'contrast-more:[--media-controls-background-color:oklch(0_0_0)]',
+    '[@media(prefers-reduced-transparency:reduce)]:[--media-tooltip-background-color:oklch(0_0_0)]',
+    'contrast-more:[--media-tooltip-background-color:oklch(0_0_0)]',
+    'pointer-fine:has-[[data-controls]:not([data-visible])]:[--media-controls-transition-duration:300ms]',
+    'pointer-coarse:has-[[data-controls]:not([data-visible])]:[--media-controls-transition-duration:150ms]',
+    'motion-reduce:has-[[data-controls]:not([data-visible])]:[--media-controls-transition-duration:50ms]',
     // Caption track CSS variables (consumed by the native caption bridge in light DOM)
     '[--media-caption-track-y:--spacing(-2)]',
     '[--media-caption-track-delay:25ms]',
-    '[--media-caption-track-duration:var(--controls-transition-duration)]',
+    '[--media-caption-track-duration:var(--media-controls-transition-duration)]',
     'has-[[data-controls][data-visible]]:[--media-caption-track-y:--spacing(-18)]',
     '@2xl/media-root:has-[[data-controls][data-visible]]:*:[--media-caption-track-y:--spacing(-12)]',
     // Native caption track container
@@ -83,7 +83,7 @@ export const container = (isShadowDOM: boolean) =>
         ]
       : [],
     // Fullscreen
-    '[&:fullscreen]:[--container-border-radius:0]',
+    '[&:fullscreen]:[--media-container-border-radius:0]',
     {
       '[&:fullscreen_video]:object-contain': !isShadowDOM,
       '[&:fullscreen_::slotted(video)]:object-contain': isShadowDOM,
@@ -96,14 +96,14 @@ export const controls = cn(
   baseControls,
   // Position & wrapping layout (small)
   'absolute bottom-1 inset-x-1',
-  '[--base-side-offset:5] [--base-boundary-offset:1]',
-  '[--volume-mask:linear-gradient(to_right,transparent_10%,black_25%,black_100%)]',
+  '[--media-base-side-offset:5] [--media-base-boundary-offset:1]',
+  '[--media-volume-mask:linear-gradient(to_right,transparent_10%,black_25%,black_100%)]',
   'gap-x-2 flex-wrap rounded-[--spacing(3)] group/controls',
   'text-white z-20',
   'peer-data-open/error:hidden',
-  'ease-(--controls-transition-timing-function)',
-  'duration-[calc(var(--controls-transition-duration)/2)]',
-  'not-data-visible:duration-(--controls-transition-duration)',
+  'ease-(--media-controls-transition-timing-function)',
+  'duration-[calc(var(--media-controls-transition-duration)/2)]',
+  'not-data-visible:duration-(--media-controls-transition-duration)',
   'pointer-fine:transition-[translate,filter,opacity]',
   'pointer-coarse:transition-[translate,opacity]',
   // Hidden state
@@ -111,16 +111,16 @@ export const controls = cn(
   'motion-safe:not-data-visible:translate-y-full',
   'pointer-fine:motion-safe:not-data-visible:blur-sm',
   // Single-row layout (large)
-  '@2xl/media-root:flex-nowrap @2xl/media-root:[--controls-padding:2] @2xl/media-root:[--base-side-offset:2]'
+  '@2xl/media-root:flex-nowrap @2xl/media-root:[--media-controls-padding:2] @2xl/media-root:[--media-base-side-offset:2]'
 );
 
 /* Button groups */
 
 const volumeMaskTarget = cn(
-  '[mask-image:var(--volume-mask-image,none)]',
+  '[mask-image:var(--media-volume-mask-image,none)]',
   '[mask-repeat:no-repeat]',
-  '[mask-position:var(--volume-mask-position,100%_0)]',
-  '[mask-size:var(--volume-mask-size,200%_100%)]',
+  '[mask-position:var(--media-volume-mask-position,100%_0)]',
+  '[mask-size:var(--media-volume-mask-size,200%_100%)]',
   '[transition:mask-position_50ms_ease-out]'
 );
 
@@ -129,9 +129,9 @@ export const buttonGroupEnd = cn(
   baseButtonGroup,
   volumeMaskTarget,
   'flex-1 justify-end @2xl/media-root:flex-none',
-  'group-has-[[data-volume-level][aria-expanded=true]]/controls:@max-2xl/media-root:[--volume-mask-image:var(--volume-mask)]',
-  'group-has-[[data-volume-level][aria-expanded=true]]/controls:@max-2xl/media-root:[--volume-mask-position:0_0]',
-  'group-has-[[data-volume-level][aria-expanded=true]]/controls:@max-2xl/media-root:[--volume-mask-size:400%_100%]'
+  'group-has-[[data-volume-level][aria-expanded=true]]/controls:@max-2xl/media-root:[--media-volume-mask-image:var(--media-volume-mask)]',
+  'group-has-[[data-volume-level][aria-expanded=true]]/controls:@max-2xl/media-root:[--media-volume-mask-position:0_0]',
+  'group-has-[[data-volume-level][aria-expanded=true]]/controls:@max-2xl/media-root:[--media-volume-mask-size:400%_100%]'
 );
 
 export const spacer = 'grow';
@@ -143,10 +143,10 @@ export const time = {
   controls: cn(
     baseTime.controls,
     volumeMaskTarget,
-    '[--slider-height:--spacing(5)] grow-0 shrink-0 basis-full order-[-1] px-1.5',
-    '@2xl/media-root:[--slider-height:--spacing(8)] @2xl/media-root:grow @2xl/media-root:shrink @2xl/media-root:basis-0 @2xl/media-root:order-[unset]',
-    'group-has-[[data-volume-level][aria-expanded=true]]/controls:@2xl/media-root:[--volume-mask-image:var(--volume-mask)]',
-    'group-has-[[data-volume-level][aria-expanded=true]]/controls:@2xl/media-root:[--volume-mask-position:0_0]'
+    '[--media-slider-height:--spacing(5)] grow-0 shrink-0 basis-full order-[-1] px-1.5',
+    '@2xl/media-root:[--media-slider-height:--spacing(8)] @2xl/media-root:grow @2xl/media-root:shrink @2xl/media-root:basis-0 @2xl/media-root:order-[unset]',
+    'group-has-[[data-volume-level][aria-expanded=true]]/controls:@2xl/media-root:[--media-volume-mask-image:var(--media-volume-mask)]',
+    'group-has-[[data-volume-level][aria-expanded=true]]/controls:@2xl/media-root:[--media-volume-mask-position:0_0]'
   ),
 };
 
@@ -157,7 +157,7 @@ export const error = {
   root: cn(baseError.root, 'pointer-events-none outline-none'),
   dialog: cn(baseError.dialog, 'pointer-events-auto w-full max-w-64 p-4 rounded-none'),
   content: cn(baseError.content, 'p-0 py-1.5'),
-  title: 'text-(length:--font-size-medium)',
+  title: 'text-(length:--media-font-size-medium)',
 };
 
 /* Thumbnail */
@@ -169,12 +169,12 @@ export const thumbnail = baseThumbnail;
 export const slider = {
   ...baseSlider,
   track: cn(baseSlider.track, 'ring-1 ring-black/5'),
-  value: cn(baseSlider.value, 'px-3 text-shadow-2xs text-shadow-(color:--shadow-current-color)'),
+  value: cn(baseSlider.value, 'px-3 text-shadow-2xs text-shadow-(color:--media-shadow-current-color)'),
   preview: cn(
     baseSlider.preview,
-    '[--preview-end-inset:calc(100cqi-100%)]',
-    '[--preview-left:clamp(calc(var(--max-size)/2),var(--media-slider-pointer),calc(100%-var(--max-size)/2+var(--preview-end-inset)))]',
-    '@2xl/media-root:[--preview-left:var(--media-slider-pointer)]'
+    '[--media-preview-end-inset:calc(100cqi-100%)]',
+    '[--media-preview-left:clamp(calc(var(--media-max-size)/2),var(--media-slider-pointer),calc(100%-var(--media-max-size)/2+var(--media-preview-end-inset)))]',
+    '@2xl/media-root:[--media-preview-left:var(--media-slider-pointer)]'
   ),
 };
 

--- a/site/src/content/docs/concepts/skins.mdx
+++ b/site/src/content/docs/concepts/skins.mdx
@@ -110,7 +110,7 @@ To use Tailwind or change the underlying CSS, [eject the skin](../how-to/customi
 
 ### Shared limitations
 
-- Both style systems assume a 16px root font size and use rem units for sizing.
+- Skin spacing and icons use a fixed `16px` base by default. Vanilla CSS font sizes use the same base, while Tailwind font sizes use rem units and assume a 16px root font size.
 - The default font stack includes [`Inter`](https://rsms.me/inter/), but we do not load the webfont for you. If Inter is unavailable, the skin uses system fonts.
 
 ### Ejected vanilla CSS
@@ -119,5 +119,5 @@ To use Tailwind or change the underlying CSS, [eject the skin](../how-to/customi
 
 ### Ejected Tailwind
 
-- Ejected skins currently assume the default configuration. A future CLI eject command will support custom class prefixes. For now, edit the ejected skin to use your prefix.
-- Ejected skins currently support Tailwind 4.2.x.
+- Ejected skins establish their own spacing scale but otherwise assume the default configuration. A future CLI eject command will support custom class prefixes. For now, edit the ejected skin to use your prefix.
+- Ejected skins currently support Tailwind 4.3.x.

--- a/site/src/content/docs/how-to/customize-skins.mdx
+++ b/site/src/content/docs/how-to/customize-skins.mdx
@@ -4,7 +4,6 @@ description: Learn the public customization surface for packaged Video.js skins 
 ---
 
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
-import StyleCase from '@/components/docs/StyleCase.astro';
 import EjectedSkin from '@/components/docs/EjectedSkin.astro';
 import DocsLink from '@/components/docs/DocsLink.astro';
 
@@ -46,7 +45,7 @@ Set these CSS custom properties directly on the skin:
 | `--media-accent-color` | The color of slider fills and accented controls | [`<color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) | `#f5c518` |
 | `--media-accent-text-color` | The color of text and icons shown on the accent color | [`<color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) | `black` |
 | `--media-border-radius` | The border radius of the media player | A valid [border-radius value](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/border-radius#values) | `1rem` |
-| `--media-scale-unit` | The base sizing unit for Vanilla CSS skins | [`<length>`](https://developer.mozilla.org/en-US/docs/Web/CSS/length) | `1rem` |
+| `--media-scale-unit` | The base sizing unit for skin spacing and icons | [`<length>`](https://developer.mozilla.org/en-US/docs/Web/CSS/length) | `1rem` |
 
 If you omit `--media-accent-text-color`, the skins choose a contrasting text color from `--media-accent-color` using [`contrast-color()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/contrast-color). You only need to set it when you want to override that result.
 
@@ -62,19 +61,15 @@ The audio skins adapt their main palette for light and dark mode using [`light-d
 
 The video skins keep their dark control presentation in both color schemes.
 
-<StyleCase styles={["css"]}>
-
 ### Scale with the document font size
 
-Vanilla CSS skins use `--media-scale-unit` as the base for control spacing, icon sizes, and font sizes. It defaults to `16px`, so the player UI does not change with the document root font size. Set it to `1rem` on the player or an ancestor to make the UI scale with the document root font size:
+Vanilla CSS and Tailwind skins use `--media-scale-unit` as the base for control spacing and icon sizes. Vanilla CSS skins also use it for font sizes. It defaults to `16px`, so player sizing does not change with the document root font size or the app's Tailwind spacing scale. Set it to `1rem` on the player or an ancestor to make the UI scale with the document root font size:
 
 ```css
 .player {
   --media-scale-unit: 1rem;
 }
 ```
-
-</StyleCase>
 
 You can also add your own class names to the skins.
 


### PR DESCRIPTION
## Summary

Prefix all CSS custom properties with `media-`. My original intention was to omit a prefix and keep things simple but this fixes a few issues:

- Much reduced changes of clashing with external CSS custom properties or `@property` registrations.
- Removes a clash between our internal CSS custom properties and Tailwind - e.g. the `--spacing` property silently clashes with Tailwind's `--spacing()` _function_ as discovered in testing.

### Ok, why not something like `--_spacing`? 

`--_spacing` may still collide with another design system using the same “private” convention. The underscore has no browser-enforced privacy semantics—it is only a visual hint. The CSS specification explicitly recommends library-specific prefixes to avoid clashes between independently authored systems. [W3C CSS Values §4.3](https://www.w3.org/TR/css-values-4/#dashed-idents)

The documented public API surface for CSS customization remains the same. We may add `--media-font-family` but that's still in discussion (cc @decepulis). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical rename across player UI styling; public customization vars are unchanged but any external overrides of old unprefixed names would break, and visual regressions are possible if a reference was missed.
> 
> **Overview**
> **Renames skin-owned CSS custom properties** (spacing, scale, accent, surfaces, menus, transitions, etc.) to the `--media-*` namespace across **default** and **minimal** skins in both hand-written CSS and Tailwind class strings, so internal tokens no longer collide with host pages or Tailwind’s `--spacing` machinery.
> 
> **Tailwind skin containers** now derive `--media-spacing` from `--media-scale-unit` / `--media-scale`, then **bridge** `--spacing: var(--media-spacing)` at the theme boundary so native utilities scale with the player without overriding the host’s global spacing. The old `--spacing-proxy` / descendant `--spacing` scaling approach is removed in favor of this explicit mapping.
> 
> **Migration docs** are updated to treat skin spacing as separate from site Tailwind spacing and to document runtime-derived multipliers with `--media-spacing` where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 059f73a78ac82d62bbb28735fe5eb4ef3268ba8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->