### PR TITLE
style(root): enable jsdoc formatting

### DIFF
--- a/apps/e2e/fixtures/resources.ts
+++ b/apps/e2e/fixtures/resources.ts
@@ -18,33 +18,29 @@ export const MEDIA = {
     storyboard: 'https://image.mux.com/lhnU49l1VGi3zrTAZhDm9LUUxSjpaPW9BL4jY25Kwo4/storyboard.vtt',
   },
   /**
-   * HLS/CMAF with a 4K ladder — rungs from 640x360 up to 3838x2160, so a screen
-   * emulated below the top rung has something smaller to cap to. Video-only.
+   * HLS/CMAF with a 4K ladder — rungs from 640x360 up to 3838x2160, so a screen emulated below the top rung has
+   * something smaller to cap to. Video-only.
    *
-   * The off-by-two widths are the source's near-square pixel aspect ratio rather
-   * than a typo, which is why the cap compares pixel areas instead of matching
-   * `1920x1080`-style tiers.
+   * The off-by-two widths are the source's near-square pixel aspect ratio rather than a typo, which is why the cap
+   * compares pixel areas instead of matching `1920x1080`-style tiers.
    */
   hls4k: {
     url: 'https://stream.mux.com/SfAaZ9InpM8FMfky7DkNBuTpxEDqU8Jchpa49urOWcs.m3u8',
   },
   /**
-   * HLS/CMAF carrying **no video renditions at all** — the one failure shape with
-   * no per-rendition cause behind it, since nothing resolves and so nothing
-   * reports. A video-only composition can never play it.
+   * HLS/CMAF carrying **no video renditions at all** — the one failure shape with no per-rendition cause behind it,
+   * since nothing resolves and so nothing reports. A video-only composition can never play it.
    */
   hlsAudioOnly: {
     url: 'https://stream.mux.com/2NEjLyf6ETnskbfAtbM00Vdzb97B00OKUUQcRD6LZpBRw.m3u8',
   },
   /**
-   * DRM-protected HLS, deliberately left unlicensed: the video renditions carry
-   * `EXT-X-KEY` for all three key systems and no license path is supplied, so an
-   * engine with no EME pipeline reports the source as protected. Here to be
+   * DRM-protected HLS, deliberately left unlicensed: the video renditions carry `EXT-X-KEY` for all three key systems
+   * and no license path is supplied, so an engine with no EME pipeline reports the source as protected. Here to be
    * refused, not played.
    *
-   * The playback token is signed to `exp: 2147483647` (January 2038), so this
-   * doesn't rot out from under CI. Same asset the sandbox offers as
-   * `hls-drm-unlicensed`.
+   * The playback token is signed to `exp: 2147483647` (January 2038), so this doesn't rot out from under CI. Same asset
+   * the sandbox offers as `hls-drm-unlicensed`.
    */
   hlsDrm: {
     url: 'https://stream.mux.com/FefhWnSMzDqz5z9yxssihdRx8dV6srhYJ8301uQBhRak.m3u8?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InYiLCJleHAiOjIxNDc0ODM2NDd9.jXIpJZPB7diM5M6jMVRQ6dELY5YnONzC8jJClm7CT1nm-q25F5PiCvHcdLGqerjN1V_7T9cjhSX02p1i0UiABaKX2Wa4HCf6H6ZSKbY3MiCiRJHnfZzr_cVHCuBRXJlMzXesK_VzgP4kVrVi9-Sj8fGaeQmt4mB0sgtGGM7LpGV1IJdv_9aWnqQpQK7IeWi9ivNwa9Vw-PeppfOFdyQbqYJScIAY-_k6fzGaQucONyIolFGJZuBcan3nDRvCUpSFi0vPO87jf5Zbp6kn-HeARmUTYDPBLoeVSjttxYhoeDQYtNeqbuJ3Tj6S1_9TsE_SNSNZm3lxHoJCz5Wp_YcusQ',
@@ -56,8 +52,8 @@ export const MEDIA = {
 } as const;
 
 /**
- * Caption files the Vite app serves from `apps/vite/src/public`. Real requests
- * over HTTP, unlike a `data:text/vtt` URL, which WebKit treats differently.
+ * Caption files the Vite app serves from `apps/vite/src/public`. Real requests over HTTP, unlike a `data:text/vtt` URL,
+ * which WebKit treats differently.
  */
 export const CAPTIONS = {
   /** One cue spanning 0–30s. */

--- a/apps/e2e/fixtures/selectors.ts
+++ b/apps/e2e/fixtures/selectors.ts
@@ -1,11 +1,11 @@
 /**
  * Cross-renderer selectors that work for both HTML (Web Components) and React.
  *
- * HTML uses custom element tags: `media-play-button`, `media-time-slider`, etc.
- * React uses standard elements with CSS classes: `button.media-button--play`, etc.
+ * HTML uses custom element tags: `media-play-button`, `media-time-slider`, etc. React uses standard elements with CSS
+ * classes: `button.media-button--play`, etc.
  *
- * Both renderers apply the **same data attributes** for state (`data-paused`,
- * `data-muted`, etc.), which is what tests assert against.
+ * Both renderers apply the **same data attributes** for state (`data-paused`, `data-muted`, etc.), which is what tests
+ * assert against.
  *
  * Each selector uses a CSS `,` (or) to match either renderer.
  */

--- a/apps/e2e/page-objects/player.ts
+++ b/apps/e2e/page-objects/player.ts
@@ -5,12 +5,11 @@ import { DATA_ATTRS, SELECTORS } from '../fixtures/selectors';
 /**
  * Page Object Model for the Video.js player.
  *
- * Uses cross-renderer selectors that work for both:
- * - HTML (Web Components): custom element tags like `media-play-button`
- * - React: standard elements with CSS classes like `.media-button--play`
+ * Uses cross-renderer selectors that work for both: - HTML (Web Components): custom element tags like
+ * `media-play-button` - React: standard elements with CSS classes like `.media-button--play`
  *
- * Both renderers share the same data attributes for state, so all
- * assertions against `data-paused`, `data-muted`, etc. are portable.
+ * Both renderers share the same data attributes for state, so all assertions against `data-paused`, `data-muted`, etc.
+ * are portable.
  *
  * Playwright auto-pierces Shadow DOM for HTML custom elements.
  */
@@ -291,8 +290,8 @@ export class PlayerPage {
   }
 
   /**
-   * Opens the playback rate menu and selects the first option that differs from the current rate.
-   * Skins expose rate via a menu (not cycle-on-trigger).
+   * Opens the playback rate menu and selects the first option that differs from the current rate. Skins expose rate via
+   * a menu (not cycle-on-trigger).
    */
   async selectAlternativePlaybackRate(): Promise<void> {
     const initialRate = await this.getPlaybackRate();

--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -1,10 +1,9 @@
 /**
  * Generates Vite test pages from PageEntry definitions.
  *
- * Reads the media type configs and page arrays, then writes .ts/.tsx + .html
- * files to `apps/vite/src/pages/`, which is gitignored — every page there comes
- * from this script, including the special ones (ejected skins, captions,
- * background video), which take their own templates rather than the player shell.
+ * Reads the media type configs and page arrays, then writes .ts/.tsx + .html files to `apps/vite/src/pages/`, which is
+ * gitignored — every page there comes from this script, including the special ones (ejected skins, captions, background
+ * video), which take their own templates rather than the player shell.
  *
  * Run: `pnpm --dir apps/e2e generate-pages`
  */
@@ -289,15 +288,12 @@ createRoot(document.getElementById('root')!).render(<App />);
 // ---------------------------------------------------------------------------
 
 /**
- * The SPF background-video Media, alone rather than inside a player: the
- * composition subscribes to no store features and has no controls, so a skin
- * would only add moving parts to what the spec is measuring.
+ * The SPF background-video Media, alone rather than inside a player: the composition subscribes to no store features
+ * and has no controls, so a skin would only add moving parts to what the spec is measuring.
  *
- * `?src=` picks the source, so one page serves every shape
- * `spf-background-video.spec.ts` drives — playable, MPEG-TS, encrypted,
- * audio-only — and a test can compare two of them without a page each. Assigned
- * as a property rather than interpolated into markup, since the DRM source
- * carries a signed-URL query string.
+ * `?src=` picks the source, so one page serves every shape `spf-background-video.spec.ts` drives — playable, MPEG-TS,
+ * encrypted, audio-only — and a test can compare two of them without a page each. Assigned as a property rather than
+ * interpolated into markup, since the DRM source carries a signed-URL query string.
  */
 function backgroundVideoPage(config: MediaTypeConfig, resource: string): string {
   return `${config.imports.map((imp) => `import '${imp}';`).join('\n')}
@@ -318,11 +314,10 @@ document.getElementById('root')!.append(media);
 }
 
 /**
- * The React counterpart, and the only place `onError` can be observed: the
- * component hands out no reference to its Media, so what a consumer sees is
- * whatever React's own event plumbing delivers. Failures are counted onto
- * `window` rather than rendered — the assertion is that the prop fired at all,
- * since the condition behind it isn't reachable from here by design.
+ * The React counterpart, and the only place `onError` can be observed: the component hands out no reference to its
+ * Media, so what a consumer sees is whatever React's own event plumbing delivers. Failures are counted onto `window`
+ * rather than rendered — the assertion is that the prop fired at all, since the condition behind it isn't reachable
+ * from here by design.
  */
 function reactBackgroundVideoPage(media: string, resource: string): string {
   const reactMedia = REACT_MEDIA[media];

--- a/apps/e2e/scripts/sync-ejected-skins.ts
+++ b/apps/e2e/scripts/sync-ejected-skins.ts
@@ -1,6 +1,6 @@
 /**
- * Syncs the generated ejected skin source from the docs site build
- * into the e2e test app so the ejected React test uses real output.
+ * Syncs the generated ejected skin source from the docs site build into the e2e test app so the ejected React test uses
+ * real output.
  *
  * Run after `pnpm -F site ejected-skins` and before e2e tests.
  */

--- a/apps/e2e/tests/captions.spec.ts
+++ b/apps/e2e/tests/captions.spec.ts
@@ -67,20 +67,18 @@ test.describe('Captions', () => {
 });
 
 /**
- * hls.js resets every text track on the media element when it attaches, detaches,
- * or loads a source, so a `<track>` that loaded before the source was known used
- * to end up selected but empty — the browser never parses a loaded track again.
+ * Hls.js resets every text track on the media element when it attaches, detaches, or loads a source, so a `<track>`
+ * that loaded before the source was known used to end up selected but empty — the browser never parses a loaded track
+ * again.
  *
- * Losing cues is the part no one can undo, so that is what these assert. Which
- * track is selected afterwards is the browser's call: loading a source re-runs
- * automatic text-track selection, and WebKit turns off caption tracks it did not
- * pick itself. `withPreservedTextTracks` unit tests cover the mode it restores.
+ * Losing cues is the part no one can undo, so that is what these assert. Which track is selected afterwards is the
+ * browser's call: loading a source re-runs automatic text-track selection, and WebKit turns off caption tracks it did
+ * not pick itself. `withPreservedTextTracks` unit tests cover the mode it restores.
  */
 test.describe('Captions sideloaded before an hls.js source', () => {
   /**
-   * Cues on the sideloaded track, read from the element the page author sees.
-   * A disabled track reports no cues at all, so read them through a mode that
-   * exposes them and put the track back the way it was found.
+   * Cues on the sideloaded track, read from the element the page author sees. A disabled track reports no cues at all,
+   * so read them through a mode that exposes them and put the track back the way it was found.
    */
   const englishCues = (page: Page) => {
     return page.evaluate(() => {
@@ -102,12 +100,10 @@ test.describe('Captions sideloaded before an hls.js source', () => {
   };
 
   /**
-   * Selects the track from the page rather than leaning on its `default`
-   * attribute. The element clones `<track>` children into its inner `<video>`,
-   * and whether a script-added track wins automatic text-track selection is up
-   * to the browser's caption preferences — WebKit leaves it `disabled`, which
-   * also stops it from ever loading its cues. A track has to be enabled once to
-   * load them, which is the state these tests are about.
+   * Selects the track from the page rather than leaning on its `default` attribute. The element clones `<track>`
+   * children into its inner `<video>`, and whether a script-added track wins automatic text-track selection is up to
+   * the browser's caption preferences — WebKit leaves it `disabled`, which also stops it from ever loading its cues. A
+   * track has to be enabled once to load them, which is the state these tests are about.
    */
   const showEnglishTrack = (page: Page) => {
     return page.waitForFunction(() => {

--- a/apps/e2e/tests/gestures.spec.ts
+++ b/apps/e2e/tests/gestures.spec.ts
@@ -4,15 +4,11 @@ import { DATA_ATTRS } from '../fixtures/selectors';
 import { PlayerPage } from '../page-objects/player';
 
 /**
- * Gesture tests — validates the media-gesture components respond to
- * pointer events on the player container (not individual buttons).
+ * Gesture tests — validates the media-gesture components respond to pointer events on the player container (not
+ * individual buttons).
  *
- * The player's gesture system:
- * - tap (mouse, center):  togglePaused
- * - tap (touch):          toggleControls
- * - doubletap (left):     seek backward 10s
- * - doubletap (center):   toggleFullscreen
- * - doubletap (right):    seek forward 10s
+ * The player's gesture system: - tap (mouse, center): togglePaused - tap (touch): toggleControls - doubletap (left):
+ * seek backward 10s - doubletap (center): toggleFullscreen - doubletap (right): seek forward 10s
  */
 
 // Helper to get center coordinates of an element

--- a/apps/e2e/tests/menu-scroll.spec.ts
+++ b/apps/e2e/tests/menu-scroll.spec.ts
@@ -11,8 +11,8 @@ type PanelHandle = ElementHandle<HTMLElement>;
 /**
  * Resolve the on-screen menu panel once the submenu view transition settled.
  *
- * The transition briefly leaves two panels on screen and clips their overflow,
- * so the panel is pinned to a handle to keep every later read on one element.
+ * The transition briefly leaves two panels on screen and clips their overflow, so the panel is pinned to a handle to
+ * keep every later read on one element.
  */
 async function resolveActiveMenuPanel(page: Page, player: PlayerPage): Promise<PanelHandle> {
   await expect(page.locator(SELECTORS.activeMenuPanel)).toHaveCount(1);

--- a/apps/e2e/tests/spf-background-video.spec.ts
+++ b/apps/e2e/tests/spf-background-video.spec.ts
@@ -3,24 +3,19 @@ import { expect, type Page, test } from '@playwright/test';
 import { MEDIA } from '../fixtures/resources';
 
 /**
- * The SPF background-video composition end to end: a real manifest through the
- * engine, onto the Media's `error`, and out to whichever surface the platform
- * gives a consumer.
+ * The SPF background-video composition end to end: a real manifest through the engine, onto the Media's `error`, and
+ * out to whichever surface the platform gives a consumer.
  *
- * What only a browser can establish, and so what this file is for: **nothing
- * about an unplayable source reaches the media element here.** The unit tests
- * write `state.errors` directly and assert the promotion; they cannot show that
- * the engine derives that sequence from a real playlist, and they cannot show
- * that `HTMLMediaElement.error` stays null while it does. That claim is the
- * premise the whole surface rests on — if a browser ever starts reporting these
+ * What only a browser can establish, and so what this file is for: **nothing about an unplayable source reaches the
+ * media element here.** The unit tests write `state.errors` directly and assert the promotion; they cannot show that
+ * the engine derives that sequence from a real playlist, and they cannot show that `HTMLMediaElement.error` stays null
+ * while it does. That claim is the premise the whole surface rests on — if a browser ever starts reporting these
  * itself, this is where we find out.
  *
- * The pinned variant's own shape is the other thing pinned down here. Only the
- * *selected* rendition's playlist is ever resolved, so an unplayable pick
- * produces a **cause with no verdict behind it** — nothing prunes the renditions
- * that were never probed, so the candidate set never empties. A source offering
- * no video at all is the mirror case: a verdict with no cause. Both are fatal,
- * and asserting the sequence (not just the surfaced code) is what would catch a
+ * The pinned variant's own shape is the other thing pinned down here. Only the _selected_ rendition's playlist is ever
+ * resolved, so an unplayable pick produces a **cause with no verdict behind it** — nothing prunes the renditions that
+ * were never probed, so the candidate set never empties. A source offering no video at all is the mirror case: a
+ * verdict with no cause. Both are fatal, and asserting the sequence (not just the surfaced code) is what would catch a
  * `select-tracks` refactor quietly changing which.
  *
  * @see internal/design/spf/features/errors.md

--- a/apps/e2e/tests/spf-mse-recovery.spec.ts
+++ b/apps/e2e/tests/spf-mse-recovery.spec.ts
@@ -5,25 +5,20 @@ import { PlayerPage } from '../page-objects/player';
 /**
  * SPF MediaSource attach + sourceclose-recovery smoke tests.
  *
- * Runs against the SPF engine page (`hls-video`) on every vite-*
- * project (Chromium, WebKit, Firefox). Two things under test:
+ * Runs against the SPF engine page (`hls-video`) on every vite-* project (Chromium, WebKit, Firefox). Two things under
+ * test:
  *
- * 1. The attach shape: the object URL rides a `<source>` child on every
- *    platform, not the `src` attribute. The HLS engine bakes
- *    `attachMediaSourceAsSourceElement` unconditionally because it composes
- *    `setupAirPlay`, whose native-HLS fallback has to stay a selectable
- *    sibling — `src`/`srcObject` would commit the element to the MSE resource
- *    and make any sibling inert.
- * 2. Sourceclose recovery: when the MSE attachment is torn down out from under
- *    the engine (the observable shape of an AirPlay handoff return or MMS
- *    eviction — the MediaSource fires `sourceclose`), `setupMediaSource`
- *    must rebuild a fresh MediaSource for the same source and playback
- *    must come back.
+ * 1. The attach shape: the object URL rides a `<source>` child on every platform, not the `src` attribute. The HLS engine
+ *    bakes `attachMediaSourceAsSourceElement` unconditionally because it composes `setupAirPlay`, whose native-HLS
+ *    fallback has to stay a selectable sibling — `src`/`srcObject` would commit the element to the MSE resource and
+ *    make any sibling inert.
+ * 2. Sourceclose recovery: when the MSE attachment is torn down out from under the engine (the observable shape of an
+ *    AirPlay handoff return or MMS eviction — the MediaSource fires `sourceclose`), `setupMediaSource` must rebuild a
+ *    fresh MediaSource for the same source and playback must come back.
  *
- * Position restore across the rebuild is asserted in unit tests
- * (`setup-mediasource.test.ts`, `apply-start-position.test.ts`) and verified
- * on-device for true AirPlay — this simulation's `load()` races the position
- * snapshot, so exact-position assertions would be flaky here.
+ * Position restore across the rebuild is asserted in unit tests (`setup-mediasource.test.ts`,
+ * `apply-start-position.test.ts`) and verified on-device for true AirPlay — this simulation's `load()` races the
+ * position snapshot, so exact-position assertions would be flaky here.
  */
 
 const PAGE = '/pages/html-hls-video-fmp4.html';

--- a/apps/e2e/tests/spf-unsupported-source.spec.ts
+++ b/apps/e2e/tests/spf-unsupported-source.spec.ts
@@ -5,30 +5,24 @@ import { DATA_ATTRS, SELECTORS } from '../fixtures/selectors';
 import { PlayerPage } from '../page-objects/player';
 
 /**
- * SPF unsupported-source error surfacing, end to end: engine detection →
- * adapter `error` → the player store's error feature → the dialog.
+ * SPF unsupported-source error surfacing, end to end: engine detection → adapter `error` → the player store's error
+ * feature → the dialog.
  *
- * `error-dialog.spec.ts` covers the dialog itself, but fakes the error with
- * `Object.defineProperty(video, 'error')`. Nothing there exercises a real
- * engine verdict, which is what the PRD's *Error Notices* ask is about: a
- * source the SPF engine genuinely cannot play should fail visibly instead of
- * stalling in silence.
+ * `error-dialog.spec.ts` covers the dialog itself, but fakes the error with `Object.defineProperty(video, 'error')`.
+ * Nothing there exercises a real engine verdict, which is what the PRD's _Error Notices_ ask is about: a source the SPF
+ * engine genuinely cannot play should fail visibly instead of stalling in silence.
  *
- * The source under test is an MPEG-TS ladder with no fMP4 rendition — the
- * PRD's exact legacy-format scenario. The engine derives `video/mp2t` from the
- * segment extension (no `EXT-X-MAP`), `canPlayTrack` prunes every video
- * rendition as unplayable, and `track-switching` reports the verdict for a
- * type that has renditions but none selectable. The adapter then substitutes
- * the unsupported-playback-feature code, because a cause it has no pipeline
- * for is more useful to a consumer than "a type emptied".
+ * The source under test is an MPEG-TS ladder with no fMP4 rendition — the PRD's exact legacy-format scenario. The
+ * engine derives `video/mp2t` from the segment extension (no `EXT-X-MAP`), `canPlayTrack` prunes every video rendition
+ * as unplayable, and `track-switching` reports the verdict for a type that has renditions but none selectable. The
+ * adapter then substitutes the unsupported-playback-feature code, because a cause it has no pipeline for is more useful
+ * to a consumer than "a type emptied".
  *
- * Assertions are split deliberately. The code the adapter surfaces is the
- * engine's contract and is asserted exactly — as is the empty `message`, whose
- * emptiness is load-bearing: `resolveErrorDialogDescription` prefers a
- * non-empty message over the translation a code resolves to, so engine prose
- * here would silently displace the localized copy. Dialog copy is asserted
- * against the player's own `errors.unplayable` translation, which is where
- * viewer-facing wording lives now that the engine reports a code instead.
+ * Assertions are split deliberately. The code the adapter surfaces is the engine's contract and is asserted exactly —
+ * as is the empty `message`, whose emptiness is load-bearing: `resolveErrorDialogDescription` prefers a non-empty
+ * message over the translation a code resolves to, so engine prose here would silently displace the localized copy.
+ * Dialog copy is asserted against the player's own `errors.unplayable` translation, which is where viewer-facing
+ * wording lives now that the engine reports a code instead.
  *
  * @see internal/design/spf/features/errors.md
  */

--- a/apps/e2e/tests/visual/video-skin.spec.ts
+++ b/apps/e2e/tests/visual/video-skin.spec.ts
@@ -6,11 +6,9 @@ import { PlayerPage } from '../../page-objects/player';
 /**
  * Visual snapshot tests for the video skin.
  *
- * These verify the skin's CSS and layout aren't broken — not UX interactions.
- * Strategy:
- * - Screenshot the skin container in its initial paused state
- * - Generous pixel thresholds absorb cross-platform rendering differences
- * - Animations disabled globally (configured in playwright.config.ts)
+ * These verify the skin's CSS and layout aren't broken — not UX interactions. Strategy: - Screenshot the skin container
+ * in its initial paused state - Generous pixel thresholds absorb cross-platform rendering differences - Animations
+ * disabled globally (configured in playwright.config.ts)
  */
 
 const VISUAL_PAGES = [

--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -26,9 +26,8 @@ export const PRESETS = [
 ] as const;
 
 /**
- * Presets that hand playback to a third-party embed. They render one fixed
- * source rather than the source picker's list, and have no Tailwind skin
- * variant, so the navbar disables both controls for them.
+ * Presets that hand playback to a third-party embed. They render one fixed source rather than the source picker's list,
+ * and have no Tailwind skin variant, so the navbar disables both controls for them.
  */
 export const EMBED_PRESETS = [
   'vimeo-video',

--- a/apps/sandbox/app/shared/html/skins.ts
+++ b/apps/sandbox/app/shared/html/skins.ts
@@ -95,9 +95,8 @@ async function loadLiveVideoTailwindSkin(skin: Skin): Promise<string> {
 type VideoSkinOptions = { live?: boolean };
 
 /**
- * Loads and registers the video skin for the given skin / styling combination
- * and returns its custom element tag name. Pass `live: true` to swap in the
- * `live-video` skin variant (same feature set, trimmed time UI).
+ * Loads and registers the video skin for the given skin / styling combination and returns its custom element tag name.
+ * Pass `live: true` to swap in the `live-video` skin variant (same feature set, trimmed time UI).
  */
 export function loadVideoSkinTag(
   skin: Skin,

--- a/apps/sandbox/app/shared/i18n/locale-meta.ts
+++ b/apps/sandbox/app/shared/i18n/locale-meta.ts
@@ -7,6 +7,7 @@ export type SandboxLocalePack = (typeof SANDBOX_LOCALE_PACKS)[number];
 
 /**
  * Chrome Translator API tags (desktop).
+ *
  * @see https://developer.chrome.com/docs/ai/translator-api#supported_languages
  */
 const CHROME_TRANSLATOR_LOCALE_TAGS = [
@@ -59,8 +60,8 @@ export type SandboxBrowserLocaleTag = Extract<
 >;
 
 /**
- * Locales with no Video.js pack — Chrome Translator only, excluding tags we already ship.
- * Derived from {@link CHROME_TRANSLATOR_LOCALE_TAGS} so unsupported tags never appear in the picker.
+ * Locales with no Video.js pack — Chrome Translator only, excluding tags we already ship. Derived from
+ * {@link CHROME_TRANSLATOR_LOCALE_TAGS} so unsupported tags never appear in the picker.
  */
 export const SANDBOX_BROWSER_LOCALE_TAGS: readonly SandboxBrowserLocaleTag[] = CHROME_TRANSLATOR_LOCALE_TAGS.filter(
   (tag): tag is SandboxBrowserLocaleTag => tag !== 'en' && !sandboxLocalePackSet.has(tag)

--- a/apps/sandbox/app/shared/react/skins.tsx
+++ b/apps/sandbox/app/shared/react/skins.tsx
@@ -85,10 +85,7 @@ function useLoadedComponent<Props>(
 
 type VideoSkinComponentProps = { skin: Skin; styling: Styling; live?: boolean } & VideoSkinProps;
 
-/**
- * Loads the video skin for the given skin/styling. When `live` is true,
- * the `live-video` skin variant is used instead.
- */
+/** Loads the video skin for the given skin/styling. When `live` is true, the `live-video` skin variant is used instead. */
 export function VideoSkinComponent({ skin, styling, live = false, ...props }: VideoSkinComponentProps) {
   const Component = useLoadedComponent(
     () => (live ? loadLiveVideoSkinComponent(skin, styling) : loadVideoSkinComponent(skin, styling)),

--- a/apps/sandbox/app/shared/sandbox-listener.ts
+++ b/apps/sandbox/app/shared/sandbox-listener.ts
@@ -98,15 +98,14 @@ function readLocale(): SandboxLocaleTag {
 }
 
 /**
- * Playback options read once from the query string and folded into the *initial*
- * `source`, so the engine is built with them instead of having them switched in
- * afterwards. Every key is absent unless named, leaving the default sandbox
+ * Playback options read once from the query string and folded into the _initial_ `source`, so the engine is built with
+ * them instead of having them switched in afterwards. Every key is absent unless named, leaving the default sandbox
  * behavior untouched.
  *
  * - `?maxAutoResolution=720p` caps automatic rendition selection.
  * - `?capRenditionToPlayerSize=0` stops the element's size from capping it.
- * - `?minAutoResolution=270p` lowers the floor on that size cap, whose default
- *   is `720p` — low enough here to leave a small player uncapped.
+ * - `?minAutoResolution=270p` lowers the floor on that size cap, whose default is `720p` — low enough here to leave a
+ *   small player uncapped.
  * - `?preferPlayback=native` forces the browser's own HLS.
  */
 export function getInitialPlaybackOverrides(): {

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -19,8 +19,8 @@ export interface SandboxSource {
   /** DRM protected, so only a preset that can license it should offer it. */
   drm?: boolean;
   /**
-   * Ready-made poster image URL, for a source with no Mux playback ID to derive
-   * one from. Takes precedence over the derived URL.
+   * Ready-made poster image URL, for a source with no Mux playback ID to derive one from. Takes precedence over the
+   * derived URL.
    */
   poster?: string;
   /** Structured source, for what a plain `url` cannot express. Takes precedence. */
@@ -74,10 +74,9 @@ const SIGNED_AUDIO_TOKENS = {
 } as const;
 
 /**
- * License servers for the DRM asset below, named outright rather than derived
- * from a Mux token. `source.drm` is engine neutral, so naming every system here
- * licenses whichever path the browser takes — native HLS reads the FairPlay
- * entry and leaves the rest to hls.js.
+ * License servers for the DRM asset below, named outright rather than derived from a Mux token. `source.drm` is engine
+ * neutral, so naming every system here licenses whichever path the browser takes — native HLS reads the FairPlay entry
+ * and leaves the rest to hls.js.
  */
 const DRM_SYSTEMS = {
   'com.apple.fps': {
@@ -158,13 +157,11 @@ const SOURCE_MAP = {
     subType: 'mp4',
   },
   /**
-   * Apple's official HLS example stream (bipbop advanced, fMP4): HEVC and AVC
-   * renditions of the same content in one multivariant playlist, which makes
-   * it the shared mixed-codec source — the initial pick decides a codec
-   * family and SPF's ABR must hold it for the source's lifetime (no
-   * `SourceBuffer.changeType()`). Deliberately messy beyond the codecs: not
-   * CMAF-compliant, ~44ms A/V origin skew, a 10s timestamp origin, and VTT
-   * subtitles relying on `X-TIMESTAMP-MAP`.
+   * Apple's official HLS example stream (bipbop advanced, fMP4): HEVC and AVC renditions of the same content in one
+   * multivariant playlist, which makes it the shared mixed-codec source — the initial pick decides a codec family and
+   * SPF's ABR must hold it for the source's lifetime (no `SourceBuffer.changeType()`). Deliberately messy beyond the
+   * codecs: not CMAF-compliant, ~44ms A/V origin skew, a 10s timestamp origin, and VTT subtitles relying on
+   * `X-TIMESTAMP-MAP`.
    */
   'hls-mixed-codec': {
     label: 'HLS - Apple bipbop (HEVC + AVC)',
@@ -251,19 +248,15 @@ const SOURCE_MAP = {
   /**
    * A 4K ladder over HLS, and the default source for the SPF background presets.
    *
-   * Deliberately *not* the clip {@link BACKGROUND_VIDEO_SRC} plays: the rendition
-   * ladder has to straddle a real screen for the screen-resolution cap to have
-   * anything to choose between. Its rungs run 640x360 → 3838x2160, so a display
-   * under the top rung caps to 2558x1440 instead. (Those off-by-two widths are the
-   * source's near-square pixel aspect ratio, not a typo, and they are the reason
-   * the cap compares pixel areas rather than matching `1920x1080`-style tiers.)
-   * Video-only — the source carries no audio track.
+   * Deliberately _not_ the clip {@link BACKGROUND_VIDEO_SRC} plays: the rendition ladder has to straddle a real screen
+   * for the screen-resolution cap to have anything to choose between. Its rungs run 640x360 → 3838x2160, so a display
+   * under the top rung caps to 2558x1440 instead. (Those off-by-two widths are the source's near-square pixel aspect
+   * ratio, not a typo, and they are the reason the cap compares pixel areas rather than matching `1920x1080`-style
+   * tiers.) Video-only — the source carries no audio track.
    *
-   * CMAF/fMP4, because SPF appends fMP4 segments directly and does no MPEG-TS
-   * transmuxing. Packaging follows the video quality tier — `premium` yields CMAF,
-   * while `plus`/`basic` (legacy `encoding_tier: smart`) yield MPEG-TS — which is
-   * also why a 4K ladder needs `max_resolution_tier: '2160p'` alongside
-   * `video_quality: 'premium'`.
+   * CMAF/fMP4, because SPF appends fMP4 segments directly and does no MPEG-TS transmuxing. Packaging follows the video
+   * quality tier — `premium` yields CMAF, while `plus`/`basic` (legacy `encoding_tier: smart`) yield MPEG-TS — which is
+   * also why a 4K ladder needs `max_resolution_tier: '2160p'` alongside `video_quality: 'premium'`.
    */
   'hls-4k': {
     label: 'HLS - Short 4K UHD 2160p',
@@ -339,24 +332,21 @@ export const NON_DASH_SOURCE_IDS = SOURCE_IDS.filter(
   (id) => SOURCES[id].type !== 'dash' && !isDrmSource(id) && !isMuxSource(id)
 );
 /**
- * HLS presets add the DRM asset that names its license servers outright. Both
- * hls.js and native HLS read it, each from its own half of the source — which
- * half depends on the path the browser ends up taking.
+ * HLS presets add the DRM asset that names its license servers outright. Both hls.js and native HLS read it, each from
+ * its own half of the source — which half depends on the path the browser ends up taking.
  */
 export const HLS_SOURCE_IDS = SOURCE_IDS.filter(
   (id) => SOURCES[id].type !== 'dash' && !isMuxSource(id) && id !== 'hls-drm-unlicensed'
 );
 /**
- * Mux presets add everything reached by playback ID, plus the DRM asset licensed
- * by a Mux token, which only they can read.
+ * Mux presets add everything reached by playback ID, plus the DRM asset licensed by a Mux token, which only they can
+ * read.
  */
 export const MUX_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type !== 'dash' && id !== 'hls-drm-unlicensed');
 /**
- * The SPF engine has no EME, so it can license neither DRM asset. It still gets
- * the unlicensed one: refusing a protected source visibly is the behavior worth
- * reaching here, unlike the licensable assets that would only fail obscurely.
- * Signed playback is not DRM and stays — SPF plays it once the token authorizes
- * the URL.
+ * The SPF engine has no EME, so it can license neither DRM asset. It still gets the unlicensed one: refusing a
+ * protected source visibly is the behavior worth reaching here, unlike the licensable assets that would only fail
+ * obscurely. Signed playback is not DRM and stays — SPF plays it once the token authorizes the URL.
  */
 export const MUX_SPF_SOURCE_IDS = SOURCE_IDS.filter(
   (id) => SOURCES[id].type !== 'dash' && (!isDrmSource(id) || id === 'hls-drm-unlicensed')
@@ -366,30 +356,27 @@ export const SPF_HLS_SOURCE_IDS = MUX_SPF_SOURCE_IDS.filter((id) => !isMuxSource
 export const MP4_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'mp4');
 export const DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'dash');
 /**
- * Shaka plays DASH and HLS from one element, so it is the only preset offered
- * both. The DRM assets are left out until the sandbox hands it license servers.
+ * Shaka plays DASH and HLS from one element, so it is the only preset offered both. The DRM assets are left out until
+ * the sandbox hands it license servers.
  */
 export const SHAKA_SOURCE_IDS = SOURCE_IDS.filter((id) => !isDrmSource(id) && !isMuxSource(id));
 export const DEFAULT_SOURCE: SourceId = 'hls-1';
 export const DEFAULT_AUDIO_SOURCE: SourceId = 'mp4-1';
 export const DEFAULT_DASH_SOURCE: SourceId = 'dash-1';
 /**
- * Where the SPF background presets land when entered. The 4K ladder rather than
- * {@link DEFAULT_SOURCE}, which is MPEG-TS and so is a failure case for this
- * engine rather than a demo of it.
+ * Where the SPF background presets land when entered. The 4K ladder rather than {@link DEFAULT_SOURCE}, which is
+ * MPEG-TS and so is a failure case for this engine rather than a demo of it.
  */
 export const DEFAULT_BACKGROUND_SOURCE: SourceId = 'hls-4k';
 
 export const BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/low.mp4';
 
 /**
- * Add Mux's rendition cap to a stream URL, the param `<mux-background-video>`
- * exists to demonstrate. Merged rather than appended, since a sandbox source may
- * already carry params of its own (clip bounds, a playback token).
+ * Add Mux's rendition cap to a stream URL, the param `<mux-background-video>` exists to demonstrate. Merged rather than
+ * appended, since a sandbox source may already carry params of its own (clip bounds, a playback token).
  *
- * Left alone when the URL is signed: Mux validates the whole query against the
- * token, so a param added beside one answers 403 instead of capping — which would
- * replace whatever failure that source was chosen to reach.
+ * Left alone when the URL is signed: Mux validates the whole query against the token, so a param added beside one
+ * answers 403 instead of capping — which would replace whatever failure that source was chosen to reach.
  */
 export function withMuxMaxResolution(url: string, maxResolution: string): string {
   if (!url || url.includes('token=')) return url;
@@ -427,9 +414,8 @@ export function isDrmSource(id: SourceId): boolean {
 }
 
 /**
- * Returns true when the given source is reached by playback ID, so only a preset
- * whose media builds Mux URLs can offer it — anything else has no `url` to fall
- * back to.
+ * Returns true when the given source is reached by playback ID, so only a preset whose media builds Mux URLs can offer
+ * it — anything else has no `url` to fall back to.
  */
 export function isMuxSource(id: SourceId): boolean {
   return SOURCES[id].source?.playbackId !== undefined;
@@ -460,8 +446,8 @@ export function getPosterSrc(source: SourceId): string | undefined {
 }
 
 /**
- * A CSS image to sit behind the poster while it loads. This upscales a 20px
- * thumbnail, and the browser's own smoothing does the blurring.
+ * A CSS image to sit behind the poster while it loads. This upscales a 20px thumbnail, and the browser's own smoothing
+ * does the blurring.
  */
 export function getPlaceholderSrc(source: SourceId): string | undefined {
   const id = getMuxAssetId(source);

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -32,10 +32,9 @@ function getPagePath(platform: Platform, preset: Preset): string {
 }
 
 /**
- * The SPF background presets default to their own source rather than the global
- * one, which is MPEG-TS and so is a failure case for that engine rather than a
- * demo of it. Only when nothing was asked for — an explicit `?source=` still wins,
- * so a shared link reaches the source it names.
+ * The SPF background presets default to their own source rather than the global one, which is MPEG-TS and so is a
+ * failure case for that engine rather than a demo of it. Only when nothing was asked for — an explicit `?source=` still
+ * wins, so a shared link reaches the source it names.
  */
 function isSpfBackgroundPreset(preset: Preset): boolean {
   return preset === 'hls-background-video' || preset === 'mux-background-video';

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -42,25 +42,20 @@ type NavbarProps = {
 };
 
 /**
- * What the selected media will do with a source, when that's worth labelling for
- * someone smoke-testing. The plain HLS presets are the SPF engine: no TS transmux pipeline
- * and no EME, so it refuses MPEG-TS on format and encrypted renditions on
- * protection. Derived from the pair rather than stored on the source, since every
- * source here plays fine under some other media.
+ * What the selected media will do with a source, when that's worth labelling for someone smoke-testing. The plain HLS
+ * presets are the SPF engine: no TS transmux pipeline and no EME, so it refuses MPEG-TS on format and encrypted
+ * renditions on protection. Derived from the pair rather than stored on the source, since every source here plays fine
+ * under some other media.
  *
- * Keyed on the *preset*, not a single is-SPF-HLS flag, because the variants answer
- * differently and a note promising the wrong outcome is worse than none — a
- * reviewer would file the difference as a bug:
+ * Keyed on the _preset_, not a single is-SPF-HLS flag, because the variants answer differently and a note promising the
+ * wrong outcome is worse than none — a reviewer would file the difference as a bug:
  *
- * - **DRM.** Mux encrypts video renditions and leaves audio clear. The audio-only
- *   engine resolves only the audio rendition, so it never fetches an encrypted
- *   playlist and plays the source instead of refusing it.
- * - **MPEG-TS.** Under audio-only, which specific failure depends on whether the
- *   source carries an audio rendition of its own or muxes audio into its video
- *   renditions — an absent type reports nothing and stalls silently rather than
- *   surfacing a verdict (see `internal/design/spf/features/errors.md`). Both mean
- *   nothing plays, so the note stops at that rather than naming a verdict that
- *   only appears for one of them.
+ * - **DRM.** Mux encrypts video renditions and leaves audio clear. The audio-only engine resolves only the audio
+ *   rendition, so it never fetches an encrypted playlist and plays the source instead of refusing it.
+ * - **MPEG-TS.** Under audio-only, which specific failure depends on whether the source carries an audio rendition of its
+ *   own or muxes audio into its video renditions — an absent type reports nothing and stalls silently rather than
+ *   surfacing a verdict (see `internal/design/spf/features/errors.md`). Both mean nothing plays, so the note stops at
+ *   that rather than naming a verdict that only appears for one of them.
  */
 function expectedOutcomeNote(source: SandboxSource, preset: Preset): string | undefined {
   // The background presets are the same engine again, error surface included:

--- a/apps/sandbox/templates/cdn/main.ts
+++ b/apps/sandbox/templates/cdn/main.ts
@@ -281,8 +281,8 @@ function isEmbedPreset(preset: Preset): boolean {
 /**
  * An embed fills the skin box the way `<video>` does on its own.
  *
- * TikTok's host floors itself at the portrait 325x578 its player refuses to draw
- * below, so a landscape box needs that floor cleared.
+ * TikTok's host floors itself at the portrait 325x578 its player refuses to draw below, so a landscape box needs that
+ * floor cleared.
  */
 function getEmbedMediaClass(preset: Preset): string {
   return preset === 'tiktok-video' ? 'block w-full h-full min-w-0 min-h-0' : 'block w-full h-full';

--- a/apps/sandbox/templates/firefox-mse-repro/main.ts
+++ b/apps/sandbox/templates/firefox-mse-repro/main.ts
@@ -1,9 +1,8 @@
 /**
  * Firefox MSE Init Segment Order Reproduction Harness
  *
- * Tests the Firefox bug where appending a video media segment before the
- * audio SourceBuffer has received its initialization segment causes
- * mozHasAudio to be permanently false.
+ * Tests the Firefox bug where appending a video media segment before the audio SourceBuffer has received its
+ * initialization segment causes mozHasAudio to be permanently false.
  */
 
 // ---------------------------------------------------------------------------

--- a/apps/sandbox/templates/spf-segment-loading/main.ts
+++ b/apps/sandbox/templates/spf-segment-loading/main.ts
@@ -736,9 +736,8 @@ function liveEdgeTarget(): number | undefined {
 }
 
 /**
- * Live status strip: stream type, the seekable (live) window as declared to
- * the element, and how far the playhead trails the edge. Interval-driven (not
- * an effect) because the window slides via reloads *and* the playhead moves —
+ * Live status strip: stream type, the seekable (live) window as declared to the element, and how far the playhead
+ * trails the edge. Interval-driven (not an effect) because the window slides via reloads _and_ the playhead moves —
  * both need reflecting even while nothing signal-shaped changes.
  */
 function updateLiveStatus() {

--- a/build/plugins/cdn-i18n-external-plugin.ts
+++ b/build/plugins/cdn-i18n-external-plugin.ts
@@ -10,10 +10,9 @@ export interface CdnI18nExternalPluginOptions {
 /**
  * Keeps the i18n registry out of every CDN bundle by pointing them at the shared `i18n` entry.
  *
- * The rewritten specifier is always relative, so a mirrored copy of `cdn/` resolves entirely within
- * its own origin and works offline. Sharing one registry instance no longer depends on every bundle
- * naming the same absolute URL — `@videojs/core/i18n` keeps its state on `globalThis`, so duplicate
- * instances converge on their own.
+ * The rewritten specifier is always relative, so a mirrored copy of `cdn/` resolves entirely within its own origin and
+ * works offline. Sharing one registry instance no longer depends on every bundle naming the same absolute URL —
+ * `@videojs/core/i18n` keeps its state on `globalThis`, so duplicate instances converge on their own.
  */
 export function cdnI18nExternalPlugin(options: CdnI18nExternalPluginOptions): BuildPlugin {
   const file = options.prod ? 'i18n.js' : 'i18n.dev.js';

--- a/build/plugins/inline-css-plugin.ts
+++ b/build/plugins/inline-css-plugin.ts
@@ -17,9 +17,8 @@ interface InlineCssPluginOptions {
 }
 
 /**
- * Rolldown/Vite+ pack plugin that inlines `.css?inline` imports as JavaScript
- * modules exporting the resolved CSS string. Mirrors the Vite `?inline`
- * convention so the same source works in both Vite dev and Vite+ package builds.
+ * Rolldown/Vite+ pack plugin that inlines `.css?inline` imports as JavaScript modules exporting the resolved CSS
+ * string. Mirrors the Vite `?inline` convention so the same source works in both Vite dev and Vite+ package builds.
  */
 export function inlineCssPlugin(options: InlineCssPluginOptions): BuildPlugin {
   const { skinsDir, rootDir = process.cwd(), minify = true } = options;

--- a/build/plugins/inline-template-plugin.ts
+++ b/build/plugins/inline-template-plugin.ts
@@ -10,14 +10,13 @@ interface TemplatePluginOptions {
 }
 
 /**
- * Rolldown/Vite+ pack transform plugin that minifies tagged template literals
- * marked with {@link HTML_MARKER} or {@link CSS_MARKER}.
+ * Rolldown/Vite+ pack transform plugin that minifies tagged template literals marked with {@link HTML_MARKER} or
+ * {@link CSS_MARKER}.
  *
  * - `/*html*​/` templates: collapse inter-tag whitespace, strip HTML comments.
  * - `/* css *​/` templates: full CSS minification via lightningcss.
  *
- * Only the static parts (quasis) are processed — `${...}` expression
- * interpolations are preserved as-is.
+ * Only the static parts (quasis) are processed — `${...}` expression interpolations are preserved as-is.
  */
 export function inlineTemplatePlugin(options: TemplatePluginOptions = {}): BuildPlugin {
   const { minify = true } = options;
@@ -48,8 +47,8 @@ export function inlineTemplatePlugin(options: TemplatePluginOptions = {}): Build
 // ---------------------------------------------------------------------------
 
 /**
- * Walk `code` looking for known markers followed by a backtick template
- * literal. For each match, minify the static parts and reassemble.
+ * Walk `code` looking for known markers followed by a backtick template literal. For each match, minify the static
+ * parts and reassemble.
  */
 function processTemplates(code: string, output: BuildMagicString): boolean {
   let changed = false;
@@ -138,9 +137,8 @@ function minifyHtmlQuasis(quasis: string[]): string[] {
 }
 
 /**
- * Remove whitespace that sits between a closing `>` and an opening `<`,
- * while respecting quoted attribute values (so `> <` inside an attribute
- * like `title="a > <b"` is left untouched).
+ * Remove whitespace that sits between a closing `>` and an opening `<`, while respecting quoted attribute values (so `>
+ * <` inside an attribute like `title="a > <b"` is left untouched).
  */
 function collapseInterTagWhitespace(s: string): string {
   let out = '';
@@ -197,8 +195,7 @@ const EXPR_PLACEHOLDER = '___EXPR_';
 /**
  * Minify the static parts of a CSS template literal via lightningcss.
  *
- * Expressions are replaced with safe placeholder tokens before minification,
- * then restored afterward.
+ * Expressions are replaced with safe placeholder tokens before minification, then restored afterward.
  */
 function minifyCssQuasis(quasis: string[]): string[] {
   // Fast path: single quasi (no expressions) — minify directly.
@@ -260,9 +257,8 @@ interface ParsedTemplate {
 }
 
 /**
- * Parse a backtick template literal starting at `start` (the opening `` ` ``).
- * Returns the static quasis, the raw expression source strings, and the index
- * immediately after the closing backtick.
+ * Parse a backtick template literal starting at `start` (the opening `` ` ``). Returns the static quasis, the raw
+ * expression source strings, and the index immediately after the closing backtick.
  */
 function parseTemplateLiteral(code: string, start: number): ParsedTemplate {
   const quasis: string[] = [];
@@ -315,8 +311,8 @@ interface SkipResult {
 }
 
 /**
- * Starting right after the `${`, collect everything up to the matching `}`.
- * Returns `{ src, _end }` where `_end` is the index after the closing `}`.
+ * Starting right after the `${`, collect everything up to the matching `}`. Returns `{ src, _end }` where `_end` is the
+ * index after the closing `}`.
  */
 function collectExpression(code: string, start: number): ParsedExpression {
   let i = start;

--- a/build/scripts/check-workspace.mjs
+++ b/build/scripts/check-workspace.mjs
@@ -1,20 +1,15 @@
 /**
  * Workspace consistency checker.
  *
- * Validates that manually-maintained lists across config files stay in sync
- * with the actual package structure. Run via `pnpm check:workspace`.
+ * Validates that manually-maintained lists across config files stay in sync with the actual package structure. Run via
+ * `pnpm check:workspace`.
  *
- * Checks:
- * 1. CI test coverage — every testable package is tested in CI
- * 2. Commitlint scopes — every package dir is a valid commit scope
- * 3. Root tsconfig references — every composite project is referenced
- * 4. Package metadata — non-private packages have required fields
- * 5. Release-please config — every versioned package is registered
- * 6. Bundled docs — package publishing wires include generated docs
- * 7. Define imports — no bare side-effect imports from relative paths
- * 8. i18n locales — tag lists match locale files and generated stubs
- * 9. Agent context — portable skill metadata, compatibility imports, and budgets
- * 10. Internal records — organized design docs, frontmatter, and lifecycle status
+ * Checks: 1. CI test coverage — every testable package is tested in CI 2. Commitlint scopes — every package dir is a
+ * valid commit scope 3. Root tsconfig references — every composite project is referenced 4. Package metadata —
+ * non-private packages have required fields 5. Release-please config — every versioned package is registered 6. Bundled
+ * docs — package publishing wires include generated docs 7. Define imports — no bare side-effect imports from relative
+ * paths 8. i18n locales — tag lists match locale files and generated stubs 9. Agent context — portable skill metadata,
+ * compatibility imports, and budgets 10. Internal records — organized design docs, frontmatter, and lifecycle status
  */
 import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, join, resolve, sep } from 'node:path';
@@ -86,10 +81,7 @@ function checkCiTestCoverage() {
 
 // ── Check 2: Commitlint scope-enum ──────────────────────────────────────────
 
-/**
- * Known aliases where the commit scope differs from the directory name.
- * Key: directory name, Value: expected scope.
- */
+/** Known aliases where the commit scope differs from the directory name. Key: directory name, Value: expected scope. */
 const SCOPE_ALIASES = new Map([['skins', 'skin']]);
 
 function checkCommitlintScopes() {
@@ -119,8 +111,8 @@ function checkCommitlintScopes() {
 // ── Check 3: Root tsconfig references ───────────────────────────────────────
 
 /**
- * Intentionally excluded from root references.
- * packages/icons: private, custom build script, uses outDir/rootDir instead of declarationDir.
+ * Intentionally excluded from root references. packages/icons: private, custom build script, uses outDir/rootDir
+ * instead of declarationDir.
  */
 const TSCONFIG_EXCLUDE = new Set(['packages/icons']);
 
@@ -182,10 +174,7 @@ const REQUIRED_FIELDS = ['sideEffects', 'files', 'exports'];
 /** Required only when the package has a root "." export. */
 const ROOT_EXPORT_FIELDS = ['main', 'module', 'types'];
 
-/**
- * Packages excluded from metadata checks.
- * CLI is bin-only — sideEffects/exports don't apply.
- */
+/** Packages excluded from metadata checks. CLI is bin-only — sideEffects/exports don't apply. */
 const METADATA_EXCLUDE = new Set(['cli']);
 
 function checkPackageMetadata() {
@@ -259,10 +248,9 @@ function checkReleasePleaseConfig() {
 // ── Check 6: Bundled docs publishing ─────────────────────────────────────────
 
 /**
- * `@videojs/html` and `@videojs/react` ship the per-framework markdown docs
- * subtree inside their tarballs (see `site/scripts/copy-package-docs.ts`).
- * Both wires (the `files[]` entry and the `prepack` script) must stay in sync
- * — without one, publishing silently drops the docs.
+ * `@videojs/html` and `@videojs/react` ship the per-framework markdown docs subtree inside their tarballs (see
+ * `site/scripts/copy-package-docs.ts`). Both wires (the `files[]` entry and the `prepack` script) must stay in sync —
+ * without one, publishing silently drops the docs.
  */
 function checkBundledDocs() {
   const warnings = [];
@@ -295,9 +283,8 @@ function checkBundledDocs() {
 // ── Check 7: Define imports ──────────────────────────────────────────────────
 
 /**
- * Bare side-effect imports from relative paths in the define directory cause
- * non-deterministic registration order when loaded as native ESM in the
- * browser. All registration must go through explicit safeDefine() calls.
+ * Bare side-effect imports from relative paths in the define directory cause non-deterministic registration order when
+ * loaded as native ESM in the browser. All registration must go through explicit safeDefine() calls.
  */
 function checkDefineImports() {
   const warnings = [];

--- a/build/scripts/link-aliases.mjs
+++ b/build/scripts/link-aliases.mjs
@@ -1,14 +1,10 @@
 /**
- * Exposes the checked-in, host-neutral skill catalog through client-specific
- * discovery paths:
+ * Exposes the checked-in, host-neutral skill catalog through client-specific discovery paths:
  *
- *   .agents/skills/<skill-name>/SKILL.md  (source)
- *   .claude/skills                (generated junction)
- *   .claude/plans                 (generated junction)
- *   .opencode                     (generated junction)
+ * .agents/skills/<skill-name>/SKILL.md (source) .claude/skills (generated junction) .claude/plans (generated junction)
+ * .opencode (generated junction)
  *
- * Directory junctions work on Windows without elevated privileges. Failures
- * warn instead of breaking `pnpm install`.
+ * Directory junctions work on Windows without elevated privileges. Failures warn instead of breaking `pnpm install`.
  */
 import { lstatSync, mkdirSync, readlinkSync, symlinkSync, unlinkSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';

--- a/packages/cli/src/site-modules.d.ts
+++ b/packages/cli/src/site-modules.d.ts
@@ -1,9 +1,8 @@
 /**
  * Ambient type declarations for site modules imported via Vite+ pack aliases.
  *
- * The CLI bundles code from `site/src/utils/installation/` at build time using
- * Vite+ pack's `alias` config. These declarations let `tsc` typecheck against the
- * same signatures without following into the site source tree.
+ * The CLI bundles code from `site/src/utils/installation/` at build time using Vite+ pack's `alias` config. These
+ * declarations let `tsc` typecheck against the same signatures without following into the site source tree.
  */
 
 declare module '@/utils/installation/types' {

--- a/packages/cli/src/utils/tests/site-aliases.test.ts
+++ b/packages/cli/src/utils/tests/site-aliases.test.ts
@@ -4,9 +4,8 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vite-plus/test';
 
 /**
- * The CLI aliases source files from the site package via path aliases in
- * vite.config.ts. If these aliases move, the CLI build breaks silently. This
- * test makes that failure loud.
+ * The CLI aliases source files from the site package via path aliases in vite.config.ts. If these aliases move, the CLI
+ * build breaks silently. This test makes that failure loud.
  */
 const SITE_ROOT = resolve(__dirname, '../../../../../site/src');
 

--- a/packages/core/src/core/i18n/browser-translation.ts
+++ b/packages/core/src/core/i18n/browser-translation.ts
@@ -26,8 +26,8 @@ interface BrowserTranslatorConstructor {
 
 export interface GetBrowserTranslationsOptions {
   /**
-   * When true, call `Translator.create()` for `downloadable` / `downloading` (may download the
-   * on-device model). Defaults to false — production providers only use pre-installed models.
+   * When true, call `Translator.create()` for `downloadable` / `downloading` (may download the on-device model).
+   * Defaults to false — production providers only use pre-installed models.
    */
   downloadIfNeeded?: boolean;
   /** Invoked when a model download starts and when `Translator.create()` resolves. */
@@ -41,8 +41,8 @@ const NAMED_PLACEHOLDER = /\{([^{}]+)\}/g;
 const INDEX_PLACEHOLDER = /\{\s*(\d+)\s*\}/g;
 
 /**
- * Replaces `{seconds}` with `{0}`, `{1}`, … so the Browser Translation API sees one full
- * sentence (grammar/word order preserved) while opaque numeric slots are left alone.
+ * Replaces `{seconds}` with `{0}`, `{1}`, … so the Browser Translation API sees one full sentence (grammar/word order
+ * preserved) while opaque numeric slots are left alone.
  */
 function maskNamedPlaceholders(source: string): { masked: string; slots: readonly string[] } {
   const slots: string[] = [];
@@ -115,8 +115,8 @@ function hasMissingEnglishTranslations(translations: Partial<FlatTranslations>):
 }
 
 /**
- * Translates English registry values via the on-device Browser Translation API when a pre-installed
- * model is available. Results are cached per target language tag.
+ * Translates English registry values via the on-device Browser Translation API when a pre-installed model is available.
+ * Results are cached per target language tag.
  */
 export async function getBrowserTranslations(
   locale: string,

--- a/packages/core/src/core/i18n/registry.ts
+++ b/packages/core/src/core/i18n/registry.ts
@@ -9,21 +9,21 @@ interface I18nRegistry {
 }
 
 /**
- * Well-known key for the shared registry. Its name and value shape are a cross-version contract:
- * every copy of this module in a realm must agree on them, so change the key when the shape changes.
+ * Well-known key for the shared registry. Its name and value shape are a cross-version contract: every copy of this
+ * module in a realm must agree on them, so change the key when the shape changes.
  */
 const I18N_REGISTRY_KEY = Symbol.for('@videojs/i18n-registry');
 
 type I18nRegistryHost = { [I18N_REGISTRY_KEY]?: I18nRegistry };
 
 /**
- * The registry is realm-global rather than module-global so duplicate copies of this module
- * converge on one set of translations.
+ * The registry is realm-global rather than module-global so duplicate copies of this module converge on one set of
+ * translations.
  *
- * Duplication is normal, not a bug to fix upstream: separately loaded CDN bundles, a pinned and an
- * unpinned URL for the same file, and two bundlers' output on one page all yield distinct module
- * instances. With module-scoped state, a `registerI18n` call on one instance is invisible to the
- * player reading from another, and the locale silently falls back to English.
+ * Duplication is normal, not a bug to fix upstream: separately loaded CDN bundles, a pinned and an unpinned URL for the
+ * same file, and two bundlers' output on one page all yield distinct module instances. With module-scoped state, a
+ * `registerI18n` call on one instance is invisible to the player reading from another, and the locale silently falls
+ * back to English.
  */
 function getRegistry(): I18nRegistry {
   const host = globalThis as I18nRegistryHost;
@@ -80,7 +80,8 @@ export function getCanonicalLocaleKey(locale: Locale): Locale {
 /**
  * Most-specific-first BCP 47 lookup tags (normalized). Always ends with `en` when missing from the truncated chain.
  *
- * @example `es-419-u-nu-latn` → `['es-419', 'es', 'en']`
+ * @example
+ *   `es-419-u-nu-latn` → `['es-419', 'es', 'en']`
  */
 export function findLocaleKeys(locale: Locale): Locale[] {
   const base = getCanonicalLocaleKey(locale);
@@ -153,7 +154,8 @@ export function registerI18n(locale: Locale, translations: Partial<Translations>
 }
 
 /**
- * Return the merged registered translation map for a locale. Built-in English defaults are supplied by text descriptors.
+ * Return the merged registered translation map for a locale. Built-in English defaults are supplied by text
+ * descriptors.
  *
  * @param locale - BCP 47 tag to resolve (e.g. `es-MX`, `zh-Hant-HK`).
  * @public

--- a/packages/core/src/core/i18n/tests/registry.test.ts
+++ b/packages/core/src/core/i18n/tests/registry.test.ts
@@ -104,10 +104,9 @@ describe('i18n registry', () => {
 });
 
 /**
- * A page can end up with more than one copy of this module — separately loaded CDN bundles, a
- * pinned and an unpinned URL for the same file, or two bundlers' output. Registry state is
- * realm-global so those copies still agree; these tests stand in for that duplication by loading
- * the module twice through a reset module cache.
+ * A page can end up with more than one copy of this module — separately loaded CDN bundles, a pinned and an unpinned
+ * URL for the same file, or two bundlers' output. Registry state is realm-global so those copies still agree; these
+ * tests stand in for that duplication by loading the module twice through a reset module cache.
  */
 describe('i18n registry shared across module instances', () => {
   async function loadTwoInstances() {

--- a/packages/core/src/core/ui/captions-button/core.ts
+++ b/packages/core/src/core/ui/captions-button/core.ts
@@ -14,7 +14,10 @@ export interface CaptionsButtonProps {
   label?: Text | string | ((state: CaptionsButtonState) => Text | string) | undefined;
   /** Whether the button is disabled. */
   disabled?: boolean | undefined;
-  /** When true with multiple tracks, pointer activation opens a menu instead of toggling. React sets this automatically inside `Menu.Trigger`. */
+  /**
+   * When true with multiple tracks, pointer activation opens a menu instead of toggling. React sets this automatically
+   * inside `Menu.Trigger`.
+   */
   menuTrigger?: boolean | undefined;
 }
 

--- a/packages/core/src/core/ui/error-dialog/error-dialog-i18n.ts
+++ b/packages/core/src/core/ui/error-dialog/error-dialog-i18n.ts
@@ -15,17 +15,13 @@ import {
 } from '../../i18n/text/errors';
 
 /**
- * SVTA 99 [Custom] 001 — an engine reporting that it has no pipeline for
- * something the source requires. Not a `MediaError.MEDIA_ERR_*` value: engines
- * that report SVTA codes surface them on `error.code` directly.
+ * SVTA 99 [Custom] 001 — an engine reporting that it has no pipeline for something the source requires. Not a
+ * `MediaError.MEDIA_ERR_*` value: engines that report SVTA codes surface them on `error.code` directly.
  *
- * The literal rather than an import. `@videojs/spf` defines this as
- * `SVTA_UNSUPPORTED_PLAYBACK_FEATURE` and owns its meaning, but core doesn't
- * depend on spf, and reaching it through `@videojs/media` would pull an engine
- * entry point into a barrel that has no other reason to load one. Same trade
- * `HlsVideoMediaStreamType` makes in the other direction — compatibility by
- * value, stated in a comment, instead of a dependency edge neither package
- * wants.
+ * The literal rather than an import. `@videojs/spf` defines this as `SVTA_UNSUPPORTED_PLAYBACK_FEATURE` and owns its
+ * meaning, but core doesn't depend on spf, and reaching it through `@videojs/media` would pull an engine entry point
+ * into a barrel that has no other reason to load one. Same trade `HlsVideoMediaStreamType` makes in the other direction
+ * — compatibility by value, stated in a comment, instead of a dependency edge neither package wants.
  */
 const SVTA_UNSUPPORTED_PLAYBACK_FEATURE = 99001;
 
@@ -78,8 +74,8 @@ export function getErrorDialogUnexpectedText(): Text {
 }
 
 /**
- * Resolves dialog body copy: default phrases for known {@link MediaError} defaults, literal text for
- * custom messages, otherwise the generic fallback key.
+ * Resolves dialog body copy: default phrases for known {@link MediaError} defaults, literal text for custom messages,
+ * otherwise the generic fallback key.
  */
 export function resolveErrorDialogDescription(
   error: (Pick<MediaError, 'code' | 'message'> & { context?: MediaError['context'] }) | null | undefined,

--- a/packages/core/src/core/ui/live-button/core.ts
+++ b/packages/core/src/core/ui/live-button/core.ts
@@ -16,23 +16,21 @@ export interface LiveButtonProps {
 }
 
 /**
- * Fallback offset (in seconds) from the end of the seekable window used to
- * decide "at live edge" when `liveEdgeStart` is unavailable.
+ * Fallback offset (in seconds) from the end of the seekable window used to decide "at live edge" when `liveEdgeStart`
+ * is unavailable.
  */
 const LIVE_EDGE_OFFSET = 10;
 
 /**
- * Grace window (in seconds) before `liveEdgeStart` that still counts as
- * "at the live edge". Absorbs the small gap between the player's initial
- * playback position (e.g. hls.js `liveSyncDuration`) and the manifest's
- * `HOLD-BACK`, so autoplay reliably reports live.
+ * Grace window (in seconds) before `liveEdgeStart` that still counts as "at the live edge". Absorbs the small gap
+ * between the player's initial playback position (e.g. hls.js `liveSyncDuration`) and the manifest's `HOLD-BACK`, so
+ * autoplay reliably reports live.
  */
 const LIVE_EDGE_TOLERANCE = 5;
 
 /**
- * Media state slice consumed by `LiveButtonCore` — composed by the HTML
- * and React `LiveButton` adapters from the `live`, `time`, and `buffer`
- * store slices.
+ * Media state slice consumed by `LiveButtonCore` — composed by the HTML and React `LiveButton` adapters from the
+ * `live`, `time`, and `buffer` store slices.
  */
 export type LiveButtonMediaState = Pick<MediaTimeState, 'currentTime' | 'seek'> &
   Pick<MediaBufferState, 'seekable'> &
@@ -46,8 +44,8 @@ export interface LiveButtonState extends ButtonState {
 }
 
 /**
- * Core state machine for a "Live" button. Indicates whether the player is
- * playing at the live edge and seeks to the Seekable Live Edge when activated.
+ * Core state machine for a "Live" button. Indicates whether the player is playing at the live edge and seeks to the
+ * Seekable Live Edge when activated.
  *
  * @see https://github.com/video-dev/media-ui-extensions/blob/main/proposals/0007-live-edge.md
  */

--- a/packages/core/src/core/ui/menu/item-data.ts
+++ b/packages/core/src/core/ui/menu/item-data.ts
@@ -5,14 +5,10 @@
  */
 export const MenuItemDataAttrs = {
   /**
-   * Present on all navigable item types: Item, RadioItem, CheckboxItem, and
-   * the Trigger when acting as a submenu trigger inside a parent menu.
-   * Use `[data-item]` as a shared selector to target all item types at once.
+   * Present on all navigable item types: Item, RadioItem, CheckboxItem, and the Trigger when acting as a submenu
+   * trigger inside a parent menu. Use `[data-item]` as a shared selector to target all item types at once.
    */
   item: 'data-item',
-  /**
-   * Present when the item is highlighted. Set to `pointer` when pointer
-   * movement caused the highlight; otherwise empty.
-   */
+  /** Present when the item is highlighted. Set to `pointer` when pointer movement caused the highlight; otherwise empty. */
   highlighted: 'data-highlighted',
 } as const;

--- a/packages/core/src/core/ui/mute-button/core.ts
+++ b/packages/core/src/core/ui/mute-button/core.ts
@@ -20,6 +20,7 @@ export interface MuteButtonProps {
 export interface MuteButtonState extends Pick<MediaVolumeState, 'muted'>, ButtonState {
   /**
    * Derived volume level:
+   *
    * - `off`: muted or volume is 0
    * - `low`: volume < 0.5
    * - `medium`: volume < 0.75

--- a/packages/core/src/core/ui/popover/core.ts
+++ b/packages/core/src/core/ui/popover/core.ts
@@ -36,9 +36,8 @@ export interface PopoverProps {
 }
 
 /**
- * The raw transition state managed by `createTransition`. Uses `active`
- * (not `open`) to distinguish the generic transition state machine from the
- * domain-specific `PopoverState.open`.
+ * The raw transition state managed by `createTransition`. Uses `active` (not `open`) to distinguish the generic
+ * transition state machine from the domain-specific `PopoverState.open`.
  */
 export interface PopoverInput extends TransitionState {}
 

--- a/packages/core/src/core/ui/popover/popup-host-attr.ts
+++ b/packages/core/src/core/ui/popover/popup-host-attr.ts
@@ -1,8 +1,7 @@
 /**
- * Hosted floating UI surfaces (popover, menu, tooltip, and future overlays) that support
- * parent-driven lifecycle may set {@link POPUP_HOST_ATTR}. Ancestors can discover them with
- * {@link POPUP_HOST_SELECTOR} and call methods such as `close('imperative-action')` when
- * the element implements that contract.
+ * Hosted floating UI surfaces (popover, menu, tooltip, and future overlays) that support parent-driven lifecycle may
+ * set {@link POPUP_HOST_ATTR}. Ancestors can discover them with {@link POPUP_HOST_SELECTOR} and call methods such as
+ * `close('imperative-action')` when the element implements that contract.
  */
 export const POPUP_HOST_ATTR = 'data-popup';
 

--- a/packages/core/src/core/ui/poster/core.ts
+++ b/packages/core/src/core/ui/poster/core.ts
@@ -4,8 +4,8 @@ import type { MediaMetadataState, MediaPlaybackState } from '@videojs/media';
 export type PosterMediaState = Pick<MediaPlaybackState, 'started'> & Pick<MediaMetadataState, 'poster'>;
 
 /**
- * How the poster image is faring, as the binding holding it sees it. `none`
- * means there is no image, or nothing for it to fetch.
+ * How the poster image is faring, as the binding holding it sees it. `none` means there is no image, or nothing for it
+ * to fetch.
  */
 export type PosterImageLoadState = 'none' | 'loading' | 'loaded' | 'error';
 
@@ -30,8 +30,8 @@ export interface PosterProps {
 /**
  * Turns playback and metadata into poster presentation state.
  *
- * Owns no image of its own: a binding finds one, supplies how it is faring
- * through {@link PosterCore.setImageLoadState}, and paints the result.
+ * Owns no image of its own: a binding finds one, supplies how it is faring through {@link PosterCore.setImageLoadState},
+ * and paints the result.
  */
 export class PosterCore {
   #media: PosterMediaState | null = null;

--- a/packages/core/src/core/ui/thumbnail/core.ts
+++ b/packages/core/src/core/ui/thumbnail/core.ts
@@ -15,14 +15,12 @@ export interface ThumbnailProps {
   /**
    * CORS setting forwarded to the inner `<img>`.
    *
-   * Left unset, this follows the media element: a cross-origin thumbnail
-   * `<track>` only loads when the media is CORS-enabled, so the sprite sheets
-   * its cues point at are fetched with that same mode. Pass `null` to opt out
-   * and fetch them without CORS. Thumbnails supplied directly never inherit,
-   * since they need not be related to the media element at all.
+   * Left unset, this follows the media element: a cross-origin thumbnail `<track>` only loads when the media is
+   * CORS-enabled, so the sprite sheets its cues point at are fetched with that same mode. Pass `null` to opt out and
+   * fetch them without CORS. Thumbnails supplied directly never inherit, since they need not be related to the media
+   * element at all.
    *
-   * `''` is a value like any other, read as Anonymous by the CORS-settings
-   * attribute rules — it does not opt out.
+   * `''` is a value like any other, read as Anonymous by the CORS-settings attribute rules — it does not opt out.
    */
   crossOrigin?: ThumbnailCrossOrigin | undefined;
   /** Image loading strategy forwarded to the inner `<img>`. */
@@ -48,8 +46,8 @@ export class ThumbnailCore {
   /**
    * Parse CSS constraint strings into numeric `ThumbnailConstraints`.
    *
-   * Accepts any object with string `minWidth`/`maxWidth`/`minHeight`/`maxHeight`
-   * properties — `CSSStyleDeclaration` satisfies this structurally.
+   * Accepts any object with string `minWidth`/`maxWidth`/`minHeight`/`maxHeight` properties — `CSSStyleDeclaration`
+   * satisfies this structurally.
    */
   parseConstraints(raw: {
     minWidth: string;
@@ -71,8 +69,8 @@ export class ThumbnailCore {
   }
 
   /**
-   * Calculate a uniform scale factor that fits `tileWidth × tileHeight` within the
-   * given CSS min/max constraints while preserving aspect ratio.
+   * Calculate a uniform scale factor that fits `tileWidth × tileHeight` within the given CSS min/max constraints while
+   * preserving aspect ratio.
    *
    * - Scales down when the tile exceeds max constraints.
    * - Scales up when the tile is smaller than min constraints.
@@ -94,11 +92,11 @@ export class ThumbnailCore {
   }
 
   /**
-   * Compute container and image dimensions for the current thumbnail, scaled to
-   * fit within the element's CSS min/max constraints.
+   * Compute container and image dimensions for the current thumbnail, scaled to fit within the element's CSS min/max
+   * constraints.
    *
-   * The container clips the sprite sheet via `overflow: hidden`, and the image is
-   * positioned with `transform: translate()` to show the correct tile.
+   * The container clips the sprite sheet via `overflow: hidden`, and the image is positioned with `transform:
+   * translate()` to show the correct tile.
    */
   resize(
     thumbnail: ThumbnailImage,

--- a/packages/core/src/core/ui/thumbnail/thumbnail-media-fragment.ts
+++ b/packages/core/src/core/ui/thumbnail/thumbnail-media-fragment.ts
@@ -54,9 +54,8 @@ export function parseMediaFragment(
 }
 
 /**
- * Convert an array of text cues (e.g. `VTTCue` from a `<track>` element)
- * into {@link ThumbnailImage} entries by parsing the media-fragment in
- * each cue's text.
+ * Convert an array of text cues (e.g. `VTTCue` from a `<track>` element) into {@link ThumbnailImage} entries by parsing
+ * the media-fragment in each cue's text.
  */
 export function mapCuesToThumbnails(cues: MediaTextCue[], baseURL?: string): ThumbnailImage[] {
   const images: ThumbnailImage[] = [];

--- a/packages/core/src/core/ui/time-slider/core.ts
+++ b/packages/core/src/core/ui/time-slider/core.ts
@@ -18,10 +18,7 @@ export interface TimeSliderProps extends SliderProps {
   max?: number | undefined;
   /** Leading+trailing throttle (ms) for `onValueChange` during drag. */
   changeThrottle?: number | undefined;
-  /**
-   * When true, pause playback while the user is dragging the thumb,
-   * resuming on release if it was playing before.
-   */
+  /** When true, pause playback while the user is dragging the thumb, resuming on release if it was playing before. */
   pauseOnDrag?: boolean | undefined;
 }
 
@@ -118,8 +115,8 @@ export class TimeSliderCore extends SliderCore {
   }
 
   /**
-   * Pause playback when a drag begins if `pauseOnDrag` is enabled, remembering
-   * whether media was playing so `endDrag` can resume it.
+   * Pause playback when a drag begins if `pauseOnDrag` is enabled, remembering whether media was playing so `endDrag`
+   * can resume it.
    */
   startDrag(playback: MediaPlaybackState | null | undefined): void {
     this.#wasPlayingBeforeDrag = false;
@@ -131,9 +128,8 @@ export class TimeSliderCore extends SliderCore {
   }
 
   /**
-   * Resume playback if `startDrag` paused it. Resume depends only on the intent
-   * captured at drag start, so it survives `pauseOnDrag` being toggled mid-drag.
-   * Safe to call on teardown — a no-op unless a drag paused playback.
+   * Resume playback if `startDrag` paused it. Resume depends only on the intent captured at drag start, so it survives
+   * `pauseOnDrag` being toggled mid-drag. Safe to call on teardown — a no-op unless a drag paused playback.
    */
   endDrag(playback: MediaPlaybackState | null | undefined): void {
     if (this.#wasPlayingBeforeDrag) {

--- a/packages/core/src/dom/gesture/coordinator.ts
+++ b/packages/core/src/dom/gesture/coordinator.ts
@@ -33,11 +33,10 @@ export class GestureCoordinator {
   }
 
   /**
-   * Whether a registered binding claims this tap for the given action. A claimed tap
-   * belongs to the gesture layer, so callers should leave it alone. Taps on interactive
-   * targets (buttons, sliders) are never claimed — the same filtering the pointerup
-   * listener applies. A disabled binding still claims: disabling a gesture opts out of
-   * the action, it doesn't hand the tap back to a fallback handler.
+   * Whether a registered binding claims this tap for the given action. A claimed tap belongs to the gesture layer, so
+   * callers should leave it alone. Taps on interactive targets (buttons, sliders) are never claimed — the same
+   * filtering the pointerup listener applies. A disabled binding still claims: disabling a gesture opts out of the
+   * action, it doesn't hand the tap back to a fallback handler.
    */
   claimsTap(event: PointerEvent, action: string): boolean {
     if (isInteractiveTarget(event)) return false;

--- a/packages/core/src/dom/gesture/create-tap-gesture.ts
+++ b/packages/core/src/dom/gesture/create-tap-gesture.ts
@@ -18,11 +18,15 @@ function getRecognizer(target: HTMLElement): TapRecognizer {
  * Register a tap gesture on a target element.
  *
  * @example
- * ```ts
- * const cleanup = createTapGesture(container, (event) => {
- *   store.paused ? store.play() : store.pause();
- * }, { pointer: 'mouse' });
- * ```
+ *   ```ts
+ *   const cleanup = createTapGesture(
+ *     container,
+ *     (event) => {
+ *       store.paused ? store.play() : store.pause();
+ *     },
+ *     { pointer: 'mouse' }
+ *   );
+ *   ```;
  */
 export function createTapGesture(
   target: HTMLElement,
@@ -45,11 +49,15 @@ export function createTapGesture(
  * Register a doubletap gesture on a target element.
  *
  * @example
- * ```ts
- * const cleanup = createDoubleTapGesture(container, (event) => {
- *   store.fullscreen ? store.exitFullscreen() : store.requestFullscreen();
- * }, { region: 'center' });
- * ```
+ *   ```ts
+ *   const cleanup = createDoubleTapGesture(
+ *     container,
+ *     (event) => {
+ *       store.fullscreen ? store.exitFullscreen() : store.requestFullscreen();
+ *     },
+ *     { region: 'center' }
+ *   );
+ *   ```;
  */
 export function createDoubleTapGesture(
   target: HTMLElement,

--- a/packages/core/src/dom/gesture/region.ts
+++ b/packages/core/src/dom/gesture/region.ts
@@ -3,14 +3,12 @@ import type { GestureRegion } from './gesture';
 /**
  * Determine which named region a pointer position falls into.
  *
- * Regions divide the container width equally based on how many are active:
- * - `left` + `right` → halves (50% / 50%)
- * - `left` + `center` + `right` → thirds (33% / 34% / 33%)
+ * Regions divide the container width equally based on how many are active: - `left` + `right` → halves (50% / 50%) -
+ * `left` + `center` + `right` → thirds (33% / 34% / 33%)
  *
- * Single region: `left` covers the left half, `right` the right half,
- * and `center` covers the full surface. Partial two-region combos
- * (e.g. `left` + `center`) use the same natural zones — positions outside
- * all active zones return `null` so full-surface gestures can handle them.
+ * Single region: `left` covers the left half, `right` the right half, and `center` covers the full surface. Partial
+ * two-region combos (e.g. `left` + `center`) use the same natural zones — positions outside all active zones return
+ * `null` so full-surface gestures can handle them.
  */
 export function resolveRegion(
   clientX: number,

--- a/packages/core/src/dom/gesture/tap.ts
+++ b/packages/core/src/dom/gesture/tap.ts
@@ -5,9 +5,8 @@ const DOUBLETAP_WINDOW = 200;
 /**
  * Recognizes tap vs doubletap from quick pointer-up events.
  *
- * Stateful recognizer — tracks tap count and doubletap timing.
- * The coordinator handles pointer-down timing (tap threshold) and
- * calls `handleUp()` only for quick taps that passed the threshold check.
+ * Stateful recognizer — tracks tap count and doubletap timing. The coordinator handles pointer-down timing (tap
+ * threshold) and calls `handleUp()` only for quick taps that passed the threshold check.
  */
 export class TapRecognizer implements GestureRecognizer {
   #lastTapTime = 0;

--- a/packages/core/src/dom/hotkey/aria.ts
+++ b/packages/core/src/dom/hotkey/aria.ts
@@ -20,13 +20,13 @@ const MODIFIER_ORDER: readonly HotkeyModifierKey[] = ['ctrl', 'shift', 'alt', 'm
  * Convert parsed key bindings to a WAI-ARIA `aria-keyshortcuts` formatted string.
  *
  * @example
- * ```ts
- * toAriaKeyShortcut(parseHotkeyPattern('Ctrl+Shift+f'));
- * // "Control+Shift+f"
+ *   ```ts
+ *   toAriaKeyShortcut(parseHotkeyPattern('Ctrl+Shift+f'));
+ *   // "Control+Shift+f"
  *
- * toAriaKeyShortcut([...parseHotkeyPattern('k'), ...parseHotkeyPattern('Space')]);
- * // "k Space"
- * ```
+ *   toAriaKeyShortcut([...parseHotkeyPattern('k'), ...parseHotkeyPattern('Space')]);
+ *   // "k Space"
+ *   ```;
  */
 export function toAriaKeyShortcut(bindings: ParsedHotkeyBinding[]): string {
   return bindings

--- a/packages/core/src/dom/hotkey/hotkey.ts
+++ b/packages/core/src/dom/hotkey/hotkey.ts
@@ -27,13 +27,13 @@ const MODIFIER_KEYS = new Set(['shift', 'ctrl', 'alt', 'meta']);
  * Parse a key pattern string into one or more bindings.
  *
  * @example
- * ```ts
- * parseHotkeyPattern('>');
- * // [{ modifiers: Set(), key: '>', originalKey: '>' }]
+ *   ```ts
+ *   parseHotkeyPattern('>');
+ *   // [{ modifiers: Set(), key: '>', originalKey: '>' }]
  *
- * parseHotkeyPattern('0-9');
- * // 10 bindings, one per digit
- * ```
+ *   parseHotkeyPattern('0-9');
+ *   // 10 bindings, one per digit
+ *   ```;
  */
 export function parseHotkeyPattern(pattern: string): ParsedHotkeyBinding[] {
   // Range expansion: "0-9" → individual digit bindings.
@@ -68,11 +68,10 @@ export function parseHotkeyPattern(pattern: string): ParsedHotkeyBinding[] {
 }
 
 /**
- * Single non-letter character — layout-dependent modifiers (Shift, Alt/Option)
- * were used to produce the character itself, not as deliberate modifiers
- * (e.g. Shift+. → ">", Option+Shift → ">" on some Mac layouts).
- * Letters excluded because Shift changes case intentionally (k vs K).
- * Named keys excluded because event.key.length > 1 (ArrowLeft, Tab, etc.).
+ * Single non-letter character — layout-dependent modifiers (Shift, Alt/Option) were used to produce the character
+ * itself, not as deliberate modifiers (e.g. Shift+. → ">", Option+Shift → ">" on some Mac layouts). Letters excluded
+ * because Shift changes case intentionally (k vs K). Named keys excluded because event.key.length > 1 (ArrowLeft, Tab,
+ * etc.).
  */
 function isImplicitModifierKey(key: string): boolean {
   return key.length === 1 && !/[a-z]/i.test(key);
@@ -130,15 +129,15 @@ export function getHotkeyCoordinator(target: HTMLElement): HotkeyCoordinator {
  * Register a hotkey binding on a target element.
  *
  * @example
- * ```ts
- * const cleanup = createHotkey(container, {
- *   keys: 'k',
- *   onActivate: () => store.paused ? store.play() : store.pause(),
- * });
+ *   ```ts
+ *   const cleanup = createHotkey(container, {
+ *     keys: 'k',
+ *     onActivate: () => (store.paused ? store.play() : store.pause()),
+ *   });
  *
- * // Later: remove the binding
- * cleanup();
- * ```
+ *   // Later: remove the binding
+ *   cleanup();
+ *   ```;
  *
  * @returns A cleanup function that removes the binding.
  */

--- a/packages/core/src/dom/player.ts
+++ b/packages/core/src/dom/player.ts
@@ -37,9 +37,8 @@ type ActionInput<Action> = Action extends (...args: infer Arguments) => unknown
   : never;
 
 /**
- * Actions accepting text, including narrower unions such as a string enum, so
- * a feature keeps its own value type on the provider input. `null | undefined`
- * stays mandatory because that is how a provider clears an absent input.
+ * Actions accepting text, including narrower unions such as a string enum, so a feature keeps its own value type on the
+ * provider input. `null | undefined` stays mandatory because that is how a provider clears an absent input.
  */
 type ConfigActionKey<State> = [State] extends [never]
   ? PropertyKey
@@ -54,17 +53,15 @@ type ConfigActionKey<State> = [State] extends [never]
 type ConfigStateKey<State> = [State] extends [never] ? PropertyKey : keyof State;
 
 /**
- * Maps provider inputs to feature-owned state actions and detach-persistent keys.
- * Pass the feature's source-state type when declaring a config map so both keys
- * are checked and each action accepts nullable text, including absent input.
+ * Maps provider inputs to feature-owned state actions and detach-persistent keys. Pass the feature's source-state type
+ * when declaring a config map so both keys are checked and each action accepts nullable text, including absent input.
  */
 export type PlayerFeatureConfig<State = never> = Record<
   string,
   {
     /**
-     * Source-state action applied when the input changes. It must accept the
-     * input's own value type plus `null | undefined`, since an input the author
-     * omits arrives as `undefined`. A feature's own public setter qualifies when
+     * Source-state action applied when the input changes. It must accept the input's own value type plus `null |
+     * undefined`, since an input the author omits arrives as `undefined`. A feature's own public setter qualifies when
      * it accepts that; otherwise point at a private action that does.
      */
     action: ConfigActionKey<State>;
@@ -73,9 +70,8 @@ export type PlayerFeatureConfig<State = never> = Record<
     /** How an HTML provider element names this input, when the key's own name won't do. */
     html?: {
       /**
-       * Attribute name in markup, kebab-case, for a key whose own name is taken
-       * on an element. The matching property follows from it, so `content-title`
-       * is also `element.contentTitle`. Defaults to the kebab-cased key.
+       * Attribute name in markup, kebab-case, for a key whose own name is taken on an element. The matching property
+       * follows from it, so `content-title` is also `element.contentTitle`. Defaults to the kebab-cased key.
        */
       attribute: string;
     };
@@ -184,10 +180,8 @@ export type AudioFeatures = [
 export type BackgroundFeatures = [];
 
 /**
- * Features for a live video player. Mirrors {@link VideoFeatures} but drops
- * the playback-rate feature (not meaningful for live) and adds
- * `PlayerFeature<MediaLiveState>` so the store exposes `liveEdgeStart` and
- * `targetLiveWindow`.
+ * Features for a live video player. Mirrors {@link VideoFeatures} but drops the playback-rate feature (not meaningful
+ * for live) and adds `PlayerFeature<MediaLiveState>` so the store exposes `liveEdgeStart` and `targetLiveWindow`.
  */
 export type LiveVideoFeatures = [
   PlayerFeature<MediaPlaybackState>,
@@ -206,10 +200,8 @@ export type LiveVideoFeatures = [
 ];
 
 /**
- * Features for a live audio player. Mirrors {@link AudioFeatures} but drops
- * the playback-rate feature (not meaningful for live) and adds
- * `PlayerFeature<MediaLiveState>` so the store exposes `liveEdgeStart` and
- * `targetLiveWindow`.
+ * Features for a live audio player. Mirrors {@link AudioFeatures} but drops the playback-rate feature (not meaningful
+ * for live) and adds `PlayerFeature<MediaLiveState>` so the store exposes `liveEdgeStart` and `targetLiveWindow`.
  */
 export type LiveAudioFeatures = [
   PlayerFeature<MediaPlaybackState>,

--- a/packages/core/src/dom/presentation/orientation.ts
+++ b/packages/core/src/dom/presentation/orientation.ts
@@ -2,18 +2,14 @@ import { isFunction, isNull } from '@videojs/utils/predicate';
 
 export interface ScreenOrientationLock {
   /**
-   * Requests `type`, replacing a lock already held for a different type.
-   * Requests never overlap: while one is in flight, a later call only records
-   * the new type and the running request applies it once it settles.
+   * Requests `type`, replacing a lock already held for a different type. Requests never overlap: while one is in
+   * flight, a later call only records the new type and the running request applies it once it settles.
    */
   lock(type: ScreenOrientationLockType): Promise<void>;
   unlock(): void;
 }
 
-/**
- * Orientation types accepted by the Screen Orientation API's
- * `screen.orientation.lock()`.
- */
+/** Orientation types accepted by the Screen Orientation API's `screen.orientation.lock()`. */
 export type ScreenOrientationLockType =
   | 'any'
   | 'landscape'
@@ -49,10 +45,9 @@ export function createScreenOrientationLock(): ScreenOrientationLock {
   };
 
   /**
-   * Drives the platform toward `desired`, one request at a time. A re-entrant
-   * call returns immediately because the running pass re-reads `desired` before
-   * it exits, so the last requested type wins without overlapping requests
-   * whose settle order the platform does not guarantee.
+   * Drives the platform toward `desired`, one request at a time. A re-entrant call returns immediately because the
+   * running pass re-reads `desired` before it exits, so the last requested type wins without overlapping requests whose
+   * settle order the platform does not guarantee.
    */
   const reconcile = async () => {
     if (settling) return;

--- a/packages/core/src/dom/presentation/pip.ts
+++ b/packages/core/src/dom/presentation/pip.ts
@@ -17,11 +17,10 @@ export function isPictureInPictureEnabled() {
 }
 
 /**
- * Whether this media can enter picture-in-picture at all, which is a separate
- * question from whether the browser supports it. Mirrors the branches
- * `requestPictureInPicture` takes below, so anything it would refuse to act on
- * reports as incapable here — an iframe embed whose provider has no
- * picture-in-picture can never enter it, however capable the browser is.
+ * Whether this media can enter picture-in-picture at all, which is a separate question from whether the browser
+ * supports it. Mirrors the branches `requestPictureInPicture` takes below, so anything it would refuse to act on
+ * reports as incapable here — an iframe embed whose provider has no picture-in-picture can never enter it, however
+ * capable the browser is.
  */
 export function isPictureInPictureCapable(media: EventTarget) {
   const webkitVideo = media as WebKitVideoElement;

--- a/packages/core/src/dom/store/features/live.ts
+++ b/packages/core/src/dom/store/features/live.ts
@@ -5,18 +5,15 @@ import { listen } from '@videojs/utils/dom';
 import { definePlayerFeature } from '../../feature';
 
 /**
- * Player feature exposing `liveEdgeStart` and `targetLiveWindow` in store
- * state for media that implements `MediaLiveCapability` (currently
- * `HlsJsMedia` and its delegates).
+ * Player feature exposing `liveEdgeStart` and `targetLiveWindow` in store state for media that implements
+ * `MediaLiveCapability` (currently `HlsJsMedia` and its delegates).
  *
- * - `liveEdgeStart` — presentation time marking the start of the Live Edge
- *   Window. Playing at the live edge when `currentTime >= liveEdgeStart`.
- *   `NaN` when the stream isn't live or the value is unknown.
- * - `targetLiveWindow` — `0` for standard latency live, `Infinity` for DVR,
- *   `NaN` for on-demand or unknown.
+ * - `liveEdgeStart` — presentation time marking the start of the Live Edge Window. Playing at the live edge when
+ *   `currentTime >= liveEdgeStart`. `NaN` when the stream isn't live or the value is unknown.
+ * - `targetLiveWindow` — `0` for standard latency live, `Infinity` for DVR, `NaN` for on-demand or unknown.
  *
- * Included by the {@link liveVideoFeatures} and {@link liveAudioFeatures}
- * presets; apps can also compose it into a custom preset.
+ * Included by the {@link liveVideoFeatures} and {@link liveAudioFeatures} presets; apps can also compose it into a
+ * custom preset.
  *
  * @see https://github.com/video-dev/media-ui-extensions/blob/main/proposals/0007-live-edge.md
  */

--- a/packages/core/src/dom/store/features/metadata.ts
+++ b/packages/core/src/dom/store/features/metadata.ts
@@ -25,9 +25,8 @@ interface MetadataSourceState extends Omit<MediaMetadataState, 'title' | 'poster
 }
 
 /**
- * Resolves content metadata into player state, preferring what the author set
- * over what the media carries. Included in the standard audio, video, and live
- * presets.
+ * Resolves content metadata into player state, preferring what the author set over what the media carries. Included in
+ * the standard audio, video, and live presets.
  */
 export const metadataFeature = definePlayerFeature({
   name: 'metadata',
@@ -58,8 +57,8 @@ export const metadataFeature = definePlayerFeature({
     /** The resolved content title. Set it through the player, not through the store. */
     title: ({ get }) => get()[USER_TITLE] ?? get()[MEDIA_TITLE] ?? DEFAULT_TITLE,
     /**
-     * The resolved poster URL, independent of the media element's own `poster`.
-     * Set it through the player, not through the store.
+     * The resolved poster URL, independent of the media element's own `poster`. Set it through the player, not through
+     * the store.
      */
     poster: ({ get }) => get()[USER_POSTER] ?? get()[MEDIA_POSTER] ?? DEFAULT_POSTER,
   },

--- a/packages/core/src/dom/store/features/orientation-lock.ts
+++ b/packages/core/src/dom/store/features/orientation-lock.ts
@@ -16,8 +16,8 @@ export interface OrientationLockState {
   /** Screen orientation type locked while fullscreen is active. */
   orientationLockType: ScreenOrientationLockType;
   /**
-   * Sets the locked orientation type. Absent input — nullish, or the empty
-   * string a valueless HTML attribute produces — restores the default.
+   * Sets the locked orientation type. Absent input — nullish, or the empty string a valueless HTML attribute produces —
+   * restores the default.
    */
   setOrientationLockType(value: ScreenOrientationLockType | null | undefined): void;
 }
@@ -25,9 +25,8 @@ export interface OrientationLockState {
 /**
  * Locks screen orientation while fullscreen is active.
  *
- * The orientation type is provider configuration, so it can change during the
- * player's lifetime. Unsupported browsers and rejected lock requests are
- * ignored.
+ * The orientation type is provider configuration, so it can change during the player's lifetime. Unsupported browsers
+ * and rejected lock requests are ignored.
  */
 export const orientationLockFeature = definePlayerFeature({
   name: 'orientationLock',
@@ -107,8 +106,7 @@ export const orientationLockFeature = definePlayerFeature({
 // in the site's api-docs-builder scans this module so the selector still gets
 // a reference page.
 /**
- * Select the orientation lock state (`orientationLockType`,
- * `setOrientationLockType`). Returns `undefined` when the feature is not
- * configured.
+ * Select the orientation lock state (`orientationLockType`, `setOrientationLockType`). Returns `undefined` when the
+ * feature is not configured.
  */
 export const selectOrientationLock = createSelector(orientationLockFeature);

--- a/packages/core/src/dom/store/features/presets.ts
+++ b/packages/core/src/dom/store/features/presets.ts
@@ -55,10 +55,8 @@ export const audioFeatures: AudioFeatures = [
 export const backgroundFeatures: BackgroundFeatures = [];
 
 /**
- * Features for a live video player. Mirrors {@link videoFeatures} but drops
- * {@link playbackRateFeature} (not meaningful for live) and adds
- * {@link liveFeature} so store consumers can read `liveEdgeStart` and
- * `targetLiveWindow`.
+ * Features for a live video player. Mirrors {@link videoFeatures} but drops {@link playbackRateFeature} (not meaningful
+ * for live) and adds {@link liveFeature} so store consumers can read `liveEdgeStart` and `targetLiveWindow`.
  */
 export const liveVideoFeatures: LiveVideoFeatures = [
   playbackFeature,
@@ -77,10 +75,8 @@ export const liveVideoFeatures: LiveVideoFeatures = [
 ];
 
 /**
- * Features for a live audio player. Mirrors {@link audioFeatures} but drops
- * {@link playbackRateFeature} (not meaningful for live) and adds
- * {@link liveFeature} so store consumers can read `liveEdgeStart` and
- * `targetLiveWindow`.
+ * Features for a live audio player. Mirrors {@link audioFeatures} but drops {@link playbackRateFeature} (not meaningful
+ * for live) and adds {@link liveFeature} so store consumers can read `liveEdgeStart` and `targetLiveWindow`.
  */
 export const liveAudioFeatures: LiveAudioFeatures = [
   playbackFeature,

--- a/packages/core/src/dom/store/features/tests/pip.test.ts
+++ b/packages/core/src/dom/store/features/tests/pip.test.ts
@@ -16,9 +16,8 @@ function enablePictureInPicture() {
 }
 
 /**
- * A video element as a browser that supports picture-in-picture presents one.
- * happy-dom implements neither the method nor the property, so a bare element
- * reads as media that cannot enter picture-in-picture at all.
+ * A video element as a browser that supports picture-in-picture presents one. happy-dom implements neither the method
+ * nor the property, so a bare element reads as media that cannot enter picture-in-picture at all.
  */
 function createPipCapableVideo(): HTMLVideoElement {
   const video = createMockVideo();

--- a/packages/core/src/dom/store/features/tests/text-track.test.ts
+++ b/packages/core/src/dom/store/features/tests/text-track.test.ts
@@ -5,11 +5,10 @@ import type { PlayerTarget } from '../../../player';
 import { textTrackFeature } from '../text-track';
 
 /**
- * jsdom's TextTrackList does not implement EventTarget (no addEventListener/
- * dispatchEvent), so `listen(media.textTracks, ...)` throws. The store's
- * error boundary catches this, but we can't dispatch textTracks events in
- * tests. We test what we can: initial state, track detection via `addTextTrack`,
- * and `loadstart` resync (dispatched on media, which works).
+ * Jsdom's TextTrackList does not implement EventTarget (no addEventListener/ dispatchEvent), so
+ * `listen(media.textTracks, ...)` throws. The store's error boundary catches this, but we can't dispatch textTracks
+ * events in tests. We test what we can: initial state, track detection via `addTextTrack`, and `loadstart` resync
+ * (dispatched on media, which works).
  */
 
 function createVideo(): HTMLVideoElement {
@@ -62,9 +61,8 @@ describe('textTrackFeature', () => {
 
   describe('thumbnailTrackCrossOrigin', () => {
     /**
-     * Resolve the state for a media element carrying a thumbnail track. Uses
-     * `mockTextTracks` rather than `addTextTrack`, which jsdom implements as a
-     * no-op that never populates `textTracks`.
+     * Resolve the state for a media element carrying a thumbnail track. Uses `mockTextTracks` rather than
+     * `addTextTrack`, which jsdom implements as a no-op that never populates `textTracks`.
      */
     function crossOriginFor(crossOrigin: string | undefined, kind: TextTrackKind = 'metadata') {
       const video = createVideo();

--- a/packages/core/src/dom/store/features/text-track.ts
+++ b/packages/core/src/dom/store/features/text-track.ts
@@ -22,8 +22,8 @@ function getTrackId(track: TextTrackLike, index: number): string {
 }
 
 /**
- * Caption/subtitle tracks paired with the ids exposed through `textTrackList`,
- * ordered like the captions menu so index-based fallbacks agree with the UI.
+ * Caption/subtitle tracks paired with the ids exposed through `textTrackList`, ordered like the captions menu so
+ * index-based fallbacks agree with the UI.
  */
 function getSubtitlesTracks(media: MediaTextTrackCapability): IdentifiedTrack[] {
   return Array.from(media.textTracks)
@@ -42,9 +42,8 @@ function showOnly(tracks: IdentifiedTrack[], active: TextTrackLike | null): void
 }
 
 /**
- * Map a media element's `crossOrigin` to a CORS mode. Per the CORS-settings
- * attribute, any value other than `use-credentials` is Anonymous — including
- * the empty string and unknown keywords.
+ * Map a media element's `crossOrigin` to a CORS mode. Per the CORS-settings attribute, any value other than
+ * `use-credentials` is Anonymous — including the empty string and unknown keywords.
  */
 function toCorsMode(value: string | null | undefined): MediaTextTrackState['thumbnailTrackCrossOrigin'] {
   if (isNil(value)) return null;

--- a/packages/core/src/dom/tests/setup.ts
+++ b/packages/core/src/dom/tests/setup.ts
@@ -1,5 +1,5 @@
 /**
- * jsdom test setup for `core/dom`.
+ * Jsdom test setup for `core/dom`.
  *
  * Patches missing APIs that jsdom doesn't implement but our DOM code depends on.
  */

--- a/packages/core/src/dom/tests/test-helpers.ts
+++ b/packages/core/src/dom/tests/test-helpers.ts
@@ -22,9 +22,8 @@ interface MockVideoOverrides {
 /**
  * Create an `HTMLVideoElement` with overridable properties.
  *
- * Readonly properties (`paused`, `ended`, `readyState`, `duration`, `currentSrc`,
- * `buffered`, `seekable`) are set via `Object.defineProperty`.
- * Writable properties (`currentTime`, `volume`, `muted`, `src`) are assigned directly.
+ * Readonly properties (`paused`, `ended`, `readyState`, `duration`, `currentSrc`, `buffered`, `seekable`) are set via
+ * `Object.defineProperty`. Writable properties (`currentTime`, `volume`, `muted`, `src`) are assigned directly.
  */
 export function createMockVideo(overrides: MockVideoOverrides = {}): HTMLVideoElement {
   const video = document.createElement('video');

--- a/packages/core/src/dom/ui/popover/popover-positioning.ts
+++ b/packages/core/src/dom/ui/popover/popover-positioning.ts
@@ -98,17 +98,14 @@ function getAnchorCrossAxisShift(
 /**
  * Get positioning styles for the popup element.
  *
- * When the browser supports CSS Anchor Positioning, returns native CSS properties
- * that reference the provided CSS var names for side/align offsets — no JS offset
- * values needed.
+ * When the browser supports CSS Anchor Positioning, returns native CSS properties that reference the provided CSS var
+ * names for side/align offsets — no JS offset values needed.
  *
- * When rects are provided and anchor positioning is unsupported, falls back to
- * manual JS-computed positioning. The caller must resolve offset CSS vars via
- * `getComputedStyle` and pass them as `offsets`.
+ * When rects are provided and anchor positioning is unsupported, falls back to manual JS-computed positioning. The
+ * caller must resolve offset CSS vars via `getComputedStyle` and pass them as `offsets`.
  *
- * Returns camelCase keys for standard CSS properties and `--*` keys for
- * custom properties — compatible with both React's `style` prop and
- * `applyStyles()` from `@videojs/utils/dom`.
+ * Returns camelCase keys for standard CSS properties and `--*` keys for custom properties — compatible with both
+ * React's `style` prop and `applyStyles()` from `@videojs/utils/dom`.
  */
 export function getAnchorPositionStyle(
   anchorName: string,
@@ -246,8 +243,8 @@ function getAnchorPositionCSS(
 /**
  * Compute CSS variables for sizing constraints relative to the anchor/boundary.
  *
- * Accepts a `cssVars` map so the same logic works for both popover
- * (`--media-popover-*`) and tooltip (`--media-tooltip-*`) namespaces.
+ * Accepts a `cssVars` map so the same logic works for both popover (`--media-popover-*`) and tooltip
+ * (`--media-tooltip-*`) namespaces.
  */
 export function getPositioningCSSVars(
   triggerRect: DOMRect,
@@ -286,12 +283,10 @@ export function getPositioningCSSVars(
 /**
  * Compute manual positioning when CSS Anchor Positioning is not supported.
  *
- * Returns inline `top`/`left` styles in **viewport coordinates** for use
- * with `position: fixed` (the popup is in the top layer). All rects from
- * `getBoundingClientRect()` are already viewport-relative.
+ * Returns inline `top`/`left` styles in **viewport coordinates** for use with `position: fixed` (the popup is in the
+ * top layer). All rects from `getBoundingClientRect()` are already viewport-relative.
  *
- * Offsets are resolved by the caller from CSS custom properties via
- * `getComputedStyle()` and passed as `offsets`.
+ * Offsets are resolved by the caller from CSS custom properties via `getComputedStyle()` and passed as `offsets`.
  */
 export function getManualPositionStyle(
   triggerRect: DOMRect,
@@ -370,8 +365,8 @@ export function getManualPositionStyle(
 }
 
 /**
- * Read positioning offset CSS custom properties from the
- * popup element's computed style, returning numeric pixel values.
+ * Read positioning offset CSS custom properties from the popup element's computed style, returning numeric pixel
+ * values.
  */
 export function resolveOffsets(el: Element, cssVars: PositioningCSSVars = PopoverCSSVars): PositioningOffsets {
   const computed = getComputedStyle(el);
@@ -386,9 +381,8 @@ export function resolveOffsets(el: Element, cssVars: PositioningCSSVars = Popove
 /**
  * Measure the popup's layout box for positioning.
  *
- * `getBoundingClientRect()` includes active transforms, which causes the
- * fallback position to drift while opening/closing animations scale the popup.
- * Using layout dimensions preserves the untransformed size, while the
+ * `getBoundingClientRect()` includes active transforms, which causes the fallback position to drift while
+ * opening/closing animations scale the popup. Using layout dimensions preserves the untransformed size, while the
  * side-axis scroll dimension includes content clipped by size constraints.
  */
 export function getPopupPositionRect(el: HTMLElement, side: PopoverSide): DOMRect {

--- a/packages/core/src/dom/ui/popover/popover.ts
+++ b/packages/core/src/dom/ui/popover/popover.ts
@@ -165,18 +165,15 @@ export function createPopover(options: PopoverOptions): PopoverApi {
   /**
    * The transition handler manages animation lifecycle via `createState`:
    *
-   * **Open:** `transition.open()` patches `{ active: true, status: 'starting' }`.
-   * After a double-RAF it patches `{ status: 'idle' }`, then waits for the
-   * resulting element animations before the promise resolves.
-   * Frameworks render `data-starting-style` / `data-ending-style` via
-   * `getPopupAttrs(state)` — no imperative DOM mutation needed.
+   * **Open:** `transition.open()` patches `{ active: true, status: 'starting' }`. After a double-RAF it patches `{
+   * status: 'idle' }`, then waits for the resulting element animations before the promise resolves. Frameworks render
+   * `data-starting-style` / `data-ending-style` via `getPopupAttrs(state)` — no imperative DOM mutation needed.
    *
-   * **Close:** `transition.close(el)` patches `{ status: 'ending' }` (keeping
-   * `active: true` so the element stays mounted). After a double-RAF it waits
-   * for `getAnimations()` to settle, then patches `{ active: false, status: 'idle' }`.
+   * **Close:** `transition.close(el)` patches `{ status: 'ending' }` (keeping `active: true` so the element stays
+   * mounted). After a double-RAF it waits for `getAnimations()` to settle, then patches `{ active: false, status:
+   * 'idle' }`.
    *
-   * `onOpenChange` fires immediately (before animations).
-   * `onOpenChangeComplete` fires after animations finish.
+   * `onOpenChange` fires immediately (before animations). `onOpenChangeComplete` fires after animations finish.
    */
   function commitOpen(): void {
     // React content can mount after this commit begins, so resolve the popup

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -26,10 +26,9 @@ export interface SliderOptions {
   getLargeStepPercent: () => number;
 
   /**
-   * Leading+trailing throttle (ms) for `onValueChange` during drag. When
-   * `> 0`, `onValueChange` fires immediately on the first drag move (leading
-   * edge), then at most once per window during subsequent moves. `0` (default)
-   * disables throttling — `onValueChange` fires on every pointermove.
+   * Leading+trailing throttle (ms) for `onValueChange` during drag. When `> 0`, `onValueChange` fires immediately on
+   * the first drag move (leading edge), then at most once per window during subsequent moves. `0` (default) disables
+   * throttling — `onValueChange` fires on every pointermove.
    */
   changeThrottle?: number | undefined;
   /** Adjust a raw 0–100 percent for thumb alignment. Enables `adjustForAlignment()`. */
@@ -69,9 +68,8 @@ export interface SliderApi {
   rootStyle: SliderRootStyle;
   thumbProps: SliderThumbProps;
   /**
-   * Adjust `fillPercent` and `pointerPercent` for edge thumb alignment using
-   * live DOM measurements from the root/thumb elements. No-op when
-   * `adjustPercent` was not provided or `thumbAlignment` is not `'edge'`.
+   * Adjust `fillPercent` and `pointerPercent` for edge thumb alignment using live DOM measurements from the root/thumb
+   * elements. No-op when `adjustPercent` was not provided or `thumbAlignment` is not `'edge'`.
    */
   adjustForAlignment: <S extends SliderState>(state: S) => S;
   destroy: () => void;

--- a/packages/core/src/dom/ui/transition.ts
+++ b/packages/core/src/dom/ui/transition.ts
@@ -16,15 +16,12 @@ export type TransitionElement = HTMLElement | null | (() => HTMLElement | null);
 /**
  * Manages open/close transition lifecycle via `createState`.
  *
- * **Open:** patches `{ active: true, status: 'starting' }`, then after a
- * double-RAF patches `{ status: 'idle' }` so the browser paints the
- * initial ("from") state before transitioning. It then waits for the resulting
- * element animations to finish. Reopening an active transition flushes styles
- * first so CSS transitions can restart.
+ * **Open:** patches `{ active: true, status: 'starting' }`, then after a double-RAF patches `{ status: 'idle' }` so the
+ * browser paints the initial ("from") state before transitioning. It then waits for the resulting element animations to
+ * finish. Reopening an active transition flushes styles first so CSS transitions can restart.
  *
- * **Close:** patches `{ status: 'ending' }` (keeping `active: true` so the
- * element stays mounted), then after a double-RAF waits for
- * `getAnimations()` to settle before patching `{ active: false, status: 'idle' }`.
+ * **Close:** patches `{ status: 'ending' }` (keeping `active: true` so the element stays mounted), then after a
+ * double-RAF waits for `getAnimations()` to settle before patching `{ active: false, status: 'idle' }`.
  */
 export function createTransition(): TransitionApi {
   const state = createState<TransitionState>({ active: false, status: 'idle' });

--- a/packages/core/src/dom/utils/element-props.ts
+++ b/packages/core/src/dom/utils/element-props.ts
@@ -4,11 +4,9 @@ import { isFunction, isUndefined } from '@videojs/utils/predicate';
 /**
  * Apply props to a DOM element.
  *
- * Handles both attributes and event listeners:
- * - Event props (onClick, onKeyDown, etc.) are attached as listeners
- * - Boolean props: `true` sets empty attribute, `false` removes
- * - `undefined` removes the attribute
- * - Other props are set as string attributes
+ * Handles both attributes and event listeners: - Event props (onClick, onKeyDown, etc.) are attached as listeners -
+ * Boolean props: `true` sets empty attribute, `false` removes - `undefined` removes the attribute - Other props are set
+ * as string attributes
  */
 export function applyElementProps(element: HTMLElement, props: object, options?: { signal?: AbortSignal }): void {
   const signal = options?.signal;

--- a/packages/core/src/dom/utils/state-data-attrs.ts
+++ b/packages/core/src/dom/utils/state-data-attrs.ts
@@ -4,17 +4,17 @@ import type { StateAttrMap } from '../../core/ui/types';
  * Convert state object to data attributes.
  *
  * - `true` → `data-keyname=""`
- * - truthy string/number → `data-keyname="value"`
- * - falsy → no attribute
+ * - Truthy string/number → `data-keyname="value"`
+ * - Falsy → no attribute
  *
  * @example
- * ```ts
- * const state = { paused: true, ended: false, volume: 0.5 };
- * getStateDataAttrs(state);
- * // { 'data-paused': '', 'data-volume': '0.5' }
- * ```
+ *   ```ts
+ *   const state = { paused: true, ended: false, volume: 0.5 };
+ *   getStateDataAttrs(state);
+ *   // { 'data-paused': '', 'data-volume': '0.5' }
+ *   ```
  *
- * When a mapping is provided, only mapped keys are converted.
+ *   When a mapping is provided, only mapped keys are converted.
  */
 export function getStateDataAttrs<State extends object>(
   state: State,
@@ -42,15 +42,15 @@ export function getStateDataAttrs<State extends object>(
  * Apply state as data attributes to an element.
  *
  * - `true` → sets `data-keyname=""`
- * - truthy string/number → sets `data-keyname="value"`
- * - falsy → removes the attribute
+ * - Truthy string/number → sets `data-keyname="value"`
+ * - Falsy → removes the attribute
  *
  * @example
- * ```ts
- * const state = { paused: true, ended: false };
- * applyStateDataAttrs(element, state);
- * // element has data-paused="", data-ended is removed
- * ```
+ *   ```ts
+ *   const state = { paused: true, ended: false };
+ *   applyStateDataAttrs(element, state);
+ *   // element has data-paused="", data-ended is removed
+ *   ```;
  */
 export function applyStateDataAttrs<State extends object>(
   element: HTMLElement,

--- a/packages/element/src/destroy-mixin.ts
+++ b/packages/element/src/destroy-mixin.ts
@@ -10,20 +10,17 @@ export interface Destroyable {
 /**
  * Mixin that adds a deferred destruction lifecycle to a `ReactiveElement`.
  *
- * On disconnect, schedules destruction after two animation frames.
- * If the element reconnects before the frames fire (e.g. DOM shuffling,
- * framework reconciliation), the `isConnected` check prevents destruction.
+ * On disconnect, schedules destruction after two animation frames. If the element reconnects before the frames fire
+ * (e.g. DOM shuffling, framework reconciliation), the `isConnected` check prevents destruction.
  *
- * The `keep-alive` attribute prevents automatic destruction entirely —
- * call `destroy()` manually when done.
+ * The `keep-alive` attribute prevents automatic destruction entirely — call `destroy()` manually when done.
  *
- * Subclasses override `destroyCallback()` (calling `super.destroyCallback()`)
- * to release heavy resources like stores or imperative APIs.
+ * Subclasses override `destroyCallback()` (calling `super.destroyCallback()`) to release heavy resources like stores or
+ * imperative APIs.
  *
- * Mirrors `addController`/`removeController` to track controllers
- * (needed because `ReactiveElement.#controllers` is hard-private),
- * calls `hostDestroyed()` on all tracked controllers in `destroyCallback`,
- * and guards `performUpdate()` so no updates run after destruction.
+ * Mirrors `addController`/`removeController` to track controllers (needed because `ReactiveElement.#controllers` is
+ * hard-private), calls `hostDestroyed()` on all tracked controllers in `destroyCallback`, and guards `performUpdate()`
+ * so no updates run after destruction.
  */
 export function DestroyMixin<Base extends new (...args: any[]) => ReactiveElement>(SuperClass: Base) {
   class DestroyableElement extends SuperClass {

--- a/packages/element/src/reactive-element.ts
+++ b/packages/element/src/reactive-element.ts
@@ -11,57 +11,50 @@ const propertyKeys = new Map<string, symbol>();
 /**
  * Lightweight reactive custom element base class.
  *
- * Drop-in subset of Lit's `ReactiveElement` — supports `static properties`,
- * attribute reflection, batched async updates, and reactive controllers.
- * No Shadow DOM, no `static styles`, no decorators.
+ * Drop-in subset of Lit's `ReactiveElement` — supports `static properties`, attribute reflection, batched async
+ * updates, and reactive controllers. No Shadow DOM, no `static styles`, no decorators.
  *
- * Updates are batched using the same Promise-based scheduling as Lit:
- * property changes enqueue a microtask, and the update is gated behind
- * `connectedCallback` so the first update only runs once the element
- * is in the document.
+ * Updates are batched using the same Promise-based scheduling as Lit: property changes enqueue a microtask, and the
+ * update is gated behind `connectedCallback` so the first update only runs once the element is in the document.
  *
  * Subclasses that extend another element with properties must spread them:
  *
  * @example
- * ```ts
- * class MyButton extends ReactiveElement {
- *   static override properties = {
- *     label: { type: String },
- *     disabled: { type: Boolean },
- *   };
+ *   ```ts
+ *   class MyButton extends ReactiveElement {
+ *     static override properties = {
+ *       label: { type: String },
+ *       disabled: { type: Boolean },
+ *     };
  *
- *   label = 'Click me';
- *   disabled = false;
+ *     label = 'Click me';
+ *     disabled = false;
  *
- *   protected override update(changed: PropertyValues): void {
- *     super.update(changed);
- *     this.textContent = this.label;
+ *     protected override update(changed: PropertyValues): void {
+ *       super.update(changed);
+ *       this.textContent = this.label;
+ *     }
  *   }
- * }
  *
- * // Inheritance — spread parent properties
- * class FancyButton extends MyButton {
- *   static override properties = {
- *     ...MyButton.properties,
- *     variant: { type: String },
- *   };
+ *   // Inheritance — spread parent properties
+ *   class FancyButton extends MyButton {
+ *     static override properties = {
+ *       ...MyButton.properties,
+ *       variant: { type: String },
+ *     };
  *
- *   variant = 'primary';
- * }
- * ```
+ *     variant = 'primary';
+ *   }
+ *   ```;
  */
 export class ReactiveElement extends HTMLElement {
   /**
-   * User-supplied object that maps property names to
-   * {@linkcode PropertyDeclaration} objects containing options for configuring
-   * reactive properties. When a reactive property is set the element will
-   * update and render.
+   * User-supplied object that maps property names to {@linkcode PropertyDeclaration} objects containing options for
+   * configuring reactive properties. When a reactive property is set the element will update and render.
    */
   static properties: PropertyDeclarationMap = {};
 
-  /**
-   * Returns a list of attributes corresponding to the registered properties.
-   */
+  /** Returns a list of attributes corresponding to the registered properties. */
   static get observedAttributes(): string[] {
     return [...resolve(this).attrToProp.keys()];
   }
@@ -73,22 +66,18 @@ export class ReactiveElement extends HTMLElement {
   #instanceProperties: Map<string, unknown> | undefined;
 
   /**
-   * Promise that gates the first update until `connectedCallback`. Also
-   * used to serialize updates — each `#enqueueUpdate` awaits the previous
-   * `#updatePromise`, so property changes are batched and updates never
-   * overlap. Matches Lit's scheduling model.
+   * Promise that gates the first update until `connectedCallback`. Also used to serialize updates — each
+   * `#enqueueUpdate` awaits the previous `#updatePromise`, so property changes are batched and updates never overlap.
+   * Matches Lit's scheduling model.
    */
   #updatePromise: Promise<boolean>;
 
-  /**
-   * True if there is a pending update as a result of calling
-   * `requestUpdate()`. Should only be read.
-   */
+  /** True if there is a pending update as a result of calling `requestUpdate()`. Should only be read. */
   isUpdatePending = false;
 
   /**
-   * Is set to `true` after the first update. The element code cannot assume
-   * that the DOM is fully initialized before the element `hasUpdated`.
+   * Is set to `true` after the first update. The element code cannot assume that the DOM is fully initialized before
+   * the element `hasUpdated`.
    */
   hasUpdated = false;
 
@@ -119,19 +108,17 @@ export class ReactiveElement extends HTMLElement {
   }
 
   /**
-   * Note, this method should be considered final and not overridden. It is
-   * overridden on the element instance with a function that triggers the
-   * first update.
+   * Note, this method should be considered final and not overridden. It is overridden on the element instance with a
+   * function that triggers the first update.
    */
   protected enableUpdating(_requestedUpdate: boolean): void {}
 
   /**
-   * Registers a {@linkcode ReactiveController} to participate in the
-   * element's reactive update cycle. The element automatically calls into
-   * any registered controllers during its lifecycle callbacks.
+   * Registers a {@linkcode ReactiveController} to participate in the element's reactive update cycle. The element
+   * automatically calls into any registered controllers during its lifecycle callbacks.
    *
-   * If the element is connected when `addController()` is called, the
-   * controller's `hostConnected()` callback will be immediately called.
+   * If the element is connected when `addController()` is called, the controller's `hostConnected()` callback will be
+   * immediately called.
    */
   addController(controller: ReactiveController): void {
     this.#controllers.add(controller);
@@ -146,9 +133,7 @@ export class ReactiveElement extends HTMLElement {
     this.#controllers.delete(controller);
   }
 
-  /**
-   * On first connection, enables updating and notifies controllers.
-   */
+  /** On first connection, enables updating and notifies controllers. */
   connectedCallback(): void {
     this.enableUpdating(true);
 
@@ -166,10 +151,8 @@ export class ReactiveElement extends HTMLElement {
   /**
    * Synchronizes property values when attributes change.
    *
-   * Specifically, when an attribute is set, the corresponding property is
-   * set. You should rarely need to implement this callback. If this method
-   * is overridden, `super.attributeChangedCallback(name, _old, value)` must
-   * be called.
+   * Specifically, when an attribute is set, the corresponding property is set. You should rarely need to implement this
+   * callback. If this method is overridden, `super.attributeChangedCallback(name, _old, value)` must be called.
    */
   attributeChangedCallback(attr: string, oldValue: string | null, newValue: string | null): void {
     if (oldValue === newValue) return;
@@ -195,12 +178,10 @@ export class ReactiveElement extends HTMLElement {
   }
 
   /**
-   * Requests an update which is processed asynchronously. This should be
-   * called when an element should update based on some state not triggered
-   * by setting a reactive property. In this case, pass no arguments. It
-   * should also be called when manually implementing a property setter. In
-   * this case, pass the property `name` and `oldValue` to ensure that any
-   * configured property options are honored.
+   * Requests an update which is processed asynchronously. This should be called when an element should update based on
+   * some state not triggered by setting a reactive property. In this case, pass no arguments. It should also be called
+   * when manually implementing a property setter. In this case, pass the property `name` and `oldValue` to ensure that
+   * any configured property options are honored.
    */
   requestUpdate(name?: string, oldValue?: unknown): void {
     if (name !== undefined) {
@@ -213,9 +194,8 @@ export class ReactiveElement extends HTMLElement {
   }
 
   /**
-   * Sets up the element to asynchronously update. Awaits the previous
-   * `#updatePromise` which both serializes updates and (on first update)
-   * waits for `connectedCallback` to resolve the gate.
+   * Sets up the element to asynchronously update. Awaits the previous `#updatePromise` which both serializes updates
+   * and (on first update) waits for `connectedCallback` to resolve the gate.
    */
   async #enqueueUpdate(): Promise<boolean> {
     this.isUpdatePending = true;
@@ -242,11 +222,9 @@ export class ReactiveElement extends HTMLElement {
   }
 
   /**
-   * Schedules an element update. You can override this method to change the
-   * timing of updates by returning a Promise. The update will await the
-   * returned Promise, and you should resolve the Promise to allow the update
-   * to proceed. If this method is overridden, `super.scheduleUpdate()` must
-   * be called.
+   * Schedules an element update. You can override this method to change the timing of updates by returning a Promise.
+   * The update will await the returned Promise, and you should resolve the Promise to allow the update to proceed. If
+   * this method is overridden, `super.scheduleUpdate()` must be called.
    *
    * For instance, to schedule updates to occur just before the next frame:
    *
@@ -262,12 +240,11 @@ export class ReactiveElement extends HTMLElement {
   }
 
   /**
-   * Performs an element update. Note, if an exception is thrown during the
-   * update, `firstUpdated` and `updated` will not be called.
+   * Performs an element update. Note, if an exception is thrown during the update, `firstUpdated` and `updated` will
+   * not be called.
    *
-   * Call `performUpdate()` to immediately process a pending update. This
-   * should generally not be needed, but it can be done in rare cases when
-   * you need to update synchronously.
+   * Call `performUpdate()` to immediately process a pending update. This should generally not be needed, but it can be
+   * done in rare cases when you need to update synchronously.
    */
   protected performUpdate(): void {
     // Abort any update if one is not pending when this is called.
@@ -313,8 +290,8 @@ export class ReactiveElement extends HTMLElement {
   /**
    * Invoked before `update()` to compute values needed during the update.
    *
-   * Implement `willUpdate` to compute property values that depend on other
-   * properties and are used in the rest of the update process.
+   * Implement `willUpdate` to compute property values that depend on other properties and are used in the rest of the
+   * update process.
    *
    * ```ts
    * willUpdate(changed) {
@@ -327,35 +304,30 @@ export class ReactiveElement extends HTMLElement {
   protected willUpdate(_changed: PropertyValues): void {}
 
   /**
-   * Updates the element. This method reflects property values to attributes
-   * and can be overridden to render and keep updated element DOM. Setting
-   * properties inside this method will *not* trigger another update.
+   * Updates the element. This method reflects property values to attributes and can be overridden to render and keep
+   * updated element DOM. Setting properties inside this method will _not_ trigger another update.
    */
   protected update(_changed: PropertyValues): void {}
 
   /**
-   * Invoked when the element is first updated. Implement to perform one
-   * time work on the element after update.
+   * Invoked when the element is first updated. Implement to perform one time work on the element after update.
    *
-   * Setting properties inside this method will trigger the element to
-   * update again after this update cycle completes.
+   * Setting properties inside this method will trigger the element to update again after this update cycle completes.
    */
   protected firstUpdated(_changed: PropertyValues): void {}
 
   /**
-   * Invoked whenever the element is updated. Implement to perform
-   * post-updating tasks via DOM APIs, for example, focusing an element.
+   * Invoked whenever the element is updated. Implement to perform post-updating tasks via DOM APIs, for example,
+   * focusing an element.
    *
-   * Setting properties inside this method will trigger the element to
-   * update again after this update cycle completes.
+   * Setting properties inside this method will trigger the element to update again after this update cycle completes.
    */
   protected updated(_changed: PropertyValues): void {}
 
   /**
-   * Returns a Promise that resolves when the element has completed updating.
-   * The Promise value is a boolean that is `true` if the element completed
-   * the update without triggering another update. The Promise result is
-   * `false` if a property was set inside `updated()`.
+   * Returns a Promise that resolves when the element has completed updating. The Promise value is a boolean that is
+   * `true` if the element completed the update without triggering another update. The Promise result is `false` if a
+   * property was set inside `updated()`.
    */
   get updateComplete(): Promise<boolean> {
     return this.#updatePromise;
@@ -363,11 +335,11 @@ export class ReactiveElement extends HTMLElement {
 }
 
 /**
- * Resolve `ctor.properties` into lookup Maps and install reactive accessors
- * on the prototype. Runs once per class, result is cached.
+ * Resolve `ctor.properties` into lookup Maps and install reactive accessors on the prototype. Runs once per class,
+ * result is cached.
  *
- * Subclasses that need parent properties must spread them:
- * `static override properties = { ...Parent.properties, ... }`.
+ * Subclasses that need parent properties must spread them: `static override properties = { ...Parent.properties, ...
+ * }`.
  */
 function resolve(ctor: typeof ReactiveElement): ResolvedMeta {
   const existing = cache.get(ctor);

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -1,11 +1,8 @@
-/**
- * An object that can host Reactive Controllers and call their lifecycle
- * callbacks.
- */
+/** An object that can host Reactive Controllers and call their lifecycle callbacks. */
 export interface ReactiveControllerHost {
   /**
-   * Adds a controller to the host, which sets up the controller's lifecycle
-   * methods to be called with the host's lifecycle.
+   * Adds a controller to the host, which sets up the controller's lifecycle methods to be called with the host's
+   * lifecycle.
    */
   addController(controller: ReactiveController): void;
 
@@ -13,86 +10,69 @@ export interface ReactiveControllerHost {
   removeController(controller: ReactiveController): void;
 
   /**
-   * Requests a host update which is processed asynchronously. The update can
-   * be waited on via the `updateComplete` property.
+   * Requests a host update which is processed asynchronously. The update can be waited on via the `updateComplete`
+   * property.
    */
   requestUpdate(): void;
 
   /**
-   * Returns a Promise that resolves when the host has completed updating.
-   * The Promise value is a boolean that is `true` if the element completed the
-   * update without triggering another update. The Promise result is `false` if
-   * a property was set inside `updated()`. If the Promise is rejected, an
-   * exception was thrown during the update.
+   * Returns a Promise that resolves when the host has completed updating. The Promise value is a boolean that is `true`
+   * if the element completed the update without triggering another update. The Promise result is `false` if a property
+   * was set inside `updated()`. If the Promise is rejected, an exception was thrown during the update.
    */
   readonly updateComplete: Promise<boolean>;
 }
 
 /**
- * A Reactive Controller is an object that enables sub-component code
- * organization and reuse by aggregating the state, behavior, and lifecycle
- * hooks related to a single feature.
+ * A Reactive Controller is an object that enables sub-component code organization and reuse by aggregating the state,
+ * behavior, and lifecycle hooks related to a single feature.
  *
- * Controllers are added to a host component, or other object that implements
- * the {@linkcode ReactiveControllerHost} interface, via the `addController()`
- * method. They can hook their host component's lifecycle by implementing one
- * or more of the lifecycle callbacks, or initiate an update of the host
- * component by calling `requestUpdate()` on the host.
+ * Controllers are added to a host component, or other object that implements the {@linkcode ReactiveControllerHost}
+ * interface, via the `addController()` method. They can hook their host component's lifecycle by implementing one or
+ * more of the lifecycle callbacks, or initiate an update of the host component by calling `requestUpdate()` on the
+ * host.
  */
 export interface ReactiveController {
   /**
-   * Called when the host is connected to the component tree. For custom
-   * element hosts, this corresponds to the `connectedCallback()` lifecycle,
-   * which is only called when the component is connected to the document.
+   * Called when the host is connected to the component tree. For custom element hosts, this corresponds to the
+   * `connectedCallback()` lifecycle, which is only called when the component is connected to the document.
    */
   hostConnected?(): void;
 
   /**
-   * Called when the host is disconnected from the component tree. For custom
-   * element hosts, this corresponds to the `disconnectedCallback()` lifecycle,
-   * which is called when the host or an ancestor component is disconnected
-   * from the document.
+   * Called when the host is disconnected from the component tree. For custom element hosts, this corresponds to the
+   * `disconnectedCallback()` lifecycle, which is called when the host or an ancestor component is disconnected from the
+   * document.
    */
   hostDisconnected?(): void;
 
   /**
-   * Called when the host is permanently destroyed. Unlike `hostDisconnected`,
-   * this signals that the host will not reconnect — all resources should be
-   * released.
+   * Called when the host is permanently destroyed. Unlike `hostDisconnected`, this signals that the host will not
+   * reconnect — all resources should be released.
    */
   hostDestroyed?(): void;
 
-  /**
-   * Called during the client-side host update, just before the host calls
-   * its own update.
-   */
+  /** Called during the client-side host update, just before the host calls its own update. */
   hostUpdate?(): void;
 
-  /**
-   * Called after a host update, just before the host calls `firstUpdated` and
-   * `updated`.
-   */
+  /** Called after a host update, just before the host calls `firstUpdated` and `updated`. */
   hostUpdated?(): void;
 }
 
-/**
- * A Map of property keys to previous values, provided to lifecycle methods
- * that receive changed properties.
- */
+/** A Map of property keys to previous values, provided to lifecycle methods that receive changed properties. */
 export type PropertyValues = Map<string, unknown>;
 
 /** Defines options for a reactive property. */
 export interface PropertyDeclaration {
   /**
-   * Indicates the type of the property. This is used as a hint to determine
-   * how to convert between attributes and properties.
+   * Indicates the type of the property. This is used as a hint to determine how to convert between attributes and
+   * properties.
    */
   readonly type?: typeof String | typeof Boolean | typeof Number;
 
   /**
-   * Indicates the attribute name to use for this property. If a string,
-   * that string is used as the attribute name. By default, the lowercased
-   * property name is used.
+   * Indicates the attribute name to use for this property. If a string, that string is used as the attribute name. By
+   * default, the lowercased property name is used.
    */
   readonly attribute?: string;
 }
@@ -101,11 +81,11 @@ export interface PropertyDeclaration {
  * Map of property names to {@linkcode PropertyDeclaration} options.
  *
  * @example
- * ```ts
- * static override properties = {
+ *   ```ts
+ *   static override properties = {
  *   src: { type: String },
  *   muted: { type: Boolean },
- * } satisfies PropertyDeclarationMap<keyof MyElement>;
- * ```
+ *   } satisfies PropertyDeclarationMap<keyof MyElement>;
+ *   ```;
  */
 export type PropertyDeclarationMap<K extends string = string> = Record<K, PropertyDeclaration>;

--- a/packages/html/scripts/build-dist-archive.ts
+++ b/packages/html/scripts/build-dist-archive.ts
@@ -1,13 +1,13 @@
 /**
  * Build the distribution archives attached to each `@videojs/html` GitHub release.
  *
- * Package managers outside npm — Composer for Drupal, and anything vendoring a versioned
- * tarball — need a downloadable, browser-ready copy of the player. This assembles one from the
- * production CDN bundles: entry points, the shared chunks they import, and nothing else.
+ * Package managers outside npm — Composer for Drupal, and anything vendoring a versioned tarball — need a downloadable,
+ * browser-ready copy of the player. This assembles one from the production CDN bundles: entry points, the shared chunks
+ * they import, and nothing else.
  *
- * Everything is copied out of the existing `build:cdn` output rather than rebuilt, so the archive
- * ships the same bundles the CDN serves. Sourcemaps are left out to keep the download small, and
- * their now-dangling `sourceMappingURL` comments are stripped so browsers do not request them.
+ * Everything is copied out of the existing `build:cdn` output rather than rebuilt, so the archive ships the same
+ * bundles the CDN serves. Sourcemaps are left out to keep the download small, and their now-dangling `sourceMappingURL`
+ * comments are stripped so browsers do not request them.
  *
  * Prerequisites: `@videojs/html`'s `build:cdn`. Requires `zip` and `tar` on PATH.
  */

--- a/packages/html/scripts/cdn-graph.ts
+++ b/packages/html/scripts/cdn-graph.ts
@@ -1,8 +1,8 @@
 /**
  * Module-graph helpers for the built CDN output.
  *
- * Shared by `check-cdn-self-contained.ts` and `build-dist-archive.ts` so the definition of
- * "reachable from an entry" stays identical between the guard and the archive it guards.
+ * Shared by `check-cdn-self-contained.ts` and `build-dist-archive.ts` so the definition of "reachable from an entry"
+ * stays identical between the guard and the archive it guards.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -14,19 +14,18 @@ const SPECIFIER = /(?:\bfrom|\bimport)\s*\(?\s*["']([^"']+)["']/g;
 /**
  * JSDoc blocks, dropped before the scan.
  *
- * Their `{import('…')}` type annotations are indistinguishable from dynamic imports, and the
- * modules they name are types that no bundle ever loads — third-party dev bundles are full of
- * them. Minified production bundles carry no JSDoc, so nothing real is hidden by this.
+ * Their `{import('…')}` type annotations are indistinguishable from dynamic imports, and the modules they name are
+ * types that no bundle ever loads — third-party dev bundles are full of them. Minified production bundles carry no
+ * JSDoc, so nothing real is hidden by this.
  */
 const JSDOC_BLOCK = /\/\*\*[\s\S]*?\*\//g;
 
 /**
  * Drop matches that cannot be module specifiers.
  *
- * The scan is a regex rather than a parser, so it also sees the words `from` and `import` inside
- * prose — JSDoc retained in dev bundles, and template literals such as `` `… from "${type}"` ``.
- * Real specifiers emitted by the bundler are plain paths, so anything carrying whitespace or
- * template syntax is prose.
+ * The scan is a regex rather than a parser, so it also sees the words `from` and `import` inside prose — JSDoc retained
+ * in dev bundles, and template literals such as `` `… from "${type}"` ``. Real specifiers emitted by the bundler are
+ * plain paths, so anything carrying whitespace or template syntax is prose.
  */
 function isLikelySpecifier(value: string): boolean {
   return value.length > 0 && !/[\s{}$`]/.test(value);
@@ -45,8 +44,8 @@ function isAbsoluteSpecifier(specifier: string): boolean {
 /**
  * Every file reachable from `roots` by following relative specifiers, as paths relative to `dir`.
  *
- * The CDN build emits plain ES modules with no `import.meta.url` asset references, workers, or
- * non-JavaScript files, so the static import graph is the complete set of files an entry needs.
+ * The CDN build emits plain ES modules with no `import.meta.url` asset references, workers, or non-JavaScript files, so
+ * the static import graph is the complete set of files an entry needs.
  */
 export function resolveClosure(dir: string, roots: readonly string[]): Set<string> {
   const seen = new Set<string>();
@@ -76,8 +75,8 @@ export function resolveClosure(dir: string, roots: readonly string[]): Set<strin
 }
 
 /**
- * Report specifiers that would break a copy of `dir` served from an arbitrary origin: anything
- * absolute, bare, or resolving outside the directory.
+ * Report specifiers that would break a copy of `dir` served from an arbitrary origin: anything absolute, bare, or
+ * resolving outside the directory.
  */
 export function findUnresolvableSpecifiers(dir: string, files: Iterable<string>): string[] {
   const problems: string[] = [];

--- a/packages/html/scripts/check-cdn-self-contained.ts
+++ b/packages/html/scripts/check-cdn-self-contained.ts
@@ -1,11 +1,10 @@
 /**
  * Verify the built CDN output is self-contained.
  *
- * Mirroring `cdn/` onto your own origin is a supported way to run the player (see the site's
- * "Self-host the player" guide), and the release distribution archive is cut from this output.
- * That only holds while every module specifier is relative and resolves inside the directory — a
- * single absolute URL silently reintroduces a runtime dependency on a public CDN, which fails
- * closed in offline, air-gapped, and strict-CSP deployments.
+ * Mirroring `cdn/` onto your own origin is a supported way to run the player (see the site's "Self-host the player"
+ * guide), and the release distribution archive is cut from this output. That only holds while every module specifier is
+ * relative and resolves inside the directory — a single absolute URL silently reintroduces a runtime dependency on a
+ * public CDN, which fails closed in offline, air-gapped, and strict-CSP deployments.
  *
  * Prerequisites: `@videojs/html`'s `build:cdn`.
  */

--- a/packages/html/src/define/media/mux-background-video.ts
+++ b/packages/html/src/define/media/mux-background-video.ts
@@ -4,9 +4,8 @@ import { safeDefine } from '../safe-define';
 /**
  * `<mux-background-video>` — the Mux-flavored tag for `<hls-background-video>`.
  *
- * A distinct subclass rather than a re-export because a custom-element class can
- * hold one tag name: registering the same class twice throws. The behavior is
- * entirely the shared base's.
+ * A distinct subclass rather than a re-export because a custom-element class can hold one tag name: registering the
+ * same class twice throws. The behavior is entirely the shared base's.
  */
 export class MuxBackgroundVideoElement extends MuxBackgroundVideo {
   static readonly tagName = 'mux-background-video';

--- a/packages/html/src/define/media/mux-video/spf.ts
+++ b/packages/html/src/define/media/mux-video/spf.ts
@@ -11,15 +11,13 @@ declare global {
   /**
    * The Mux video flavors in the build, keyed by engine.
    *
-   * Both flavors are the same element over a different engine, so both claim
-   * `<mux-video>` and the import path is what chooses. Each flavor's define entry
-   * adds its own key here, so the tag types as the flavor that was imported — or as
-   * the union of both when both were, which is the load-order coin flip that a
-   * single type per key cannot describe any better.
+   * Both flavors are the same element over a different engine, so both claim `<mux-video>` and the import path is what
+   * chooses. Each flavor's define entry adds its own key here, so the tag types as the flavor that was imported — or as
+   * the union of both when both were, which is the load-order coin flip that a single type per key cannot describe any
+   * better.
    *
-   * Importing both is not a supported configuration: one registration wins and the
-   * other is dropped. `safeDefine`'s tag-name override is the escape hatch for
-   * putting the loser somewhere reachable, `<mux-video-spf>` by convention.
+   * Importing both is not a supported configuration: one registration wins and the other is dropped. `safeDefine`'s
+   * tag-name override is the escape hatch for putting the loser somewhere reachable, `<mux-video-spf>` by convention.
    */
   interface MuxVideoFlavors {
     spf: MuxVideoElement;

--- a/packages/html/src/define/safe-define.ts
+++ b/packages/html/src/define/safe-define.ts
@@ -3,11 +3,10 @@ type DefinableElement = CustomElementConstructor & { tagName: string };
 /**
  * Define a custom element only if not already registered.
  *
- * `tagName` overrides the element's own, for the rare case of registering one
- * element under a second name — two flavors of the same element in one runtime,
- * say, where whichever registers first would otherwise take the name and the
- * other would silently lose it. Registering under the override does not change
- * `element.tagName`, so anything reading the class still sees its standard name.
+ * `tagName` overrides the element's own, for the rare case of registering one element under a second name — two flavors
+ * of the same element in one runtime, say, where whichever registers first would otherwise take the name and the other
+ * would silently lose it. Registering under the override does not change `element.tagName`, so anything reading the
+ * class still sees its standard name.
  */
 export function safeDefine(element: DefinableElement, tagName: string = element.tagName): void {
   const registry = globalThis.customElements;

--- a/packages/html/src/define/skin-element.ts
+++ b/packages/html/src/define/skin-element.ts
@@ -14,9 +14,8 @@ const STYLES_ID = '__media-styles';
 const sharedSheet = createShadowStyle(sharedStyles);
 
 /**
- * Base element for skin definitions. Attaches a shadow root, clones
- * `static template` into it, and applies shared + per-skin styles
- * via `adoptedStyleSheets` (or `<style>` fallback).
+ * Base element for skin definitions. Attaches a shadow root, clones `static template` into it, and applies shared +
+ * per-skin styles via `adoptedStyleSheets` (or `<style>` fallback).
  */
 export class SkinElement extends ReactiveElement {
   static shadowRootOptions: ShadowRootInit = { mode: 'open' };

--- a/packages/html/src/define/tests/media-aliases.test.ts
+++ b/packages/html/src/define/tests/media-aliases.test.ts
@@ -1,11 +1,9 @@
 /**
  * Tags that are two names for one element rather than two elements.
  *
- * The thing worth asserting is that both register: a custom-element class can
- * hold one tag name, so an alias has to be a subclass of the shared base, not a
- * re-export of it. Importing both entries in one realm is a supported
- * configuration — unlike the flavor tags in `define/media/mux-video`, where two
- * engines compete for one name.
+ * The thing worth asserting is that both register: a custom-element class can hold one tag name, so an alias has to be
+ * a subclass of the shared base, not a re-export of it. Importing both entries in one realm is a supported
+ * configuration — unlike the flavor tags in `define/media/mux-video`, where two engines compete for one name.
  */
 import { describe, expect, it } from 'vite-plus/test';
 

--- a/packages/html/src/define/tests/registration.test.ts
+++ b/packages/html/src/define/tests/registration.test.ts
@@ -1,14 +1,13 @@
 import { afterAll, beforeAll, describe, expect, it, type MockInstance, vi } from 'vite-plus/test';
 
 /**
- * Tests that composite define files register all expected custom elements
- * and that provider/parent elements are defined before consumer/child elements.
+ * Tests that composite define files register all expected custom elements and that provider/parent elements are defined
+ * before consumer/child elements.
  *
- * Tests run sequentially. Each dynamically imports a composite define file and
- * checks the batch of `customElements.define()` calls that resulted. Because
- * modules are cached within a test file, shared sub-elements (e.g. slider parts)
- * are only registered by the first composite that imports them — subsequent
- * composites skip them via `safeDefine`. This is intentional and tested.
+ * Tests run sequentially. Each dynamically imports a composite define file and checks the batch of
+ * `customElements.define()` calls that resulted. Because modules are cached within a test file, shared sub-elements
+ * (e.g. slider parts) are only registered by the first composite that imports them — subsequent composites skip them
+ * via `safeDefine`. This is intentional and tested.
  */
 describe('composite define registration', () => {
   let spy: MockInstance;

--- a/packages/html/src/i18n/types.ts
+++ b/packages/html/src/i18n/types.ts
@@ -3,12 +3,10 @@ import type { ReactiveElement } from '@videojs/element';
 import type { Constructor } from '@videojs/utils/types';
 
 /**
- * `Constructor<ReactiveElement>` does not imply static `properties`; this intersection matches how
- * mixins spread {@link ReactiveElement.properties} from their base.
+ * `Constructor<ReactiveElement>` does not imply static `properties`; this intersection matches how mixins spread
+ * {@link ReactiveElement.properties} from their base.
  */
 export type ReactiveElementMixinBase = Constructor<ReactiveElement> & Pick<typeof ReactiveElement, 'properties'>;
 
-/**
- * Function to load partial or full translations for a given locale.
- */
+/** Function to load partial or full translations for a given locale. */
 export type LocaleLoader = (tag: string) => Promise<Partial<FlatTranslations> | undefined>;

--- a/packages/html/src/media/background-video/template.ts
+++ b/packages/html/src/media/background-video/template.ts
@@ -2,9 +2,8 @@ import { serializeAttributes } from '@videojs/utils/dom';
 import { pick } from '@videojs/utils/object';
 
 /**
- * Attributes forwarded to the inner `<video>`. `src` is deliberately not one of
- * them: each element decides what to do with it, whether that is assigning the
- * inner video or handing it to a playback engine, and serializing it into the
+ * Attributes forwarded to the inner `<video>`. `src` is deliberately not one of them: each element decides what to do
+ * with it, whether that is assigning the inner video or handing it to a playback engine, and serializing it into the
  * template would start a native load either way.
  */
 export const VideoAttributes = [
@@ -21,12 +20,11 @@ export const VideoAttributes = [
 ] as const;
 
 /**
- * The shadow template both background-video elements render: a `<slot>` for a
- * placeholder image, and a `<video>` stretched over the host.
+ * The shadow template both background-video elements render: a `<slot>` for a placeholder image, and a `<video>`
+ * stretched over the host.
  *
- * Shared so the two can't drift in presentation. `object-fit` and
- * `object-position` are the only styling hooks — a background video has no
- * controls to theme.
+ * Shared so the two can't drift in presentation. `object-fit` and `object-position` are the only styling hooks — a
+ * background video has no controls to theme.
  */
 export function getTemplateHTML(attrs: Record<string, string>) {
   return /*html*/ `

--- a/packages/html/src/media/google-cast/google-cast-element.ts
+++ b/packages/html/src/media/google-cast/google-cast-element.ts
@@ -6,17 +6,16 @@ import { MediaComponentElement } from '../media-component-element';
 /**
  * Adds Google Cast support to the surrounding player's media.
  *
- * Renders nothing — place it inside the player as a sibling of the media
- * element and it registers a {@link GoogleCast} media component with the
- * active media host.
+ * Renders nothing — place it inside the player as a sibling of the media element and it registers a {@link GoogleCast}
+ * media component with the active media host.
  *
  * @example
- * ```html
- * <video-player>
+ *   ```html
+ *   <video-player>
  *   <hlsjs-video src="https://example.com/stream.m3u8"></hlsjs-video>
  *   <google-cast receiver="YOUR_APP_ID"></google-cast>
- * </video-player>
- * ```
+ *   </video-player>
+ *   ```;
  */
 export class GoogleCastElement extends MediaComponentElement<GoogleCast> {
   static readonly tagName = 'google-cast';

--- a/packages/html/src/media/hls-background-video/media.ts
+++ b/packages/html/src/media/hls-background-video/media.ts
@@ -14,43 +14,36 @@ const HlsBackgroundVideoBase = MediaAttachMixin(HTMLElement) as unknown as Const
 /**
  * A muted, looping, chrome-less video over the SPF background-video engine.
  *
- * The SPF-backed counterpart to `<background-video>`, which plays its source
- * natively. This one streams HLS through the engine, which pins a single
- * rendition for the session rather than adapting, and drops audio and text
- * handling entirely — the shape an ambient hero video actually wants.
+ * The SPF-backed counterpart to `<background-video>`, which plays its source natively. This one streams HLS through the
+ * engine, which pins a single rendition for the session rather than adapting, and drops audio and text handling
+ * entirely — the shape an ambient hero video actually wants.
  *
- * Nearer an image than a player, and `src` is the whole surface. Replaces the
- * standalone `mux-background-video` package, whose `audio`, `debug`, `preload`,
- * and `max-resolution` attributes are all deliberately absent. Capping which
- * rendition is fetched is a delivery param on the URL — `?max_resolution=720p`
- * on a Mux stream, for one — which keeps the renditions it excludes out of the
- * manifest rather than merely unpicked; `preload` would have nothing to say,
- * since the engine loads from the moment it has a source. And unlike
- * `<background-video>` there are no `nomuted` / `noloop` / `noautoplay` opt-outs:
- * those three are what this element is for, so the adapter fixes them on at
- * attach.
+ * Nearer an image than a player, and `src` is the whole surface. Replaces the standalone `mux-background-video`
+ * package, whose `audio`, `debug`, `preload`, and `max-resolution` attributes are all deliberately absent. Capping
+ * which rendition is fetched is a delivery param on the URL — `?max_resolution=720p` on a Mux stream, for one — which
+ * keeps the renditions it excludes out of the manifest rather than merely unpicked; `preload` would have nothing to
+ * say, since the engine loads from the moment it has a source. And unlike `<background-video>` there are no `nomuted` /
+ * `noloop` / `noautoplay` opt-outs: those three are what this element is for, so the adapter fixes them on at attach.
  *
- * Takes no structured `source` — `src` is an HLS URL, as the package it replaces
- * required. Mux playback-ID identity, poster, and storyboard belong to
- * `<mux-video>`; none of them mean anything without controls to hang them on.
+ * Takes no structured `source` — `src` is an HLS URL, as the package it replaces required. Mux playback-ID identity,
+ * poster, and storyboard belong to `<mux-video>`; none of them mean anything without controls to hang them on.
  *
- * Nothing about an unplayable source reaches the inner `<video>` on its own, so
- * `error` on it stays null and the element sits at `readyState 0`. The engine
- * reports each condition and logs it, the Media promotes the fatal one, and this
- * element re-fires it as its own `error` / `'error'` — the one place a consumer
- * holding the element can see a source that never appears.
+ * Nothing about an unplayable source reaches the inner `<video>` on its own, so `error` on it stays null and the
+ * element sits at `readyState 0`. The engine reports each condition and logs it, the Media promotes the fatal one, and
+ * this element re-fires it as its own `error` / `'error'` — the one place a consumer holding the element can see a
+ * source that never appears.
+ *
+ * @example
+ *   ```html
+ *   <hls-background-video src="https://stream.mux.com/PLAYBACK_ID.m3u8?max_resolution=720p">
+ *   <img src="https://image.mux.com/PLAYBACK_ID/thumbnail.webp?time=0" alt="" />
+ *   </hls-background-video>
+ *   ```;
  *
  * @fires error - Fired when a fatal condition is reported. Read `error` for it.
  *
- * `<mux-background-video>` is this element under the name the package it replaces
- * used. Same class, so the tag is a naming choice and nothing more.
- *
- * @example
- * ```html
- * <hls-background-video src="https://stream.mux.com/PLAYBACK_ID.m3u8?max_resolution=720p">
- *   <img src="https://image.mux.com/PLAYBACK_ID/thumbnail.webp?time=0" alt="" />
- * </hls-background-video>
- * ```
+ *   `<mux-background-video>` is this element under the name the package it replaces used. Same class, so the tag is a
+ *   naming choice and nothing more.
  */
 // Deliberately not `CustomMediaElement`, matching `<background-video>`: a
 // background video needs one property, not the full WHATWG media API.
@@ -128,10 +121,9 @@ export class HlsBackgroundVideo extends HlsBackgroundVideoBase {
   }
 
   /**
-   * What made the current source unplayable, or `null`. An SVTA code rather than
-   * a `MediaError` one — 99001 where this player has no pipeline for what the
-   * source needs, with the specifics logged. Reset by a new source, and not on
-   * the inner `<video>`, which never learns of it.
+   * What made the current source unplayable, or `null`. An SVTA code rather than a `MediaError` one — 99001 where this
+   * player has no pipeline for what the source needs, with the specifics logged. Reset by a new source, and not on the
+   * inner `<video>`, which never learns of it.
    */
   get error(): HlsVideoMediaError | null {
     return this.#media.error;

--- a/packages/html/src/media/media-component-element.ts
+++ b/packages/html/src/media/media-component-element.ts
@@ -22,13 +22,12 @@ function resolveMediaHost(media: Media | null): MediaHost | null {
 }
 
 /**
- * Abstract base for elements that register a media component (e.g. Mux Data,
- * Google Cast) with the media provided by the surrounding player.
+ * Abstract base for elements that register a media component (e.g. Mux Data, Google Cast) with the media provided by
+ * the surrounding player.
  *
- * Place inside a player, as a sibling of the media element. The component is
- * registered when a media host becomes available, follows the media when it
- * changes, is removed when this element disconnects, and is destroyed with
- * this element.
+ * Place inside a player, as a sibling of the media element. The component is registered when a media host becomes
+ * available, follows the media when it changes, is removed when this element disconnects, and is destroyed with this
+ * element.
  */
 export abstract class MediaComponentElement<Component extends MediaComponent> extends UIElement {
   #component: Component | null = null;
@@ -38,9 +37,8 @@ export abstract class MediaComponentElement<Component extends MediaComponent> ex
   /**
    * Create the media component this element registers. Called once, lazily.
    *
-   * Must be a method rather than a field: upgrading an element that is already
-   * in the document runs its constructor while connected, so the media context
-   * callback below can fire before subclass field initializers have run.
+   * Must be a method rather than a field: upgrading an element that is already in the document runs its constructor
+   * while connected, so the media context callback below can fire before subclass field initializers have run.
    */
   protected abstract createComponent(): Component;
 

--- a/packages/html/src/media/mux-audio/mixin.ts
+++ b/packages/html/src/media/mux-audio/mixin.ts
@@ -3,9 +3,8 @@ import type { AnyConstructor, Constructor } from '@videojs/utils/types';
 /**
  * What this mixin needs from whichever Mux Media the element hosts.
  *
- * Structural on purpose: the hls.js-backed `MuxMedia` and the SPF-backed
- * `MuxAudioMedia` satisfy it identically, and `src` is the WHATWG surface
- * rather than anything engine-specific, so the element itself has no engine.
+ * Structural on purpose: the hls.js-backed `MuxMedia` and the SPF-backed `MuxAudioMedia` satisfy it identically, and
+ * `src` is the WHATWG surface rather than anything engine-specific, so the element itself has no engine.
  */
 interface MuxAudioHost {
   readonly src: string;
@@ -17,16 +16,13 @@ interface MuxAudioElementLike extends HTMLElement {
 }
 
 /**
- * The Mux-specific element behavior for audio, over any Mux Media: reflecting the
- * derived `src` back to the attribute.
+ * The Mux-specific element behavior for audio, over any Mux Media: reflecting the derived `src` back to the attribute.
  *
- * Much thinner than {@link MuxVideoMixin} because the rest of what that one does
- * has no meaning here — Mux publishes no poster or storyboard for an audio-only
- * asset, and an `<audio>` element renders neither.
+ * Much thinner than {@link MuxVideoMixin} because the rest of what that one does has no meaning here — Mux publishes no
+ * poster or storyboard for an audio-only asset, and an `<audio>` element renders neither.
  *
- * A mixin rather than a base class for the same reason as the video one: each
- * flavor's element is built on a different `CustomMediaElement`, so there is no
- * common class to extend, only a common host contract.
+ * A mixin rather than a base class for the same reason as the video one: each flavor's element is built on a different
+ * `CustomMediaElement`, so there is no common class to extend, only a common host contract.
  */
 export function MuxAudioMixin<Class extends AnyConstructor<HTMLElement>>(BaseClass: Class): Class {
   class MuxAudioElement extends (BaseClass as unknown as Constructor<MuxAudioElementLike>) {

--- a/packages/html/src/media/mux-audio/spf.ts
+++ b/packages/html/src/media/mux-audio/spf.ts
@@ -9,13 +9,11 @@ const MuxAudioBase = MuxAudioMixin(MediaAttachMixin(CustomMediaElement('audio', 
 /**
  * `<mux-audio>` over the SPF audio-only Mux Media instead of the hls.js-backed one.
  *
- * Shares its name with the flavor in `./hls-js` on purpose: the import path picks
- * the engine, and nothing else about the surface moves. Deliberately not exported
- * from this directory's barrel, so importing one flavor never pulls the other's
- * engine in with it.
+ * Shares its name with the flavor in `./hls-js` on purpose: the import path picks the engine, and nothing else about
+ * the surface moves. Deliberately not exported from this directory's barrel, so importing one flavor never pulls the
+ * other's engine in with it.
  *
- * The engine underneath is the subtractive audio-only one, so only the audio
- * renditions of the playback ID are fetched — unlike the hls.js-backed flavor,
- * which runs the full engine and downloads video renditions it never plays.
+ * The engine underneath is the subtractive audio-only one, so only the audio renditions of the playback ID are fetched
+ * — unlike the hls.js-backed flavor, which runs the full engine and downloads video renditions it never plays.
  */
 export class MuxAudio extends MuxAudioBase {}

--- a/packages/html/src/media/mux-background-video/index.ts
+++ b/packages/html/src/media/mux-background-video/index.ts
@@ -1,14 +1,11 @@
 /**
- * The Mux-flavored name for `HlsBackgroundVideo` — the same class, not a subclass
- * or a variant. Kept because `<mux-background-video>` is what the standalone
- * package this element replaces was called.
+ * The Mux-flavored name for `HlsBackgroundVideo` — the same class, not a subclass or a variant. Kept because
+ * `<mux-background-video>` is what the standalone package this element replaces was called.
  *
- * There is no Mux identity to add, because there is no Mux input to take: `src`
- * is an HLS URL, and capping which rendition is fetched is a param on it rather
- * than an attribute. `../hls-background-video` carries the whole surface.
+ * There is no Mux identity to add, because there is no Mux input to take: `src` is an HLS URL, and capping which
+ * rendition is fetched is a param on it rather than an attribute. `../hls-background-video` carries the whole surface.
  *
- * The two tags register from separate `define/media` entries, each subclassing
- * this base with its own `tagName`, so importing both is fine — they are two names
- * for one element, not two elements competing for one name.
+ * The two tags register from separate `define/media` entries, each subclassing this base with its own `tagName`, so
+ * importing both is fine — they are two names for one element, not two elements competing for one name.
  */
 export { HlsBackgroundVideo as MuxBackgroundVideo } from '../hls-background-video';

--- a/packages/html/src/media/mux-data/mux-data-element.ts
+++ b/packages/html/src/media/mux-data/mux-data-element.ts
@@ -4,28 +4,24 @@ import { MuxData, type MuxDataProps } from '@videojs/media/dom/mux';
 import { MediaComponentElement } from '../media-component-element';
 
 /**
- * Adds [Mux Data](https://www.mux.com/data) monitoring to the surrounding
- * player's media.
+ * Adds [Mux Data](https://www.mux.com/data) monitoring to the surrounding player's media.
  *
- * Renders nothing — place it inside the player as a sibling of the media
- * element and it registers a {@link MuxData} media component with the active
- * media host.
+ * Renders nothing — place it inside the player as a sibling of the media element and it registers a {@link MuxData}
+ * media component with the active media host.
  *
- * Mux-hosted playback needs no `env-key`: the view reports the Mux playback ID
- * as its `video_id`, which Mux attributes to the owning environment. Set
- * `env-key` to monitor sources Mux doesn't host.
+ * Mux-hosted playback needs no `env-key`: the view reports the Mux playback ID as its `video_id`, which Mux attributes
+ * to the owning environment. Set `env-key` to monitor sources Mux doesn't host.
  *
- * Any media element works. When the media plays through an hls.js or dash.js
- * engine, that engine is handed to the Mux Data SDK so the view also carries
- * stream-level detail such as rendition switches and request timing.
+ * Any media element works. When the media plays through an hls.js or dash.js engine, that engine is handed to the Mux
+ * Data SDK so the view also carries stream-level detail such as rendition switches and request timing.
  *
  * @example
- * ```html
- * <video-player>
+ *   ```html
+ *   <video-player>
  *   <mux-video src="https://stream.mux.com/abc123.m3u8"></mux-video>
  *   <mux-data player-software-name="mux-video"></mux-data>
- * </video-player>
- * ```
+ *   </video-player>
+ *   ```;
  */
 export class MuxDataElement extends MediaComponentElement<MuxData> {
   static readonly tagName = 'mux-data';

--- a/packages/html/src/media/mux-video/mixin.ts
+++ b/packages/html/src/media/mux-video/mixin.ts
@@ -6,9 +6,8 @@ import type { AnyConstructor, Constructor } from '@videojs/utils/types';
 /**
  * What this mixin needs from whichever Mux Media the element hosts.
  *
- * Structural on purpose: the hls.js-backed `MuxMedia` and the SPF-backed one
- * satisfy it identically, and everything here is Mux identity or the WHATWG
- * surface — nothing engine-specific — so the element itself has no engine.
+ * Structural on purpose: the hls.js-backed `MuxMedia` and the SPF-backed one satisfy it identically, and everything
+ * here is Mux identity or the WHATWG surface — nothing engine-specific — so the element itself has no engine.
  */
 interface MuxVideoHost {
   src: string;
@@ -24,12 +23,11 @@ interface MuxVideoElementLike extends HTMLElement {
 }
 
 /**
- * The Mux-specific element behavior, over any Mux Media: the `poster-time`
- * attribute, `src` reflection, and the storyboard `<track>` child.
+ * The Mux-specific element behavior, over any Mux Media: the `poster-time` attribute, `src` reflection, and the
+ * storyboard `<track>` child.
  *
- * Mixin rather than a base class because each flavor's element is built on a
- * different `CustomMediaElement`, so there is no common class to extend — only a
- * common host contract.
+ * Mixin rather than a base class because each flavor's element is built on a different `CustomMediaElement`, so there
+ * is no common class to extend — only a common host contract.
  */
 export function MuxVideoMixin<Class extends AnyConstructor<HTMLElement>>(BaseClass: Class): Class {
   class MuxVideoElement extends (BaseClass as unknown as Constructor<MuxVideoElementLike>) {

--- a/packages/html/src/media/mux-video/spf.ts
+++ b/packages/html/src/media/mux-video/spf.ts
@@ -9,9 +9,8 @@ const MuxVideoBase = MuxVideoMixin(MediaAttachMixin(CustomMediaElement('video', 
 /**
  * `<mux-video>` over the SPF-backed Mux Media instead of the hls.js-backed one.
  *
- * Shares its name with the flavor in `./hls-js` on purpose: the import path picks
- * the engine, and nothing else about the surface moves. Deliberately not exported
- * from this directory's barrel, so importing one flavor never pulls the other's
- * engine in with it.
+ * Shares its name with the flavor in `./hls-js` on purpose: the import path picks the engine, and nothing else about
+ * the surface moves. Deliberately not exported from this directory's barrel, so importing one flavor never pulls the
+ * other's engine in with it.
  */
 export class MuxVideo extends MuxVideoBase {}

--- a/packages/html/src/media/tests/media-component-element.test.ts
+++ b/packages/html/src/media/tests/media-component-element.test.ts
@@ -30,9 +30,8 @@ class TestMediaComponentElement extends MediaComponentElement<FakeComponent> {
   static readonly tagName = 'test-media-component';
 
   /**
-   * Subclass field initializers run after the base constructor, which is the
-   * window the media context callback can fire in during a custom element
-   * upgrade. Reading the component here proves it resolves that early.
+   * Subclass field initializers run after the base constructor, which is the window the media context callback can fire
+   * in during a custom element upgrade. Reading the component here proves it resolves that early.
    */
   readonly componentDuringFieldInit = this.component;
 

--- a/packages/html/src/player/create-player.ts
+++ b/packages/html/src/player/create-player.ts
@@ -36,42 +36,42 @@ export interface CreatePlayerResult<Store extends PlayerStore> {
  * Creates a player factory with a typed store, provider mixin, and controller.
  *
  * @example
- * ```ts
- * import { createPlayer, UIElement, selectPlayback } from '@videojs/html';
- * import { videoFeatures } from '@videojs/html/video';
+ *   ```ts
+ *   import { createPlayer, UIElement, selectPlayback } from '@videojs/html';
+ *   import { videoFeatures } from '@videojs/html/video';
  *
- * const { ProviderMixin, PlayerController, context } = createPlayer({
- *   features: videoFeatures,
- * });
+ *   const { ProviderMixin, PlayerController, context } = createPlayer({
+ *     features: videoFeatures,
+ *   });
  *
- * // Provider element: owns the store, provides context to descendants
- * class VideoPlayer extends ProviderMixin(UIElement) {}
- * customElements.define('video-player', VideoPlayer);
+ *   // Provider element: owns the store, provides context to descendants
+ *   class VideoPlayer extends ProviderMixin(UIElement) {}
+ *   customElements.define('video-player', VideoPlayer);
  *
- * // Control element with selector
- * class PlayButton extends UIElement {
- *   #playback = new PlayerController(this, context, selectPlayback);
- * }
- * ```
+ *   // Control element with selector
+ *   class PlayButton extends UIElement {
+ *     #playback = new PlayerController(this, context, selectPlayback);
+ *   }
+ *   ```;
  *
- * @label Video
  * @param config - Player configuration with features.
+ * @label Video
  */
 export function createPlayer(config: CreatePlayerConfig<VideoFeatures>): CreatePlayerResult<VideoPlayerStore>;
 
 /**
  * Creates a player factory for audio media.
  *
- * @label Audio
  * @param config - Player configuration with features.
+ * @label Audio
  */
 export function createPlayer(config: CreatePlayerConfig<AudioFeatures>): CreatePlayerResult<AudioPlayerStore>;
 
 /**
  * Creates a player factory with custom features.
  *
- * @label Generic
  * @param config - Player configuration with features.
+ * @label Generic
  */
 export function createPlayer<const Features extends AnyPlayerFeature[]>(
   config: CreatePlayerConfig<Features>

--- a/packages/html/src/player/player-controller.ts
+++ b/packages/html/src/player/player-controller.ts
@@ -11,25 +11,25 @@ export type PlayerControllerHost = ReactiveControllerHost & HTMLElement;
 /**
  * Reactive controller for accessing player store state.
  *
- * Without selector: Returns the store, does NOT subscribe to changes.
- * With selector: Returns selected state, subscribes with shallowEqual comparison.
+ * Without selector: Returns the store, does NOT subscribe to changes. With selector: Returns selected state, subscribes
+ * with shallowEqual comparison.
  *
  * @example
- * ```ts
- * // Store access (no subscription)
- * class Controls extends UIElement {
- *   #player = new PlayerController(this, playerContext);
+ *   ```ts
+ *   // Store access (no subscription)
+ *   class Controls extends UIElement {
+ *     #player = new PlayerController(this, playerContext);
  *
- *   handleClick() {
- *     this.#player.value.setVolume(0.5);
+ *     handleClick() {
+ *       this.#player.value.setVolume(0.5);
+ *     }
  *   }
- * }
  *
- * // Selector-based subscription
- * class PlayButton extends UIElement {
- *   #playback = new PlayerController(this, playerContext, selectPlayback);
- * }
- * ```
+ *   // Selector-based subscription
+ *   class PlayButton extends UIElement {
+ *     #playback = new PlayerController(this, playerContext, selectPlayback);
+ *   }
+ *   ```;
  */
 export class PlayerController<Store extends PlayerStore, Result = Store> implements ReactiveController {
   readonly #host: PlayerControllerHost;
@@ -39,16 +39,16 @@ export class PlayerController<Store extends PlayerStore, Result = Store> impleme
   #store: StoreController<Store, Result> | null = null;
 
   /**
-   * @label Without Selector
    * @param host - The host element that owns this controller.
    * @param context - Player context to resolve the store from.
+   * @label Without Selector
    */
   constructor(host: PlayerControllerHost, context: PlayerContext<Store>);
   /**
-   * @label With Selector
    * @param host - The host element that owns this controller.
    * @param context - Player context to resolve the store from.
    * @param selector - Derives a value from the player store state.
+   * @label With Selector
    */
   constructor(
     host: PlayerControllerHost,

--- a/packages/html/src/presets/live-audio.ts
+++ b/packages/html/src/presets/live-audio.ts
@@ -1,4 +1,7 @@
-/** Live audio player preset — `liveAudioFeatures` (adds `liveFeature`, drops `playbackRateFeature`) with a skin that includes a Live button. */
+/**
+ * Live audio player preset — `liveAudioFeatures` (adds `liveFeature`, drops `playbackRateFeature`) with a skin that
+ * includes a Live button.
+ */
 export { liveAudioFeatures } from '@videojs/core/dom';
 export { MinimalLiveAudioSkinElement } from '../define/live-audio/minimal-skin';
 export { MinimalLiveAudioSkinTailwindElement } from '../define/live-audio/minimal-skin.tailwind';

--- a/packages/html/src/presets/live-video.ts
+++ b/packages/html/src/presets/live-video.ts
@@ -1,4 +1,7 @@
-/** Live video player preset — `liveVideoFeatures` (adds `liveFeature`, drops `playbackRateFeature`) with a skin that includes a Live button. */
+/**
+ * Live video player preset — `liveVideoFeatures` (adds `liveFeature`, drops `playbackRateFeature`) with a skin that
+ * includes a Live button.
+ */
 export { liveVideoFeatures } from '@videojs/core/dom';
 export { MinimalLiveVideoSkinElement } from '../define/live-video/minimal-skin';
 export { MinimalLiveVideoSkinTailwindElement } from '../define/live-video/minimal-skin.tailwind';

--- a/packages/html/src/store/media-attach-mixin.ts
+++ b/packages/html/src/store/media-attach-mixin.ts
@@ -8,11 +8,10 @@ import { type MediaContext, mediaContext } from '../player/context';
 export type MediaAttachMixin = <Class extends AnyConstructor<HTMLElement>>(BaseClass: Class) => Class;
 
 /**
- * Create a mixin that consumes `mediaContext` and registers the
- * element as the media with the player.
+ * Create a mixin that consumes `mediaContext` and registers the element as the media with the player.
  *
- * Uses the raw context-request protocol so it works with any
- * `HTMLElement` subclass — no `ReactiveControllerHost` required.
+ * Uses the raw context-request protocol so it works with any `HTMLElement` subclass — no `ReactiveControllerHost`
+ * required.
  *
  * @param context - The media context to consume.
  */

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -41,8 +41,8 @@ interface ConfigInput {
 }
 
 /**
- * Name each input on the element. A key whose own name is taken there declares
- * an `html.attribute` instead, and the property follows from that.
+ * Name each input on the element. A key whose own name is taken there declares an `html.attribute` instead, and the
+ * property follows from that.
  */
 function resolveInputs(config: PlayerFeatureConfig): ConfigInput[] {
   return Object.entries(config).map(([key, entry]) => {
@@ -59,15 +59,12 @@ function resolveInputs(config: PlayerFeatureConfig): ConfigInput[] {
 }
 
 /**
- * Create a mixin that provides player context to descendant elements and
- * owns the `store.attach()` lifecycle.
+ * Create a mixin that provides player context to descendant elements and owns the `store.attach()` lifecycle.
  *
- * Media and container elements register themselves via media/container
- * contexts. When a media element is available, the provider calls
- * `store.attach({ media, container })`.
+ * Media and container elements register themselves via media/container contexts. When a media element is available, the
+ * provider calls `store.attach({ media, container })`.
  *
- * Plain `<video>`/`<audio>` elements that cannot consume context are tracked
- * through the provider subtree.
+ * Plain `<video>`/`<audio>` elements that cannot consume context are tracked through the provider subtree.
  *
  * @param options - Provider options with contexts, store factory, and feature configuration.
  */

--- a/packages/html/src/ui/container/container-element.ts
+++ b/packages/html/src/ui/container/container-element.ts
@@ -13,8 +13,7 @@ import { UIElement } from '../ui-element';
 /**
  * The visual, interactive player boundary.
  *
- * A container registers itself with its closest player and provides popup
- * coordination to the controls it contains.
+ * A container registers itself with its closest player and provides popup coordination to the controls it contains.
  */
 export class ContainerElement extends UIElement implements MediaContainer {
   static readonly tagName = 'media-container';

--- a/packages/html/src/ui/context-part-element.ts
+++ b/packages/html/src/ui/context-part-element.ts
@@ -11,8 +11,8 @@ export interface PartContextValue<State extends object> {
 }
 
 /**
- * Abstract base for compound-component part elements that consume a parent
- * context and apply data attributes from `ctx.state` + `ctx.stateAttrMap`.
+ * Abstract base for compound-component part elements that consume a parent context and apply data attributes from
+ * `ctx.state` + `ctx.stateAttrMap`.
  *
  * Subclasses only need to declare the `consumer` property:
  *

--- a/packages/html/src/ui/live-button/live-button-element.ts
+++ b/packages/html/src/ui/live-button/live-button-element.ts
@@ -19,12 +19,11 @@ import { PlayerController } from '../../player/player-controller';
 import { UIElement } from '../ui-element';
 
 /**
- * `<media-live-button>` — selects from `live`, `time`, and `buffer` features
- * and composes them into the `LiveButtonMediaState` consumed by
- * `LiveButtonCore`.
+ * `<media-live-button>` — selects from `live`, `time`, and `buffer` features and composes them into the
+ * `LiveButtonMediaState` consumed by `LiveButtonCore`.
  *
- * Doesn't extend `MediaButtonElement` because that base couples a button to
- * a single feature selector; the LiveButton needs three.
+ * Doesn't extend `MediaButtonElement` because that base couples a button to a single feature selector; the LiveButton
+ * needs three.
  */
 export class LiveButtonElement extends UIElement {
   static readonly tagName = 'media-live-button';
@@ -130,9 +129,8 @@ export class LiveButtonElement extends UIElement {
   }
 
   /**
-   * Compose the LiveButton media state from the three feature slices.
-   * Returns `null` when any are missing so the button stays disabled until
-   * all three features are registered on the player.
+   * Compose the LiveButton media state from the three feature slices. Returns `null` when any are missing so the button
+   * stays disabled until all three features are registered on the player.
    */
   #getMedia(): LiveButtonMediaState | null {
     const live = this.live.value;

--- a/packages/html/src/ui/poster/poster-element.ts
+++ b/packages/html/src/ui/poster/poster-element.ts
@@ -18,9 +18,8 @@ function composedChildren(element: Element): Element[] {
 }
 
 /**
- * The first image an element composes. A skin forwards its own
- * `<slot name="poster">` in, so the image is a slot or two down and may be
- * wrapped in a `<picture>` or a framework image component.
+ * The first image an element composes. A skin forwards its own `<slot name="poster">` in, so the image is a slot or two
+ * down and may be wrapped in a `<picture>` or a framework image component.
  */
 function findImage(element: Element): HTMLImageElement | null {
   for (const child of composedChildren(element)) {
@@ -35,9 +34,8 @@ function findImage(element: Element): HTMLImageElement | null {
 }
 
 /**
- * Whether anything already points this image somewhere, which answers both
- * whether the author owns the source and whether there is a download to wait
- * for. A `<source>` counts: inside a `<picture>` it can win over the `src`.
+ * Whether anything already points this image somewhere, which answers both whether the author owns the source and
+ * whether there is a download to wait for. A `<source>` counts: inside a `<picture>` it can win over the `src`.
  */
 function hasSource(img: HTMLImageElement): boolean {
   if (img.hasAttribute('src') || img.hasAttribute('srcset')) return true;
@@ -48,9 +46,9 @@ function hasSource(img: HTMLImageElement): boolean {
 }
 
 /**
- * Whether `complete` on this image describes a request. It is also true for one
- * that omits both `src` and `srcset`, whatever a parent `<picture>` is fetching
- * on its behalf, so only an image sourced from its own attributes can be read.
+ * Whether `complete` on this image describes a request. It is also true for one that omits both `src` and `srcset`,
+ * whatever a parent `<picture>` is fetching on its behalf, so only an image sourced from its own attributes can be
+ * read.
  */
 function hasOwnSource(img: HTMLImageElement): boolean {
   return !!img.getAttribute('src') || img.hasAttribute('srcset');
@@ -62,15 +60,12 @@ type ImageLoadState = 'pending' | 'loaded' | 'error';
 /**
  * `<media-poster>` — sets `src` on a poster image it does not own.
  *
- * The image is a child, as in `<picture>`, but sourcing runs the other way
- * around: `<picture>` treats the `src` on its `<img>` as the fallback, while
- * here an image with no source of its own is the one this element fills in.
- * Give the child a `src`, a `srcset`, or `<source>` candidates and it is yours,
- * left alone.
+ * The image is a child, as in `<picture>`, but sourcing runs the other way around: `<picture>` treats the `src` on its
+ * `<img>` as the fallback, while here an image with no source of its own is the one this element fills in. Give the
+ * child a `src`, a `srcset`, or `<source>` candidates and it is yours, left alone.
  *
- * Renders no image of its own, so include one:
- * `<media-poster><img alt=""></media-poster>`. Inside a skin, an
- * `<img slot="poster">` of yours replaces the one the skin carries.
+ * Renders no image of its own, so include one: `<media-poster><img alt=""></media-poster>`. Inside a skin, an `<img
+ * slot="poster">` of yours replaces the one the skin carries.
  */
 export class PosterElement extends UIElement {
   static readonly tagName = 'media-poster';
@@ -147,9 +142,8 @@ export class PosterElement extends UIElement {
   }
 
   /**
-   * Ownership is settled once, when an image becomes active: after the first fill
-   * the `src` we set would itself look authored. Re-slot an image with a source
-   * to hand it back, the way React decides a field is controlled at mount.
+   * Ownership is settled once, when an image becomes active: after the first fill the `src` we set would itself look
+   * authored. Re-slot an image with a source to hand it back, the way React decides a field is controlled at mount.
    */
   #adopt(next: HTMLImageElement | null): void {
     if (next === this.#image) return;

--- a/packages/html/src/ui/poster/tests/poster-element.test.ts
+++ b/packages/html/src/ui/poster/tests/poster-element.test.ts
@@ -43,9 +43,8 @@ interface Harness {
 }
 
 /**
- * Mounts the poster the way a skin does: inside a shadow root that forwards its
- * own `<slot name="poster">` into the element, carrying a plain image as that
- * slot's fallback content.
+ * Mounts the poster the way a skin does: inside a shadow root that forwards its own `<slot name="poster">` into the
+ * element, carrying a plain image as that slot's fallback content.
  */
 async function mount(options: { authorMarkup?: string } = {}): Promise<Harness> {
   ensureDefined(TestProviderElement);

--- a/packages/html/src/ui/thumbnail/tests/thumbnail-element.test.ts
+++ b/packages/html/src/ui/thumbnail/tests/thumbnail-element.test.ts
@@ -47,10 +47,9 @@ function nextFrame(): Promise<void> {
 }
 
 /**
- * Mount a thumbnail inside a player reporting the given media CORS mode and
- * return the `crossorigin` attribute its inner `<img>` settles on. The player
- * context resolves a frame after connect, so settle across a few updates
- * rather than reading the first one.
+ * Mount a thumbnail inside a player reporting the given media CORS mode and return the `crossorigin` attribute its
+ * inner `<img>` settles on. The player context resolves a frame after connect, so settle across a few updates rather
+ * than reading the first one.
  */
 async function renderCrossOrigin(
   mediaCrossOrigin: MediaTextTrackState['thumbnailTrackCrossOrigin'],

--- a/packages/html/src/ui/thumbnail/thumbnail-element.ts
+++ b/packages/html/src/ui/thumbnail/thumbnail-element.ts
@@ -66,8 +66,8 @@ export class ThumbnailElement extends UIElement {
   }
 
   /**
-   * Set thumbnail images directly, bypassing the automatic `<track>` detection.
-   * When set, this takes priority over the text track path.
+   * Set thumbnail images directly, bypassing the automatic `<track>` detection. When set, this takes priority over the
+   * text track path.
    */
   get thumbnails(): ThumbnailImage[] | undefined {
     return this.#externalThumbnails;
@@ -160,14 +160,13 @@ export class ThumbnailElement extends UIElement {
   }
 
   /**
-   * Leaving `crossOrigin` unset means "follow the media element", so thumbnails
-   * keep working on a CORS-enabled player without a skin having to thread an
-   * attribute through. `null` opts out and fetches the sprites no-CORS, which is
-   * also what removing the attribute produces. A bare `crossorigin` is passed
-   * straight through, since the CORS-settings attribute reads it as Anonymous.
+   * Leaving `crossOrigin` unset means "follow the media element", so thumbnails keep working on a CORS-enabled player
+   * without a skin having to thread an attribute through. `null` opts out and fetches the sprites no-CORS, which is
+   * also what removing the attribute produces. A bare `crossorigin` is passed straight through, since the CORS-settings
+   * attribute reads it as Anonymous.
    *
-   * Only the `<track>` path inherits: `thumbnails` set directly may point at a
-   * host that has nothing to do with the media element.
+   * Only the `<track>` path inherits: `thumbnails` set directly may point at a host that has nothing to do with the
+   * media element.
    */
   #resolveCrossOrigin(textTrack: MediaTextTrackState | undefined): string | undefined {
     if (isNull(this.crossOrigin)) return undefined;

--- a/packages/html/src/ui/time-slider/time-slider-chapters/time-slider-chapters-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-chapters/time-slider-chapters-element.ts
@@ -17,8 +17,8 @@ import { UIElement } from '../../ui-element';
 /**
  * Clones a light-DOM template once per normalized chapter range.
  *
- * The required template must contain exactly one HTML root element. When no chapter cues are available, the template
- * is cloned once for a full-duration range.
+ * The required template must contain exactly one HTML root element. When no chapter cues are available, the template is
+ * cloned once for a full-duration range.
  */
 export class TimeSliderChaptersElement extends UIElement {
   static readonly tagName = 'media-time-slider-chapters';

--- a/packages/html/src/ui/title/title-element.ts
+++ b/packages/html/src/ui/title/title-element.ts
@@ -9,8 +9,8 @@ import { UIElement } from '../ui-element';
 /**
  * Displays the resolved content title.
  *
- * The element owns its text content. Set the title through the player's
- * `content-title` attribute rather than by writing children.
+ * The element owns its text content. Set the title through the player's `content-title` attribute rather than by
+ * writing children.
  */
 export class TitleElement extends UIElement {
   static readonly tagName = 'media-title';

--- a/packages/html/src/ui/tooltip/tooltip-shortcut-element.ts
+++ b/packages/html/src/ui/tooltip/tooltip-shortcut-element.ts
@@ -1,6 +1,9 @@
 import { UIElement } from '../ui-element';
 
-/** Shortcut hint inside `media-tooltip`. CSS skins: `class="media-tooltip__kbd"`; Tailwind skins: `class` from `popup.tooltipShortcut`. */
+/**
+ * Shortcut hint inside `media-tooltip`. CSS skins: `class="media-tooltip__kbd"`; Tailwind skins: `class` from
+ * `popup.tooltipShortcut`.
+ */
 export class TooltipShortcutElement extends UIElement {
   static readonly tagName = 'media-tooltip-shortcut';
 

--- a/packages/html/vite.config.ts
+++ b/packages/html/vite.config.ts
@@ -122,19 +122,15 @@ const mediaDir = 'src/define/media';
 const mediaDirPath = resolve(packageDir, mediaDir);
 
 /**
- * Media entries, one bundle per module under `src/define/media` — or per flavor,
- * for a module that is a directory.
+ * Media entries, one bundle per module under `src/define/media` — or per flavor, for a module that is a directory.
  *
- * Discovered from the definitions so the npm and CDN delivery surfaces cannot
- * drift. A directory ships its index as the flavor-neutral bundle and each flavor
- * beside it, so `media/mux-video/spf` reads the same as the npm subpath it
- * mirrors. The installation page derives CDN URLs from npm media subpaths, so
- * the two layouts matching is what keeps a flavor reachable there without a
- * translation step.
+ * Discovered from the definitions so the npm and CDN delivery surfaces cannot drift. A directory ships its index as the
+ * flavor-neutral bundle and each flavor beside it, so `media/mux-video/spf` reads the same as the npm subpath it
+ * mirrors. The installation page derives CDN URLs from npm media subpaths, so the two layouts matching is what keeps a
+ * flavor reachable there without a translation step.
  *
- * A CDN page picks bundles at runtime rather than by import path, so this is
- * where two flavors of one element can end up in a single realm — see the
- * tag-collision note in `define/media/mux-video/spf`.
+ * A CDN page picks bundles at runtime rather than by import path, so this is where two flavors of one element can end
+ * up in a single realm — see the tag-collision note in `define/media/mux-video/spf`.
  */
 const cdnMediaEntries = readdirSync(mediaDirPath, { withFileTypes: true })
   .flatMap((entry) => {
@@ -158,9 +154,9 @@ const cdnLocaleEntries = localeTags.map((tag) => ({
 }));
 
 /**
- * Every CDN bundle the build emits, as `{ src, name }` where `name` is the output path without
- * its extension. Exported so the distribution archive can take its entry points from the build
- * definition rather than guessing which built files are entries and which are shared chunks.
+ * Every CDN bundle the build emits, as `{ src, name }` where `name` is the output path without its extension. Exported
+ * so the distribution archive can take its entry points from the build definition rather than guessing which built
+ * files are entries and which are shared chunks.
  *
  * The `src` paths are relative to this package, so importers must run from the package root.
  */

--- a/packages/icons/scripts/format-icons.ts
+++ b/packages/icons/scripts/format-icons.ts
@@ -46,12 +46,11 @@ function removeFillCurrentColor(node: XastElement): void {
 }
 
 /**
- * When the root `<svg>` has `fill="none"` but every shape descendant uses
- * `fill="currentColor"` (directly or inherited from a `<g>`), hoist
- * `fill="currentColor"` to the root and strip it from descendants.
+ * When the root `<svg>` has `fill="none"` but every shape descendant uses `fill="currentColor"` (directly or inherited
+ * from a `<g>`), hoist `fill="currentColor"` to the root and strip it from descendants.
  *
- * With `multipass: true`, SVGO's `collapseGroups` will then clean up any
- * `<g>` elements left with no attributes on the next pass.
+ * With `multipass: true`, SVGO's `collapseGroups` will then clean up any `<g>` elements left with no attributes on the
+ * next pass.
  */
 const hoistCurrentColorFill: CustomPlugin = {
   name: 'hoistCurrentColorFill',

--- a/packages/media/src/core/drm.ts
+++ b/packages/media/src/core/drm.ts
@@ -1,6 +1,6 @@
 /**
- * EME key system identifiers. The value is what a CDM is asked for, and what
- * `source.drm` — and each engine's own DRM configuration — is keyed by.
+ * EME key system identifiers. The value is what a CDM is asked for, and what `source.drm` — and each engine's own DRM
+ * configuration — is keyed by.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess
  */
@@ -18,8 +18,8 @@ export interface DrmSystemConfig {
   /** License server the CDM's license request is POSTed to. */
   licenseUrl: string;
   /**
-   * URL of the DRM server (application) certificate. FairPlay needs one unless
-   * its CDM is pre-provisioned; Widevine and PlayReady ignore it.
+   * URL of the DRM server (application) certificate. FairPlay needs one unless its CDM is pre-provisioned; Widevine and
+   * PlayReady ignore it.
    */
   serverCertificateUrl?: string | undefined;
 }
@@ -27,9 +27,8 @@ export interface DrmSystemConfig {
 /**
  * License servers keyed by EME key system id — the shape of `source.drm`.
  *
- * Name every system you hold a license server for: which one is negotiated is
- * the browser's choice, and each playback path reads the systems it can reach.
- * hls.js's own `drmSystems` takes the same shape, so a single object describes
- * DRM for either engine.
+ * Name every system you hold a license server for: which one is negotiated is the browser's choice, and each playback
+ * path reads the systems it can reach. hls.js's own `drmSystems` takes the same shape, so a single object describes DRM
+ * for either engine.
  */
 export type DrmSystemsConfig = Partial<Record<KeySystem, DrmSystemConfig>>;

--- a/packages/media/src/core/media-tracks/audio-rendition.ts
+++ b/packages/media/src/core/media-tracks/audio-rendition.ts
@@ -1,8 +1,8 @@
 import { selectedChanged } from './audio-rendition-list';
 
 /**
- * The consumer should use the `selected` setter to select one or multiple
- * renditions that the engine is allowed to play.
+ * The consumer should use the `selected` setter to select one or multiple renditions that the engine is allowed to
+ * play.
  */
 export class AudioRendition {
   src: string | undefined;

--- a/packages/media/src/core/media-tracks/video-rendition.ts
+++ b/packages/media/src/core/media-tracks/video-rendition.ts
@@ -1,8 +1,8 @@
 import { activeChanged, selectedChanged } from './video-rendition-list';
 
 /**
- * The consumer should use the `selected` setter to select one or multiple
- * renditions that the engine is allowed to play.
+ * The consumer should use the `selected` setter to select one or multiple renditions that the engine is allowed to
+ * play.
  */
 export class VideoRendition {
   src: string | undefined;

--- a/packages/media/src/core/predicate.ts
+++ b/packages/media/src/core/predicate.ts
@@ -62,9 +62,8 @@ export function isMediaVolumeCapable(value: unknown): value is MediaVolumeCapabi
 }
 
 /**
- * Whether the media reports a mute at all, which is a narrower question than
- * `isMediaVolumeCapable`: an embed can take a mute command while offering no way
- * to set a level.
+ * Whether the media reports a mute at all, which is a narrower question than `isMediaVolumeCapable`: an embed can take
+ * a mute command while offering no way to set a level.
  */
 export function isMediaMutedCapable(value: unknown): value is Pick<MediaVolumeCapability, 'muted'> {
   if (!isObject(value)) return false;
@@ -83,9 +82,8 @@ export function isMediaPlaybackRateCapable(value: unknown): value is MediaPlayba
 }
 
 /**
- * Only `requestPictureInPicture` is required. A native video element carries it
- * but leaves exiting to `document`, so demanding the pair would rule out the one
- * media that most certainly can.
+ * Only `requestPictureInPicture` is required. A native video element carries it but leaves exiting to `document`, so
+ * demanding the pair would rule out the one media that most certainly can.
  */
 export function isMediaPictureInPictureCapable(value: unknown): value is MediaPictureInPictureCapability {
   if (!isObject(value)) return false;

--- a/packages/media/src/core/state.ts
+++ b/packages/media/src/core/state.ts
@@ -15,9 +15,7 @@ export interface MediaPlaybackState {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/ended
    */
   ended: boolean;
-  /**
-   * Whether playback has started (played or seeked).
-   */
+  /** Whether playback has started (played or seeked). */
   started: boolean;
   /**
    * Whether playback is stalled waiting for data.
@@ -61,9 +59,8 @@ export interface MediaVolumeState {
    */
   volumeAvailability: MediaFeatureAvailability;
   /**
-   * Whether the media can be muted. Separate from `volumeAvailability` because
-   * the two come apart: an embed can take a mute command while offering no way
-   * to set a level, and iOS Safari refuses a volume write on media that mutes
+   * Whether the media can be muted. Separate from `volumeAvailability` because the two come apart: an embed can take a
+   * mute command while offering no way to set a level, and iOS Safari refuses a volume write on media that mutes
    * perfectly well.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/muted
@@ -137,8 +134,8 @@ export interface MediaStreamTypeState {
   /**
    * Current stream delivery type.
    *
-   * Components use this to show live-specific UI (for example, a live
-   * indicator or a "jump to live edge" button) or hide the time display.
+   * Components use this to show live-specific UI (for example, a live indicator or a "jump to live edge" button) or
+   * hide the time display.
    *
    * @see {@link MediaStreamTypes} for the canonical string values.
    * @see https://github.com/video-dev/media-ui-extensions/blob/main/proposals/0010-stream-type.md
@@ -151,8 +148,8 @@ export interface MediaMetadataState {
   /** The resolved content title. Set it through the player, not through the store. */
   title: string;
   /**
-   * The resolved poster URL, independent of the media element's own `poster`.
-   * Set it through the player, not through the store.
+   * The resolved poster URL, independent of the media element's own `poster`. Set it through the player, not through
+   * the store.
    */
   poster: string;
 }
@@ -161,8 +158,7 @@ export interface MediaLiveState {
   /**
    * Playback time where the live edge begins.
    *
-   * Playback is live when `currentTime >= liveEdgeStart`. `NaN` when the
-   * stream is not live or the value is unknown.
+   * Playback is live when `currentTime >= liveEdgeStart`. `NaN` when the stream is not live or the value is unknown.
    *
    * @see https://github.com/video-dev/media-ui-extensions/blob/main/proposals/0007-live-edge.md
    */
@@ -170,8 +166,8 @@ export interface MediaLiveState {
   /**
    * Describes the kind of live window available. This value is not a duration.
    *
-   * `0` for a sliding live window, `Infinity` for a live event with playback
-   * history, and `NaN` for on-demand or unknown.
+   * `0` for a sliding live window, `Infinity` for a live event with playback history, and `NaN` for on-demand or
+   * unknown.
    */
   targetLiveWindow: number;
 }
@@ -228,8 +224,8 @@ export interface MediaControlsState {
   /**
    * Keep controls visible during a sustained interaction.
    *
-   * The returned function releases the lock. Multiple concurrent locks are
-   * supported and each release function is idempotent.
+   * The returned function releases the lock. Multiple concurrent locks are supported and each release function is
+   * idempotent.
    */
   requestControlsLock(): () => void;
   /** Toggle controls visibility. Returns the new `controlsVisible` value. */
@@ -330,10 +326,9 @@ export interface MediaTextTrackState {
   /** The `<track>` element's `src` for resolving relative cue text URLs. */
   thumbnailTrackSrc: string | null;
   /**
-   * The media element's CORS mode, mapped through the CORS-settings-attribute
-   * rules, or `null` when it is not in CORS mode. Thumbnail UI fetches the
-   * sprite sheets the cues point at with this mode, since a cross-origin
-   * `<track>` only loads at all when the media element is CORS-enabled.
+   * The media element's CORS mode, mapped through the CORS-settings-attribute rules, or `null` when it is not in CORS
+   * mode. Thumbnail UI fetches the sprite sheets the cues point at with this mode, since a cross-origin `<track>` only
+   * loads at all when the media element is CORS-enabled.
    */
   thumbnailTrackCrossOrigin: 'anonymous' | 'use-credentials' | null;
   /** All text tracks available on the media element. */
@@ -341,9 +336,8 @@ export interface MediaTextTrackState {
   /** Whether captions/subtitles are currently enabled. */
   subtitlesShowing: boolean;
   /**
-   * Toggle captions/subtitles visibility. Showing restores the track that was
-   * last showing, or the first caption/subtitle track when there is none.
-   * Returns the new enabled value.
+   * Toggle captions/subtitles visibility. Showing restores the track that was last showing, or the first
+   * caption/subtitle track when there is none. Returns the new enabled value.
    */
   toggleSubtitles(forceShow?: boolean): boolean;
   /** Select a captions/subtitles track by menu value, or disable with `"off"`. */

--- a/packages/media/src/core/types.ts
+++ b/packages/media/src/core/types.ts
@@ -31,9 +31,8 @@ export type MediaFeatureAvailability = 'available' | 'unavailable' | 'unsupporte
 /**
  * Rendition height, as the `{height}p` shorthand streaming providers use.
  *
- * Options that accept one match renditions by pixel area rather than by
- * literal height, so anamorphic variants land in the bucket their source
- * material belongs to.
+ * Options that accept one match renditions by pixel area rather than by literal height, so anamorphic variants land in
+ * the bucket their source material belongs to.
  */
 export type MediaResolution = '270p' | '360p' | '480p' | '540p' | '720p' | '1080p' | '1440p' | '2160p';
 
@@ -425,12 +424,10 @@ export interface MediaPictureInPictureCapability {
 /**
  * Canonical values for {@link MediaStreamType}.
  *
- * - `ON_DEMAND` — a finite-duration asset (VOD). Scrubbing is generally
- *   supported across the full timeline.
- * - `LIVE` — a live or DVR stream. The seekable window may slide as new
- *   segments are published, and `duration` is typically `Infinity`.
- * - `UNKNOWN` — the stream type has not been determined yet (no source,
- *   or metadata has not loaded).
+ * - `ON_DEMAND` — a finite-duration asset (VOD). Scrubbing is generally supported across the full timeline.
+ * - `LIVE` — a live or DVR stream. The seekable window may slide as new segments are published, and `duration` is
+ *   typically `Infinity`.
+ * - `UNKNOWN` — the stream type has not been determined yet (no source, or metadata has not loaded).
  */
 export const MediaStreamTypes = {
   ON_DEMAND: 'on-demand',
@@ -454,21 +451,19 @@ export interface MediaLiveEvents {
 
 export interface MediaLiveCapability {
   /**
-   * Playback time where the live edge begins. Playback is live when
-   * `currentTime >= liveEdgeStart`. `NaN` when the stream is not live or the
-   * value is unknown.
+   * Playback time where the live edge begins. Playback is live when `currentTime >= liveEdgeStart`. `NaN` when the
+   * stream is not live or the value is unknown.
    *
-   * No change event fires for this value alone. Read it again when `seekable`,
-   * `targetLiveWindow`, or `streamType` changes.
+   * No change event fires for this value alone. Read it again when `seekable`, `targetLiveWindow`, or `streamType`
+   * changes.
    *
    * @see https://github.com/video-dev/media-ui-extensions/blob/main/proposals/0007-live-edge.md
    */
   readonly liveEdgeStart: number;
   /**
-   * Describes the kind of live window available. `0` for a sliding live
-   * window, `Infinity` for a live event with playback history, and `NaN` for
-   * on-demand or unknown. This value is not a duration. Fires
-   * `targetlivewindowchange` when it changes.
+   * Describes the kind of live window available. `0` for a sliding live window, `Infinity` for a live event with
+   * playback history, and `NaN` for on-demand or unknown. This value is not a duration. Fires `targetlivewindowchange`
+   * when it changes.
    */
   readonly targetLiveWindow: number;
 }
@@ -519,13 +514,11 @@ export interface MediaPosterCapability {
 export type MediaContentValue = string | null | undefined;
 
 /**
- * Standardized content metadata reported by a media implementation. The named
- * keys are the shared vocabulary player features read; a media may report keys
- * of its own alongside them.
+ * Standardized content metadata reported by a media implementation. The named keys are the shared vocabulary player
+ * features read; a media may report keys of its own alongside them.
  *
- * Report a key only for a value the media can vouch for. Omit it otherwise —
- * an empty string is a deliberate blank that stops a feature's fallback chain,
- * so reporting `''` for "not loaded yet" suppresses the author's fallback.
+ * Report a key only for a value the media can vouch for. Omit it otherwise — an empty string is a deliberate blank that
+ * stops a feature's fallback chain, so reporting `''` for "not loaded yet" suppresses the author's fallback.
  */
 export interface MediaContentData {
   /** Title of the content. */
@@ -545,15 +538,12 @@ export interface MediaContentDataEvents {
 /**
  * Optional media-owned content metadata.
  *
- * `undefined` means the media does not support content data at all. A defined
- * bag — including an empty one — means it does, and its keys may come and go
- * as a source loads or is replaced.
+ * `undefined` means the media does not support content data at all. A defined bag — including an empty one — means it
+ * does, and its keys may come and go as a source loads or is replaced.
  *
- * Implementations dispatch `contentdatachange` when the bag changes, and only
- * then; an assignment that leaves every key and value alone stays quiet. They
- * are also expected to clear content data when the source is replaced. Nothing
- * enforces that second half, so a media that skips it reports stale metadata
- * across a source change.
+ * Implementations dispatch `contentdatachange` when the bag changes, and only then; an assignment that leaves every key
+ * and value alone stays quiet. They are also expected to clear content data when the source is replaced. Nothing
+ * enforces that second half, so a media that skips it reports stale metadata across a source change.
  */
 export interface MediaContentDataCapability {
   readonly contentData: MediaContentData | undefined;

--- a/packages/media/src/dom/cloudflare/media.ts
+++ b/packages/media/src/dom/cloudflare/media.ts
@@ -17,7 +17,8 @@ import { type CloudflareStreamApi, type CloudflareStreamPlayerApi, loadCloudflar
 const CloudflareMediaBase = MediaPlayedRangesMixin(EventTarget);
 
 /**
- * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the
+ *   new value.
  */
 export class CloudflareMedia extends CloudflareMediaBase implements Partial<Video> {
   #target: HTMLIFrameElement | null = null;

--- a/packages/media/src/dom/cloudflare/props.ts
+++ b/packages/media/src/dom/cloudflare/props.ts
@@ -2,9 +2,8 @@ import type { Video } from '../../core/types';
 import type { CloudflareSource } from './source';
 
 /**
- * The `Video` members the Cloudflare host accepts, plus the source that names
- * the video. `playsInline` is stored and reported but never reaches the player:
- * the Stream embed has no inline-playback knob and plays inline on its own.
+ * The `Video` members the Cloudflare host accepts, plus the source that names the video. `playsInline` is stored and
+ * reported but never reaches the player: the Stream embed has no inline-playback knob and plays inline on its own.
  */
 export interface CloudflareMediaProps extends Pick<
   Video,

--- a/packages/media/src/dom/cloudflare/source.ts
+++ b/packages/media/src/dom/cloudflare/source.ts
@@ -3,16 +3,14 @@ import { type CloudflareMediaProps, cloudflareMediaDefaultProps } from './props'
 
 /**
  * Cloudflare Stream engine options, spelled exactly as Cloudflare spells them
- * (https://developers.cloudflare.com/stream/viewing-videos/using-the-stream-player/).
- * They are serialized onto the embed URL verbatim, so what you write here is
- * what the player reads. The embed reads them once, when its URL is built, so
- * changing them after the iframe exists only takes effect on the next embed.
+ * (https://developers.cloudflare.com/stream/viewing-videos/using-the-stream-player/). They are serialized onto the
+ * embed URL verbatim, so what you write here is what the player reads. The embed reads them once, when its URL is
+ * built, so changing them after the iframe exists only takes effect on the next embed.
  *
- * Parameters the host owns are deliberately absent: `controls`, `autoplay`,
- * `loop`, `muted`, `preload`, and `poster` come from the props of the same name,
- * so configuring them here would give two ways to say one thing. The index
- * signature still carries anything not listed here, so undocumented knobs and
- * whatever Cloudflare adds next keep working.
+ * Parameters the host owns are deliberately absent: `controls`, `autoplay`, `loop`, `muted`, `preload`, and `poster`
+ * come from the props of the same name, so configuring them here would give two ways to say one thing. The index
+ * signature still carries anything not listed here, so undocumented knobs and whatever Cloudflare adds next keep
+ * working.
  */
 export interface CloudflareEngineConfig extends Record<string, unknown> {
   /** BCP 47 language of the text track to show by default (`'en'`, `'de'`). */
@@ -50,9 +48,8 @@ export interface ParsedCloudflareSource {
   /** Whether `id` is a signed token rather than a plain video UID. */
   signed: boolean;
   /**
-   * Per-customer embed origin (`https://customer-<code>.cloudflarestream.com`)
-   * when the source names one, otherwise null for the shared host. Signed and
-   * access-controlled videos are only served from the customer origin, so it has
+   * Per-customer embed origin (`https://customer-<code>.cloudflarestream.com`) when the source names one, otherwise
+   * null for the shared host. Signed and access-controlled videos are only served from the customer origin, so it has
    * to survive parsing rather than being collapsed into the shared one.
    */
   origin: string | null;
@@ -64,9 +61,8 @@ export function parseCloudflareVideoId(src: string) {
 }
 
 /**
- * Parse a Cloudflare Stream source string. Recognizes `videodelivery.net` and
- * `cloudflarestream.com` URLs (embed, iframe, manifest, and thumbnail paths all
- * carry the id in the same position), raw 32-character video UIDs, and signed
+ * Parse a Cloudflare Stream source string. Recognizes `videodelivery.net` and `cloudflarestream.com` URLs (embed,
+ * iframe, manifest, and thumbnail paths all carry the id in the same position), raw 32-character video UIDs, and signed
  * tokens, which stand in for the UID wherever it appears.
  */
 export function parseCloudflareSource(src: string): ParsedCloudflareSource | null {

--- a/packages/media/src/dom/cloudflare/tests/media.test.ts
+++ b/packages/media/src/dom/cloudflare/tests/media.test.ts
@@ -100,9 +100,8 @@ function createEmptySrcIframe(): HTMLIFrameElement {
 }
 
 /**
- * An iframe as a server-rendered page delivers it: the embed URL is already in
- * the markup and the frame has navigated to it, so a same-origin read of its
- * location throws the way a real cross-origin embed does.
+ * An iframe as a server-rendered page delivers it: the embed URL is already in the markup and the frame has navigated
+ * to it, so a same-origin read of its location throws the way a real cross-origin embed does.
  */
 function createServerRenderedIframe(src: string): HTMLIFrameElement {
   const iframe = document.createElement('iframe');

--- a/packages/media/src/dom/dash/media-tracks.ts
+++ b/packages/media/src/dom/dash/media-tracks.ts
@@ -11,17 +11,14 @@ type DashEngineHost = HTMLVideoElementHost & {
 type MediaTracksHost = DashEngineHost & MediaVideoTrackCapability & MediaVideoRenditionCapability;
 
 /**
- * Mirrors the dash.js video representations of the active stream into the
- * media element's `videoRenditions` list, and wires user selection back to
- * `engine.setRepresentationForTypeById()`.
+ * Mirrors the dash.js video representations of the active stream into the media element's `videoRenditions` list, and
+ * wires user selection back to `engine.setRepresentationForTypeById()`.
  *
- * DASH representations belong to an adaptation set rather than to a flat list,
- * so they are hung off a single `'main'` video track — the one the renditions of
- * the stream that is playing are read from.
+ * DASH representations belong to an adaptation set rather than to a flat list, so they are hung off a single `'main'`
+ * video track — the one the renditions of the stream that is playing are read from.
  *
- * Requires the media-tracks mixin (track-list infrastructure) to be applied
- * earlier in the chain so the host exposes `addVideoTrack`, `videoRenditions`,
- * and friends.
+ * Requires the media-tracks mixin (track-list infrastructure) to be applied earlier in the chain so the host exposes
+ * `addVideoTrack`, `videoRenditions`, and friends.
  */
 export function DashMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
   class DashMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {
@@ -176,17 +173,16 @@ export function DashMediaMediaTracksMixin<Base extends Constructor<MediaTracksHo
 }
 
 /**
- * dash.js plays a pinned representation only while its own bitrate switching is
- * off, so selecting a rendition takes this setting alongside the representation.
+ * Dash.js plays a pinned representation only while its own bitrate switching is off, so selecting a rendition takes
+ * this setting alongside the representation.
  */
 function autoSwitchBitrate(video: boolean): dashjs.MediaPlayerSettingClass {
   return { streaming: { abr: { autoSwitchBitrate: { video } } } };
 }
 
 /**
- * Representation bitrate in bits per second. `bandwidth` is what the manifest
- * declares; the kbit reading is dash.js's own derived value, kept as a fallback
- * for representations that carry one without the other.
+ * Representation bitrate in bits per second. `bandwidth` is what the manifest declares; the kbit reading is dash.js's
+ * own derived value, kept as a fallback for representations that carry one without the other.
  */
 function toBitrate(representation: dashjs.Representation): number | undefined {
   const { bandwidth, bitrateInKbit } = representation;

--- a/packages/media/src/dom/dash/media.ts
+++ b/packages/media/src/dom/dash/media.ts
@@ -16,10 +16,7 @@ export interface DashSource {
 
 /** The engines a DASH source can configure. */
 export interface DashEngineConfig {
-  /**
-   * dash.js's own settings, passed through untouched. Replacing them resets any
-   * previously applied settings.
-   */
+  /** Dash.js's own settings, passed through untouched. Replacing them resets any previously applied settings. */
   dashJs?: dashjs.MediaPlayerSettingClass | undefined;
 }
 
@@ -67,9 +64,8 @@ class DashMediaBase
   }
 
   /**
-   * Underlying playback engine — the dash.js `MediaPlayerClass` instance. An
-   * advanced escape hatch for direct engine access; normal playback is driven
-   * through this element's own properties and methods.
+   * Underlying playback engine — the dash.js `MediaPlayerClass` instance. An advanced escape hatch for direct engine
+   * access; normal playback is driven through this element's own properties and methods.
    */
   get engine() {
     return this.#engine;
@@ -90,11 +86,10 @@ class DashMediaBase
   }
 
   /**
-   * Structured source: the MPD URL in `src`, plus dash.js settings in
-   * `engine.dashJs`. Replacing it re-derives `src`.
+   * Structured source: the MPD URL in `src`, plus dash.js settings in `engine.dashJs`. Replacing it re-derives `src`.
    *
-   * dash.js takes settings on a live player, so changing `engine.dashJs`
-   * re-applies them in place instead of recreating the engine.
+   * Dash.js takes settings on a live player, so changing `engine.dashJs` re-applies them in place instead of recreating
+   * the engine.
    */
   get source(): DashSource | null {
     return this.#source;
@@ -136,6 +131,7 @@ class DashMediaBase
 }
 
 /**
- * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the
+ *   new value.
  */
 export class DashMedia extends DashMediaMediaTracksMixin(DashMediaBase) {}

--- a/packages/media/src/dom/dash/tests/dash-media.test.ts
+++ b/packages/media/src/dom/dash/tests/dash-media.test.ts
@@ -6,7 +6,7 @@ vi.mock('dashjs', () => {
     QUALITY_CHANGE_RENDERED: 'qualityChangeRendered',
   };
 
-  /** dash.js merges every `updateSettings()` call into the current settings. */
+  /** Dash.js merges every `updateSettings()` call into the current settings. */
   function merge(target: Record<string, any>, source: Record<string, any>) {
     for (const [key, value] of Object.entries(source)) {
       const isPlainObject = typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -102,7 +102,7 @@ function setup() {
   return { media, video, engine: media.engine as unknown as MockEngine };
 }
 
-/** dash.js announces a stream with the video representations it can play. */
+/** Dash.js announces a stream with the video representations it can play. */
 function initStream(engine: MockEngine, representations: MockRepresentation[]) {
   engine.representations = representations;
   engine.emit('streamInitialized', { error: null });

--- a/packages/media/src/dom/google-cast/google-cast-augments.d.ts
+++ b/packages/media/src/dom/google-cast/google-cast-augments.d.ts
@@ -1,6 +1,6 @@
 /**
- * Augments `@types/chromecast-caf-sender` with HLS segment format
- * properties added after the community types were last updated.
+ * Augments `@types/chromecast-caf-sender` with HLS segment format properties added after the community types were last
+ * updated.
  */
 declare namespace chrome.cast.media {
   enum HlsSegmentFormat {

--- a/packages/media/src/dom/google-cast/google-cast-provider.ts
+++ b/packages/media/src/dom/google-cast/google-cast-provider.ts
@@ -23,13 +23,11 @@ type RemotePlayerListener = (event?: cast.framework.RemotePlayerChangedEvent) =>
 type GoogleCastConfig = GoogleCastProps;
 
 /**
- * Cast provider + lifecycle. Created by the {@link GoogleCast} component and
- * installed as the host's `targetOverride` while a cast session is connected,
- * so its getters/setters route through the cast receiver; when disconnected the
- * host falls through to the attached target. Also owns the cast framework
- * integration, the `RemotePlayback` instance exposed via
- * {@link GoogleCastProvider#remote}, and dispatches media events on the attached
- * target (forwarded by the host) while casting.
+ * Cast provider + lifecycle. Created by the {@link GoogleCast} component and installed as the host's `targetOverride`
+ * while a cast session is connected, so its getters/setters route through the cast receiver; when disconnected the host
+ * falls through to the attached target. Also owns the cast framework integration, the `RemotePlayback` instance exposed
+ * via {@link GoogleCastProvider#remote}, and dispatches media events on the attached target (forwarded by the host)
+ * while casting.
  */
 export class GoogleCastProvider {
   target: HTMLMediaTargetLike | null = null;

--- a/packages/media/src/dom/google-cast/remote-playback.ts
+++ b/packages/media/src/dom/google-cast/remote-playback.ts
@@ -16,16 +16,15 @@ let callbackIdCount = 0;
  * Implementation of the W3C [`RemotePlayback`](https://developer.mozilla.org/en-US/docs/Web/API/RemotePlayback)
  * interface backed by Google Cast.
  *
- * Surfaced via `host.remote` while the {@link GoogleCastProvider} is in the
- * provider chain. The public API must strictly conform to the W3C spec:
+ * Surfaced via `host.remote` while the {@link GoogleCastProvider} is in the provider chain. The public API must
+ * strictly conform to the W3C spec:
  *
  * - Properties: `state`
  * - Methods: `watchAvailability`, `cancelWatchAvailability`, `prompt`
  * - Events: `connecting`, `connect`, `disconnect`
  *
- * Internal state mutations are pushed by {@link GoogleCastProvider} through
- * private callbacks registered via `provider.bindHooks(...)` in the constructor —
- * do not add public methods or properties that aren't part of the spec.
+ * Internal state mutations are pushed by {@link GoogleCastProvider} through private callbacks registered via
+ * `provider.bindHooks(...)` in the constructor — do not add public methods or properties that aren't part of the spec.
  */
 export class RemotePlayback extends EventTarget {
   #provider: GoogleCastProvider;

--- a/packages/media/src/dom/hls-js/airplay-bridge.ts
+++ b/packages/media/src/dom/hls-js/airplay-bridge.ts
@@ -5,11 +5,9 @@ import Hls from 'hls.js';
 import type { HlsEngineHost } from './types';
 
 /**
- * Adds an AirPlay-capable fallback `<source>` to the attached video element so
- * Safari can hand the original HLS manifest off to AirPlay receivers while
- * local playback continues through hls.js (MSE).
- * When wireless-target changes, suspends hls.js loading so we don't double-fetch
- * alongside the AirPlay receiver.
+ * Adds an AirPlay-capable fallback `<source>` to the attached video element so Safari can hand the original HLS
+ * manifest off to AirPlay receivers while local playback continues through hls.js (MSE). When wireless-target changes,
+ * suspends hls.js loading so we don't double-fetch alongside the AirPlay receiver.
  *
  * Implements the WebKit-recommended pattern:
  * https://webkit.org/blog/15036/how-to-use-media-source-extensions-with-airplay/

--- a/packages/media/src/dom/hls-js/cap-level.ts
+++ b/packages/media/src/dom/hls-js/cap-level.ts
@@ -5,9 +5,8 @@ import type { MediaResolution } from '../../core/types';
 /**
  * Live cap inputs the installed cap-level controller reads on every evaluation.
  *
- * hls.js fixes `capLevelController` when the engine is constructed, so the class
- * cannot carry values that change during playback. The media element owns this
- * object and mutates it in place instead, which is what lets a cap change skip
+ * Hls.js fixes `capLevelController` when the engine is constructed, so the class cannot carry values that change during
+ * playback. The media element owns this object and mutates it in place instead, which is what lets a cap change skip
  * rebuilding the engine.
  */
 export interface RenditionCapPolicy {
@@ -24,9 +23,8 @@ export interface RenditionCapPolicy {
 /**
  * Floor applied to the player-size cap unless a source names another.
  *
- * The low rungs of a ladder are there for bad network conditions, and at that
- * end the relationship between resolution and perceived quality stops holding:
- * a small player capped to 360p looks worse than its size alone suggests. No
+ * The low rungs of a ladder are there for bad network conditions, and at that end the relationship between resolution
+ * and perceived quality stops holding: a small player capped to 360p looks worse than its size alone suggests. No
  * reliable signal exists to key that on, so a fixed floor stands in for one.
  */
 export const DEFAULT_MIN_AUTO_RESOLUTION: MediaResolution = '720p';
@@ -37,19 +35,15 @@ export interface RenditionCapController {
 }
 
 /**
- * Pixel area of a resolution shorthand, assuming 16:9 — `'720p'` is
- * `1280 × 720`, or `921_600`.
+ * Pixel area of a resolution shorthand, assuming 16:9 — `'720p'` is `1280 × 720`, or `921_600`.
  *
- * Renditions are matched on area rather than literal height so anamorphic
- * variants are judged by how many pixels they actually carry: a 2560×1080
- * ultrawide rendition costs more than 16:9 1080p and is capped accordingly.
+ * Renditions are matched on area rather than literal height so anamorphic variants are judged by how many pixels they
+ * actually carry: a 2560×1080 ultrawide rendition costs more than 16:9 1080p and is capped accordingly.
  *
- * Mirrors `maxResolutionToPixelArea` in `@videojs/spf`, and agrees with it on
- * every rung whose 16:9 width is a whole number. It parts company at `'480p'`
- * on purpose: 16:9 at 480 tall is 853.33 wide, ladders ship the rounded-up
- * 854×480, and the exact area would put the standard 480p rendition over its
- * own cap. Rounding the width up admits it while still excluding anything
- * genuinely wider.
+ * Mirrors `maxResolutionToPixelArea` in `@videojs/spf`, and agrees with it on every rung whose 16:9 width is a whole
+ * number. It parts company at `'480p'` on purpose: 16:9 at 480 tall is 853.33 wide, ladders ship the rounded-up
+ * 854×480, and the exact area would put the standard 480p rendition over its own cap. Rounding the width up admits it
+ * while still excluding anything genuinely wider.
  */
 export function resolutionToPixelArea(resolution: MediaResolution | undefined): number {
   if (resolution === undefined) return Number.POSITIVE_INFINITY;
@@ -64,17 +58,15 @@ export function resolutionToPixelArea(resolution: MediaResolution | undefined): 
 /**
  * Highest level index that keeps automatic selection at or below `resolution`.
  *
- * `autoLevelCapping` is a ceiling on the *index*, so every level at or below it
- * stays eligible. That makes the answer the end of the leading run that fits the
- * budget, not the single best match: hls.js orders levels by height, so a wider
- * rendition can exceed the pixel budget from a lower index, and capping at the
- * best match would leave it selectable.
+ * `autoLevelCapping` is a ceiling on the _index_, so every level at or below it stays eligible. That makes the answer
+ * the end of the leading run that fits the budget, not the single best match: hls.js orders levels by height, so a
+ * wider rendition can exceed the pixel budget from a lower index, and capping at the best match would leave it
+ * selectable.
  *
- * Falls back to index `0` when even the lowest rung is over budget — playing
- * something over-spec beats refusing to adapt.
+ * Falls back to index `0` when even the lowest rung is over budget — playing something over-spec beats refusing to
+ * adapt.
  *
- * Returns `undefined` when there is nothing to cap: no resolution requested, or
- * no levels to choose from.
+ * Returns `undefined` when there is nothing to cap: no resolution requested, or no levels to choose from.
  */
 export function levelIndexAtOrBelow(
   levels: readonly Level[],
@@ -94,17 +86,15 @@ export function levelIndexAtOrBelow(
 /**
  * Lowest level index that keeps a rendition at or above `resolution` eligible.
  *
- * The complement of {@link levelIndexAtOrBelow}, for raising a ceiling rather
- * than lowering one, and reasoned the same way: `autoLevelCapping` is a ceiling
- * on the *index*, so the cheapest ceiling that still admits the floor is the
- * first index that reaches it. Every rung below stays eligible either way, which
- * is what keeps this a bound on capping rather than a quality minimum.
+ * The complement of {@link levelIndexAtOrBelow}, for raising a ceiling rather than lowering one, and reasoned the same
+ * way: `autoLevelCapping` is a ceiling on the _index_, so the cheapest ceiling that still admits the floor is the first
+ * index that reaches it. Every rung below stays eligible either way, which is what keeps this a bound on capping rather
+ * than a quality minimum.
  *
- * Falls back to the top of the ladder when no rendition reaches the floor — a
- * floor nothing can satisfy has no cap to raise.
+ * Falls back to the top of the ladder when no rendition reaches the floor — a floor nothing can satisfy has no cap to
+ * raise.
  *
- * Returns `undefined` when there is no floor to apply: no resolution requested,
- * or no levels to choose from.
+ * Returns `undefined` when there is no floor to apply: no resolution requested, or no levels to choose from.
  */
 export function levelIndexAtOrAbove(
   levels: readonly Level[],
@@ -124,19 +114,17 @@ type CapLevelControllerClass = typeof Hls.DefaultConfig.capLevelController;
 /**
  * Build the `capLevelController` class to hand to the hls.js constructor.
  *
- * `hls.autoLevelCapping` has exactly one writer: hls.js's own
- * `CapLevelController`, which rewrites it on a one-second interval for as long
- * as `capLevelToPlayerSize` is on — and it is on by default here. Assigning the
- * property from outside is undone within a second, so a cap has to be applied
- * from inside the controller rather than in competition with it.
+ * `hls.autoLevelCapping` has exactly one writer: hls.js's own `CapLevelController`, which rewrites it on a one-second
+ * interval for as long as `capLevelToPlayerSize` is on — and it is on by default here. Assigning the property from
+ * outside is undone within a second, so a cap has to be applied from inside the controller rather than in competition
+ * with it.
  *
- * The only seam hls.js offers is `getMaxLevel()`, which every value the capping
- * loop writes passes through. Overriding it makes the requested ceiling part of
- * the same single-writer computation.
+ * The only seam hls.js offers is `getMaxLevel()`, which every value the capping loop writes passes through. Overriding
+ * it makes the requested ceiling part of the same single-writer computation.
  *
  * @param policy - Live cap inputs, re-read on every evaluation.
- * @param BaseController - Controller to layer on top of, so a controller passed
- *   through `source.engine.capLevelController` keeps its behavior.
+ * @param BaseController - Controller to layer on top of, so a controller passed through
+ *   `source.engine.capLevelController` keeps its behavior.
  */
 export function createCapLevelController(
   policy: RenditionCapPolicy,
@@ -180,15 +168,13 @@ export function createCapLevelController(
     }
 
     /**
-     * hls.js derives its player-size ceiling from these two, so reporting an
-     * unbounded measurement is how `capToPlayerSize: false` switches that
-     * ceiling off while leaving the rest of the base controller intact.
+     * Hls.js derives its player-size ceiling from these two, so reporting an unbounded measurement is how
+     * `capToPlayerSize: false` switches that ceiling off while leaving the rest of the base controller intact.
      *
-     * Returning early from `getMaxLevel()` instead would be the obvious way to
-     * skip the size cap, and it would also skip the levels `capLevelOnFPSDrop`
-     * has restricted: those are filtered inside the same `super.getMaxLevel()`
-     * call, and `restrictedLevels` is private, so there is no way to reapply
-     * them afterwards. Neutralizing the input keeps one path for both.
+     * Returning early from `getMaxLevel()` instead would be the obvious way to skip the size cap, and it would also
+     * skip the levels `capLevelOnFPSDrop` has restricted: those are filtered inside the same `super.getMaxLevel()`
+     * call, and `restrictedLevels` is private, so there is no way to reapply them afterwards. Neutralizing the input
+     * keeps one path for both.
      */
     get mediaWidth(): number {
       return this.#sizeApplies ? super.mediaWidth : Number.POSITIVE_INFINITY;
@@ -203,9 +189,8 @@ export function createCapLevelController(
     }
 
     /**
-     * What `super` allows with player size out of the picture — the ladder minus
-     * whatever `capLevelOnFPSDrop` has restricted. Reached through the same
-     * unbounded-measurement seam the toggle uses, since `restrictedLevels` is
+     * What `super` allows with player size out of the picture — the ladder minus whatever `capLevelOnFPSDrop` has
+     * restricted. Reached through the same unbounded-measurement seam the toggle uses, since `restrictedLevels` is
      * private and not readable any other way.
      */
     #topAllowedLevel(capLevelIndex: number): number {
@@ -219,13 +204,11 @@ export function createCapLevelController(
     }
 
     /**
-     * Intersect hls.js's player-size ceiling with the requested one. Deferring
-     * to `super` first keeps the behavior it owns — notably the level
-     * restrictions `capLevelOnFPSDrop` accumulates.
+     * Intersect hls.js's player-size ceiling with the requested one. Deferring to `super` first keeps the behavior it
+     * owns — notably the level restrictions `capLevelOnFPSDrop` accumulates.
      *
-     * The translation from resolution to level index happens here, not when the
-     * policy is set, because levels arrive after the option does and shift
-     * whenever hls.js drops one.
+     * The translation from resolution to level index happens here, not when the policy is set, because levels arrive
+     * after the option does and shift whenever hls.js drops one.
      */
     getMaxLevel(capLevelIndex: number): number {
       const { levels } = this.#hls;
@@ -252,11 +235,9 @@ export function createCapLevelController(
     }
 
     /**
-     * hls.js measures the element here and writes the ceiling it derives. It
-     * backs out entirely when the element has no measurable size — sensible for
-     * a cap that *is* the element's size, but a requested resolution ceiling
-     * does not depend on layout. A player that is hidden, detached, or not laid
-     * out yet still has to honor it.
+     * Hls.js measures the element here and writes the ceiling it derives. It backs out entirely when the element has no
+     * measurable size — sensible for a cap that _is_ the element's size, but a requested resolution ceiling does not
+     * depend on layout. A player that is hidden, detached, or not laid out yet still has to honor it.
      */
     detectPlayerSize() {
       super.detectPlayerSize();
@@ -282,10 +263,9 @@ export function createCapLevelController(
     /**
      * The ceiling on its own, for when the size measurement is unavailable.
      *
-     * Neither `capToPlayerSize` nor `minAutoResolution` reaches this path, and
-     * neither has anything to do here: both describe a cap derived from the
-     * element's size, and this is precisely the case where no such cap exists —
-     * there is none to switch off, and none for a floor to lift.
+     * Neither `capToPlayerSize` nor `minAutoResolution` reaches this path, and neither has anything to do here: both
+     * describe a cap derived from the element's size, and this is precisely the case where no such cap exists — there
+     * is none to switch off, and none for a floor to lift.
      */
     #applyResolutionCap() {
       const { levels } = this.#hls;

--- a/packages/media/src/dom/hls-js/drm.ts
+++ b/packages/media/src/dom/hls-js/drm.ts
@@ -1,21 +1,17 @@
 import Hls, { type MediaKeyFunc } from 'hls.js';
 
 /**
- * Hardware-backed Widevine security level. Preferred (but not required) so
- * content restricted to L1 devices plays where the CDM supports it.
+ * Hardware-backed Widevine security level. Preferred (but not required) so content restricted to L1 devices plays where
+ * the CDM supports it.
  */
 const HARDWARE_ROBUSTNESS = 'HW_SECURE_ALL';
 
 /**
- * Round off EME playback on a fresh engine. What to play and where to license
- * it is hls.js's own configuration, reached through `source.engine`
- * (`emeEnabled`, `drmSystems`); this only fills in what hls.js leaves to the
- * caller:
+ * Round off EME playback on a fresh engine. What to play and where to license it is hls.js's own configuration, reached
+ * through `source.engine` (`emeEnabled`, `drmSystems`); this only fills in what hls.js leaves to the caller:
  *
- * - Prefers a hardware-backed Widevine CDM, falling back to whatever robustness
- *   the browser offers.
- * - Surfaces non-fatal key system errors in development, which are otherwise
- *   silent.
+ * - Prefers a hardware-backed Widevine CDM, falling back to whatever robustness the browser offers.
+ * - Surfaces non-fatal key system errors in development, which are otherwise silent.
  *
  * A `requestMediaKeySystemAccessFunc` of your own takes precedence over both.
  */
@@ -49,9 +45,8 @@ const requestKeySystemAccess: MediaKeyFunc = (keySystem, supportedConfigurations
 };
 
 /**
- * Duplicate the requested key system configurations with hardware-level video
- * robustness ahead of the originals. `requestMediaKeySystemAccess()` resolves
- * with the first supported entry, so this prefers a hardware CDM without
+ * Duplicate the requested key system configurations with hardware-level video robustness ahead of the originals.
+ * `requestMediaKeySystemAccess()` resolves with the first supported entry, so this prefers a hardware CDM without
  * failing when only software security is available.
  */
 function withHardwareRobustness(configurations: MediaKeySystemConfiguration[]): MediaKeySystemConfiguration[] {

--- a/packages/media/src/dom/hls-js/live.ts
+++ b/packages/media/src/dom/hls-js/live.ts
@@ -97,9 +97,8 @@ export function HlsJsMediaLiveMixin<Base extends Constructor<HlsEngineHost>>(Bas
     }
 
     /**
-     * Arm a one-shot seek-to-live on the first user-initiated `play`. Skipped
-     * when `autoplay` is set, since hls.js positions at the live edge during
-     * its own startup sequence and a programmatic seek would race that.
+     * Arm a one-shot seek-to-live on the first user-initiated `play`. Skipped when `autoplay` is set, since hls.js
+     * positions at the live edge during its own startup sequence and a programmatic seek would race that.
      */
     #armSeekToLive() {
       this.#disarmSeekToLive();

--- a/packages/media/src/dom/hls-js/media-tracks.ts
+++ b/packages/media/src/dom/hls-js/media-tracks.ts
@@ -40,13 +40,11 @@ function getAudioTrackKind(audioTrack: HlsJsMediaAudioTrack): string {
 }
 
 /**
- * Mirrors hls.js manifest levels and alternate audio into the media element's
- * `videoRenditions` / `audioTracks` lists, and wires user selection back to
- * `engine.nextLevel` and `engine.audioTrack`.
+ * Mirrors hls.js manifest levels and alternate audio into the media element's `videoRenditions` / `audioTracks` lists,
+ * and wires user selection back to `engine.nextLevel` and `engine.audioTrack`.
  *
- * Requires the media-tracks mixin (track-list infrastructure) to be applied
- * earlier in the chain so the host exposes `addVideoTrack`, `videoRenditions`,
- * and friends.
+ * Requires the media-tracks mixin (track-list infrastructure) to be applied earlier in the chain so the host exposes
+ * `addVideoTrack`, `videoRenditions`, and friends.
  */
 export function HlsJsMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
   class HlsJsMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -40,12 +40,11 @@ export interface HlsMediaProps {
 /**
  * Structured HLS source: which source to play, plus how to play it.
  *
- * Playback options are namespaced by engine. There are two paths here — hls.js
- * and the browser's own HLS support — and only one of them runs, so a source
- * describes both without either engine reading the other's options.
+ * Playback options are namespaced by engine. There are two paths here — hls.js and the browser's own HLS support — and
+ * only one of them runs, so a source describes both without either engine reading the other's options.
  *
- * `preferPlayback` and the engine options are all read when the engine is
- * constructed, so changing any of them recreates it.
+ * `preferPlayback` and the engine options are all read when the engine is constructed, so changing any of them
+ * recreates it.
  */
 export interface HlsSource {
   /** Manifest URL. Mirrors the host's `src` property. */
@@ -53,79 +52,66 @@ export interface HlsSource {
   /** MIME type of the source. Takes precedence over inference from `src`. */
   type?: SourceType | undefined;
   /**
-   * Preferred playback path: `'mse'` for hls.js, `'native'` for the browser's
-   * own HLS support. Ignored when the preferred path cannot play the source.
+   * Preferred playback path: `'mse'` for hls.js, `'native'` for the browser's own HLS support. Ignored when the
+   * preferred path cannot play the source.
    */
   preferPlayback?: PlaybackType | undefined;
   /**
    * License servers for protected content, keyed by EME key system id.
    *
-   * Engine neutral, because which engine plays is decided later: hls.js is
-   * handed every system named here (with EME switched on), and native playback
-   * negotiates the `com.apple.fps` entry itself. Name every system you hold a
-   * license server for — which one is used is the browser's choice.
+   * Engine neutral, because which engine plays is decided later: hls.js is handed every system named here (with EME
+   * switched on), and native playback negotiates the `com.apple.fps` entry itself. Name every system you hold a license
+   * server for — which one is used is the browser's choice.
    */
   drm?: DrmSystemsConfig | undefined;
   /**
    * Highest resolution adaptive bitrate selection may choose on its own.
    *
-   * A ceiling on automatic selection, not a filter on what is available:
-   * renditions above it stay in `videoRenditions` and can still be selected by
-   * hand. Matching is by pixel area, so a `'720p'` cap admits any rendition at
-   * or below 1280×720 worth of pixels. When every rendition sits above the cap,
-   * the smallest one is used.
+   * A ceiling on automatic selection, not a filter on what is available: renditions above it stay in `videoRenditions`
+   * and can still be selected by hand. Matching is by pixel area, so a `'720p'` cap admits any rendition at or below
+   * 1280×720 worth of pixels. When every rendition sits above the cap, the smallest one is used.
    *
-   * Applied live — changing it never rebuilds the playback engine. Requires the
-   * hls.js (MSE) engine; native HLS playback ignores it.
+   * Applied live — changing it never rebuilds the playback engine. Requires the hls.js (MSE) engine; native HLS
+   * playback ignores it.
    *
-   * For Mux sources this is distinct from `playback.maxResolution`, which asks
-   * Mux to leave higher renditions out of the manifest altogether.
+   * For Mux sources this is distinct from `playback.maxResolution`, which asks Mux to leave higher renditions out of
+   * the manifest altogether.
    */
   maxAutoResolution?: MediaResolution | undefined;
   /**
-   * Whether the element's rendered size caps automatic selection. Defaults to
-   * `true`.
+   * Whether the element's rendered size caps automatic selection. Defaults to `true`.
    *
-   * A 400px-wide player has no use for a 4K rendition, so selection is held to
-   * the smallest rendition that still covers the element, measured in device
-   * pixels — a `2` device pixel ratio asks for twice what a CSS measurement
-   * would. The cap follows the element as it resizes, and `minAutoResolution`
-   * bounds how far down it can go. Set it to `false` for a player whose layout
-   * size understates what it needs, such as one that goes fullscreen without a
-   * resize.
+   * A 400px-wide player has no use for a 4K rendition, so selection is held to the smallest rendition that still covers
+   * the element, measured in device pixels — a `2` device pixel ratio asks for twice what a CSS measurement would. The
+   * cap follows the element as it resizes, and `minAutoResolution` bounds how far down it can go. Set it to `false` for
+   * a player whose layout size understates what it needs, such as one that goes fullscreen without a resize.
    *
-   * Which rendition covers the element is hls.js's own judgement, weighed on
-   * the largest dimension rather than pixel area, so it can land elsewhere than
-   * `maxAutoResolution` would for the same ladder.
+   * Which rendition covers the element is hls.js's own judgement, weighed on the largest dimension rather than pixel
+   * area, so it can land elsewhere than `maxAutoResolution` would for the same ladder.
    *
-   * Applied live — changing it never rebuilds the playback engine. Requires the
-   * hls.js (MSE) engine; native HLS playback ignores it. Setting hls.js's own
-   * `capLevelToPlayerSize` through `source.engine.hlsJs` is a different thing:
-   * it stops the loop *every* cap here is evaluated on, and takes a rebuild.
+   * Applied live — changing it never rebuilds the playback engine. Requires the hls.js (MSE) engine; native HLS
+   * playback ignores it. Setting hls.js's own `capLevelToPlayerSize` through `source.engine.hlsJs` is a different
+   * thing: it stops the loop _every_ cap here is evaluated on, and takes a rebuild.
    */
   capRenditionToPlayerSize?: boolean | undefined;
   /**
-   * Lowest resolution `capRenditionToPlayerSize` may cap down to. Defaults to
-   * `'720p'`.
+   * Lowest resolution `capRenditionToPlayerSize` may cap down to. Defaults to `'720p'`.
    *
-   * Not a quality floor. It bounds the size-derived cap and nothing else: when
-   * bandwidth is poor, adaptive selection still drops below it, because the cap
-   * is a ceiling and selection stays free underneath. Nor does it raise an
-   * explicit `maxAutoResolution` — asking for at most `'360p'` alongside a
-   * `'720p'` floor yields `'360p'`.
+   * Not a quality floor. It bounds the size-derived cap and nothing else: when bandwidth is poor, adaptive selection
+   * still drops below it, because the cap is a ceiling and selection stays free underneath. Nor does it raise an
+   * explicit `maxAutoResolution` — asking for at most `'360p'` alongside a `'720p'` floor yields `'360p'`.
    *
-   * The default exists because the low rungs of a ladder are there for poor
-   * network conditions, and capping a small player to them looks worse than its
-   * size suggests. Name a lower rung to weaken the floor, or `'270p'` to lift it
+   * The default exists because the low rungs of a ladder are there for poor network conditions, and capping a small
+   * player to them looks worse than its size suggests. Name a lower rung to weaken the floor, or `'270p'` to lift it
    * for any real ladder.
    *
-   * Applied live — changing it never rebuilds the playback engine. Requires the
-   * hls.js (MSE) engine; native HLS playback ignores it.
+   * Applied live — changing it never rebuilds the playback engine. Requires the hls.js (MSE) engine; native HLS
+   * playback ignores it.
    */
   minAutoResolution?: MediaResolution | undefined;
   /**
-   * Playback options, keyed by the engine that reads them. Only one of the two
-   * engines below ends up playing, and each reads only its own key.
+   * Playback options, keyed by the engine that reads them. Only one of the two engines below ends up playing, and each
+   * reads only its own key.
    */
   engine?: HlsEngineConfig | undefined;
 }
@@ -133,16 +119,14 @@ export interface HlsSource {
 /** The engines an HLS source can configure. */
 export interface HlsEngineConfig {
   /**
-   * hls.js's own configuration, passed through untouched. A `drmSystems` of its
-   * own replaces `source.drm` for hls.js — an escape hatch for licensing MSE
-   * playback differently, or for the parts of hls.js's DRM configuration
-   * `source.drm` does not cover.
+   * Hls.js's own configuration, passed through untouched. A `drmSystems` of its own replaces `source.drm` for hls.js —
+   * an escape hatch for licensing MSE playback differently, or for the parts of hls.js's DRM configuration `source.drm`
+   * does not cover.
    */
   hlsJs?: Partial<HlsJsConfig> | undefined;
   /**
-   * Options for the browser's own HLS playback, used whenever the native path
-   * is the one taken. Its `drmSystems` replaces `source.drm` for that path in
-   * the same way.
+   * Options for the browser's own HLS playback, used whenever the native path is the one taken. Its `drmSystems`
+   * replaces `source.drm` for that path in the same way.
    */
   nativeHls?: NativeHlsConfig | undefined;
 }
@@ -157,7 +141,8 @@ export const hlsMediaDefaultProps: HlsMediaProps = {
 class HlsMediaEvent extends Event {}
 
 /**
- * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the
+ *   new value.
  * @fires streamtypechange - Fired when the detected stream type changes. Read `streamType` for the new value.
  * @fires targetlivewindowchange - Fired when the target live window changes. Read `targetLiveWindow` for the new value.
  */
@@ -198,9 +183,8 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   /**
-   * Underlying playback engine — the hls.js `Hls` instance when playing via
-   * MSE, otherwise `null`. An advanced escape hatch for direct engine access;
-   * normal playback is driven through this element's own properties and methods.
+   * Underlying playback engine — the hls.js `Hls` instance when playing via MSE, otherwise `null`. An advanced escape
+   * hatch for direct engine access; normal playback is driven through this element's own properties and methods.
    */
   get engine() {
     return this.#delegate?.engine ?? null;
@@ -231,9 +215,8 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   /**
-   * Media source URL. Assigning it replaces the identity half of `source` and
-   * leaves `type` and the engine options intact, so changing the URL never
-   * disturbs engine configuration.
+   * Media source URL. Assigning it replaces the identity half of `source` and leaves `type` and the engine options
+   * intact, so changing the URL never disturbs engine configuration.
    */
   get src() {
     return this.#src;
@@ -263,12 +246,11 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   /**
-   * Structured source: what to play (`src`, an optional `type`) plus how to play
-   * it (`preferPlayback`, `engine`). Assigning it derives `src`.
+   * Structured source: what to play (`src`, an optional `type`) plus how to play it (`preferPlayback`, `engine`).
+   * Assigning it derives `src`.
    *
-   * Sources are compared structurally, so reassigning an equivalent object — an
-   * inline React prop, for instance — is a no-op. Only a change to the engine
-   * options (or to the resolved content type) recreates the playback engine.
+   * Sources are compared structurally, so reassigning an equivalent object — an inline React prop, for instance — is a
+   * no-op. Only a change to the engine options (or to the resolved content type) recreates the playback engine.
    */
   get source(): HlsSource | null {
     return this.#source;
@@ -336,17 +318,15 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   /**
    * Presentation time marking the start of the Live Edge Window.
    *
-   * Derived from the delegate on every read; `NaN` when no delegate is
-   * attached or the stream is not live.
+   * Derived from the delegate on every read; `NaN` when no delegate is attached or the stream is not live.
    */
   get liveEdgeStart() {
     return this.#delegate?.liveEdgeStart ?? Number.NaN;
   }
 
   /**
-   * Seekable range size for live content. `0` for standard live, `Infinity`
-   * for DVR, `NaN` for on-demand or unknown. Fires `targetlivewindowchange`
-   * when the value changes (bridged from the delegate).
+   * Seekable range size for live content. `0` for standard live, `Infinity` for DVR, `NaN` for on-demand or unknown.
+   * Fires `targetlivewindowchange` when the value changes (bridged from the delegate).
    */
   get targetLiveWindow() {
     return this.#delegate?.targetLiveWindow ?? Number.NaN;
@@ -414,10 +394,9 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   /**
-   * A native delegate carrying the native half of the source — the DRM
-   * configuration and the native engine options, which it applies the same
-   * precedence to. Its `src` is assigned separately, once the delegate is wired
-   * up, and carries what is set here forward.
+   * A native delegate carrying the native half of the source — the DRM configuration and the native engine options,
+   * which it applies the same precedence to. Its `src` is assigned separately, once the delegate is wired up, and
+   * carries what is set here forward.
    */
   #createNativeDelegate(
     drm: DrmSystemsConfig | undefined,
@@ -477,10 +456,9 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   /**
-   * Every value the engine is constructed from. Compared structurally, so
-   * equivalent engine options never trigger a rebuild — including nested ones
-   * like `drmSystems`, which a flat comparison would see as changed whenever
-   * the object identity did.
+   * Every value the engine is constructed from. Compared structurally, so equivalent engine options never trigger a
+   * rebuild — including nested ones like `drmSystems`, which a flat comparison would see as changed whenever the object
+   * identity did.
    */
   #engineConfigKey() {
     const { type, preferPlayback, drm, engine } = this.#source ?? {};
@@ -500,13 +478,11 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 }
 
 /**
- * hls.js configuration with the source's DRM licensing folded in. hls.js takes
- * `drmSystems` in the same shape as `source.drm`, so the standardized config is
- * what it plays from unless `engine.hlsJs` names servers of its own.
+ * Hls.js configuration with the source's DRM licensing folded in. hls.js takes `drmSystems` in the same shape as
+ * `source.drm`, so the standardized config is what it plays from unless `engine.hlsJs` names servers of its own.
  *
- * hls.js runs key exchange only while `emeEnabled` is set, so configured DRM
- * switches it on — short of an explicit `emeEnabled: false`, which stays a way
- * to describe a source's licensing without acting on it.
+ * Hls.js runs key exchange only while `emeEnabled` is set, so configured DRM switches it on — short of an explicit
+ * `emeEnabled: false`, which stays a way to describe a source's licensing without acting on it.
  */
 function withDrmSystems(
   hlsJs: Partial<HlsJsConfig> | undefined,

--- a/packages/media/src/dom/hls-js/metadata-tracks.ts
+++ b/packages/media/src/dom/hls-js/metadata-tracks.ts
@@ -4,12 +4,10 @@ import Hls from 'hls.js';
 import type { HlsEngineHost } from './types';
 
 /**
- * Ensures user-authored metadata and chapters `<track>` elements stay loaded
- * when hls.js is active.
+ * Ensures user-authored metadata and chapters `<track>` elements stay loaded when hls.js is active.
  *
- * hls.js forcibly clears all cues from text tracks on manifest loads and media
- * attaches. This mixin re-enables those tracks by forcing `mode = 'hidden'`
- * and reloading the track source when cues have been wiped.
+ * Hls.js forcibly clears all cues from text tracks on manifest loads and media attaches. This mixin re-enables those
+ * tracks by forcing `mode = 'hidden'` and reloading the track source when cues have been wiped.
  */
 export function HlsJsMediaMetadataTracksMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
   class HlsJsMediaMetadataTracks extends (BaseClass as Constructor<HlsEngineHost>) {

--- a/packages/media/src/dom/hls-js/preload.ts
+++ b/packages/media/src/dom/hls-js/preload.ts
@@ -6,15 +6,15 @@ import type { HlsEngineHost } from './types';
 export type PreloadType = '' | 'none' | 'metadata' | 'auto';
 
 /**
- * Manages HLS preload behavior by mapping the media element's `preload`
- * attribute to hls.js `startLoad` / buffer-limit configuration.
+ * Manages HLS preload behavior by mapping the media element's `preload` attribute to hls.js `startLoad` / buffer-limit
+ * configuration.
  *
  * - `'auto'` or already playing → full buffer limits, immediate start.
  * - `'metadata'` → minimal buffer (1 byte / 1 second), limits raised on play.
  * - `'none'` / `''` → no start, deferred load on play.
  *
- * Loading is started at most once per source. Widening the limits afterwards is
- * a plain config write, never a second `startLoad()`.
+ * Loading is started at most once per source. Widening the limits afterwards is a plain config write, never a second
+ * `startLoad()`.
  */
 export function HlsJsMediaPreloadMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
   class HlsJsMediaPreload extends (BaseClass as Constructor<HlsEngineHost>) {
@@ -76,14 +76,12 @@ export function HlsJsMediaPreloadMixin<Base extends Constructor<HlsEngineHost>>(
       const defaultSize = this.#defaultMaxBufferSize;
 
       /**
-       * Applies buffer limits, and starts loading only if this source has not
-       * been started yet.
+       * Applies buffer limits, and starts loading only if this source has not been started yet.
        *
-       * Once loading is under way, writing the limits is enough: hls.js reads
-       * both off `config` on every tick and its ticker is already armed. A
-       * second `startLoad()` would open with hls.js's own `stopLoad()`, which
-       * aborts the in-flight segment — and that abort resets the controller to
-       * IDLE a task later, so the next tick re-requests and re-aborts, forever.
+       * Once loading is under way, writing the limits is enough: hls.js reads both off `config` on every tick and its
+       * ticker is already armed. A second `startLoad()` would open with hls.js's own `stopLoad()`, which aborts the
+       * in-flight segment — and that abort resets the controller to IDLE a task later, so the next tick re-requests and
+       * re-aborts, forever.
        */
       const load = (length?: number, size?: number) => {
         const { engine } = this;

--- a/packages/media/src/dom/hls-js/tests/cap-level.test.ts
+++ b/packages/media/src/dom/hls-js/tests/cap-level.test.ts
@@ -78,9 +78,8 @@ interface SetupOptions {
   /** Defaults to on, as a source without the key does. */
   capToPlayerSize?: boolean;
   /**
-   * Left unset by default, unlike a source, whose absent key means `'720p'`.
-   * The floor and the size cap it bounds are then measurable one at a time; the
-   * default itself is a property of the source layer, covered there.
+   * Left unset by default, unlike a source, whose absent key means `'720p'`. The floor and the size cap it bounds are
+   * then measurable one at a time; the default itself is a property of the source layer, covered there.
    */
   minAutoResolution?: MediaResolution | undefined;
   levels?: FakeLevel[];

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -547,8 +547,8 @@ describe('HlsJsMedia', () => {
     }
 
     /**
-     * Minimal stand-in for an `Hls` instance, enough to build the controller the
-     * element installed and ask it what the current policy resolves to.
+     * Minimal stand-in for an `Hls` instance, enough to build the controller the element installed and ask it what the
+     * current policy resolves to.
      */
     function probeEngine(levels: Array<{ width: number; height: number; bitrate: number }>) {
       const listeners = new Map<string, Array<{ fn: (...args: any[]) => void; ctx: unknown }>>();
@@ -578,9 +578,8 @@ describe('HlsJsMedia', () => {
     /**
      * What the engine's installed cap controller resolves the policy to now.
      *
-     * The probe defaults to a viewport larger than the whole ladder, so the
-     * player-size ceiling never binds and a requested resolution is what is
-     * being measured. Pass a smaller one to measure the size cap itself.
+     * The probe defaults to a viewport larger than the whole ladder, so the player-size ceiling never binds and a
+     * requested resolution is what is being measured. Pass a smaller one to measure the size cap itself.
      */
     function cappedIndex(media: HlsJsMedia, playerSize = { width: 4096, height: 2160 }) {
       const engine = probeEngine(LADDER);

--- a/packages/media/src/dom/hls-js/tests/text-tracks.test.ts
+++ b/packages/media/src/dom/hls-js/tests/text-tracks.test.ts
@@ -3,9 +3,8 @@ import { describe, expect, it, vi } from 'vite-plus/test';
 import { withPreservedTextTracks } from '../text-tracks';
 
 /**
- * jsdom has no text track implementation, so the media element and its tracks
- * are stubbed with the parts the helper touches: `cues` reads as `null` while a
- * track is disabled, exactly as the spec requires.
+ * Jsdom has no text track implementation, so the media element and its tracks are stubbed with the parts the helper
+ * touches: `cues` reads as `null` while a track is disabled, exactly as the spec requires.
  */
 class FakeTextTrack {
   mode: TextTrackMode = 'disabled';

--- a/packages/media/src/dom/hls-js/text-tracks.ts
+++ b/packages/media/src/dom/hls-js/text-tracks.ts
@@ -18,20 +18,17 @@ interface TextTrackSnapshot {
 }
 
 /**
- * Runs an hls.js call that attaches, detaches, or loads a source, leaving the
- * `<track>` children hls.js does not own the way it found them.
+ * Runs an hls.js call that attaches, detaches, or loads a source, leaving the `<track>` children hls.js does not own
+ * the way it found them.
  *
- * hls.js resets *every* text track on the media element at those points: it
- * clears the cues of all of them and disables the ones it takes for subtitles,
- * without checking which tracks it created. Tracks sideloaded from `<track>`
- * elements are collateral damage, and losing their cues is permanent — an
- * element that finished loading is never parsed again, so the track keeps
- * reporting `showing` while rendering nothing. It surfaces whenever a `<track>`
- * outlives a source assignment, most visibly when `src` arrives after the
- * element connected and its default track already loaded.
+ * Hls.js resets _every_ text track on the media element at those points: it clears the cues of all of them and disables
+ * the ones it takes for subtitles, without checking which tracks it created. Tracks sideloaded from `<track>` elements
+ * are collateral damage, and losing their cues is permanent — an element that finished loading is never parsed again,
+ * so the track keeps reporting `showing` while rendering nothing. It surfaces whenever a `<track>` outlives a source
+ * assignment, most visibly when `src` arrives after the element connected and its default track already loaded.
  *
- * Cues are the objects the browser parsed, so putting back the ones hls.js took
- * restores the track without refetching its resource.
+ * Cues are the objects the browser parsed, so putting back the ones hls.js took restores the track without refetching
+ * its resource.
  */
 export function withPreservedTextTracks<T>(media: HTMLMediaElement | null, action: () => T): T {
   const snapshots = media ? snapshotTextTracks(media) : [];
@@ -95,14 +92,12 @@ function withReadableCues<T>(track: TextTrack, action: () => T): T {
 }
 
 /**
- * Bridges hls.js non-native text tracks to native `<track>` elements so the
- * rest of the player can treat them like any other text track.
+ * Bridges hls.js non-native text tracks to native `<track>` elements so the rest of the player can treat them like any
+ * other text track.
  *
- * When `renderTextTracksNatively: false`, hls.js fires
- * `NON_NATIVE_TEXT_TRACKS_FOUND` with track metadata and `CUES_PARSED` with
- * VTTCues. This mixin creates `<track>` elements on the media target and
- * forwards cues into them. It also syncs user track-mode changes back to
- * hls.js via `engine.subtitleTrack`.
+ * When `renderTextTracksNatively: false`, hls.js fires `NON_NATIVE_TEXT_TRACKS_FOUND` with track metadata and
+ * `CUES_PARSED` with VTTCues. This mixin creates `<track>` elements on the media target and forwards cues into them. It
+ * also syncs user track-mode changes back to hls.js via `engine.subtitleTrack`.
  */
 export function HlsJsMediaTextTracksMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
   class HlsJsMediaTextTracks extends (BaseClass as Constructor<HlsEngineHost>) {

--- a/packages/media/src/dom/media-host/media-host.ts
+++ b/packages/media/src/dom/media-host/media-host.ts
@@ -120,9 +120,8 @@ export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events ext
   };
 
   /**
-   * Current stream type (`'on-demand'`, `'live'`, or `'unknown'`). Defaults to
-   * `'unknown'`; detecting hosts update it automatically, and consumers can set
-   * it to override detection.
+   * Current stream type (`'on-demand'`, `'live'`, or `'unknown'`). Defaults to `'unknown'`; detecting hosts update it
+   * automatically, and consumers can set it to override detection.
    */
   get streamType() {
     return getMediaProp(this, 'streamType') ?? this.#streamType;

--- a/packages/media/src/dom/media-played-ranges/media-played-ranges.ts
+++ b/packages/media/src/dom/media-played-ranges/media-played-ranges.ts
@@ -29,15 +29,14 @@ export interface MediaPlayedRangesAPI {
 }
 
 /**
- * Mixin that tracks played ranges for media hosts lacking a native
- * `HTMLMediaElement.played` (e.g. iframe-based embeds like Vimeo).
+ * Mixin that tracks played ranges for media hosts lacking a native `HTMLMediaElement.played` (e.g. iframe-based embeds
+ * like Vimeo).
  *
- * Listens for standard media events the host dispatches on itself
- * (`play`, `pause`, `ended`, `seeking`, `seeked`) and derives a
- * `TimeRanges`-like `played` value from the host's `currentTime` / `paused`.
+ * Listens for standard media events the host dispatches on itself (`play`, `pause`, `ended`, `seeking`, `seeked`) and
+ * derives a `TimeRanges`-like `played` value from the host's `currentTime` / `paused`.
  *
  * @example
- * class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) { ... }
+ *   class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) { ... }
  */
 export function MediaPlayedRangesMixin<Base extends Constructor<EventTarget & { destroy?(): void }>>(
   BaseClass: Base

--- a/packages/media/src/dom/mux/drm.ts
+++ b/packages/media/src/dom/mux/drm.ts
@@ -4,18 +4,15 @@ import type { DrmSystemsConfig } from '../../core/drm';
 import { createMuxQuery, MUX_VIDEO_DOMAIN, type MuxJWT, type MuxSourceBase } from './source';
 
 /**
- * Build the license servers a source describes, keyed by EME key system id —
- * `source.drm` as any other source would name it. Mux signs one license token
- * per playback ID and serves every system from a URL derived from it, so
+ * Build the license servers a source describes, keyed by EME key system id — `source.drm` as any other source would
+ * name it. Mux signs one license token per playback ID and serves every system from a URL derived from it, so
  * `drm.token` is all a caller provides.
  *
- * Returns `undefined` when no license token is present, or when the token is
- * not scoped to DRM — an unsigned license request is always rejected, so there
- * is nothing useful to configure.
+ * Returns `undefined` when no license token is present, or when the token is not scoped to DRM — an unsigned license
+ * request is always rejected, so there is nothing useful to configure.
  *
- * Separate from `./source` because it is the one part of the Mux source an
- * engine that licenses differently — or, like SPF today, doesn't license at
- * all — has nothing to do with.
+ * Separate from `./source` because it is the one part of the Mux source an engine that licenses differently — or, like
+ * SPF today, doesn't license at all — has nothing to do with.
  *
  * @internal
  */

--- a/packages/media/src/dom/mux/media.ts
+++ b/packages/media/src/dom/mux/media.ts
@@ -13,14 +13,13 @@ import {
 } from './source';
 
 /**
- * Structured Mux source for the hls.js-backed Media: Mux identity and params
- * from {@link MuxSourceBase}, plus everything the HLS layer takes — `type`,
- * `preferPlayback`, and its `engine` config.
+ * Structured Mux source for the hls.js-backed Media: Mux identity and params from {@link MuxSourceBase}, plus everything
+ * the HLS layer takes — `type`, `preferPlayback`, and its `engine` config.
  */
 export interface MuxSource extends HlsSource, MuxSourceBase {
   /**
-   * The inherited license servers, or a Mux license `token` to derive them from.
-   * Redeclared because both halves name `drm`, and Mux's is the wider of the two.
+   * The inherited license servers, or a Mux license `token` to derive them from. Redeclared because both halves name
+   * `drm`, and Mux's is the wider of the two.
    */
   drm?: MuxDrmParams | undefined;
 }
@@ -36,7 +35,8 @@ export const muxMediaDefaultProps: MuxMediaProps = {
 };
 
 /**
- * @fires sourcechange - Fired when `source` changes, either directly or by parsing a new `src`. Read `source` for the new value.
+ * @fires sourcechange - Fired when `source` changes, either directly or by parsing a new `src`. Read `source` for the
+ *   new value.
  * @fires contentdatachange - Fired when the derived `contentData` changes. Read `contentData` for the new value.
  */
 export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
@@ -44,13 +44,11 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
   #contentData: MuxContentData = {};
 
   /**
-   * Media source URL. Setting a Mux stream URL
-   * (`https://stream.mux.com/<playback-id>.m3u8?...`) extracts the playback ID
-   * and query params into `source`; other URLs are kept as a plain `source.src`.
+   * Media source URL. Setting a Mux stream URL (`https://stream.mux.com/<playback-id>.m3u8?...`) extracts the playback
+   * ID and query params into `source`; other URLs are kept as a plain `source.src`.
    *
-   * Only playback options carry over. Mux identity comes from the URL, and the
-   * signed `poster`, `storyboard`, and `drm` tokens are scoped to a playback ID,
-   * so carrying them onto a different source would build rejected URLs.
+   * Only playback options carry over. Mux identity comes from the URL, and the signed `poster`, `storyboard`, and `drm`
+   * tokens are scoped to a playback ID, so carrying them onto a different source would build rejected URLs.
    */
   get src(): string {
     return super.src;
@@ -78,21 +76,18 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
   }
 
   /**
-   * Structured Mux source. Setting it derives `src` from the playback ID,
-   * custom domain, and `playback` params (appended as `snake_case` query
-   * params). A `playback.token` replaces all other params — signed URLs bake
-   * them into the token. Engine options live under `engine`.
+   * Structured Mux source. Setting it derives `src` from the playback ID, custom domain, and `playback` params
+   * (appended as `snake_case` query params). A `playback.token` replaces all other params — signed URLs bake them into
+   * the token. Engine options live under `engine`.
    *
-   * A `drm.token` fills in `drm` itself: Mux's FairPlay, Widevine, and
-   * PlayReady license servers for this playback ID, so protected media plays
-   * whichever path the browser takes. License servers named alongside the token
-   * win, key by key, for content Mux does not license.
+   * A `drm.token` fills in `drm` itself: Mux's FairPlay, Widevine, and PlayReady license servers for this playback ID,
+   * so protected media plays whichever path the browser takes. License servers named alongside the token win, key by
+   * key, for content Mux does not license.
    *
-   * `playback.maxResolution` and `playback.minResolution` are server-side: they
-   * decide which renditions Mux puts in the manifest at all. The inherited
-   * `maxAutoResolution` and `minAutoResolution` only look like their pair —
-   * those are client-side and bound which of the renditions that *do* arrive
-   * adaptive selection reaches for. The two halves are independent.
+   * `playback.maxResolution` and `playback.minResolution` are server-side: they decide which renditions Mux puts in the
+   * manifest at all. The inherited `maxAutoResolution` and `minAutoResolution` only look like their pair — those are
+   * client-side and bound which of the renditions that _do_ arrive adaptive selection reaches for. The two halves are
+   * independent.
    */
   get source(): MuxSource | null {
     return this.#source;
@@ -125,14 +120,12 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
   }
 
   /**
-   * Image URLs `source` describes rather than plays: `poster` from its `poster`
-   * params, `storyboard` from its `storyboard` params. A key is absent when the
-   * URL can't be built — no playback ID, or signed playback without a matching
-   * image token.
+   * Image URLs `source` describes rather than plays: `poster` from its `poster` params, `storyboard` from its
+   * `storyboard` params. A key is absent when the URL can't be built — no playback ID, or signed playback without a
+   * matching image token.
    *
-   * Derived from `source` and nothing else. The same object is handed back
-   * until one of those URLs changes, and `contentdatachange` announces it when
-   * it does. Nothing here is applied for you, apart from the thumbnail track
+   * Derived from `source` and nothing else. The same object is handed back until one of those URLs changes, and
+   * `contentdatachange` announces it when it does. Nothing here is applied for you, apart from the thumbnail track
    * `<mux-video>` adds from `storyboard` (and drops for live streams).
    */
   get contentData(): MuxContentData {
@@ -157,13 +150,12 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
 }
 
 /**
- * Resolve Mux's DRM authoring input into the license servers the HLS layer
- * licenses from. Which engine ends up playing is decided later, and both read
- * `drm`, so a signed Mux source plays either way.
+ * Resolve Mux's DRM authoring input into the license servers the HLS layer licenses from. Which engine ends up playing
+ * is decided later, and both read `drm`, so a signed Mux source plays either way.
  *
- * `token` is Mux's own input and stops here — it names no license server, and a
- * key system is what everything downstream expects to find. Servers the caller
- * named win, key by key, so their own licensing replaces the derived URLs.
+ * `token` is Mux's own input and stops here — it names no license server, and a key system is what everything
+ * downstream expects to find. Servers the caller named win, key by key, so their own licensing replaces the derived
+ * URLs.
  */
 function withMuxDrm(source: MuxSource): Pick<HlsSource, 'drm'> {
   const { token: _token, ...systems } = source.drm ?? {};

--- a/packages/media/src/dom/mux/mux-data-engine.ts
+++ b/packages/media/src/dom/mux/mux-data-engine.ts
@@ -14,21 +14,18 @@ const warnedEngines = new WeakSet<object>();
 /**
  * Pick the `mux-embed` integration for a media's playback engine.
  *
- * `mux-embed` monitors the media element on its own, and an engine integration
- * is what adds engine-level data on top: rendition switches, request timing and
- * throughput, and engine errors. It ships two — hls.js and dash.js — and each
- * one is wired through a different option, so handing a dash.js player to the
- * hls.js option leaves the view with element-level data only.
+ * `mux-embed` monitors the media element on its own, and an engine integration is what adds engine-level data on top:
+ * rendition switches, request timing and throughput, and engine errors. It ships two — hls.js and dash.js — and each
+ * one is wired through a different option, so handing a dash.js player to the hls.js option leaves the view with
+ * element-level data only.
  *
- * Engines are matched by shape rather than by class so this module imports
- * neither hls.js nor dash.js. Mux Data can be registered with any media without
- * pulling an engine it will never touch into the bundle (dash.js in particular
- * reads `window` on import), and a media whose engine has no integration — a
- * raw `<video>`, native HLS, or an SPF playback engine — is monitored from the
- * element alone instead of through the wrong integration.
+ * Engines are matched by shape rather than by class so this module imports neither hls.js nor dash.js. Mux Data can be
+ * registered with any media without pulling an engine it will never touch into the bundle (dash.js in particular reads
+ * `window` on import), and a media whose engine has no integration — a raw `<video>`, native HLS, or an SPF playback
+ * engine — is monitored from the element alone instead of through the wrong integration.
  *
- * @returns Options to spread into a `Mux.monitor()` call. Empty when the engine
- *   has no integration, which leaves element-level monitoring intact.
+ * @returns Options to spread into a `Mux.monitor()` call. Empty when the engine has no integration, which leaves
+ *   element-level monitoring intact.
  */
 export function toMuxDataEngineOptions(engine: unknown): MuxDataEngineOptions {
   if (isDashJsEngine(engine)) return { dashjs: engine };
@@ -57,12 +54,12 @@ export function toMuxDataEngineOptions(engine: unknown): MuxDataEngineOptions {
 // match means the integration has everything it needs. Both monitors subscribe
 // through `on` / `off`; the rendition APIs are what tell the two engines apart.
 
-/** hls.js: its monitor reads renditions from `levels`. */
+/** Hls.js: its monitor reads renditions from `levels`. */
 function isHlsJsEngine(engine: unknown): engine is MuxDataHlsJsEngine {
   return hasMethods(engine, ['on', 'off']) && Array.isArray((engine as { levels?: unknown }).levels);
 }
 
-/** dash.js: its monitor reads renditions through the track and rendition-list getters. */
+/** Dash.js: its monitor reads renditions through the track and rendition-list getters. */
 function isDashJsEngine(engine: unknown): engine is MuxDataDashJsEngine {
   if (!hasMethods(engine, ['on', 'off', 'getCurrentTrackFor'])) return false;
 
@@ -71,7 +68,7 @@ function isDashJsEngine(engine: unknown): engine is MuxDataDashJsEngine {
   return hasMethods(engine, ['getRepresentationsByType']) || hasMethods(engine, ['getBitrateInfoListFor']);
 }
 
-/** hls.js's own class, the only place its event names and error details are published. */
+/** Hls.js's own class, the only place its event names and error details are published. */
 function toHlsJsClass(engine: object): MuxDataHlsJsClass | undefined {
   const engineClass: unknown = engine.constructor;
 

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -32,15 +32,12 @@ export const muxDataDefaultProps: MuxDataProps = {
 const MUX_VIDEO_DOMAIN = 'mux.com';
 
 /**
- * What Mux Data needs from the media it monitors: the source being played, a
- * `loadstart` to re-monitor on, and — for engine-backed playback — the engine
- * itself.
+ * What Mux Data needs from the media it monitors: the source being played, a `loadstart` to re-monitor on, and — for
+ * engine-backed playback — the engine itself.
  *
- * `engine` is deliberately untyped. Every engine-backed media host exposes one,
- * but they are unrelated types (an hls.js instance, a dash.js player, an SPF
- * composition), and which of them Mux Data can hook is decided by
- * {@link toMuxDataEngineOptions}, not by this contract. Media with no JS engine
- * simply omit it.
+ * `engine` is deliberately untyped. Every engine-backed media host exposes one, but they are unrelated types (an hls.js
+ * instance, a dash.js player, an SPF composition), and which of them Mux Data can hook is decided by
+ * {@link toMuxDataEngineOptions}, not by this contract. Media with no JS engine simply omit it.
  */
 export interface MuxDataMedia extends EventTarget {
   readonly engine?: unknown;
@@ -138,9 +135,8 @@ export class MuxData implements MuxDataProps {
   }
 
   /**
-   * Mux Data environment key. Omitted from the beacon when unset, which is the
-   * norm for Mux-hosted playback: the view reports the Mux playback ID as its
-   * `video_id` (see {@link toVideoId}) and Mux attributes it to the owning
+   * Mux Data environment key. Omitted from the beacon when unset, which is the norm for Mux-hosted playback: the view
+   * reports the Mux playback ID as its `video_id` (see {@link toVideoId}) and Mux attributes it to the owning
    * environment. Set this to monitor sources Mux doesn't host.
    */
   get envKey() {

--- a/packages/media/src/dom/mux/source/source.ts
+++ b/packages/media/src/dom/mux/source/source.ts
@@ -1,9 +1,8 @@
 /**
- * The Mux source: playback identity, the params that modify it, and the URLs
- * derived from both. Engine-neutral on purpose — every Mux Media needs it, and
- * they don't share an engine. Nothing here may reach for a specific one
- * (license-server derivation lives in `../drm.ts`, for the engines that
- * license), because `@videojs/spf` imports this module for its own Mux Media.
+ * The Mux source: playback identity, the params that modify it, and the URLs derived from both. Engine-neutral on
+ * purpose — every Mux Media needs it, and they don't share an engine. Nothing here may reach for a specific one
+ * (license-server derivation lives in `../drm.ts`, for the engines that license), because `@videojs/spf` imports this
+ * module for its own Mux Media.
  */
 import { parseJwt } from '@videojs/utils/jwt';
 import { isNil } from '@videojs/utils/predicate';
@@ -21,9 +20,9 @@ export type MuxImageExt = 'webp' | 'jpg' | 'png';
 export type MuxPosterFitMode = 'preserve' | 'stretch' | 'crop' | 'smartcrop' | 'pad';
 
 /**
- * Playback modifiers appended to the stream URL as `snake_case` query params
- * (e.g. `assetStartTime` → `asset_start_time`). A signed playback `token`
- * replaces every other param — they must be baked into the signing token.
+ * Playback modifiers appended to the stream URL as `snake_case` query params (e.g. `assetStartTime` →
+ * `asset_start_time`). A signed playback `token` replaces every other param — they must be baked into the signing
+ * token.
  */
 export interface MuxPlaybackParams {
   token?: string | undefined;
@@ -53,8 +52,8 @@ export interface MuxPlaybackParams {
 }
 
 /**
- * Modifiers for the poster still, appended to the image URL as `snake_case`
- * query params. Mux serves it from its `thumbnail` image endpoint.
+ * Modifiers for the poster still, appended to the image URL as `snake_case` query params. Mux serves it from its
+ * `thumbnail` image endpoint.
  */
 export interface MuxPosterParams {
   token?: string | undefined;
@@ -89,27 +88,23 @@ export interface MuxStoryboardParams {
 }
 
 /**
- * Mux's DRM authoring input: a license token, in place of the license servers
- * `source.drm` normally names. Servers named outright alongside it still win,
- * key by key, for content Mux does not license.
+ * Mux's DRM authoring input: a license token, in place of the license servers `source.drm` normally names. Servers
+ * named outright alongside it still win, key by key, for content Mux does not license.
  */
 export interface MuxDrmParams extends DrmSystemsConfig {
   /**
-   * DRM license token: a JWT signed for the playback ID with the DRM (`d`)
-   * audience. Mux derives every license server URL from it, so it is the only
-   * thing a caller supplies. DRM playback is always signed, so a matching
+   * DRM license token: a JWT signed for the playback ID with the DRM (`d`) audience. Mux derives every license server
+   * URL from it, so it is the only thing a caller supplies. DRM playback is always signed, so a matching
    * `playback.token` is required alongside it.
    */
   token?: string | undefined;
 }
 
 /**
- * What identifies a Mux stream and modifies it, independent of what plays it.
- * `playbackId` and `customDomain` identify the stream and derive the URL; `src`
- * is a fallback for playing a non-Mux URL.
+ * What identifies a Mux stream and modifies it, independent of what plays it. `playbackId` and `customDomain` identify
+ * the stream and derive the URL; `src` is a fallback for playing a non-Mux URL.
  *
- * Each Mux Media extends this with whatever its own engine takes — see
- * `MuxSource` for the hls.js-backed one.
+ * Each Mux Media extends this with whatever its own engine takes — see `MuxSource` for the hls.js-backed one.
  */
 export interface MuxSourceBase {
   /** Manifest URL. Derived from `playbackId` when there is one. */
@@ -124,9 +119,8 @@ export interface MuxSourceBase {
 }
 
 /**
- * Serialize params to a query string (`?a=1&b=2`), mapping camelCase keys to
- * `snake_case` and skipping nullish values. A `token` replaces every other
- * param — signed URLs bake all modifiers into the token itself.
+ * Serialize params to a query string (`?a=1&b=2`), mapping camelCase keys to `snake_case` and skipping nullish values.
+ * A `token` replaces every other param — signed URLs bake all modifiers into the token itself.
  */
 export function createMuxQuery(params: Record<string, unknown> = {}): string {
   const { token, ...rest } = params;
@@ -162,9 +156,8 @@ export function createMuxVideoURL(source?: MuxSourceBase | null): string | undef
 }
 
 /**
- * Parse a Mux stream URL (`https://stream.<domain>/<playback-id>.m3u8?...`)
- * into a `MuxSourceBase`, mapping `snake_case` query params back to camelCase
- * playback params. Returns `undefined` for non-Mux URLs.
+ * Parse a Mux stream URL (`https://stream.<domain>/<playback-id>.m3u8?...`) into a `MuxSourceBase`, mapping
+ * `snake_case` query params back to camelCase playback params. Returns `undefined` for non-Mux URLs.
  */
 export function parseMuxVideoURL(src: string): MuxSourceBase | undefined {
   if (!src) return undefined;
@@ -198,9 +191,8 @@ export function parseMuxVideoURL(src: string): MuxSourceBase | undefined {
 }
 
 /**
- * Coerce a query param string back to the boolean/number types declared on
- * `MuxPlaybackParams`. Numbers only convert when the string round-trips exactly
- * (so `1080p`, `007`, and JWTs stay strings).
+ * Coerce a query param string back to the boolean/number types declared on `MuxPlaybackParams`. Numbers only convert
+ * when the string round-trips exactly (so `1080p`, `007`, and JWTs stay strings).
  */
 function parseMuxParamValue(value: string): string | number | boolean {
   if (value === 'true') return true;
@@ -213,14 +205,12 @@ function parseMuxParamValue(value: string): string | number | boolean {
 }
 
 /**
- * Image URLs a Mux source describes rather than plays, as every Mux Media
- * exposes them through `contentData`. A key is absent when its URL can't be
- * built — no playback ID, or signed playback without a matching image token.
+ * Image URLs a Mux source describes rather than plays, as every Mux Media exposes them through `contentData`. A key is
+ * absent when its URL can't be built — no playback ID, or signed playback without a matching image token.
  *
- * Names the two keys a Mux source actually derives. The index signature comes
- * from `MediaContentData`, which the shared `contentData` capability is typed
- * as, so it can't be closed off here — extending it is what keeps this
- * assignable to that contract.
+ * Names the two keys a Mux source actually derives. The index signature comes from `MediaContentData`, which the shared
+ * `contentData` capability is typed as, so it can't be closed off here — extending it is what keeps this assignable to
+ * that contract.
  */
 export interface MuxContentData extends MediaContentData {
   readonly poster?: string;
@@ -228,8 +218,7 @@ export interface MuxContentData extends MediaContentData {
 }
 
 /**
- * Build the poster image URL a source describes. Read through `MuxMedia`'s
- * `contentData`.
+ * Build the poster image URL a source describes. Read through `MuxMedia`'s `contentData`.
  *
  * @internal
  */
@@ -249,8 +238,7 @@ export function createMuxPosterURL(source?: MuxSourceBase | null): string | unde
 }
 
 /**
- * Build the storyboard (thumbnail sprite) VTT URL a source describes. Read
- * through `MuxMedia`'s `contentData`.
+ * Build the storyboard (thumbnail sprite) VTT URL a source describes. Read through `MuxMedia`'s `contentData`.
  *
  * @internal
  */

--- a/packages/media/src/dom/mux/tests/mux-media.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-media.test.ts
@@ -621,7 +621,7 @@ describe('MuxMedia', () => {
       return { media, video };
     }
 
-    /** jsdom has no `MediaEncryptedEvent`; only these two fields are read. */
+    /** Jsdom has no `MediaEncryptedEvent`; only these two fields are read. */
     function fireEncrypted(video: HTMLVideoElement) {
       video.dispatchEvent(Object.assign(new Event('encrypted'), { initDataType: 'skd', initData: new ArrayBuffer(8) }));
     }

--- a/packages/media/src/dom/native-hls/drm.ts
+++ b/packages/media/src/dom/native-hls/drm.ts
@@ -15,8 +15,8 @@ import { createFairPlayEme } from './fairplay-eme';
 import { createFairPlayWebKit } from './fairplay-webkit';
 
 /**
- * What the mixin needs from whatever it is composed onto: the DRM half of the
- * source, and somewhere to put an error the media element never reports.
+ * What the mixin needs from whatever it is composed onto: the DRM half of the source, and somewhere to put an error the
+ * media element never reports.
  */
 export type NativeHlsDrmHost = NativeMediaHost & {
   readonly source: {
@@ -27,22 +27,19 @@ export type NativeHlsDrmHost = NativeMediaHost & {
 };
 
 /**
- * Play DRM-protected HLS natively, configured by `source.drm` (or, where the
- * native path needs licensing of its own, `source.engine.nativeHls.drmSystems`).
+ * Play DRM-protected HLS natively, configured by `source.drm` (or, where the native path needs licensing of its own,
+ * `source.engine.nativeHls.drmSystems`).
  *
- * Native HLS has no JS engine to hand key exchange to, so this mixin does it
- * against the media element directly: it answers the element's key requests by
- * fetching an application certificate and trading the CDM's SPC for a CKC at
- * the license server. Only FairPlay is reachable this way — Widevine and
- * PlayReady content needs the hls.js (MSE) engine.
+ * Native HLS has no JS engine to hand key exchange to, so this mixin does it against the media element directly: it
+ * answers the element's key requests by fetching an application certificate and trading the CDM's SPC for a CKC at the
+ * license server. Only FairPlay is reachable this way — Widevine and PlayReady content needs the hls.js (MSE) engine.
  *
- * The configuration is read when a key request arrives rather than up front,
- * so assigning `source` and letting the element load are independent, and a
- * license server updated on a playing source is picked up without a reload;
- * state is released on `emptied`, when the element starts on a new resource.
+ * The configuration is read when a key request arrives rather than up front, so assigning `source` and letting the
+ * element load are independent, and a license server updated on a playing source is picked up without a reload; state
+ * is released on `emptied`, when the element starts on a new resource.
  *
- * Encrypted content with nothing configured fails loudly. Safari otherwise
- * stalls without explanation, which is indistinguishable from a slow network.
+ * Encrypted content with nothing configured fails loudly. Safari otherwise stalls without explanation, which is
+ * indistinguishable from a slow network.
  */
 export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost>>(BaseClass: Base) {
   class NativeHlsMediaDrm extends (BaseClass as Constructor<NativeHlsDrmHost>) {
@@ -102,9 +99,8 @@ export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost
     }
 
     /**
-     * The license servers in effect: `source.drm`, or the native engine's own
-     * `drmSystems` where one is named — an escape hatch replaces what it is an
-     * escape from rather than merging with it.
+     * The license servers in effect: `source.drm`, or the native engine's own `drmSystems` where one is named — an
+     * escape hatch replaces what it is an escape from rather than merging with it.
      */
     #drmSystems(): DrmSystemsConfig {
       const { drm, engine } = this.source ?? {};

--- a/packages/media/src/dom/native-hls/errors.ts
+++ b/packages/media/src/dom/native-hls/errors.ts
@@ -15,12 +15,11 @@ export function NativeHlsMediaErrorsMixin<Base extends Constructor<NativeMediaHo
     }
 
     /**
-     * Announce `error` as coming from this media, latching it as the current
-     * error when it is fatal. Non-fatal errors are announced only — playback
-     * continues, so they must not stand in for whatever fails next.
+     * Announce `error` as coming from this media, latching it as the current error when it is fatal. Non-fatal errors
+     * are announced only — playback continues, so they must not stand in for whatever fails next.
      *
-     * For siblings producing errors the media element never reports itself:
-     * DRM key exchange, notably, which fails entirely outside the element.
+     * For siblings producing errors the media element never reports itself: DRM key exchange, notably, which fails
+     * entirely outside the element.
      *
      * @internal
      */

--- a/packages/media/src/dom/native-hls/fairplay-eme.ts
+++ b/packages/media/src/dom/native-hls/fairplay-eme.ts
@@ -15,9 +15,8 @@ import {
 } from './fairplay';
 
 /**
- * FairPlay negotiates against the manifest rather than a codec, holds no
- * persistent state, and needs no device identifier — the narrowest
- * configuration Safari will grant.
+ * FairPlay negotiates against the manifest rather than a codec, holds no persistent state, and needs no device
+ * identifier — the narrowest configuration Safari will grant.
  */
 const FAIRPLAY_CONFIGURATION: MediaKeySystemConfiguration = {
   initDataTypes: [FAIRPLAY_INIT_DATA_TYPE],
@@ -29,8 +28,8 @@ const FAIRPLAY_CONFIGURATION: MediaKeySystemConfiguration = {
 
 export interface FairPlayEmeOptions {
   /**
-   * Called when the CDM refuses to create a session in the one situation the
-   * legacy WebKit API still serves: an AirPlay receiver on an affected OS.
+   * Called when the CDM refuses to create a session in the one situation the legacy WebKit API still serves: an AirPlay
+   * receiver on an affected OS.
    */
   onUnsupported?: (() => void) | undefined;
 }
@@ -38,11 +37,9 @@ export interface FairPlayEmeOptions {
 /**
  * Standard EME FairPlay, driven by the media element's `encrypted` event.
  *
- * Key exchange is the documented three-step dance: negotiate access to the key
- * system and give the CDM its application certificate, open a session and let
- * it generate an SPC, then trade that SPC for a CKC at the license server. Key
- * system access and the certificate are shared by every session on the source,
- * so they are resolved once and reused.
+ * Key exchange is the documented three-step dance: negotiate access to the key system and give the CDM its application
+ * certificate, open a session and let it generate an SPC, then trade that SPC for a CKC at the license server. Key
+ * system access and the certificate are shared by every session on the source, so they are resolved once and reused.
  */
 export function createFairPlayEme(context: FairPlayContext, options: FairPlayEmeOptions = {}): FairPlayKeySystem {
   const { media, signal, reportError } = context;

--- a/packages/media/src/dom/native-hls/fairplay-webkit.ts
+++ b/packages/media/src/dom/native-hls/fairplay-webkit.ts
@@ -12,8 +12,8 @@ import {
 } from './fairplay';
 
 /**
- * The pre-EME WebKit key API. Still shipped by Safari, undeclared in
- * `lib.dom`, and only reachable through `window.WebKitMediaKeys`.
+ * The pre-EME WebKit key API. Still shipped by Safari, undeclared in `lib.dom`, and only reachable through
+ * `window.WebKitMediaKeys`.
  */
 interface WebKitMediaKeySession extends EventTarget {
   readonly error: { code: number; systemCode: number } | null;
@@ -47,12 +47,10 @@ export function supportsWebKitFairPlay(media: HTMLMediaElement): boolean {
 /**
  * Legacy WebKit FairPlay, driven by `webkitneedkey`.
  *
- * This exists for one reason: on some OS versions EME cannot generate a
- * license request while the playback target is an AirPlay receiver, and the
- * pre-EME API can. It mirrors the EME flow with the older calls, and differs
- * in two ways — the application certificate is mandatory (it is packed into
- * the session's initialization data rather than handed to the CDM), and
- * `webkitSetMediaKeys` / `update` are synchronous.
+ * This exists for one reason: on some OS versions EME cannot generate a license request while the playback target is an
+ * AirPlay receiver, and the pre-EME API can. It mirrors the EME flow with the older calls, and differs in two ways —
+ * the application certificate is mandatory (it is packed into the session's initialization data rather than handed to
+ * the CDM), and `webkitSetMediaKeys` / `update` are synchronous.
  *
  * Remove this once the underlying WebKit issue is fixed.
  *
@@ -161,13 +159,11 @@ export function createFairPlayWebKit(context: FairPlayContext): FairPlayKeySyste
 }
 
 /**
- * Repack `webkitneedkey` initialization data into what
- * `WebKitMediaKeys.createSession()` expects.
+ * Repack `webkitneedkey` initialization data into what `WebKitMediaKeys.createSession()` expects.
  *
- * In:  the raw event data — a `skd://` URI as UTF-16LE, in newer WebKit builds
- *      behind a 4-byte little-endian byte count.
- * Out: that data verbatim, then the content ID and the application
- *      certificate, each behind their own 4-byte little-endian byte count.
+ * In: the raw event data — a `skd://` URI as UTF-16LE, in newer WebKit builds behind a 4-byte little-endian byte count.
+ * Out: that data verbatim, then the content ID and the application certificate, each behind their own 4-byte
+ * little-endian byte count.
  */
 function packInitData(initData: ArrayBuffer, certificate: ArrayBuffer): Uint8Array<ArrayBuffer> {
   const source = new Uint8Array(initData);
@@ -197,9 +193,8 @@ function packInitData(initData: ArrayBuffer, certificate: ArrayBuffer): Uint8Arr
 }
 
 /**
- * The content ID FairPlay keys the session on: everything after the scheme in
- * the `skd://` URI. Locating the scheme rather than skipping a fixed prefix
- * covers both the bare URI older WebKit sends and the length-prefixed form.
+ * The content ID FairPlay keys the session on: everything after the scheme in the `skd://` URI. Locating the scheme
+ * rather than skipping a fixed prefix covers both the bare URI older WebKit sends and the length-prefixed form.
  */
 function getContentId(initData: ArrayBuffer): string {
   const decoded = new TextDecoder('utf-16le').decode(initData);

--- a/packages/media/src/dom/native-hls/fairplay.ts
+++ b/packages/media/src/dom/native-hls/fairplay.ts
@@ -11,8 +11,8 @@ export const FAIRPLAY_INIT_DATA_TYPE = 'skd';
 export const FAIRPLAY_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
 
 /**
- * `context` values carried by the `MediaError`s key exchange produces. The
- * message is prose meant for a person; this is the part to branch on.
+ * `context` values carried by the `MediaError`s key exchange produces. The message is prose meant for a person; this is
+ * the part to branch on.
  */
 export const NativeHlsDrmErrors = {
   /** The content is encrypted but `source.engine.nativeHls.drmSystems` is missing something required. */
@@ -53,8 +53,8 @@ export const NativeHlsDrmMessages = {
 } as const;
 
 /**
- * One FairPlay implementation, driven by the DRM mixin: it hands over each key
- * request the media element makes and closes everything down between sources.
+ * One FairPlay implementation, driven by the DRM mixin: it hands over each key request the media element makes and
+ * closes everything down between sources.
  */
 export interface FairPlayKeySystem {
   /** Serve a single key request (`encrypted` or `webkitneedkey`). */
@@ -68,9 +68,8 @@ export interface FairPlayContext {
   /** The element the CDM is bound to. */
   media: HTMLMediaElement;
   /**
-   * The FairPlay entry of the source's DRM configuration, read on every use
-   * rather than captured — a license server updated on a playing source (a
-   * rotated token, say) has to reach the next request.
+   * The FairPlay entry of the source's DRM configuration, read on every use rather than captured — a license server
+   * updated on a playing source (a rotated token, say) has to reach the next request.
    */
   readonly config: DrmSystemConfig;
   /** Aborted when the source is replaced or the media detaches. */
@@ -85,9 +84,8 @@ export function createDrmError(message: string, context: NativeHlsDrmErrorContex
 }
 
 /**
- * Coerce anything thrown during key exchange into a reportable error. An error
- * raised further down already describes what failed, so it passes through
- * rather than being flattened into the caller's more general message.
+ * Coerce anything thrown during key exchange into a reportable error. An error raised further down already describes
+ * what failed, so it passes through rather than being flattened into the caller's more general message.
  */
 export function toDrmError(cause: unknown, message: string, context: NativeHlsDrmErrorContext): MediaError {
   if (cause instanceof MediaError) return cause;
@@ -99,9 +97,8 @@ export function toDrmError(cause: unknown, message: string, context: NativeHlsDr
 }
 
 /**
- * Fetch the FairPlay application certificate. Resolves `null` when the source
- * names no certificate URL — EME can still negotiate with a pre-provisioned
- * CDM, so whether that is fatal is the caller's call.
+ * Fetch the FairPlay application certificate. Resolves `null` when the source names no certificate URL — EME can still
+ * negotiate with a pre-provisioned CDM, so whether that is fatal is the caller's call.
  */
 export async function requestAppCertificate({ config, signal }: FairPlayContext): Promise<ArrayBuffer | null> {
   const { serverCertificateUrl } = config;
@@ -127,8 +124,8 @@ export async function requestAppCertificate({ config, signal }: FairPlayContext)
 }
 
 /**
- * Exchange a server playback context (SPC) for a content key context (CKC).
- * FairPlay license servers take the raw SPC bytes as the request body.
+ * Exchange a server playback context (SPC) for a content key context (CKC). FairPlay license servers take the raw SPC
+ * bytes as the request body.
  */
 export async function requestLicenseKey(
   { config, signal }: FairPlayContext,

--- a/packages/media/src/dom/native-hls/live.ts
+++ b/packages/media/src/dom/native-hls/live.ts
@@ -3,9 +3,7 @@ import type { Constructor } from '@videojs/utils/types';
 import type { NativeMediaHost } from './errors';
 import { getStreamInfoFromSrc, looksLikeM3u8 } from './m3u8-utils';
 
-/**
- * @fires targetlivewindowchange - Fired when the target live window changes. Read `targetLiveWindow` for the new value.
- */
+/** @fires targetlivewindowchange - Fired when the target live window changes. Read `targetLiveWindow` for the new value. */
 export function NativeHlsMediaLiveMixin<Base extends Constructor<NativeMediaHost>>(BaseClass: Base) {
   // Native HLS does not expose manifest-level `HOLD-BACK` / `PART-HOLD-BACK`
   // through a JS API, so we fetch the m3u8 ourselves and parse the relevant
@@ -20,18 +18,16 @@ export function NativeHlsMediaLiveMixin<Base extends Constructor<NativeMediaHost
     #currentSrc = '';
 
     /**
-     * Describes the kind of live window available. `0` for a sliding live
-     * window, `Infinity` for a live event with playback history, and `NaN` for
-     * on-demand or unknown. This value is not a duration.
+     * Describes the kind of live window available. `0` for a sliding live window, `Infinity` for a live event with
+     * playback history, and `NaN` for on-demand or unknown. This value is not a duration.
      */
     get targetLiveWindow() {
       return this.#targetLiveWindow;
     }
 
     /**
-     * Playback time where the live edge begins. Calculated from the newest
-     * available time and the playlist's live-edge offset. `NaN` when the
-     * stream is not live or the offset is unavailable.
+     * Playback time where the live edge begins. Calculated from the newest available time and the playlist's live-edge
+     * offset. `NaN` when the stream is not live or the offset is unavailable.
      */
     get liveEdgeStart() {
       if (this.#liveEdgeStartOffset === undefined) return Number.NaN;

--- a/packages/media/src/dom/native-hls/m3u8-utils.ts
+++ b/packages/media/src/dom/native-hls/m3u8-utils.ts
@@ -11,21 +11,17 @@
 
 export interface StreamInfo {
   /**
-   * Describes the kind of live window available. `0` for a sliding live
-   * window, `Infinity` for a live event with playback history, and `NaN` for
-   * on-demand. This value is not a duration.
+   * Describes the kind of live window available. `0` for a sliding live window, `Infinity` for a live event with
+   * playback history, and `NaN` for on-demand. This value is not a duration.
    */
   targetLiveWindow: number;
-  /**
-   * Offset (seconds) from `seekable.end` at which the live edge window begins.
-   * `undefined` when the stream is not live.
-   */
+  /** Offset (seconds) from `seekable.end` at which the live edge window begins. `undefined` when the stream is not live. */
   liveEdgeStartOffset: number | undefined;
 }
 
 /**
- * Returns `true` when `src` looks like an HLS playlist URL. Permissive: a
- * path or query string containing `.m3u8` is enough.
+ * Returns `true` when `src` looks like an HLS playlist URL. Permissive: a path or query string containing `.m3u8` is
+ * enough.
  */
 export function looksLikeM3u8(src: string) {
   return src.toLowerCase().includes('.m3u8');
@@ -34,17 +30,15 @@ export function looksLikeM3u8(src: string) {
 /**
  * Returns `true` when the playlist text is a multivariant (master) playlist.
  *
- * The presence of `#EXT-X-STREAM-INF` is conclusive — media playlists only
- * contain `#EXTINF` segment tags.
+ * The presence of `#EXT-X-STREAM-INF` is conclusive — media playlists only contain `#EXTINF` segment tags.
  */
 export function isMultivariantPlaylist(playlist: string) {
   return playlist.includes('#EXT-X-STREAM-INF');
 }
 
 /**
- * Resolves the first media playlist URL referenced by a multivariant
- * playlist, relative to `baseUrl`. Returns `null` when none is found or the
- * URL cannot be parsed.
+ * Resolves the first media playlist URL referenced by a multivariant playlist, relative to `baseUrl`. Returns `null`
+ * when none is found or the URL cannot be parsed.
  */
 export function resolveFirstMediaPlaylistUrl(multivariant: string, baseUrl: string): string | null {
   const lines = multivariant.split(/\r?\n/);
@@ -68,17 +62,13 @@ export function resolveFirstMediaPlaylistUrl(multivariant: string, baseUrl: stri
 }
 
 /**
- * Parses the subset of media-playlist tags needed to derive live edge state:
- * `#EXT-X-PLAYLIST-TYPE`, `#EXT-X-ENDLIST`, `#EXT-X-TARGETDURATION`,
- * `#EXT-X-PART-INF`.
+ * Parses the subset of media-playlist tags needed to derive live edge state: `#EXT-X-PLAYLIST-TYPE`, `#EXT-X-ENDLIST`,
+ * `#EXT-X-TARGETDURATION`, `#EXT-X-PART-INF`.
  *
- * See spec:
- * - VOD or `#EXT-X-ENDLIST` present → on-demand, `targetLiveWindow = NaN`.
- * - `EVENT` playlist → DVR, `targetLiveWindow = Infinity`.
- * - Otherwise → standard live sliding window, `targetLiveWindow = 0`.
+ * See spec: - VOD or `#EXT-X-ENDLIST` present → on-demand, `targetLiveWindow = NaN`. - `EVENT` playlist → DVR,
+ * `targetLiveWindow = Infinity`. - Otherwise → standard live sliding window, `targetLiveWindow = 0`.
  *
- * The edge offset is `PART-TARGET * 2` for low-latency live and
- * `TARGETDURATION * 3` otherwise.
+ * The edge offset is `PART-TARGET * 2` for low-latency live and `TARGETDURATION * 3` otherwise.
  */
 export function parseStreamInfo(playlist: string): StreamInfo {
   const lines = playlist.split(/\r?\n/);
@@ -131,10 +121,10 @@ async function fetchPlaylist(url: string, init: RequestInit): Promise<{ text: st
 }
 
 /**
- * Fetches the HLS playlist at `src`, following the first variant if it's a
- * multivariant playlist, and parses it into a {@link StreamInfo}.
+ * Fetches the HLS playlist at `src`, following the first variant if it's a multivariant playlist, and parses it into a
+ * {@link StreamInfo}.
  *
- * @throws when the fetch fails or no media playlist URL can be resolved.
+ * @throws When the fetch fails or no media playlist URL can be resolved.
  */
 export async function getStreamInfoFromSrc(src: string, signal?: AbortSignal): Promise<StreamInfo> {
   const init: RequestInit = signal ? { signal } : {};

--- a/packages/media/src/dom/native-hls/media.ts
+++ b/packages/media/src/dom/native-hls/media.ts
@@ -21,18 +21,16 @@ export interface NativeHlsMediaProps {
 /**
  * Structured native HLS source: which source to play, plus how to play it.
  *
- * Playback options sit under `engine`, keyed by engine, rather than at the top
- * level. Native HLS is one of two paths `HlsJsVideo` can take, and namespacing
- * by engine lets a single source describe both without either reading the
+ * Playback options sit under `engine`, keyed by engine, rather than at the top level. Native HLS is one of two paths
+ * `HlsJsVideo` can take, and namespacing by engine lets a single source describe both without either reading the
  * other's options.
  */
 export interface NativeHlsSource {
   /** Manifest URL. Mirrors the host's `src` property. */
   src?: string | undefined;
   /**
-   * License servers for protected content, keyed by EME key system id. Safari
-   * negotiates keys itself and reaches FairPlay only, so the `com.apple.fps`
-   * entry is the one read here — the rest can ride along for an engine that can
+   * License servers for protected content, keyed by EME key system id. Safari negotiates keys itself and reaches
+   * FairPlay only, so the `com.apple.fps` entry is the one read here — the rest can ride along for an engine that can
    * negotiate them.
    */
   drm?: DrmSystemsConfig | undefined;
@@ -47,14 +45,13 @@ export interface NativeHlsEngineConfig {
 }
 
 /**
- * Native HLS playback options. There is no JS engine to configure here — the
- * browser plays the manifest itself — so this is what Video.js does around it.
+ * Native HLS playback options. There is no JS engine to configure here — the browser plays the manifest itself — so
+ * this is what Video.js does around it.
  */
 export interface NativeHlsConfig {
   /**
-   * License servers for protected content, keyed by EME key system id. An
-   * escape hatch for licensing native playback differently from every other
-   * path: naming it replaces `source.drm` here, and nowhere else.
+   * License servers for protected content, keyed by EME key system id. An escape hatch for licensing native playback
+   * differently from every other path: naming it replaces `source.drm` here, and nowhere else.
    */
   drmSystems?: DrmSystemsConfig | undefined;
 }
@@ -71,21 +68,17 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
   #source: NativeHlsSource | null = nativeHlsMediaDefaultProps.source;
   #preload = nativeHlsMediaDefaultProps.preload;
 
-  /**
-   * Underlying playback engine — always `null`. Native HLS has no JS engine;
-   * the browser handles playback directly.
-   */
+  /** Underlying playback engine — always `null`. Native HLS has no JS engine; the browser handles playback directly. */
   get engine() {
     return null;
   }
 
   /**
-   * Media source URL. Assigning it replaces the identity half of `source` and
-   * leaves `engine` intact, so changing the URL never disturbs key exchange.
+   * Media source URL. Assigning it replaces the identity half of `source` and leaves `engine` intact, so changing the
+   * URL never disturbs key exchange.
    *
-   * Like the element's own `src`, assigning it always loads — including the URL
-   * already playing. This is the imperative half of the API, and what
-   * `HlsJsMedia` loads its native delegate through.
+   * Like the element's own `src`, assigning it always loads — including the URL already playing. This is the imperative
+   * half of the API, and what `HlsJsMedia` loads its native delegate through.
    */
   get src() {
     return this.#src;
@@ -108,16 +101,13 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
   }
 
   /**
-   * Structured source: what to play (`src`) plus how to play it
-   * (`engine.nativeHls`). Assigning it derives `src`.
+   * Structured source: what to play (`src`) plus how to play it (`engine.nativeHls`). Assigning it derives `src`.
    *
-   * Only a new URL reaches the element, so reassigning an equivalent source —
-   * an inline React prop, for instance — neither reloads nor disturbs key
-   * exchange. Use `src` or `load()` to reload what is already playing.
+   * Only a new URL reaches the element, so reassigning an equivalent source — an inline React prop, for instance —
+   * neither reloads nor disturbs key exchange. Use `src` or `load()` to reload what is already playing.
    *
-   * Unlike `HlsJsMedia`, this does not announce a `sourcechange`. It is also
-   * the delegate `HlsJsMedia` plays native sources through, and every event it
-   * dispatches is re-dispatched there — which already announces its own.
+   * Unlike `HlsJsMedia`, this does not announce a `sourcechange`. It is also the delegate `HlsJsMedia` plays native
+   * sources through, and every event it dispatches is re-dispatched there — which already announces its own.
    */
   get source(): NativeHlsSource | null {
     return this.#source;

--- a/packages/media/src/dom/native-hls/stream-type.ts
+++ b/packages/media/src/dom/native-hls/stream-type.ts
@@ -3,9 +3,7 @@ import type { Constructor } from '@videojs/utils/types';
 import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
 import type { NativeMediaHost } from './errors';
 
-/**
- * @fires streamtypechange - Fired when the detected stream type changes. Read `streamType` for the new value.
- */
+/** @fires streamtypechange - Fired when the detected stream type changes. Read `streamType` for the new value. */
 export function NativeHlsMediaStreamTypeMixin<Base extends Constructor<NativeMediaHost>>(BaseClass: Base) {
   class NativeHlsMediaStreamType extends (BaseClass as Constructor<NativeMediaHost>) {
     #streamType: MediaStreamType = MediaStreamTypes.UNKNOWN;

--- a/packages/media/src/dom/native-hls/tests/drm.test.ts
+++ b/packages/media/src/dom/native-hls/tests/drm.test.ts
@@ -24,7 +24,7 @@ function skdInitData(contentId: string): ArrayBuffer {
   return bytes.buffer;
 }
 
-/** jsdom implements neither `MediaEncryptedEvent` nor `webkitneedkey`. */
+/** Jsdom implements neither `MediaEncryptedEvent` nor `webkitneedkey`. */
 function fireKeyRequest(
   video: HTMLVideoElement,
   type: 'encrypted' | 'webkitneedkey' = 'encrypted',
@@ -148,9 +148,8 @@ function stubFetch() {
 }
 
 /**
- * Licensed the standard way, through `source.drm`. Systems only an MSE engine
- * can negotiate are welcome there — one source describes every path — so the
- * helper takes whatever a caller would name.
+ * Licensed the standard way, through `source.drm`. Systems only an MSE engine can negotiate are welcome there — one
+ * source describes every path — so the helper takes whatever a caller would name.
  */
 function setup(
   drm: DrmSystemsConfig | null = { 'com.apple.fps': { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL } }
@@ -175,8 +174,8 @@ function setup(
 }
 
 /**
- * Let the setup chain (key access → certificate → session → license) settle.
- * Yielding to the macrotask queue drains every microtask in between.
+ * Let the setup chain (key access → certificate → session → license) settle. Yielding to the macrotask queue drains
+ * every microtask in between.
  */
 async function settle() {
   for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
@@ -482,8 +481,8 @@ describe('NativeHlsMediaDrmMixin', () => {
 
   describe('legacy WebKit fallback', () => {
     /**
-     * Drive the one handover the legacy path exists for: EME cannot generate a
-     * request while the playback target is an AirPlay receiver.
+     * Drive the one handover the legacy path exists for: EME cannot generate a request while the playback target is an
+     * AirPlay receiver.
      */
     async function setupFallback() {
       const eme = stubKeySystem();

--- a/packages/media/src/dom/native-hls/tests/media.test.ts
+++ b/packages/media/src/dom/native-hls/tests/media.test.ts
@@ -8,8 +8,8 @@ const DRM: NativeHlsSource['engine'] = {
 };
 
 /**
- * jsdom implements neither the media load algorithm nor its events, so what
- * reaches the element is observed through the assignments themselves.
+ * Jsdom implements neither the media load algorithm nor its events, so what reaches the element is observed through the
+ * assignments themselves.
  */
 function setup() {
   const video = document.createElement('video');

--- a/packages/media/src/dom/shaka/live.ts
+++ b/packages/media/src/dom/shaka/live.ts
@@ -127,9 +127,8 @@ export function ShakaMediaLiveMixin<Base extends Constructor<ShakaEngineHost>>(B
     }
 
     /**
-     * Arm a one-shot seek-to-live on the first user-initiated `play`. Skipped
-     * when `autoplay` is set, since Shaka positions at the live edge during
-     * its own startup sequence and a programmatic seek would race that.
+     * Arm a one-shot seek-to-live on the first user-initiated `play`. Skipped when `autoplay` is set, since Shaka
+     * positions at the live edge during its own startup sequence and a programmatic seek would race that.
      */
     #armSeekToLive() {
       this.#disarmSeekToLive();

--- a/packages/media/src/dom/shaka/media-tracks.ts
+++ b/packages/media/src/dom/shaka/media-tracks.ts
@@ -14,17 +14,14 @@ type MediaTracksHost = ShakaEngineHost &
   MediaVideoRenditionCapability;
 
 /**
- * Mirrors the Shaka video and audio tracks of the loaded asset into the media
- * element's `videoRenditions` / `audioTracks` lists, and wires user selection
- * back to `engine.selectVideoTrack()` and `engine.selectAudioTrack()`.
+ * Mirrors the Shaka video and audio tracks of the loaded asset into the media element's `videoRenditions` /
+ * `audioTracks` lists, and wires user selection back to `engine.selectVideoTrack()` and `engine.selectAudioTrack()`.
  *
- * Shaka video tracks are a flattened view over the manifest's variants rather
- * than a list of their own, so they are hung off a single `'main'` video track —
- * the one the renditions of the asset that is playing are read from.
+ * Shaka video tracks are a flattened view over the manifest's variants rather than a list of their own, so they are
+ * hung off a single `'main'` video track — the one the renditions of the asset that is playing are read from.
  *
- * Requires the media-tracks mixin (track-list infrastructure) to be applied
- * earlier in the chain so the host exposes `addVideoTrack`, `videoRenditions`,
- * and friends.
+ * Requires the media-tracks mixin (track-list infrastructure) to be applied earlier in the chain so the host exposes
+ * `addVideoTrack`, `videoRenditions`, and friends.
  */
 export function ShakaMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
   class ShakaMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -28,9 +28,8 @@ if (didShimSelf) {
 type Opaque = string | number | boolean | bigint | symbol | null | undefined | ArrayBufferView;
 
 /**
- * Every level optional. Shaka's own configuration type describes a fully
- * resolved configuration, while `configure()` merges whatever subset it is
- * handed into the current one.
+ * Every level optional. Shaka's own configuration type describes a fully resolved configuration, while `configure()`
+ * merges whatever subset it is handed into the current one.
  */
 type DeepPartial<T> = T extends Opaque | readonly any[] | ((...args: any[]) => any)
   ? T
@@ -42,21 +41,20 @@ export type ShakaConfig = DeepPartial<shaka.extern.PlayerConfiguration>;
 /** Structured Shaka source: which source to play, plus how to play it. */
 export interface ShakaSource {
   /**
-   * Manifest URL. Shaka plays DASH, HLS, and progressive files from the same
-   * property. Mirrors the host's `src` property.
+   * Manifest URL. Shaka plays DASH, HLS, and progressive files from the same property. Mirrors the host's `src`
+   * property.
    */
   src?: string | undefined;
   /**
-   * MIME type of the source. Handed to Shaka as the type to parse `src` as,
-   * which is what makes an extensionless manifest URL playable.
+   * MIME type of the source. Handed to Shaka as the type to parse `src` as, which is what makes an extensionless
+   * manifest URL playable.
    */
   type?: string | undefined;
   /**
    * License servers for protected content, keyed by EME key system id.
    *
-   * Translated into the `drm.servers` and `drm.advanced` Shaka configures EME
-   * from. Name every system you hold a license server for — which one is used
-   * is the browser's choice.
+   * Translated into the `drm.servers` and `drm.advanced` Shaka configures EME from. Name every system you hold a
+   * license server for — which one is used is the browser's choice.
    */
   drm?: DrmSystemsConfig | undefined;
   /** Playback options, keyed by the engine that reads them. */
@@ -66,10 +64,9 @@ export interface ShakaSource {
 /** The engines a Shaka source can configure. */
 export interface ShakaEngineConfig {
   /**
-   * Shaka Player's own configuration, passed through untouched. Replacing it
-   * resets any previously applied configuration. A `drm.servers` of its own
-   * replaces `source.drm` — an escape hatch for licensing against the parts of
-   * Shaka's DRM configuration `source.drm` does not cover.
+   * Shaka Player's own configuration, passed through untouched. Replacing it resets any previously applied
+   * configuration. A `drm.servers` of its own replaces `source.drm` — an escape hatch for licensing against the parts
+   * of Shaka's DRM configuration `source.drm` does not cover.
    */
   shaka?: ShakaConfig | undefined;
 }
@@ -89,10 +86,9 @@ export const shakaMediaDefaultProps: ShakaMediaProps = {
 };
 
 /**
- * Configuration this element applies on top of Shaka's own defaults — the
- * Shaka spelling of what the hls.js media ships (`capLevelToPlayerSize`):
- * adaptation stays within renditions no larger than the element rendering
- * them. Anything under `source.engine.shaka` overrides it.
+ * Configuration this element applies on top of Shaka's own defaults — the Shaka spelling of what the hls.js media ships
+ * (`capLevelToPlayerSize`): adaptation stays within renditions no larger than the element rendering them. Anything
+ * under `source.engine.shaka` overrides it.
  */
 const defaultShakaConfig: ShakaConfig = {
   abr: { restrictToElementSize: true },
@@ -197,24 +193,21 @@ class ShakaMediaBase
   }
 
   /**
-   * Underlying playback engine — the Shaka `Player` instance, or `null` when
-   * the browser cannot run it. An advanced escape hatch for direct engine
-   * access; normal playback is driven through this element's own properties
-   * and methods.
+   * Underlying playback engine — the Shaka `Player` instance, or `null` when the browser cannot run it. An advanced
+   * escape hatch for direct engine access; normal playback is driven through this element's own properties and
+   * methods.
    */
   get engine() {
     return this.#engine;
   }
 
   /**
-   * The last playback failure Shaka could not recover from, or `null`. Shaka
-   * loads asynchronously, so a manifest that cannot be played fails after `src`
-   * was assigned rather than at the assignment; the `error` event is when to
-   * read this.
+   * The last playback failure Shaka could not recover from, or `null`. Shaka loads asynchronously, so a manifest that
+   * cannot be played fails after `src` was assigned rather than at the assignment; the `error` event is when to read
+   * this.
    *
-   * A Shaka failure says more about what went wrong than the media element's
-   * own `error` does, so it wins while there is one; anything the element failed
-   * on by itself still reads through.
+   * A Shaka failure says more about what went wrong than the media element's own `error` does, so it wins while there
+   * is one; anything the element failed on by itself still reads through.
    */
   get error() {
     return this.#error ?? super.error;
@@ -242,20 +235,17 @@ class ShakaMediaBase
   }
 
   /**
-   * How much to fetch before playback is asked for, mirroring the media
-   * element's own `preload`. Shaka has no split between "know the source" and
-   * "buffer it", so this maps onto when and how `engine.load()` runs:
+   * How much to fetch before playback is asked for, mirroring the media element's own `preload`. Shaka has no split
+   * between "know the source" and "buffer it", so this maps onto when and how `engine.load()` runs:
    *
    * - `'auto'` — load immediately with the configured buffering goals.
-   * - `'metadata'` — load immediately, holding buffering to about a segment;
-   *   the configured goals come back on the first play intent.
+   * - `'metadata'` — load immediately, holding buffering to about a segment; the configured goals come back on the first
+   *   play intent.
    * - `'none'` / `''` — hold the load entirely until the first play intent.
    *
-   * A play intent is a `play` event, a target that is already playing, or
-   * `autoplay` — which the spec lets override `preload` for good reason: with
-   * nothing fetched there is nothing whose readiness could ever fire it.
-   * Widening (`none` → `auto`) takes effect immediately; narrowing after a
-   * load began cannot un-fetch and leaves it alone.
+   * A play intent is a `play` event, a target that is already playing, or `autoplay` — which the spec lets override
+   * `preload` for good reason: with nothing fetched there is nothing whose readiness could ever fire it. Widening
+   * (`none` → `auto`) takes effect immediately; narrowing after a load began cannot un-fetch and leaves it alone.
    */
   get preload(): MediaPreloadType {
     return this.#preload;
@@ -283,11 +273,11 @@ class ShakaMediaBase
   }
 
   /**
-   * Structured source: what to play (`src`, an optional `type`) plus how to
-   * play it (`drm`, `engine.shaka`). Replacing it re-derives `src`.
+   * Structured source: what to play (`src`, an optional `type`) plus how to play it (`drm`, `engine.shaka`). Replacing
+   * it re-derives `src`.
    *
-   * Shaka takes configuration on a live player, so changing `engine.shaka`
-   * re-applies it in place instead of recreating the engine.
+   * Shaka takes configuration on a live player, so changing `engine.shaka` re-applies it in place instead of recreating
+   * the engine.
    */
   get source(): ShakaSource | null {
     return this.#source;
@@ -395,10 +385,9 @@ class ShakaMediaBase
   }
 
   /**
-   * Holds Shaka's buffering to about one segment — the closest analog of
-   * fetching "metadata" an engine that always buffers through MSE has. The
-   * goals in force are captured first so the first play intent can put back
-   * exactly what configuration produced them.
+   * Holds Shaka's buffering to about one segment — the closest analog of fetching "metadata" an engine that always
+   * buffers through MSE has. The goals in force are captured first so the first play intent can put back exactly what
+   * configuration produced them.
    */
   #clampBuffering(engine: shaka.Player) {
     const { bufferingGoal, rebufferingGoal } = engine.getConfiguration().streaming;
@@ -433,12 +422,10 @@ class ShakaMediaBase
   }
 
   /**
-   * Shaka's `attach()`, `load()`, `unload()`, and `detach()` are asynchronous,
-   * and the player orders them itself: each takes an internal lock in call
-   * order, and a newer one interrupts whatever it supersedes. So a call is
-   * issued as it comes — holding it until the one before it settles would keep
-   * a new source waiting on a manifest that hangs, when cutting that load short
-   * is the point of assigning one.
+   * Shaka's `attach()`, `load()`, `unload()`, and `detach()` are asynchronous, and the player orders them itself: each
+   * takes an internal lock in call order, and a newer one interrupts whatever it supersedes. So a call is issued as it
+   * comes — holding it until the one before it settles would keep a new source waiting on a manifest that hangs, when
+   * cutting that load short is the point of assigning one.
    *
    * Nothing awaits these, so a rejection is reported rather than left unhandled.
    */
@@ -477,7 +464,8 @@ class ShakaMediaBase
 }
 
 /**
- * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the
+ *   new value.
  * @fires error - Fired when playback fails in a way Shaka could not recover from. Read `error` for the failure.
  * @fires streamtypechange - Fired when the detected stream type changes. Read `streamType` for the new value.
  * @fires targetlivewindowchange - Fired when `targetLiveWindow` changes. Read it for the new value.
@@ -489,10 +477,9 @@ export class ShakaMedia extends ShakaMediaLiveMixin(
 let arePolyfillsInstalled = false;
 
 /**
- * Patches the browser APIs Shaka expects before anything reads them. Shaka
- * ships these as polyfills it does not install itself, and both
- * `isBrowserSupported()` and the DRM path depend on them — FairPlay EME on
- * Safari is patched in from here. Installing is global, so it happens once.
+ * Patches the browser APIs Shaka expects before anything reads them. Shaka ships these as polyfills it does not install
+ * itself, and both `isBrowserSupported()` and the DRM path depend on them — FairPlay EME on Safari is patched in from
+ * here. Installing is global, so it happens once.
  */
 function installPolyfills() {
   if (arePolyfillsInstalled) return;
@@ -503,19 +490,17 @@ function installPolyfills() {
 }
 
 /**
- * Everything Shaka is configured from. Compared structurally, so equivalent
- * options never re-apply — including nested ones like `drm`, which a flat
- * comparison would see as changed whenever the object identity did.
+ * Everything Shaka is configured from. Compared structurally, so equivalent options never re-apply — including nested
+ * ones like `drm`, which a flat comparison would see as changed whenever the object identity did.
  */
 function engineConfigKey(source: ShakaSource | null) {
   return { drm: source?.drm ?? null, shaka: source?.engine?.shaka ?? null };
 }
 
 /**
- * Shaka configuration with the source's DRM licensing folded in. Shaka names
- * license servers under `drm.servers` and server certificates under
- * `drm.advanced`, so `source.drm` is translated into both — unless
- * `engine.shaka.drm.servers` names servers of its own, which replaces it.
+ * Shaka configuration with the source's DRM licensing folded in. Shaka names license servers under `drm.servers` and
+ * server certificates under `drm.advanced`, so `source.drm` is translated into both — unless `engine.shaka.drm.servers`
+ * names servers of its own, which replaces it.
  */
 function withDrmConfig(config: ShakaConfig | undefined, drm: DrmSystemsConfig | undefined) {
   const systems = Object.entries(drm ?? {});
@@ -557,14 +542,11 @@ const abortedCodes = new Set<number>([shaka.util.Error.Code.LOAD_INTERRUPTED, sh
 /**
  * A Shaka failure as a `MediaError`, or `null` when there is nothing to report.
  *
- * Only a failure Shaka gave up on is reported. Shaka marks one it means to
- * retry as recoverable and fires it on the way through, and an announced error
- * stands until the next load — so announcing those would leave the error UI
- * over playback that is still running. Whatever a retry cannot save comes back
- * as critical.
+ * Only a failure Shaka gave up on is reported. Shaka marks one it means to retry as recoverable and fires it on the way
+ * through, and an announced error stands until the next load — so announcing those would leave the error UI over
+ * playback that is still running. Whatever a retry cannot save comes back as critical.
  *
- * Shaka classifies a failure by category rather than by a media error code, so
- * the code is derived from that.
+ * Shaka classifies a failure by category rather than by a media error code, so the code is derived from that.
  */
 function toMediaError(error: unknown): MediaError | null {
   if (!isShakaError(error)) {

--- a/packages/media/src/dom/shaka/server-shim.ts
+++ b/packages/media/src/dom/shaka/server-shim.ts
@@ -1,10 +1,8 @@
 /**
- * Shaka's UMD bundle reads the browser global `self` while it evaluates, so
- * importing it on a server runtime throws before any feature detection can
- * run. Evaluated ahead of `shaka-player` — keep it the first import of
- * `media.ts` — this lends that evaluation a `self`, and `media.ts` takes it
- * back as soon as shaka is through: a patched server global left behind would
- * only confuse other libraries' environment detection.
+ * Shaka's UMD bundle reads the browser global `self` while it evaluates, so importing it on a server runtime throws
+ * before any feature detection can run. Evaluated ahead of `shaka-player` — keep it the first import of `media.ts` —
+ * this lends that evaluation a `self`, and `media.ts` takes it back as soon as shaka is through: a patched server
+ * global left behind would only confuse other libraries' environment detection.
  */
 export const didShimSelf = typeof self === 'undefined';
 

--- a/packages/media/src/dom/spotify/media.ts
+++ b/packages/media/src/dom/spotify/media.ts
@@ -23,7 +23,8 @@ import { buildSpotifyIframeSrc, parseSpotifySource, type SpotifySource } from '.
 const SpotifyMediaBase = MediaPlayedRangesMixin(EventTarget);
 
 /**
- * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the
+ *   new value.
  */
 export class SpotifyMedia extends SpotifyMediaBase implements Partial<Video> {
   #target: HTMLIFrameElement | null = null;

--- a/packages/media/src/dom/spotify/props.ts
+++ b/packages/media/src/dom/spotify/props.ts
@@ -2,13 +2,11 @@ import type { Video } from '../../core/types';
 import type { SpotifySource } from './source';
 
 /**
- * The `Video` members the Spotify host accepts, plus the source that names the
- * entity. Narrower than the other embed hosts by one pair: the embed takes no
- * volume or mute command and reports neither value, so `muted` and
- * `defaultMuted` are absent rather than inert — a prop that cannot reach the
- * player reads as a capability the player has. `poster` has no artwork of its
- * own to replace and `playsInline` no inline-playback switch, so those two are
- * kept for a uniform prop shape but are stored and reported without effect.
+ * The `Video` members the Spotify host accepts, plus the source that names the entity. Narrower than the other embed
+ * hosts by one pair: the embed takes no volume or mute command and reports neither value, so `muted` and `defaultMuted`
+ * are absent rather than inert — a prop that cannot reach the player reads as a capability the player has. `poster` has
+ * no artwork of its own to replace and `playsInline` no inline-playback switch, so those two are kept for a uniform
+ * prop shape but are stored and reported without effect.
  */
 export interface SpotifyMediaProps extends Pick<
   Video,

--- a/packages/media/src/dom/spotify/source.ts
+++ b/packages/media/src/dom/spotify/source.ts
@@ -2,28 +2,22 @@ import { serializeEmbedParams } from '../utils';
 import type { SpotifyMediaProps } from './props';
 
 /**
- * Spotify engine options, spelled exactly as Spotify spells them
- * (https://developer.spotify.com/documentation/embeds). They are serialized onto
- * the embed URL verbatim, so what you write here is what the embed reads.
+ * Spotify engine options, spelled exactly as Spotify spells them (https://developer.spotify.com/documentation/embeds).
+ * They are serialized onto the embed URL verbatim, so what you write here is what the embed reads.
  *
- * Spotify publishes only a handful of them, and the ones the host owns are
- * deliberately absent: the start position comes from the `t` parameter on `src`.
- * The index signature still carries anything not listed here, so undocumented
+ * Spotify publishes only a handful of them, and the ones the host owns are deliberately absent: the start position
+ * comes from the `t` parameter on `src`. The index signature still carries anything not listed here, so undocumented
  * knobs and whatever Spotify adds next keep working.
  */
 export interface SpotifyEngineConfig extends Record<string, unknown> {
   /** Start position in seconds. */
   t?: number;
   /**
-   * `0` renders the embed in its dark theme. Defaults to the light theme. Spotify
-   * documents no other value, and the embed goes by whether the parameter is
-   * there, so leaving it out is the only way to ask for the default.
+   * `0` renders the embed in its dark theme. Defaults to the light theme. Spotify documents no other value, and the
+   * embed goes by whether the parameter is there, so leaving it out is the only way to ask for the default.
    */
   theme?: 0;
-  /**
-   * Embed the video variant of an episode when it has one. Not a URL parameter:
-   * the video embed lives at its own path.
-   */
+  /** Embed the video variant of an episode when it has one. Not a URL parameter: the video embed lives at its own path. */
   preferVideo?: boolean;
   /** `referrerpolicy` for the embed iframe. Not a Spotify embed parameter. */
   referrerPolicy?: ReferrerPolicy;
@@ -62,10 +56,9 @@ export function parseSpotifyEntityId(src: string) {
 }
 
 /**
- * Parse a Spotify source string. Recognizes `open.spotify.com` URLs for every
- * embeddable entity — including the localized (`/intl-de/`) and already-embedded
- * (`/embed/`) forms, since the entity type and id sit in the same place in all of
- * them — `spotify:<type>:<id>` URIs, and start positions via the `t` parameter.
+ * Parse a Spotify source string. Recognizes `open.spotify.com` URLs for every embeddable entity — including the
+ * localized (`/intl-de/`) and already-embedded (`/embed/`) forms, since the entity type and id sit in the same place in
+ * all of them — `spotify:<type>:<id>` URIs, and start positions via the `t` parameter.
  */
 export function parseSpotifySource(src: string): ParsedSpotifySource | null {
   if (!src) return null;

--- a/packages/media/src/dom/spotify/tests/media.test.ts
+++ b/packages/media/src/dom/spotify/tests/media.test.ts
@@ -24,13 +24,11 @@ type ReadyListener = () => void;
 type PlaybackUpdateListener = (event: SpotifyPlaybackUpdateEvent) => void;
 
 /**
- * Stands in for a controller from the live iframe API, including the part that
- * matters most to this host: `createController` never drives the element it is
- * handed. It builds an iframe of its own and swaps it in for the target — but
- * only through `parentElement`, so a target that is detached, or one parented by
- * a shadow root rather than an element, is left alone. Reproducing that exactly
- * is the point: a mock that swapped on `parentNode` hid a bug where this host
- * followed the controller onto an iframe that was never in the document.
+ * Stands in for a controller from the live iframe API, including the part that matters most to this host:
+ * `createController` never drives the element it is handed. It builds an iframe of its own and swaps it in for the
+ * target — but only through `parentElement`, so a target that is detached, or one parented by a shadow root rather than
+ * an element, is left alone. Reproducing that exactly is the point: a mock that swapped on `parentNode` hid a bug where
+ * this host followed the controller onto an iframe that was never in the document.
  */
 class MockController {
   static instances: MockController[] = [];
@@ -1243,8 +1241,8 @@ describe('SpotifyMedia source', () => {
 });
 
 /**
- * Runs last: it settles the module-level API promise that every test above
- * bypasses through the `SpotifyIframeApi` global, and nothing can unsettle it.
+ * Runs last: it settles the module-level API promise that every test above bypasses through the `SpotifyIframeApi`
+ * global, and nothing can unsettle it.
  */
 describe('loadSpotifyIframeApi', () => {
   it('passes the API on to a ready callback the host page installed', async () => {

--- a/packages/media/src/dom/tiktok/media.ts
+++ b/packages/media/src/dom/tiktok/media.ts
@@ -34,7 +34,8 @@ import { buildTikTokIframeSrc, shouldBootstrapTikTokEmbed, type TikTokSource } f
 const TikTokMediaBase = MediaPlayedRangesMixin(EventTarget);
 
 /**
- * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the
+ *   new value.
  */
 export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
   #target: HTMLIFrameElement | null = null;

--- a/packages/media/src/dom/tiktok/props.ts
+++ b/packages/media/src/dom/tiktok/props.ts
@@ -2,15 +2,13 @@ import type { Video } from '../../core/types';
 import type { TikTokSource } from './source';
 
 /**
- * The `Video` members the TikTok host accepts, plus the source that names the
- * video. `playsInline` and `poster` are stored and reported but never reach the
- * embed: it always plays inline and draws the video's own cover image.
+ * The `Video` members the TikTok host accepts, plus the source that names the video. `playsInline` and `poster` are
+ * stored and reported but never reach the embed: it always plays inline and draws the video's own cover image.
  *
- * `preload` reaches no TikTok parameter either, but it is not inert: anything
- * but `'none'` has the host bring TikTok's dormant player up with an `autoplay`
- * it then parks (see `shouldBootstrapTikTokEmbed`), which `controls` also opts
- * out of by handing playback to TikTok's own chrome. That buys commands the
- * embed answers, not metadata — TikTok reports a duration of 0 until it plays.
+ * `preload` reaches no TikTok parameter either, but it is not inert: anything but `'none'` has the host bring TikTok's
+ * dormant player up with an `autoplay` it then parks (see `shouldBootstrapTikTokEmbed`), which `controls` also opts out
+ * of by handing playback to TikTok's own chrome. That buys commands the embed answers, not metadata — TikTok reports a
+ * duration of 0 until it plays.
  */
 export interface TikTokMediaProps extends Pick<
   Video,

--- a/packages/media/src/dom/tiktok/source.ts
+++ b/packages/media/src/dom/tiktok/source.ts
@@ -2,15 +2,12 @@ import { serializeEmbedParams } from '../utils';
 import type { TikTokMediaProps } from './props';
 
 /**
- * TikTok engine options, spelled exactly as TikTok spells them
- * (https://developers.tiktok.com/doc/embed-player). They are serialized onto the
- * embed URL verbatim, so what you write here is what the player reads.
+ * TikTok engine options, spelled exactly as TikTok spells them (https://developers.tiktok.com/doc/embed-player). They
+ * are serialized onto the embed URL verbatim, so what you write here is what the player reads.
  *
- * Parameters the host owns are deliberately absent: `autoplay`, `controls`,
- * `loop`, and `muted` come from the props of the same name, so configuring them
- * here would give two ways to say one thing. The index signature still carries
- * anything not listed here, so undocumented knobs and whatever TikTok adds next
- * keep working.
+ * Parameters the host owns are deliberately absent: `autoplay`, `controls`, `loop`, and `muted` come from the props of
+ * the same name, so configuring them here would give two ways to say one thing. The index signature still carries
+ * anything not listed here, so undocumented knobs and whatever TikTok adds next keep working.
  */
 export interface TikTokEngineConfig extends Record<string, unknown> {
   /** Show the closed-caption button. Defaults to `1`. */
@@ -52,8 +49,8 @@ export interface TikTokSourceEngineConfig {
 }
 
 /**
- * Parsed pieces of a TikTok source URL. TikTok embeds one thing — a video named
- * by a numeric id — so the id is all there is to take from a source.
+ * Parsed pieces of a TikTok source URL. TikTok embeds one thing — a video named by a numeric id — so the id is all
+ * there is to take from a source.
  */
 export interface ParsedTikTokSource {
   /** Numeric video id. */
@@ -66,8 +63,8 @@ export function parseTikTokVideoId(src: string) {
 }
 
 /**
- * Parse a TikTok source string. Recognizes raw numeric ids, `player/v1/` embed
- * URLs, `share/video/` links, and the `@user/video/` URLs the app hands out.
+ * Parse a TikTok source string. Recognizes raw numeric ids, `player/v1/` embed URLs, `share/video/` links, and the
+ * `@user/video/` URLs the app hands out.
  */
 export function parseTikTokSource(src: string): ParsedTikTokSource | null {
   if (!src) return null;
@@ -83,9 +80,9 @@ export function parseTikTokSource(src: string): ParsedTikTokSource | null {
 
 /**
  * Whether the embed has to carry an `autoplay` nobody asked for. TikTok builds its player lazily: without one it
- * creates no media element, never reports `onPlayerReady`, and drops every command silently, until something is
- * clicked inside the frame — which a frame under a player skin never gets. The host parks the player as soon as it
- * is up, so this buys one that answers commands, not a video that plays.
+ * creates no media element, never reports `onPlayerReady`, and drops every command silently, until something is clicked
+ * inside the frame — which a frame under a player skin never gets. The host parks the player as soon as it is up, so
+ * this buys one that answers commands, not a video that plays.
  */
 export function shouldBootstrapTikTokEmbed(props: Partial<TikTokMediaProps> = {}) {
   // `preload="none"` trades those working controls back for an untouched network, and `controls` hands the player

--- a/packages/media/src/dom/tiktok/tests/media.test.ts
+++ b/packages/media/src/dom/tiktok/tests/media.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/** jsdom only gives a connected iframe the window the embed posts from. */
+/** Jsdom only gives a connected iframe the window the embed posts from. */
 function createIframe(): HTMLIFrameElement {
   const iframe = document.createElement('iframe');
 

--- a/packages/media/src/dom/twitch/media.ts
+++ b/packages/media/src/dom/twitch/media.ts
@@ -36,7 +36,8 @@ import { buildTwitchIframeSrc, parseTwitchSource, type TwitchSource } from './so
 const TwitchMediaBase = MediaPlayedRangesMixin(EventTarget);
 
 /**
- * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the
+ *   new value.
  */
 export class TwitchMedia extends TwitchMediaBase implements Partial<Video> {
   #target: HTMLIFrameElement | null = null;

--- a/packages/media/src/dom/twitch/props.ts
+++ b/packages/media/src/dom/twitch/props.ts
@@ -2,12 +2,10 @@ import type { Video } from '../../core/types';
 import type { TwitchSource } from './source';
 
 /**
- * The `Video` members the Twitch host accepts, plus the source that names the
- * video or channel. Three of them never reach the embed: `loop`, which it has no
- * parameter for and the host emulates by seeking a finished VOD back to the
- * start (a live channel never ends, so it never repeats); `playsInline`, which
- * Twitch decides for itself on a phone; and `poster`, which the embed draws
- * itself and offers no way to replace.
+ * The `Video` members the Twitch host accepts, plus the source that names the video or channel. Three of them never
+ * reach the embed: `loop`, which it has no parameter for and the host emulates by seeking a finished VOD back to the
+ * start (a live channel never ends, so it never repeats); `playsInline`, which Twitch decides for itself on a phone;
+ * and `poster`, which the embed draws itself and offers no way to replace.
  */
 export interface TwitchMediaProps extends Pick<
   Video,

--- a/packages/media/src/dom/twitch/source.ts
+++ b/packages/media/src/dom/twitch/source.ts
@@ -4,25 +4,20 @@ import { TWITCH_PLAYER_ORIGIN } from './player-api';
 import { type TwitchMediaProps, twitchMediaDefaultProps } from './props';
 
 /**
- * Twitch engine options, spelled exactly as Twitch spells them
- * (https://dev.twitch.tv/docs/embed/video-and-clips/). They are serialized onto
- * the embed URL verbatim, so what you write here is what the player reads.
+ * Twitch engine options, spelled exactly as Twitch spells them (https://dev.twitch.tv/docs/embed/video-and-clips/).
+ * They are serialized onto the embed URL verbatim, so what you write here is what the player reads.
  *
- * Parameters the host owns are deliberately absent: `video` and `channel` come
- * from `src`, and `controls`, `autoplay` and `muted` come from the props of the
- * same name, so configuring them here would give two ways to say one thing. So
- * are the ones Twitch documents for something other than the player URL —
- * `allowfullscreen` is an iframe attribute set by inclusion, and `quality`
- * belongs to the scripted embed's `setQuality` — since naming them here would
- * promise an effect the URL cannot have. The index signature still carries
- * anything not listed, so undocumented knobs and whatever Twitch adds next keep
- * working.
+ * Parameters the host owns are deliberately absent: `video` and `channel` come from `src`, and `controls`, `autoplay`
+ * and `muted` come from the props of the same name, so configuring them here would give two ways to say one thing. So
+ * are the ones Twitch documents for something other than the player URL — `allowfullscreen` is an iframe attribute set
+ * by inclusion, and `quality` belongs to the scripted embed's `setQuality` — since naming them here would promise an
+ * effect the URL cannot have. The index signature still carries anything not listed, so undocumented knobs and whatever
+ * Twitch adds next keep working.
  */
 export interface TwitchEngineConfig extends Record<string, unknown> {
   /**
-   * Every hostname the embed may be framed by. Twitch checks the frame's
-   * ancestors against it and refuses to play when the current page is missing,
-   * which is why the page's own hostname is always included on top of this.
+   * Every hostname the embed may be framed by. Twitch checks the frame's ancestors against it and refuses to play when
+   * the current page is missing, which is why the page's own hostname is always included on top of this.
    */
   parent?: string | readonly string[];
   /** Collection to play through, starting from the video named by `src`. */
@@ -30,9 +25,8 @@ export interface TwitchEngineConfig extends Record<string, unknown> {
   /** Start position, spelled the way Twitch spells timestamps: `1h30m10s`. */
   time?: string;
   /**
-   * `referrerpolicy` for the embed iframe. Not a Twitch embed parameter, so it
-   * never reaches the URL: the React player applies it to the iframe it renders,
-   * and the HTML player reads its own `referrerpolicy` attribute instead.
+   * `referrerpolicy` for the embed iframe. Not a Twitch embed parameter, so it never reaches the URL: the React player
+   * applies it to the iframe it renders, and the HTML player reads its own `referrerpolicy` attribute instead.
    */
   referrerPolicy?: ReferrerPolicy;
 }
@@ -67,9 +61,8 @@ export function parseTwitchVideoId(src: string) {
 }
 
 /**
- * Parse a Twitch source string. Recognizes VOD URLs (`twitch.tv/videos/<id>`
- * and `twitch.tv/?video=<id>`) and channel URLs (`twitch.tv/<channel>`), with
- * or without the `www.` and `go.` hosts, and with or without a trailing slash.
+ * Parse a Twitch source string. Recognizes VOD URLs (`twitch.tv/videos/<id>` and `twitch.tv/?video=<id>`) and channel
+ * URLs (`twitch.tv/<channel>`), with or without the `www.` and `go.` hosts, and with or without a trailing slash.
  */
 export function parseTwitchSource(src: string): ParsedTwitchSource | null {
   if (!src) return null;

--- a/packages/media/src/dom/twitch/tests/media.test.ts
+++ b/packages/media/src/dom/twitch/tests/media.test.ts
@@ -28,9 +28,8 @@ afterEach(() => {
 });
 
 /**
- * An iframe with a stand-in for the embed's window. It is the whole protocol
- * surface: commands are posted to it, and only messages claiming to come from it
- * are allowed to drive state.
+ * An iframe with a stand-in for the embed's window. It is the whole protocol surface: commands are posted to it, and
+ * only messages claiming to come from it are allowed to drive state.
  */
 function createIframe(): HTMLIFrameElement {
   const iframe = document.createElement('iframe');
@@ -55,8 +54,8 @@ function embedOf(iframe: HTMLIFrameElement): EmbedWindow {
 }
 
 /**
- * Post a message as the embed would. A real `MessageEvent` cannot name an
- * arbitrary object as its `source`, so the event is assembled by hand.
+ * Post a message as the embed would. A real `MessageEvent` cannot name an arbitrary object as its `source`, so the
+ * event is assembled by hand.
  */
 function postFromWindow(source: unknown, data: unknown): void {
   const event = new Event('message');

--- a/packages/media/src/dom/utils/embed-params.ts
+++ b/packages/media/src/dom/utils/embed-params.ts
@@ -1,7 +1,6 @@
 /**
- * Serialize embed options into a query string. Booleans become `1`/`0`, which is
- * how both the YouTube and Vimeo embeds spell them, and nullish values are
- * dropped so an unset option is absent rather than the string `"undefined"`.
+ * Serialize embed options into a query string. Booleans become `1`/`0`, which is how both the YouTube and Vimeo embeds
+ * spell them, and nullish values are dropped so an unset option is absent rather than the string `"undefined"`.
  */
 export function serializeEmbedParams(props: Record<string, unknown>): string {
   const params = new URLSearchParams();

--- a/packages/media/src/dom/utils/media-components.ts
+++ b/packages/media/src/dom/utils/media-components.ts
@@ -52,7 +52,10 @@ export function setMediaProp<T extends TargetLike, K extends keyof T>(host: Medi
   if (own) (own as Record<K, T[K]>)[prop] = value;
 }
 
-/** Find the object that owns a media property: the first component `override` exposing it, otherwise the attached target. */
+/**
+ * Find the object that owns a media property: the first component `override` exposing it, otherwise the attached
+ * target.
+ */
 export function getMediaOwner<T extends TargetLike>(host: MediaHost<T>, prop: keyof T): Partial<T> | null {
   for (const component of getMediaComponents(host).values()) {
     const override = component.targetOverride as Partial<T> | null | undefined;

--- a/packages/media/src/dom/utils/time-ranges.ts
+++ b/packages/media/src/dom/utils/time-ranges.ts
@@ -1,9 +1,8 @@
 import type { TimeRangeLike } from '../../core/types';
 
 /**
- * A `TimeRanges`-shaped object holding a single range. Embed hosts only ever
- * know one contiguous buffered or seekable span, so they report it through this
- * rather than constructing a real `TimeRanges`, which has no public constructor.
+ * A `TimeRanges`-shaped object holding a single range. Embed hosts only ever know one contiguous buffered or seekable
+ * span, so they report it through this rather than constructing a real `TimeRanges`, which has no public constructor.
  */
 export function createTimeRange(start: number, end: number): TimeRangeLike {
   return { length: 1, start: () => start, end: () => end };

--- a/packages/media/src/dom/vimeo/media.ts
+++ b/packages/media/src/dom/vimeo/media.ts
@@ -69,8 +69,10 @@ export const vimeoMediaDefaultProps: VimeoMediaProps = {
 const VimeoMediaBase = MediaPlayedRangesMixin(EventTarget);
 
 /**
- * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
- * @fires contentdatachange - Fired when the embed reports a title and when that title is cleared. Read `contentData` for the new value.
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the
+ *   new value.
+ * @fires contentdatachange - Fired when the embed reports a title and when that title is cleared. Read `contentData`
+ *   for the new value.
  */
 export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
   #target: HTMLIFrameElement | null = null;
@@ -397,23 +399,20 @@ export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
   }
 
   /**
-   * Metadata Vimeo reports about the loaded video, keyed by what it is — `title`
-   * for now. Unlike a Mux source, none of it can be derived from `src`; the embed
-   * has to report it, so the key is absent until then and empties again across a
-   * source change. `contentdatachange` announces both.
+   * Metadata Vimeo reports about the loaded video, keyed by what it is — `title` for now. Unlike a Mux source, none of
+   * it can be derived from `src`; the embed has to report it, so the key is absent until then and empties again across
+   * a source change. `contentdatachange` announces both.
    */
   get contentData(): MediaContentData {
     return this.#contentData;
   }
 
   /**
-   * Store the title the embed reported, reporting whether the content data
-   * changed. Announcing is left to the caller, which knows when the rest of what
-   * it is writing is in step.
+   * Store the title the embed reported, reporting whether the content data changed. Announcing is left to the caller,
+   * which knows when the rest of what it is writing is in step.
    *
-   * Vimeo cannot tell "no title yet" from "the title is blank" — a failed read
-   * falls back to the current value — and a blank would read as a deliberate one,
-   * stopping a consumer's fallback chain. So an empty title is reported as an
+   * Vimeo cannot tell "no title yet" from "the title is blank" — a failed read falls back to the current value — and a
+   * blank would read as a deliberate one, stopping a consumer's fallback chain. So an empty title is reported as an
    * absent key rather than an empty string.
    */
   #setTitle(value: string): boolean {

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -81,8 +81,8 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
   }
 
   /**
-   * Bind the iframe hosting the embed. The player follows once an embed URL can be resolved,
-   * which may not be now: an iframe attached before `src` is set is picked up by the next `load()`.
+   * Bind the iframe hosting the embed. The player follows once an embed URL can be resolved, which may not be now: an
+   * iframe attached before `src` is set is picked up by the next `load()`.
    */
   attach(target: HTMLIFrameElement | null): void {
     if (!target || this.#target === target) return;

--- a/packages/media/src/dom/youtube/source.ts
+++ b/packages/media/src/dom/youtube/source.ts
@@ -3,15 +3,13 @@ import { type YouTubeMediaProps, youtubeMediaDefaultProps } from './props';
 
 /**
  * YouTube engine options, spelled exactly as YouTube spells them
- * (https://developers.google.com/youtube/player_parameters). They are serialized
- * onto the embed URL verbatim, so what you write here is what the player reads.
+ * (https://developers.google.com/youtube/player_parameters). They are serialized onto the embed URL verbatim, so what
+ * you write here is what the player reads.
  *
- * Parameters the host owns are deliberately absent: `autoplay`, `controls`, and
- * `playsinline` come from the props of the same name, so configuring them here
- * would give two ways to say one thing. Parameters YouTube has deprecated
- * (`modestbranding`, `showinfo`, `autohide`, `theme`, and `listType: 'search'`)
- * are absent too. The index signature still carries anything not listed here, so
- * undocumented knobs and whatever YouTube adds next keep working.
+ * Parameters the host owns are deliberately absent: `autoplay`, `controls`, and `playsinline` come from the props of
+ * the same name, so configuring them here would give two ways to say one thing. Parameters YouTube has deprecated
+ * (`modestbranding`, `showinfo`, `autohide`, `theme`, and `listType: 'search'`) are absent too. The index signature
+ * still carries anything not listed here, so undocumented knobs and whatever YouTube adds next keep working.
  */
 export interface YouTubeEngineConfig extends Record<string, unknown> {
   /** ISO 639-1 language to display captions in. Pair with `cc_load_policy`. */
@@ -86,10 +84,9 @@ export function parseYouTubeVideoId(src: string) {
 }
 
 /**
- * Parse a YouTube source string. Recognizes raw 11-character ids, `youtu.be`
- * short links, `watch?v=`, `embed/`, `v/`, `shorts/` and `live/` URLs (with or
- * without the `-nocookie` host), playlist URLs via the `list` parameter, and
- * start times via the `t` parameter.
+ * Parse a YouTube source string. Recognizes raw 11-character ids, `youtu.be` short links, `watch?v=`, `embed/`, `v/`,
+ * `shorts/` and `live/` URLs (with or without the `-nocookie` host), playlist URLs via the `list` parameter, and start
+ * times via the `t` parameter.
  */
 export function parseYouTubeSource(src: string): ParsedYouTubeSource | null {
   if (!src) return null;
@@ -148,8 +145,8 @@ export function buildYouTubeIframeSrc(src: string, props: Partial<YouTubeMediaPr
 }
 
 /**
- * Parse the `t` parameter from a YouTube URL and convert it to seconds.
- * Supports formats like: `t=171`, `t=171s`, `t=2m51s`, `t=2m`, `t=1h30m15s`.
+ * Parse the `t` parameter from a YouTube URL and convert it to seconds. Supports formats like: `t=171`, `t=171s`,
+ * `t=2m51s`, `t=2m`, `t=1h30m15s`.
  */
 function parseStartTime(url: string): number | null {
   const tValue = /[?&]t=([\dhms]+)/i.exec(url)?.[1]?.toLowerCase();

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -23,28 +23,27 @@ export interface CreateI18nOptions {
 
 export interface I18nProviderProps {
   /**
-   * Forces the active locale. Omit to inherit the nearest non-empty `lang` by walking DOM
-   * ancestors from {@link langRootRef} when set, otherwise from `document.documentElement`
-   * (typically `<html lang>`). Updates when any `lang` attribute changes anywhere under `<html>`,
-   * or when subtree moves alter which ancestor supplies `lang`. For SSR, pass `locale` explicitly.
+   * Forces the active locale. Omit to inherit the nearest non-empty `lang` by walking DOM ancestors from
+   * {@link langRootRef} when set, otherwise from `document.documentElement` (typically `<html lang>`). Updates when any
+   * `lang` attribute changes anywhere under `<html>`, or when subtree moves alter which ancestor supplies `lang`. For
+   * SSR, pass `locale` explicitly.
    */
   locale?: Locale;
   /**
-   * Element whose ancestor chain is searched for a non-empty `lang` when {@link locale} is
-   * omitted—for example a ref to your player shell `HTMLElement`.
+   * Element whose ancestor chain is searched for a non-empty `lang` when {@link locale} is omitted—for example a ref to
+   * your player shell `HTMLElement`.
    */
   langRootRef?: RefObject<Element | null>;
   /**
-   * Per-locale string overrides merged on top of the global registry and any lazy built-in
-   * packs for {@link locale}. Applies to translated
-   * `aria-label` values and tooltip copy for skin controls wired through `useTranslator`.
+   * Per-locale string overrides merged on top of the global registry and any lazy built-in packs for {@link locale}.
+   * Applies to translated `aria-label` values and tooltip copy for skin controls wired through `useTranslator`.
    *
    * @example
-   * ```tsx
-   * <I18nProvider locale="ja" translations={{ buttons: { play: '再生', pause: '一時停止' } }}>
-   *   <VideoSkin />
-   * </I18nProvider>
-   * ```
+   *   ```tsx
+   *   <I18nProvider locale="ja" translations={{ buttons: { play: '再生', pause: '一時停止' } }}>
+   *     <VideoSkin />
+   *   </I18nProvider>;
+   *   ```;
    */
   translations?: Partial<Translations>;
   children: ReactNode;
@@ -130,8 +129,8 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
 const defaultI18n = createI18n();
 
 /**
- * Resolves locale and supplies a typed translator to descendants. Mount this explicitly for
- * translated controls, forced locales, SSR copy, or locale-aware player roots.
+ * Resolves locale and supplies a typed translator to descendants. Mount this explicitly for translated controls, forced
+ * locales, SSR copy, or locale-aware player roots.
  *
  * @public
  */

--- a/packages/react/src/media/google-cast/google-cast.tsx
+++ b/packages/react/src/media/google-cast/google-cast.tsx
@@ -12,17 +12,16 @@ export type GoogleCastProps = Partial<GoogleCastComponentProps>;
 /**
  * Adds Google Cast support to the surrounding player's media.
  *
- * Renders nothing — place it inside the Player as a sibling of the
- * media component (e.g. `<HlsJsVideo />`) and it registers a `GoogleCast`
- * media component with the active media.
+ * Renders nothing — place it inside the Player as a sibling of the media component (e.g. `<HlsJsVideo />`) and it
+ * registers a `GoogleCast` media component with the active media.
  *
  * @example
- * ```tsx
- * <Player>
- *   <HlsJsVideo src="https://example.com/stream.m3u8" />
- *   <GoogleCast receiver="YOUR_APP_ID" />
- * </Player>
- * ```
+ *   ```tsx
+ *   <Player>
+ *     <HlsJsVideo src="https://example.com/stream.m3u8" />
+ *     <GoogleCast receiver="YOUR_APP_ID" />
+ *   </Player>;
+ *   ```;
  */
 export function GoogleCast(props: GoogleCastProps): ReactNode {
   const component = useMediaComponent(GoogleCastComponent);

--- a/packages/react/src/media/hls-background-video/media.tsx
+++ b/packages/react/src/media/hls-background-video/media.tsx
@@ -21,29 +21,23 @@ export interface HlsBackgroundVideoProps
     Partial<HlsBackgroundVideoMediaProps> {}
 
 /**
- * A muted, looping, chrome-less video over the SPF background-video engine — the
- * React counterpart to `<hls-background-video>`, and the replacement for the
- * standalone `mux-background-video` package's component.
+ * A muted, looping, chrome-less video over the SPF background-video engine — the React counterpart to
+ * `<hls-background-video>`, and the replacement for the standalone `mux-background-video` package's component.
  *
- * `src` is an HLS URL and the whole surface. Capping which rendition is fetched
- * is a param on that URL (`?max_resolution=720p` on a Mux stream, for one) rather
- * than a prop, which keeps the renditions it excludes out of the manifest instead
- * of merely unpicked.
+ * `src` is an HLS URL and the whole surface. Capping which rendition is fetched is a param on that URL
+ * (`?max_resolution=720p` on a Mux stream, for one) rather than a prop, which keeps the renditions it excludes out of
+ * the manifest instead of merely unpicked.
  *
- * There is no structured Mux `source`: playback-ID identity, poster, and
- * storyboard belong to `MuxVideo`, since none of them mean anything without
- * controls to hang them on.
+ * There is no structured Mux `source`: playback-ID identity, poster, and storyboard belong to `MuxVideo`, since none of
+ * them mean anything without controls to hang them on.
  *
- * `onError` fires for an unplayable source, which it could not do on its own:
- * nothing about one reaches the media element, so the `<video>`'s own `error`
- * stays null at `readyState 0`. The engine reports the condition, the Media
- * promotes the fatal one, and this component re-fires it on the `<video>` — where
- * a handler already listening for a failed source receives it. Which condition it
- * was is on the console and `engine.state.errors`; the handler gets "this source
- * won't play", which is the decision a background video actually has to make.
+ * `onError` fires for an unplayable source, which it could not do on its own: nothing about one reaches the media
+ * element, so the `<video>`'s own `error` stays null at `readyState 0`. The engine reports the condition, the Media
+ * promotes the fatal one, and this component re-fires it on the `<video>` — where a handler already listening for a
+ * failed source receives it. Which condition it was is on the console and `engine.state.errors`; the handler gets "this
+ * source won't play", which is the decision a background video actually has to make.
  *
- * `MuxBackgroundVideo` is this same component under the name the package it
- * replaces used — an alias, not a variant.
+ * `MuxBackgroundVideo` is this same component under the name the package it replaces used — an alias, not a variant.
  */
 export const HlsBackgroundVideo = forwardRef<HTMLVideoElement, HlsBackgroundVideoProps>(function HlsBackgroundVideo(
   { children, ...props },

--- a/packages/react/src/media/hls-background-video/tests/media.test.tsx
+++ b/packages/react/src/media/hls-background-video/tests/media.test.tsx
@@ -7,9 +7,8 @@ const NO_SUPPORTED_VIDEO_TRACK = 2011;
 const MANIFEST_FEATURE_UNSUPPORTED = 2039;
 
 /**
- * The component owns its Media and hands out no reference to it, so the engine
- * is reached by tracking what it constructs. Everything else about the entry is
- * the real thing.
+ * The component owns its Media and hands out no reference to it, so the engine is reached by tracking what it
+ * constructs. Everything else about the entry is the real thing.
  */
 const instances: { engine: { state: { errors: { set(value: unknown): void } } } }[] = vi.hoisted(() => []);
 

--- a/packages/react/src/media/mux-background-video/index.ts
+++ b/packages/react/src/media/mux-background-video/index.ts
@@ -1,12 +1,10 @@
 /**
- * The Mux-flavored name for `HlsBackgroundVideo` — the same component, not a
- * wrapper. Kept because `MuxBackgroundVideo` is what the standalone package this
- * replaces exported.
+ * The Mux-flavored name for `HlsBackgroundVideo` — the same component, not a wrapper. Kept because `MuxBackgroundVideo`
+ * is what the standalone package this replaces exported.
  *
- * There is no Mux identity to add, because there is no Mux input to take: `src` is
- * an HLS URL, and capping which rendition is fetched is a param on it rather than
- * a prop. `../hls-background-video` carries the whole surface, including the
- * `Props` namespace member the alias inherits with it.
+ * There is no Mux identity to add, because there is no Mux input to take: `src` is an HLS URL, and capping which
+ * rendition is fetched is a param on it rather than a prop. `../hls-background-video` carries the whole surface,
+ * including the `Props` namespace member the alias inherits with it.
  */
 export {
   HlsBackgroundVideo as MuxBackgroundVideo,

--- a/packages/react/src/media/mux-data/mux-data.tsx
+++ b/packages/react/src/media/mux-data/mux-data.tsx
@@ -10,28 +10,24 @@ import { useSyncProps } from '../../utils/use-sync-props';
 export type MuxDataProps = Partial<MuxDataComponentProps>;
 
 /**
- * Adds [Mux Data](https://www.mux.com/data) monitoring to the surrounding
- * player's media.
+ * Adds [Mux Data](https://www.mux.com/data) monitoring to the surrounding player's media.
  *
- * Renders nothing — place it inside the Player as a sibling of the
- * media component (e.g. `<MuxVideo />`) and it registers a `MuxData` media
- * component with the active media.
+ * Renders nothing — place it inside the Player as a sibling of the media component (e.g. `<MuxVideo />`) and it
+ * registers a `MuxData` media component with the active media.
  *
- * Mux-hosted playback needs no `envKey`: the view reports the Mux playback ID
- * as its `video_id`, which Mux attributes to the owning environment. Set
- * `envKey` to monitor sources Mux doesn't host.
+ * Mux-hosted playback needs no `envKey`: the view reports the Mux playback ID as its `video_id`, which Mux attributes
+ * to the owning environment. Set `envKey` to monitor sources Mux doesn't host.
  *
- * Any media component works. When the media plays through an hls.js or dash.js
- * engine, that engine is handed to the Mux Data SDK so the view also carries
- * stream-level detail such as rendition switches and request timing.
+ * Any media component works. When the media plays through an hls.js or dash.js engine, that engine is handed to the Mux
+ * Data SDK so the view also carries stream-level detail such as rendition switches and request timing.
  *
  * @example
- * ```tsx
- * <Player>
- *   <MuxVideo source={{ playbackId: 'abc123' }} />
- *   <MuxData playerSoftwareName="mux-video" />
- * </Player>
- * ```
+ *   ```tsx
+ *   <Player>
+ *     <MuxVideo source={{ playbackId: 'abc123' }} />
+ *     <MuxData playerSoftwareName="mux-video" />
+ *   </Player>;
+ *   ```;
  */
 export function MuxData(props: MuxDataProps): ReactNode {
   const component = useMediaComponent(MuxDataComponent);

--- a/packages/react/src/media/mux-video/storyboard.tsx
+++ b/packages/react/src/media/mux-video/storyboard.tsx
@@ -7,8 +7,8 @@ import { useCallback, useSyncExternalStore } from 'react';
 /**
  * What the storyboard track needs from whichever Mux Media renders it.
  *
- * Structural on purpose: the hls.js-backed `MuxMedia` and the SPF-backed one
- * satisfy it identically, so this component carries no engine.
+ * Structural on purpose: the hls.js-backed `MuxMedia` and the SPF-backed one satisfy it identically, so this component
+ * carries no engine.
  */
 export interface MuxStoryboardMedia {
   readonly streamType: MediaStreamType | undefined;
@@ -17,10 +17,7 @@ export interface MuxStoryboardMedia {
   removeEventListener(type: string, listener: () => void): void;
 }
 
-/**
- * Renders the storyboard track in its own component so media changes don't
- * re-render the whole media component.
- */
+/** Renders the storyboard track in its own component so media changes don't re-render the whole media component. */
 export function MuxStoryboard({ media }: { media: MuxStoryboardMedia }) {
   const subscribe = useCallback(
     (onChange: () => void) => {

--- a/packages/react/src/media/tests/mux-video.test.tsx
+++ b/packages/react/src/media/tests/mux-video.test.tsx
@@ -7,9 +7,8 @@ import { describe, expect, it, vi } from 'vite-plus/test';
 import { MuxVideo } from '../mux-video';
 
 /**
- * Render and capture the host instance the `source` prop was written to, so
- * assertions can read the derived `src` off the real media rather than spying on
- * whichever internal setter happens to write it.
+ * Render and capture the host instance the `source` prop was written to, so assertions can read the derived `src` off
+ * the real media rather than spying on whichever internal setter happens to write it.
  */
 function renderWithMedia(ui: ReactElement) {
   const source = vi.spyOn(MuxMedia.prototype, 'source', 'set');

--- a/packages/react/src/media/tests/spotify-audio.test.tsx
+++ b/packages/react/src/media/tests/spotify-audio.test.tsx
@@ -6,9 +6,8 @@ import { SpotifyAudio } from '../spotify-audio/media';
 const TRACK_URL = 'https://open.spotify.com/track/1301WleyT98MSxVHPZCA6M';
 
 /**
- * Stands in for a controller from the live iframe API, including the part React
- * has to survive: `createController` builds an iframe of its own and replaces the
- * element it was handed with it.
+ * Stands in for a controller from the live iframe API, including the part React has to survive: `createController`
+ * builds an iframe of its own and replaces the element it was handed with it.
  */
 class MockController {
   static instances: MockController[] = [];

--- a/packages/react/src/player/context.tsx
+++ b/packages/react/src/player/context.tsx
@@ -42,10 +42,9 @@ export function usePlayerContext(): PlayerContextValue {
 /**
  * Access the player store from within a Player.
  *
- * This standalone hook has no knowledge of your configured features, so it
- * returns an untyped `UnknownStore` whose state properties are typed as
- * `unknown`. For typed access, use the `usePlayer` returned by `createPlayer()`,
- * or pass a premade selector to recover the type from its return value.
+ * This standalone hook has no knowledge of your configured features, so it returns an untyped `UnknownStore` whose
+ * state properties are typed as `unknown`. For typed access, use the `usePlayer` returned by `createPlayer()`, or pass
+ * a premade selector to recover the type from its return value.
  *
  * @label Without Selector
  */
@@ -53,11 +52,11 @@ export function usePlayer(): UnknownStore;
 /**
  * Select a value from the player store. Re-renders when the selected value changes.
  *
- * The selector receives `UnknownState`, so an inline selector returns `unknown`.
- * Pass a premade selector (e.g. `selectPlayback`) to get a typed result.
+ * The selector receives `UnknownState`, so an inline selector returns `unknown`. Pass a premade selector (e.g.
+ * `selectPlayback`) to get a typed result.
  *
- * @label With Selector
  * @param selector - Derives a value from the player store state.
+ * @label With Selector
  */
 export function usePlayer<R>(selector: (state: UnknownState) => R): R;
 export function usePlayer<R>(selector?: (state: UnknownState) => R) {
@@ -69,8 +68,8 @@ export function usePlayer<R>(selector?: (state: UnknownState) => R) {
 /**
  * Access player state when available, but return `undefined` outside a Player.
  *
- * This is useful for components that can operate without player context
- * (e.g. they accept fully explicit props as a fallback).
+ * This is useful for components that can operate without player context (e.g. they accept fully explicit props as a
+ * fallback).
  */
 /** @label Without Selector */
 export function useOptionalPlayer(): UnknownStore | undefined;

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -48,24 +48,24 @@ export type UsePlayerHook<Store extends PlayerStore> = {
 /**
  * Create a player instance with a typed Player component and hooks.
  *
- * @label Video
  * @param config - Player configuration with features and optional display name.
+ * @label Video
  */
 export function createPlayer(config: CreatePlayerConfig<VideoFeatures>): CreatePlayerResult<VideoPlayerStore>;
 
 /**
  * Create a player for audio media.
  *
- * @label Audio
  * @param config - Player configuration with features and optional display name.
+ * @label Audio
  */
 export function createPlayer(config: CreatePlayerConfig<AudioFeatures>): CreatePlayerResult<AudioPlayerStore>;
 
 /**
  * Create a player with custom features.
  *
- * @label Generic
  * @param config - Player configuration with features and optional display name.
+ * @label Generic
  */
 export function createPlayer<const Features extends AnyPlayerFeature[]>(
   config: CreatePlayerConfig<Features>

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -85,11 +85,9 @@ function VolumePopover(): ReactNode {
 }
 
 /**
- * Minimal audio skin configured for live playback. Mirrors
- * {@link MinimalAudioSkin} but omits the time slider and the current /
- * duration / remaining time displays. A flexible spacer stretches between
- * the play and volume controls so they sit at opposite edges of the
- * control bar.
+ * Minimal audio skin configured for live playback. Mirrors {@link MinimalAudioSkin} but omits the time slider and the
+ * current / duration / remaining time displays. A flexible spacer stretches between the play and volume controls so
+ * they sit at opposite edges of the control bar.
  */
 export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -70,10 +70,9 @@ export function TooltipPopup(props: Omit<Tooltip.PopupProps, 'children' | 'class
 }
 
 /**
- * Default audio skin configured for live playback. Mirrors {@link AudioSkin}
- * but omits the time slider and the current / duration time displays. A
- * flexible spacer stretches between the play and volume controls so they
- * sit at opposite edges of the control bar.
+ * Default audio skin configured for live playback. Mirrors {@link AudioSkin} but omits the time slider and the current /
+ * duration time displays. A flexible spacer stretches between the play and volume controls so they sit at opposite
+ * edges of the control bar.
  */
 export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -113,11 +113,9 @@ function VolumePopover(): ReactNode {
 }
 
 /**
- * Minimal video skin configured for live playback. Mirrors
- * {@link MinimalVideoSkin} but omits the time slider and the current /
- * duration / remaining time displays. A flexible spacer stretches between
- * the start and end button groups so they sit at opposite edges of the
- * control bar.
+ * Minimal video skin configured for live playback. Mirrors {@link MinimalVideoSkin} but omits the time slider and the
+ * current / duration / remaining time displays. A flexible spacer stretches between the start and end button groups so
+ * they sit at opposite edges of the control bar.
  */
 function CaptionsTrigger(): ReactNode {
   const t = useTranslator();

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -97,10 +97,9 @@ function VolumePopover(): ReactNode {
 }
 
 /**
- * Default video skin configured for live playback. Mirrors {@link VideoSkin}
- * but omits the time slider and the duration / current-time displays. A
- * flexible spacer stretches between the start and end button groups so they
- * sit at opposite edges of the control bar.
+ * Default video skin configured for live playback. Mirrors {@link VideoSkin} but omits the time slider and the duration
+ * / current-time displays. A flexible spacer stretches between the start and end button groups so they sit at opposite
+ * edges of the control bar.
  */
 function CaptionsTrigger(): ReactNode {
   const t = useTranslator();

--- a/packages/react/src/presets/types.ts
+++ b/packages/react/src/presets/types.ts
@@ -11,18 +11,17 @@ export type BaseSkinProps<T = unknown> = PropsWithChildren<
 
 export type BaseVideoSkinProps<T = unknown> = BaseSkinProps<T> & {
   /**
-   * Draws the poster image, in place of the `<img>` the skin renders. The URL
-   * still comes from the player, as `src` alongside the rest of the image
-   * props — undefined until one resolves.
+   * Draws the poster image, in place of the `<img>` the skin renders. The URL still comes from the player, as `src`
+   * alongside the rest of the image props — undefined until one resolves.
    *
    * @example
-   * ```tsx
-   * <VideoSkin
-   *   renderPoster={({ src, ...props }: ComponentProps<'img'>) =>
-   *     src ? <Image {...props} src={src} alt="" fill /> : null
-   *   }
-   * />
-   * ```
+   *   ```tsx
+   *   <VideoSkin
+   *     renderPoster={({ src, ...props }: ComponentProps<'img'>) =>
+   *       src ? <Image {...props} src={src} alt="" fill /> : null
+   *     }
+   *   />;
+   *   ```;
    */
   renderPoster?: Poster.Props['render'];
 };

--- a/packages/react/src/testing/mocks.tsx
+++ b/packages/react/src/testing/mocks.tsx
@@ -1,10 +1,9 @@
 /**
  * Shared test helpers for `@videojs/react`.
  *
- * Provides factory functions for common mock objects used across component
- * tests. `vi.mock()` blocks must still live in each test file (Vitest hoists
- * them before imports), but non-mock helpers like store and wrapper factories
- * can be shared here.
+ * Provides factory functions for common mock objects used across component tests. `vi.mock()` blocks must still live in
+ * each test file (Vitest hoists them before imports), but non-mock helpers like store and wrapper factories can be
+ * shared here.
  */
 
 import type { ReactNode } from 'react';
@@ -38,8 +37,8 @@ export function createMockStore(state: Record<string, unknown> = {}): MockStore 
 /**
  * Create a React wrapper that provides `PlayerContextProvider`.
  *
- * Accepts an optional store state seed. Returns the wrapper component,
- * the mock store, and the context value for assertions.
+ * Accepts an optional store state seed. Returns the wrapper component, the mock store, and the context value for
+ * assertions.
  */
 export function createPlayerWrapper(storeState: Record<string, unknown> = {}): {
   store: MockStore;

--- a/packages/react/src/ui/audio-track-radio-group/audio-track-radio-group.tsx
+++ b/packages/react/src/ui/audio-track-radio-group/audio-track-radio-group.tsx
@@ -33,16 +33,16 @@ export interface AudioTrackRadioGroupProps
  * Renders menu radio options for the player's audio tracks.
  *
  * @example
- * ```tsx
- * <AudioTrackRadioGroup
- *   renderItem={(props, item) => (
- *     <Menu.RadioItem {...props}>
- *       {item.label}
- *       <Menu.ItemIndicator checked={item.checked} />
- *     </Menu.RadioItem>
- *   )}
- * />
- * ```
+ *   ```tsx
+ *   <AudioTrackRadioGroup
+ *     renderItem={(props, item) => (
+ *       <Menu.RadioItem {...props}>
+ *         {item.label}
+ *         <Menu.ItemIndicator checked={item.checked} />
+ *       </Menu.RadioItem>
+ *     )}
+ *   />;
+ *   ```;
  */
 export const AudioTrackRadioGroup = forwardRef<HTMLDivElement, AudioTrackRadioGroupProps>(
   function AudioTrackRadioGroup(componentProps, forwardedRef) {

--- a/packages/react/src/ui/audio-track/use-audio-track-options.ts
+++ b/packages/react/src/ui/audio-track/use-audio-track-options.ts
@@ -26,8 +26,8 @@ const useAudioTrackRadioOptions = createRadioOptionsHook({
 });
 
 /**
- * Create audio track menu options from the player audio track state. Returns
- * `null` when the audio track feature is not configured.
+ * Create audio track menu options from the player audio track state. Returns `null` when the audio track feature is not
+ * configured.
  *
  * @param props - Optional `label`, `formatTrack`, and `disabled` overrides.
  */

--- a/packages/react/src/ui/buffering-indicator/buffering-indicator.tsx
+++ b/packages/react/src/ui/buffering-indicator/buffering-indicator.tsx
@@ -17,17 +17,17 @@ export interface BufferingIndicatorProps
  * Visibility is delayed (default 500ms) to avoid flashing on quick buffers.
  *
  * @example
- * ```tsx
- * <BufferingIndicator />
+ *   ```tsx
+ *   <BufferingIndicator />
  *
- * <BufferingIndicator delay={1000} />
+ *   <BufferingIndicator delay={1000} />
  *
- * <BufferingIndicator
+ *   <BufferingIndicator
  *   render={(props, state) => (
- *     <div {...props}>{state.visible && <Spinner />}</div>
+ *   <div {...props}>{state.visible && <Spinner />}</div>
  *   )}
- * />
- * ```
+ *   />
+ *   ```;
  */
 export const BufferingIndicator = forwardRef(function BufferingIndicator(
   componentProps: BufferingIndicatorProps,

--- a/packages/react/src/ui/captions-radio-group/captions-radio-group.tsx
+++ b/packages/react/src/ui/captions-radio-group/captions-radio-group.tsx
@@ -29,16 +29,16 @@ export interface CaptionsRadioGroupProps
  * Renders menu radio items for the player's captions and subtitles tracks.
  *
  * @example
- * ```tsx
- * <CaptionsRadioGroup
- *   renderItem={(props, item) => (
- *     <Menu.RadioItem {...props}>
- *       {item.label}
- *       <Menu.ItemIndicator checked={item.checked} />
- *     </Menu.RadioItem>
- *   )}
- * />
- * ```
+ *   ```tsx
+ *   <CaptionsRadioGroup
+ *     renderItem={(props, item) => (
+ *       <Menu.RadioItem {...props}>
+ *         {item.label}
+ *         <Menu.ItemIndicator checked={item.checked} />
+ *       </Menu.RadioItem>
+ *     )}
+ *   />;
+ *   ```;
  */
 export const CaptionsRadioGroup = forwardRef<HTMLDivElement, CaptionsRadioGroupProps>(
   function CaptionsRadioGroup(componentProps, forwardedRef) {

--- a/packages/react/src/ui/captions-radio-group/use-captions-options.ts
+++ b/packages/react/src/ui/captions-radio-group/use-captions-options.ts
@@ -27,9 +27,8 @@ const useCaptionsRadioOptions = createRadioOptionsHook({
 });
 
 /**
- * Create captions menu options (including an `Off` option) from the player
- * text track state. Returns `null` when the text tracks feature is not
- * configured.
+ * Create captions menu options (including an `Off` option) from the player text track state. Returns `null` when the
+ * text tracks feature is not configured.
  *
  * @param props - Optional `label`, `formatTrack`, and `disabled` overrides.
  */

--- a/packages/react/src/ui/hooks/use-button.ts
+++ b/packages/react/src/ui/hooks/use-button.ts
@@ -19,19 +19,19 @@ export interface UseButtonReturnValue {
  * Hook for button behavior with keyboard and pointer interaction.
  *
  * @example
- * ```tsx
- * const { getButtonProps, buttonRef } = useButton({
- *   displayName: 'PlayButton',
- *   onActivate: () => togglePlayback(),
- *   isDisabled: () => disabled,
- * });
+ *   ```tsx
+ *   const { getButtonProps, buttonRef } = useButton({
+ *     displayName: 'PlayButton',
+ *     onActivate: () => togglePlayback(),
+ *     isDisabled: () => disabled,
+ *   });
  *
- * return useRender('button', componentProps, {
- *   state,
- *   ref: [forwardedRef, buttonRef],
- *   props: [elementProps, getButtonProps],
- * });
- * ```
+ *   return useRender('button', componentProps, {
+ *     state,
+ *     ref: [forwardedRef, buttonRef],
+ *     props: [elementProps, getButtonProps],
+ *   });
+ *   ```;
  *
  * @param params - Button configuration with activation handler and disabled check.
  */

--- a/packages/react/src/ui/hooks/use-slider.ts
+++ b/packages/react/src/ui/hooks/use-slider.ts
@@ -51,9 +51,8 @@ export interface UseSliderReturnValue<State extends SliderState = SliderState> {
 /**
  * Manages slider input lifecycle for React.
  *
- * Wraps `createSlider()` from `@videojs/core/dom` and subscribes to its
- * input state via `useSnapshot`. Returns split props for the root
- * (pointer events) and thumb (keyboard/focus) elements.
+ * Wraps `createSlider()` from `@videojs/core/dom` and subscribes to its input state via `useSnapshot`. Returns split
+ * props for the root (pointer events) and thumb (keyboard/focus) elements.
  */
 export function useSlider<State extends SliderState = SliderState>(
   options: UseSliderOptions<State>

--- a/packages/react/src/ui/live-button/live-button.tsx
+++ b/packages/react/src/ui/live-button/live-button.tsx
@@ -15,21 +15,18 @@ const DISPLAY_NAME = 'LiveButton';
 export interface LiveButtonProps extends UIComponentProps<'button', LiveButtonCore.State>, LiveButtonCore.Props {}
 
 /**
- * A button that indicates live status and seeks to the live edge when
- * pressed. Exposes `data-live` while the stream is live (or DVR) and
- * `data-live-edge` while playing at the live edge so skins can style a
- * red-dot ↔ grey-dot treatment.
+ * A button that indicates live status and seeks to the live edge when pressed. Exposes `data-live` while the stream is
+ * live (or DVR) and `data-live-edge` while playing at the live edge so skins can style a red-dot ↔ grey-dot treatment.
  *
- * Selects from `live`, `time`, and `buffer` features and composes them
- * itself rather than going through `createMediaButton`, since the LiveButton
- * needs three feature slices to detect the live edge and seek.
+ * Selects from `live`, `time`, and `buffer` features and composes them itself rather than going through
+ * `createMediaButton`, since the LiveButton needs three feature slices to detect the live edge and seek.
  *
  * Displays the translated live badge when no children are provided.
  *
  * @example
- * ```tsx
- * <LiveButton />
- * ```
+ *   ```tsx
+ *   <LiveButton />;
+ *   ```;
  *
  * @see https://github.com/video-dev/media-ui-extensions/blob/main/proposals/0007-live-edge.md
  */

--- a/packages/react/src/ui/menu/menu-content.tsx
+++ b/packages/react/src/ui/menu/menu-content.tsx
@@ -18,7 +18,10 @@ import { callKeyDownHandler, preventMenuKeyDefault } from './menu-keyboard';
 
 export interface MenuContentProps extends UIComponentProps<'div', MenuState> {}
 
-/** Container for menu items. Positioned relative to the trigger at root level; renders in-place as a submenu panel when nested. */
+/**
+ * Container for menu items. Positioned relative to the trigger at root level; renders in-place as a submenu panel when
+ * nested.
+ */
 export const MenuContent = forwardRef<HTMLDivElement, MenuContentProps>(function MenuContent(
   { render, className, style, onKeyDown, onBlur, ...elementProps },
   forwardedRef

--- a/packages/react/src/ui/menu/menu-trigger.tsx
+++ b/packages/react/src/ui/menu/menu-trigger.tsx
@@ -22,9 +22,8 @@ export interface MenuTriggerProps extends Omit<
 }
 
 /**
- * Button that toggles the menu visibility. At root level renders a `<button>`.
- * When inside a parent menu (as a submenu trigger), renders as a `<div role="menuitem">`
- * that opens the submenu on click or ArrowRight.
+ * Button that toggles the menu visibility. At root level renders a `<button>`. When inside a parent menu (as a submenu
+ * trigger), renders as a `<div role="menuitem">` that opens the submenu on click or ArrowRight.
  */
 export const MenuTrigger = forwardRef<HTMLButtonElement | HTMLDivElement, MenuTriggerProps>(function MenuTrigger(
   { render, className, style, disabled, onClick, onKeyDown, ...elementProps },

--- a/packages/react/src/ui/play-button/play-button.tsx
+++ b/packages/react/src/ui/play-button/play-button.tsx
@@ -10,17 +10,17 @@ export interface PlayButtonProps extends UIComponentProps<'button', PlayButtonCo
  * A button that toggles playback.
  *
  * @example
- * ```tsx
- * <PlayButton />
+ *   ```tsx
+ *   <PlayButton />
  *
- * <PlayButton
+ *   <PlayButton
  *   render={(props, state) => (
- *     <button {...props}>
- *       {state.paused ? <PlayIcon /> : <PauseIcon />}
- *     </button>
+ *   <button {...props}>
+ *   {state.paused ? <PlayIcon /> : <PauseIcon />}
+ *   </button>
  *   )}
- * />
- * ```
+ *   />
+ *   ```;
  */
 export const PlayButton = createMediaButton<PlayButtonCore, PlayButtonProps>({
   displayName: 'PlayButton',

--- a/packages/react/src/ui/playback-rate-button/playback-rate-button.tsx
+++ b/packages/react/src/ui/playback-rate-button/playback-rate-button.tsx
@@ -11,17 +11,17 @@ export interface PlaybackRateButtonProps
  * A button that cycles through playback rates.
  *
  * @example
- * ```tsx
- * <PlaybackRateButton />
+ *   ```tsx
+ *   <PlaybackRateButton />
  *
- * <PlaybackRateButton
+ *   <PlaybackRateButton
  *   render={(props, state) => (
- *     <button {...props}>
- *       {state.rate}&times;
- *     </button>
+ *   <button {...props}>
+ *   {state.rate}&times;
+ *   </button>
  *   )}
- * />
- * ```
+ *   />
+ *   ```;
  */
 export const PlaybackRateButton = createMediaButton<PlaybackRateButtonCore, PlaybackRateButtonProps>({
   displayName: 'PlaybackRateButton',

--- a/packages/react/src/ui/playback-rate-radio-group/playback-rate-radio-group.tsx
+++ b/packages/react/src/ui/playback-rate-radio-group/playback-rate-radio-group.tsx
@@ -33,16 +33,16 @@ export interface PlaybackRateRadioGroupProps
  * Renders menu radio items for the player's available playback rates.
  *
  * @example
- * ```tsx
- * <PlaybackRateRadioGroup
- *   renderItem={(props, item) => (
- *     <Menu.RadioItem {...props}>
- *       {item.label}
- *       <Menu.ItemIndicator checked={item.checked} />
- *     </Menu.RadioItem>
- *   )}
- * />
- * ```
+ *   ```tsx
+ *   <PlaybackRateRadioGroup
+ *     renderItem={(props, item) => (
+ *       <Menu.RadioItem {...props}>
+ *         {item.label}
+ *         <Menu.ItemIndicator checked={item.checked} />
+ *       </Menu.RadioItem>
+ *     )}
+ *   />;
+ *   ```;
  */
 export const PlaybackRateRadioGroup = forwardRef<HTMLDivElement, PlaybackRateRadioGroupProps>(
   function PlaybackRateRadioGroup(componentProps, forwardedRef) {

--- a/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
+++ b/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
@@ -33,8 +33,8 @@ const usePlaybackRateRadioOptions = createRadioOptionsHook({
 });
 
 /**
- * Create playback rate menu options from the player playback rate state.
- * Returns `null` when the playback rate feature is not configured.
+ * Create playback rate menu options from the player playback rate state. Returns `null` when the playback rate feature
+ * is not configured.
  *
  * @param props - Optional `label`, `formatRate`, and `disabled` overrides.
  */

--- a/packages/react/src/ui/popover/popover-popup.tsx
+++ b/packages/react/src/ui/popover/popover-popup.tsx
@@ -9,7 +9,10 @@ import { usePopupPosition } from './use-popup-position';
 
 export interface PopoverPopupProps extends UIComponentProps<'div', PopoverState> {}
 
-/** Container for the popover content. Positioned relative to the trigger using CSS anchor positioning with a JavaScript fallback. */
+/**
+ * Container for the popover content. Positioned relative to the trigger using CSS anchor positioning with a JavaScript
+ * fallback.
+ */
 export const PopoverPopup = forwardRef<HTMLDivElement, PopoverPopupProps>(function PopoverPopup(
   { render, className, style, ...elementProps },
   forwardedRef

--- a/packages/react/src/ui/poster/poster.tsx
+++ b/packages/react/src/ui/poster/poster.tsx
@@ -19,27 +19,25 @@ interface ImageRequest {
 /**
  * Displays the video poster image. Shows before playback starts, hides after.
  *
- * Renders an `<img>`, so `srcset`, `sizes`, `loading`, and the rest of the
- * image attributes are yours. Leave the source off and the player's resolved
- * `poster` fills it in.
+ * Renders an `<img>`, so `srcset`, `sizes`, `loading`, and the rest of the image attributes are yours. Leave the source
+ * off and the player's resolved `poster` fills it in.
  *
- * The image is decorative unless you say otherwise. Describe a poster that
- * carries meaning by passing your own `alt`.
+ * The image is decorative unless you say otherwise. Describe a poster that carries meaning by passing your own `alt`.
  *
  * @example
- * ```tsx
- * <VideoPlayer poster="poster.jpg">
+ *   ```tsx
+ *   <VideoPlayer poster="poster.jpg">
  *   <Poster />
- * </VideoPlayer>
+ *   </VideoPlayer>
  *
- * <Poster srcSet="poster-480.jpg 480w, poster-1080.jpg 1080w" sizes="100vw" />
+ *   <Poster srcSet="poster-480.jpg 480w, poster-1080.jpg 1080w" sizes="100vw" />
  *
- * <Poster
+ *   <Poster
  *   render={({ src, ...props }: ComponentProps<'img'>) =>
- *     src ? <Image {...props} src={src} alt="" fill /> : null
+ *   src ? <Image {...props} src={src} alt="" fill /> : null
  *   }
- * />
- * ```
+ *   />
+ *   ```;
  */
 export const Poster = forwardRef(function Poster(
   componentProps: PosterProps,

--- a/packages/react/src/ui/quality-radio-group/quality-radio-group.tsx
+++ b/packages/react/src/ui/quality-radio-group/quality-radio-group.tsx
@@ -29,17 +29,17 @@ export interface QualityRadioGroupProps
  * Renders menu radio items for the player's video renditions.
  *
  * @example
- * ```tsx
- * <QualityRadioGroup
- *   renderItem={(props, item) => (
- *     <Menu.RadioItem {...props}>
- *       {item.label}
- *       {item.tier ? <sup>{item.tier}</sup> : null}
- *       <Menu.ItemIndicator checked={item.checked} />
- *     </Menu.RadioItem>
- *   )}
- * />
- * ```
+ *   ```tsx
+ *   <QualityRadioGroup
+ *     renderItem={(props, item) => (
+ *       <Menu.RadioItem {...props}>
+ *         {item.label}
+ *         {item.tier ? <sup>{item.tier}</sup> : null}
+ *         <Menu.ItemIndicator checked={item.checked} />
+ *       </Menu.RadioItem>
+ *     )}
+ *   />;
+ *   ```;
  */
 export const QualityRadioGroup = forwardRef<HTMLDivElement, QualityRadioGroupProps>(
   function QualityRadioGroup(componentProps, forwardedRef) {

--- a/packages/react/src/ui/quality/use-quality-options.ts
+++ b/packages/react/src/ui/quality/use-quality-options.ts
@@ -26,9 +26,8 @@ const useQualityRadioOptions = createRadioOptionsHook({
 });
 
 /**
- * Create quality menu options (including an `Auto` option) from the player
- * video rendition state. Returns `null` when the quality feature is not
- * configured.
+ * Create quality menu options (including an `Auto` option) from the player video rendition state. Returns `null` when
+ * the quality feature is not configured.
  *
  * @param props - Optional `label`, `formatRendition`, and `disabled` overrides.
  */

--- a/packages/react/src/ui/seek-button/seek-button.tsx
+++ b/packages/react/src/ui/seek-button/seek-button.tsx
@@ -10,18 +10,18 @@ export interface SeekButtonProps extends UIComponentProps<'button', SeekButtonCo
  * A button that seeks forward or backward by a configurable number of seconds.
  *
  * @example
- * ```tsx
- * <SeekButton seconds={-10} />
+ *   ```tsx
+ *   <SeekButton seconds={-10} />
  *
- * <SeekButton
+ *   <SeekButton
  *   seconds={30}
  *   render={(props, state) => (
- *     <button {...props}>
- *       {state.direction === 'backward' ? <RewindIcon /> : <FastForwardIcon />}
- *     </button>
+ *   <button {...props}>
+ *   {state.direction === 'backward' ? <RewindIcon /> : <FastForwardIcon />}
+ *   </button>
  *   )}
- * />
- * ```
+ *   />
+ *   ```;
  */
 export const SeekButton = createMediaButton<SeekButtonCore, SeekButtonProps>({
   displayName: 'SeekButton',

--- a/packages/react/src/ui/thumbnail/tests/thumbnail.test.tsx
+++ b/packages/react/src/ui/thumbnail/tests/thumbnail.test.tsx
@@ -8,8 +8,8 @@ import { Thumbnail, type ThumbnailProps } from '../thumbnail';
 afterEach(cleanup);
 
 /**
- * Render a thumbnail inside a player reporting the given media CORS mode and
- * return the `crossorigin` attribute its inner `<img>` ends up with.
+ * Render a thumbnail inside a player reporting the given media CORS mode and return the `crossorigin` attribute its
+ * inner `<img>` ends up with.
  */
 function renderCrossOrigin(
   thumbnailTrackCrossOrigin: MediaTextTrackState['thumbnailTrackCrossOrigin'],

--- a/packages/react/src/ui/thumbnail/thumbnail.tsx
+++ b/packages/react/src/ui/thumbnail/thumbnail.tsx
@@ -22,13 +22,12 @@ export interface ThumbnailProps extends UIComponentProps<'div', ThumbnailCore.St
 }
 
 /**
- * Leaving `crossOrigin` unset means "follow the media element", so thumbnails
- * keep working on a CORS-enabled player without a skin having to thread a prop
- * through. `null` opts out and fetches the sprites no-CORS. `''` is passed
+ * Leaving `crossOrigin` unset means "follow the media element", so thumbnails keep working on a CORS-enabled player
+ * without a skin having to thread a prop through. `null` opts out and fetches the sprites no-CORS. `''` is passed
  * straight through, since the CORS-settings attribute reads it as Anonymous.
  *
- * Only the `<track>` path inherits: `thumbnails` passed directly may point at a
- * host that has nothing to do with the media element.
+ * Only the `<track>` path inherits: `thumbnails` passed directly may point at a host that has nothing to do with the
+ * media element.
  */
 function resolveCrossOrigin(
   explicit: ThumbnailCore.Props['crossOrigin'],

--- a/packages/react/src/ui/time/time-group.tsx
+++ b/packages/react/src/ui/time/time-group.tsx
@@ -16,13 +16,13 @@ export interface GroupProps extends UIComponentProps<'span', GroupState> {
  * Container for composed time displays. Renders a `<span>` element.
  *
  * @example
- * ```tsx
- * <Time.Group>
- *   <Time.Value type="current" />
- *   <Time.Separator />
- *   <Time.Value type="duration" />
- * </Time.Group>
- * ```
+ *   ```tsx
+ *   <Time.Group>
+ *     <Time.Value type="current" />
+ *     <Time.Separator />
+ *     <Time.Value type="duration" />
+ *   </Time.Group>;
+ *   ```;
  */
 export const Group = forwardRef(function Group(
   componentProps: GroupProps,

--- a/packages/react/src/ui/time/time-separator.tsx
+++ b/packages/react/src/ui/time/time-separator.tsx
@@ -16,10 +16,10 @@ export interface SeparatorProps extends UIComponentProps<'span', SeparatorState>
  * Divider between time values. Hidden from screen readers.
  *
  * @example
- * ```tsx
- * <Time.Separator />
- * <Time.Separator> of </Time.Separator>
- * ```
+ *   ```tsx
+ *   <Time.Separator />
+ *   <Time.Separator> of </Time.Separator>
+ *   ```;
  */
 export const Separator = forwardRef(function Separator(
   componentProps: SeparatorProps,

--- a/packages/react/src/ui/time/time-value.tsx
+++ b/packages/react/src/ui/time/time-value.tsx
@@ -18,11 +18,11 @@ export interface ValueProps extends Omit<UIComponentProps<'time', TimeCore.State
  * Displays a formatted time value (current, duration, or remaining).
  *
  * @example
- * ```tsx
- * <Time.Value />
- * <Time.Value type="duration" />
- * <Time.Value type="remaining" negativeSign="−" />
- * ```
+ *   ```tsx
+ *   <Time.Value />
+ *   <Time.Value type="duration" />
+ *   <Time.Value type="remaining" negativeSign="−" />
+ *   ```;
  */
 export const Value = forwardRef(function Value(
   componentProps: ValueProps,

--- a/packages/react/src/ui/title/title.tsx
+++ b/packages/react/src/ui/title/title.tsx
@@ -14,17 +14,16 @@ export interface TitleProps extends Omit<UIComponentProps<'span', TitleCore.Stat
 /**
  * Displays the resolved content title.
  *
- * The component owns its text content. Set the title through the player's
- * `title` prop rather than by passing children.
+ * The component owns its text content. Set the title through the player's `title` prop rather than by passing children.
  *
  * Renders nothing when no title resolves.
  *
  * @example
- * ```tsx
- * <Title />
+ *   ```tsx
+ *   <Title />
  *
- * <Title className="title" />
- * ```
+ *   <Title className="title" />
+ *   ```;
  */
 export const Title = forwardRef(function Title(
   componentProps: TitleProps,

--- a/packages/react/src/ui/tooltip/tooltip-popup.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-popup.tsx
@@ -11,7 +11,10 @@ import { TooltipShortcut } from './tooltip-shortcut';
 
 export interface TooltipPopupProps extends UIComponentProps<'div', TooltipState> {}
 
-/** Container for the tooltip content. Positioned relative to the trigger using CSS anchor positioning with a JavaScript fallback. */
+/**
+ * Container for the tooltip content. Positioned relative to the trigger using CSS anchor positioning with a JavaScript
+ * fallback.
+ */
 export const TooltipPopup = forwardRef<HTMLDivElement, TooltipPopupProps>(function TooltipPopup(
   { render, className, style, children, ...elementProps },
   forwardedRef

--- a/packages/react/src/utils/merge-props.ts
+++ b/packages/react/src/utils/merge-props.ts
@@ -2,9 +2,7 @@ import type { ComponentPropsWithRef, CSSProperties, ElementType, SyntheticEvent 
 
 type Props<T extends ElementType = ElementType> = ComponentPropsWithRef<T>;
 
-/**
- * Check if a key is an event handler key (on* with capital letter).
- */
+/** Check if a key is an event handler key (on* with capital letter). */
 function isEventHandlerKey(key: string): boolean {
   return (
     key.charCodeAt(0) === 111 /* o */ &&
@@ -14,16 +12,12 @@ function isEventHandlerKey(key: string): boolean {
   );
 }
 
-/**
- * Check if a key/value pair is an event handler (includes undefined values).
- */
+/** Check if a key/value pair is an event handler (includes undefined values). */
 function isEventHandler(key: string, value: unknown): boolean {
   return isEventHandlerKey(key) && (typeof value === 'function' || typeof value === 'undefined');
 }
 
-/**
- * Merge two event handlers - external runs first, ours runs second.
- */
+/** Merge two event handlers - external runs first, ours runs second. */
 function mergeEventHandlers(
   ours: ((event: SyntheticEvent) => void) | undefined,
   theirs: ((event: SyntheticEvent) => void) | undefined
@@ -38,18 +32,14 @@ function mergeEventHandlers(
   };
 }
 
-/**
- * Merge two className values - concatenate strings.
- */
+/** Merge two className values - concatenate strings. */
 function mergeClassNames(ours: string | undefined, theirs: string | undefined): string | undefined {
   if (theirs && ours) return `${theirs} ${ours}`;
 
   return theirs || ours;
 }
 
-/**
- * Merge two style objects - theirs overwrites conflicts.
- */
+/** Merge two style objects - theirs overwrites conflicts. */
 function mergeStyles(ours: CSSProperties | undefined, theirs: CSSProperties | undefined): CSSProperties | undefined {
   if (!theirs) return ours;
 
@@ -58,9 +48,7 @@ function mergeStyles(ours: CSSProperties | undefined, theirs: CSSProperties | un
   return { ...ours, ...theirs };
 }
 
-/**
- * Merge a single props object into accumulated result.
- */
+/** Merge a single props object into accumulated result. */
 function mergeOne<T extends ElementType>(
   merged: Record<string, unknown>,
   props: Props<T> | undefined
@@ -91,19 +79,20 @@ function mergeOne<T extends ElementType>(
  * Merge multiple props objects.
  *
  * - Event handlers (on*): chained - external first, ours second
- * - className: concatenated
- * - style: merged objects (external wins conflicts)
- * - other: last one wins
+ * - ClassName: concatenated
+ * - Style: merged objects (external wins conflicts)
+ * - Other: last one wins
+ *
+ * @example
+ *   ```ts
+ *   const merged = mergeProps(
+ *     { onClick: ourHandler, className: 'base' },
+ *     { onClick: theirHandler, className: 'custom' }
+ *   );
+ *   // { onClick: chainedHandler, className: 'custom base' }
+ *   ```;
  *
  * @public
- * @example
- * ```ts
- * const merged = mergeProps(
- *   { onClick: ourHandler, className: 'base' },
- *   { onClick: theirHandler, className: 'custom' }
- * );
- * // { onClick: chainedHandler, className: 'custom base' }
- * ```
  */
 export function mergeProps<T extends ElementType>(...propSets: (Props<T> | undefined)[]): Props<T> {
   let merged: Record<string, unknown> = {};

--- a/packages/react/src/utils/types.ts
+++ b/packages/react/src/utils/types.ts
@@ -14,10 +14,8 @@ export type RenderProp<State> = ReactElement | RenderFunction<HTMLProps, State>;
 /**
  * Standard props for UI components.
  *
- * Provides consistent API across all UI components:
- * - `className` as string or function of state
- * - `style` as object or function of state
- * - `render` prop for element customization
+ * Provides consistent API across all UI components: - `className` as string or function of state - `style` as object or
+ * function of state - `render` prop for element customization
  */
 export type UIComponentProps<TagName extends keyof React.JSX.IntrinsicElements, State> = Omit<
   React.JSX.IntrinsicElements[TagName],

--- a/packages/react/src/utils/use-composed-refs.ts
+++ b/packages/react/src/utils/use-composed-refs.ts
@@ -23,10 +23,10 @@ function setRef<T>(ref: OptionalRef<T>, value: T): (() => void) | void | undefin
  * Compose multiple refs into a single callback ref.
  *
  * @example
- * ```tsx
- * const composedRef = composeRefs(ref1, ref2, ref3);
- * return <div ref={composedRef} />;
- * ```
+ *   ```tsx
+ *   const composedRef = composeRefs(ref1, ref2, ref3);
+ *   return <div ref={composedRef} />;
+ *   ```;
  */
 export function composeRefs<T>(...refs: (OptionalRef<T> | OptionalRef<T>[])[]): RefCallback<T> {
   const flatRefs = refs.flat();
@@ -58,10 +58,10 @@ export function composeRefs<T>(...refs: (OptionalRef<T> | OptionalRef<T>[])[]): 
  * Memoized for stable reference.
  *
  * @example
- * ```tsx
- * const composedRef = useComposedRefs(forwardedRef, localRef);
- * return <div ref={composedRef} />;
- * ```
+ *   ```tsx
+ *   const composedRef = useComposedRefs(forwardedRef, localRef);
+ *   return <div ref={composedRef} />;
+ *   ```;
  */
 export function useComposedRefs<T>(...refs: OptionalRef<T>[]): RefCallback<T> {
   return useCallback(composeRefs(...refs), [...refs]);

--- a/packages/react/src/utils/use-destroy.ts
+++ b/packages/react/src/utils/use-destroy.ts
@@ -7,18 +7,16 @@ interface Destroyable {
 }
 
 /**
- * Destroy an instance on unmount, deferring destruction to survive React
- * StrictMode's simulated unmount/re-mount cycle.
+ * Destroy an instance on unmount, deferring destruction to survive React StrictMode's simulated unmount/re-mount cycle.
  *
- * StrictMode runs effects, then immediately runs cleanup, then re-runs
- * effects — all synchronously. By deferring `destroy()` to a macrotask,
- * the re-mount effect can cancel it before it fires.
+ * StrictMode runs effects, then immediately runs cleanup, then re-runs effects — all synchronously. By deferring
+ * `destroy()` to a macrotask, the re-mount effect can cancel it before it fires.
  *
  * @param instance - Object with a `destroy()` method.
- * @param setup - Optional setup called on first mount. Skipped on StrictMode
- *   re-mount since the previous setup was never torn down.
- * @param teardown - Optional teardown called right before `destroy()` on real
- *   unmount. Skipped on StrictMode simulated unmount.
+ * @param setup - Optional setup called on first mount. Skipped on StrictMode re-mount since the previous setup was
+ *   never torn down.
+ * @param teardown - Optional teardown called right before `destroy()` on real unmount. Skipped on StrictMode simulated
+ *   unmount.
  */
 export function useDestroy(instance: Destroyable, setup?: () => void, teardown?: () => void): void {
   const pendingRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/packages/react/src/utils/use-latest-ref.ts
+++ b/packages/react/src/utils/use-latest-ref.ts
@@ -3,8 +3,8 @@ import { useRef } from 'react';
 /**
  * Keep a ref that always points to the latest value.
  *
- * Useful for capturing callbacks or derived values inside closures
- * that are created once (e.g. factory callbacks) without stale reads.
+ * Useful for capturing callbacks or derived values inside closures that are created once (e.g. factory callbacks)
+ * without stale reads.
  */
 export function useLatestRef<Value>(value: Value): Readonly<{ current: Value }> {
   const ref = useRef(value);

--- a/packages/react/src/utils/use-media-component.ts
+++ b/packages/react/src/utils/use-media-component.ts
@@ -6,13 +6,12 @@ import { useMedia } from '../player/context';
 import { useDestroy } from './use-destroy';
 
 /**
- * Create a media component (e.g. `GoogleCast`, `MuxData`) and register it
- * with the media provided by the surrounding player context.
+ * Create a media component (e.g. `GoogleCast`, `MuxData`) and register it with the media provided by the surrounding
+ * player context.
  *
- * Instantiates the component class once, registers it when a media host is
- * available, follows the media when it changes, and destroys the component
- * on unmount. Media that is not a media host (e.g. a plain `<video>`
- * element) cannot carry media components and is ignored.
+ * Instantiates the component class once, registers it when a media host is available, follows the media when it
+ * changes, and destroys the component on unmount. Media that is not a media host (e.g. a plain `<video>` element)
+ * cannot carry media components and is ignored.
  */
 export function useMediaComponent<Component extends MediaComponent & { destroy(): void }>(
   ComponentClass: new () => Component

--- a/packages/react/src/utils/use-media-instance.ts
+++ b/packages/react/src/utils/use-media-instance.ts
@@ -7,14 +7,12 @@ import { useDestroy } from './use-destroy';
 /**
  * Create and manage a media instance lifecycle within a player context.
  *
- * Instantiates the media class once, attaches it to the player on mount,
- * and safely detaches on unmount using a functional updater to avoid race
- * conditions when swapping media components (e.g. DashVideo → HlsJsVideo).
+ * Instantiates the media class once, attaches it to the player on mount, and safely detaches on unmount using a
+ * functional updater to avoid race conditions when swapping media components (e.g. DashVideo → HlsJsVideo).
  *
- * An optional `setup` callback runs once on mount — e.g. to add media
- * components via `addMediaComponent`. Components registered there are destroyed
- * together with the media instance on unmount (`media.destroy()` destroys
- * all of its registered components).
+ * An optional `setup` callback runs once on mount — e.g. to add media components via `addMediaComponent`. Components
+ * registered there are destroyed together with the media instance on unmount (`media.destroy()` destroys all of its
+ * registered components).
  */
 export function useMediaInstance<Instance extends Media & { destroy(): void }>(
   MediaClass: new () => Instance,

--- a/packages/react/src/utils/use-render.tsx
+++ b/packages/react/src/utils/use-render.tsx
@@ -46,22 +46,19 @@ function getElementRef(element: ReactElement): Ref<unknown> | undefined {
 /**
  * Render a UI component element.
  *
- * Handles:
- * - Default tag rendering
- * - Render prop (element or function)
- * - Props merging (event handlers chained, className concatenated, style merged)
- * - Ref composition
- * - className/style as functions of state
+ * Handles: - Default tag rendering - Render prop (element or function) - Props merging (event handlers chained,
+ * className concatenated, style merged) - Ref composition - className/style as functions of state
+ *
+ * @example
+ *   ```tsx
+ *   return renderElement('button', componentProps, {
+ *     state,
+ *     ref: [forwardedRef, buttonRef],
+ *     props: [{ type: 'button' }, elementProps, getButtonProps],
+ *   });
+ *   ```;
  *
  * @public
- * @example
- * ```tsx
- * return renderElement('button', componentProps, {
- *   state,
- *   ref: [forwardedRef, buttonRef],
- *   props: [{ type: 'button' }, elementProps, getButtonProps],
- * });
- * ```
  */
 export function renderElement<
   State extends object,

--- a/packages/react/src/utils/use-safe-id.ts
+++ b/packages/react/src/utils/use-safe-id.ts
@@ -5,10 +5,9 @@ const UNSAFE_CHARS = /[^a-zA-Z0-9_-]/g;
 /**
  * Generate a CSS-safe identifier from React's `useId()`.
  *
- * `useId()` returns values like `:r0:` which contain colons — invalid
- * in CSS `<dashed-ident>` tokens (used by `anchor-name` / `position-anchor`).
- * This hook strips non-alphanumeric/underscore/hyphen characters and
- * optionally prepends a prefix.
+ * `useId()` returns values like `:r0:` which contain colons — invalid in CSS `<dashed-ident>` tokens (used by
+ * `anchor-name` / `position-anchor`). This hook strips non-alphanumeric/underscore/hyphen characters and optionally
+ * prepends a prefix.
  */
 export function useSafeId(prefix?: string): string {
   const raw = useId().replace(UNSAFE_CHARS, '');

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -24,8 +24,8 @@ export const button = {
   seek: hideAtSmall,
   captions: hideAtSmall,
   /**
-   * Live variant: wide pill button with a status dot rendered via `::before`
-   * (gray → red at the live edge) and "LIVE" as the button's own text.
+   * Live variant: wide pill button with a status dot rendered via `::before` (gray → red at the live edge) and "LIVE"
+   * as the button's own text.
    */
   live: cn(
     'inline-flex items-center gap-1.5',

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -29,8 +29,8 @@ export const button = {
   pip: hideAtSmall,
   fullscreen: hideAtSmall,
   /**
-   * Live variant: wide pill button with a status dot rendered via `::before`
-   * (gray → red at the live edge) and "LIVE" as the button's own text.
+   * Live variant: wide pill button with a status dot rendered via `::before` (gray → red at the live edge) and "LIVE"
+   * as the button's own text.
    */
   live: cn(
     'inline-flex items-center gap-1.5',

--- a/packages/skins/vjsc/styles/tokens.ts
+++ b/packages/skins/vjsc/styles/tokens.ts
@@ -6,10 +6,7 @@ export interface SkinToken {
   description: string;
 }
 
-/**
- * Stable classification for every `--media-*` custom property used by a
- * Skin.
- */
+/** Stable classification for every `--media-*` custom property used by a Skin. */
 export const tokens = {
   '--media-accent-color': {
     kind: 'public',

--- a/packages/spf/scripts/measure-size.js
+++ b/packages/spf/scripts/measure-size.js
@@ -3,9 +3,7 @@
 /**
  * Measure SPF bundle size
  *
- * Usage:
- *   pnpm size                    # Measure the HLS engine entry (@videojs/spf/hls)
- *   pnpm size:all                # Measure all exports (all.ts)
+ * Usage: pnpm size # Measure the HLS engine entry (@videojs/spf/hls) pnpm size:all # Measure all exports (all.ts)
  */
 
 import { execSync } from 'node:child_process';

--- a/packages/spf/src/all.ts
+++ b/packages/spf/src/all.ts
@@ -1,8 +1,8 @@
 /**
  * All SPF exports (public + internal) for bundle size measurement.
  *
- * This file exports everything implemented in SPF, including internal APIs.
- * Use this for accurate bundle size measurements during development.
+ * This file exports everything implemented in SPF, including internal APIs. Use this for accurate bundle size
+ * measurements during development.
  *
  * For the public API, import from './index' instead.
  */

--- a/packages/spf/src/core/actors/actor.ts
+++ b/packages/spf/src/core/actors/actor.ts
@@ -1,17 +1,16 @@
 /**
  * Generic actor types.
  *
- * An actor owns its snapshot (finite state + non-finite context) and
- * notifies observers when it changes. Mirrors the XState snapshot model:
- * `snapshot.value` is the bounded operational mode, `snapshot.context`
- * holds arbitrary non-finite data.
+ * An actor owns its snapshot (finite state + non-finite context) and notifies observers when it changes. Mirrors the
+ * XState snapshot model: `snapshot.value` is the bounded operational mode, `snapshot.context` holds arbitrary
+ * non-finite data.
  */
 
 import type { Machine, MachineSnapshot } from '../machine';
 
 /**
- * Complete actor snapshot: finite state + non-finite context.
- * Extends `MachineSnapshot` with context — the non-finite data managed by the actor.
+ * Complete actor snapshot: finite state + non-finite context. Extends `MachineSnapshot` with context — the non-finite
+ * data managed by the actor.
  */
 export interface ActorSnapshot<State extends string, Context extends object> extends MachineSnapshot<State> {
   context: Context;
@@ -25,8 +24,8 @@ export interface SignalActor<State extends string, Context extends object> exten
 /**
  * A message-driven actor with no reactive snapshot.
  *
- * Use for actors that coordinate async work but have no state that external
- * consumers need to observe. Analogous to XState's `fromCallback`.
+ * Use for actors that coordinate async work but have no state that external consumers need to observe. Analogous to
+ * XState's `fromCallback`.
  */
 export interface CallbackActor<Message extends { type: string }> {
   send(message: Message): void;

--- a/packages/spf/src/core/actors/create-machine-actor.ts
+++ b/packages/spf/src/core/actors/create-machine-actor.ts
@@ -7,9 +7,7 @@ import type { ActorSnapshot, SignalActor } from './actor';
 // Runner interfaces
 // =============================================================================
 
-/**
- * Minimal interface for any runner that can be used with createMachineActor.
- */
+/** Minimal interface for any runner that can be used with createMachineActor. */
 export interface RunnerLike {
   schedule<Value = void, Err = unknown>(task: TaskLike<Value, Err>): Promise<Value>;
   abortAll(): void;
@@ -22,8 +20,7 @@ export interface RunnerLike {
 // =============================================================================
 
 /**
- * Context passed to message handlers.
- * `runner` is present and typed as the exact runner instance only when the
+ * Context passed to message handlers. `runner` is present and typed as the exact runner instance only when the
  * definition includes a runner factory.
  */
 export type HandlerContext<
@@ -35,18 +32,15 @@ export type HandlerContext<
   /** Context snapshot captured at dispatch time. Stale after any `setContext` call. */
   context: Context;
   /**
-   * Live untracked read of the current context. Use in async task closures that
-   * execute after the handler returns — e.g. `getCtx: getContext` passed to tasks
-   * scheduled on the runner, so each task reads the context committed by the
+   * Live untracked read of the current context. Use in async task closures that execute after the handler returns —
+   * e.g. `getCtx: getContext` passed to tasks scheduled on the runner, so each task reads the context committed by the
    * previous task rather than the stale snapshot from dispatch time.
    */
   getContext: () => Context;
   setContext: (next: Context) => void;
 } & (RunnerFactory extends () => infer R ? { runner: R } : object);
 
-/**
- * Definition for a single user-defined state.
- */
+/** Definition for a single user-defined state. */
 export type ActorStateDefinition<
   UserState extends string,
   Context extends object,
@@ -54,10 +48,9 @@ export type ActorStateDefinition<
   RunnerFactory extends (() => RunnerLike) | undefined,
 > = {
   /**
-   * When the actor's runner settles while in this state, automatically
-   * transition to this state. The framework owns the generation-token logic —
-   * re-registering after each `runner.schedule()` call so that
-   * `abortAll()` + reschedule correctly supersedes stale callbacks.
+   * When the actor's runner settles while in this state, automatically transition to this state. The framework owns the
+   * generation-token logic — re-registering after each `runner.schedule()` call so that `abortAll()` + reschedule
+   * correctly supersedes stale callbacks.
    */
   onSettled?: UserState;
   /** Message handlers active in this state. Messages with no handler are silently dropped. */
@@ -72,8 +65,8 @@ export type ActorStateDefinition<
 /**
  * Full actor definition passed to `createMachineActor`.
  *
- * `UserState` is the set of domain-meaningful states. `'destroyed'` is always
- * added by the framework as the implicit terminal state — do not include it here.
+ * `UserState` is the set of domain-meaningful states. `'destroyed'` is always added by the framework as the implicit
+ * terminal state — do not include it here.
  */
 export type ActorDefinition<
   UserState extends string,
@@ -82,11 +75,11 @@ export type ActorDefinition<
   RunnerFactory extends (() => RunnerLike) | undefined = undefined,
 > = {
   /**
-   * Runner factory — called once at `createMachineActor()` time.
-   * The runner lives for the full actor lifetime and is destroyed with it.
+   * Runner factory — called once at `createMachineActor()` time. The runner lives for the full actor lifetime and is
+   * destroyed with it.
    *
    * @example
-   * runner: () => new SerialRunner()
+   *   runner: () => new SerialRunner();
    */
   runner?: RunnerFactory;
   /** Initial state. */
@@ -94,8 +87,8 @@ export type ActorDefinition<
   /** Initial context. */
   context: Context;
   /**
-   * Per-state definitions. States with no definition silently drop all messages.
-   * All user-defined states must appear as keys in the `UserState` union.
+   * Per-state definitions. States with no definition silently drop all messages. All user-defined states must appear as
+   * keys in the `UserState` union.
    */
   states: Partial<Record<UserState, ActorStateDefinition<UserState, Context, Message, RunnerFactory>>>;
 };
@@ -120,41 +113,39 @@ export interface MessageActor<
 /**
  * Creates a message-driven actor from a declarative definition.
  *
- * The actor owns a reactive snapshot signal (state + context), an optional
- * runner, and dispatches incoming messages to per-state handlers. `'destroyed'`
- * is always the implicit terminal state — `destroy()` transitions there
+ * The actor owns a reactive snapshot signal (state + context), an optional runner, and dispatches incoming messages to
+ * per-state handlers. `'destroyed'` is always the implicit terminal state — `destroy()` transitions there
  * unconditionally and all subsequent `send()` calls are no-ops.
  *
- * When a state declares `onSettled`, the framework calls `runner.whenSettled()`
- * after the handler returns. The runner owns the generation-token logic — if
- * new tasks are scheduled before the current batch settles, the callback is
+ * When a state declares `onSettled`, the framework calls `runner.whenSettled()` after the handler returns. The runner
+ * owns the generation-token logic — if new tasks are scheduled before the current batch settles, the callback is
  * automatically superseded.
  *
  * @example
- * const actor = createMachineActor({
+ *   const actor = createMachineActor({
  *   runner: () => new SerialRunner(),
  *   initial: 'idle',
  *   context: {},
  *   states: {
- *     idle: {
- *       on: {
- *         load: (msg, { transition, runner }) => {
- *           segments.forEach(s => runner.schedule(new Task(...)));
- *           transition('loading');
- *         }
- *       }
- *     },
- *     loading: {
- *       onSettled: 'idle',
- *       on: {
- *         load: (msg, { runner }) => {
- *           runner.abortAll();
- *           segments.forEach(s => runner.schedule(new Task(...)));
- *         }
- *       }
- *     }
+ *   idle: {
+ *   on: {
+ *   load: (msg, { transition, runner }) => {
+ *   segments.forEach(s => runner.schedule(new Task(...)));
+ *   transition('loading');
  *   }
- * });
+ *   }
+ *   },
+ *   loading: {
+ *   onSettled: 'idle',
+ *   on: {
+ *   load: (msg, { runner }) => {
+ *   runner.abortAll();
+ *   segments.forEach(s => runner.schedule(new Task(...)));
+ *   }
+ *   }
+ *   }
+ *   }
+ *   });
  */
 export function createMachineActor<
   UserState extends string,

--- a/packages/spf/src/core/actors/create-transition-actor.ts
+++ b/packages/spf/src/core/actors/create-transition-actor.ts
@@ -10,13 +10,11 @@ import type { ActorSnapshot } from './actor';
 /**
  * A reducer-shaped actor: `(context, message) => context`.
  *
- * No finite states — the snapshot carries `value: 'active' | 'destroyed'`
- * as a universal lifecycle marker rather than domain state. The interesting
- * state is entirely in the context, which is reactive via `snapshot`.
+ * No finite states — the snapshot carries `value: 'active' | 'destroyed'` as a universal lifecycle marker rather than
+ * domain state. The interesting state is entirely in the context, which is reactive via `snapshot`.
  *
- * Use this when the actor has context that needs to be reactive but no
- * meaningful state machine (e.g., a message-driven model with DOM side
- * effects). For actors that need per-state behavior, use `createMachineActor`.
+ * Use this when the actor has context that needs to be reactive but no meaningful state machine (e.g., a message-driven
+ * model with DOM side effects). For actors that need per-state behavior, use `createMachineActor`.
  */
 export interface TransitionActor<Context extends object, Message extends { type: string }> extends Machine<
   ActorSnapshot<'active' | 'destroyed', Context>
@@ -31,18 +29,16 @@ export interface TransitionActor<Context extends object, Message extends { type:
 /**
  * Creates a reducer-shaped actor from an initial context and a reducer function.
  *
- * The reducer receives the current context and a message and returns the next
- * context. Returning the same reference (by identity) skips the signal update —
- * so early-returning `context` unchanged is both the no-op and the optimization.
+ * The reducer receives the current context and a message and returns the next context. Returning the same reference (by
+ * identity) skips the signal update — so early-returning `context` unchanged is both the no-op and the optimization.
  *
- * Side effects (e.g. DOM mutations) may be performed inside the reducer.
- * They run synchronously before the signal is updated.
+ * Side effects (e.g. DOM mutations) may be performed inside the reducer. They run synchronously before the signal is
+ * updated.
  *
  * @example
- * const actor = createTransitionActor(
- *   { count: 0 },
- *   (context, message: { type: 'increment' }) => ({ count: context.count + 1 })
- * );
+ *   const actor = createTransitionActor({ count: 0 }, (context, message: { type: 'increment' }) => ({
+ *     count: context.count + 1,
+ *   }));
  */
 export function createTransitionActor<Context extends object, Message extends { type: string }>(
   initialContext: Context,

--- a/packages/spf/src/core/composition/create-composition.ts
+++ b/packages/spf/src/core/composition/create-composition.ts
@@ -1,59 +1,51 @@
 import { type ReadonlySignal, type Signal, signal } from '../signals/primitives';
 
 /**
- * Cleanup returned by a behavior. Behaviors may return:
- * - `void` / `undefined` — no cleanup needed
- * - A function — called on destroy (may return a Promise)
- * - An object with `destroy()` — called on destroy (may return a Promise)
+ * Cleanup returned by a behavior. Behaviors may return: - `void` / `undefined` — no cleanup needed - A function —
+ * called on destroy (may return a Promise) - An object with `destroy()` — called on destroy (may return a Promise)
  */
 export type BehaviorCleanup = void | (() => void | Promise<void>) | { destroy(): void | Promise<void> };
 
 /**
  * A signal map keyed by the fields of `S`. Each field is a writable signal.
  *
- * Optional fields on `S` map to required signal slots whose value type
- * includes `undefined`, ensuring every key has a signal even when the
- * underlying value is absent.
+ * Optional fields on `S` map to required signal slots whose value type includes `undefined`, ensuring every key has a
+ * signal even when the underlying value is absent.
  *
  * Used in two roles:
- * - Engine-side **construction**: `Composition<S, C>` exposes its public
- *   surface as `StateSignals<S>` (everything writable) so external code
- *   can read or write any slot.
- * - Behavior **input convenience**: a behavior that writes to every slot
- *   can type its setup state param as `StateSignals<{ ... }>` rather than
- *   spelling out per-slot `Signal<T>` types.
  *
- * Behaviors that mix read-only and writable slots type the setup param
- * directly as a slot map (`{ x: Signal<T>; y: ReadonlySignal<U> }`)
- * instead of going through `StateSignals<>`.
+ * - Engine-side **construction**: `Composition<S, C>` exposes its public surface as `StateSignals<S>` (everything
+ *   writable) so external code can read or write any slot.
+ * - Behavior **input convenience**: a behavior that writes to every slot can type its setup state param as
+ *   `StateSignals<{ ... }>` rather than spelling out per-slot `Signal<T>` types.
+ *
+ * Behaviors that mix read-only and writable slots type the setup param directly as a slot map (`{ x: Signal<T>; y:
+ * ReadonlySignal<U> }`) instead of going through `StateSignals<>`.
  */
 export type StateSignals<S extends object> = { [K in keyof S]-?: Signal<S[K]> };
 
 /**
- * A signal map keyed by the fields of `C`. Each field is a writable signal
- * for a platform object or actor reference. Same dual role as
- * `StateSignals<S>` — see its docblock.
+ * A signal map keyed by the fields of `C`. Each field is a writable signal for a platform object or actor reference.
+ * Same dual role as `StateSignals<S>` — see its docblock.
  */
 export type ContextSignals<C extends object> = { [K in keyof C]-?: Signal<C[K]> };
 
 /**
- * Slot-map shape — a record where each value is at least a `ReadonlySignal`.
- * `Signal<T>` is structurally a subtype of `ReadonlySignal<T>` (it adds
- * `.set()`), so a writable slot satisfies this bound too.
+ * Slot-map shape — a record where each value is at least a `ReadonlySignal`. `Signal<T>` is structurally a subtype of
+ * `ReadonlySignal<T>` (it adds `.set()`), so a writable slot satisfies this bound too.
  *
- * This is the bound used for behavior `state` / `context` slot maps. It
- * lets a single behavior declare a *heterogeneous* slot map where some
- * slots are `Signal<T>` (writable) and others are `ReadonlySignal<T>`
- * (read-only) — making read/write intent explicit at the call site and
- * giving body-level enforcement (TS rejects `.set()` on a read-only slot).
+ * This is the bound used for behavior `state` / `context` slot maps. It lets a single behavior declare a
+ * _heterogeneous_ slot map where some slots are `Signal<T>` (writable) and others are `ReadonlySignal<T>` (read-only) —
+ * making read/write intent explicit at the call site and giving body-level enforcement (TS rejects `.set()` on a
+ * read-only slot).
  */
 export type AnySlotMap = Record<PropertyKey, ReadonlySignal<unknown>>;
 
 /**
  * The deps object passed to each behavior by the composition.
  *
- * - `state` — slot map for state fields (reactive data). Per-slot read/
- *   write intent expressed via `Signal<T>` vs `ReadonlySignal<T>`.
+ * - `state` — slot map for state fields (reactive data). Per-slot read/ write intent expressed via `Signal<T>` vs
+ *   `ReadonlySignal<T>`.
  * - `context` — slot map for platform objects and actor references.
  * - `config` — static configuration, passed once at composition creation.
  */
@@ -64,21 +56,16 @@ export interface BehaviorDeps<StateMap extends AnySlotMap, ContextMap extends An
 }
 
 /**
- * A behavior announces the state and context keys it needs alongside a
- * `setup` function that receives deps (state, context, config) and
- * returns an optional cleanup handle.
+ * A behavior announces the state and context keys it needs alongside a `setup` function that receives deps (state,
+ * context, config) and returns an optional cleanup handle.
  *
- * The `stateKeys` / `contextKeys` declarations are the runtime expression
- * of the behavior's contract — the caller (e.g. `createComposition`) uses
- * them to know which signals to provide. The setup parameter type
- * declares the *slot map* (per-slot `Signal<T>` vs `ReadonlySignal<T>`);
- * together they form a complete contract.
+ * The `stateKeys` / `contextKeys` declarations are the runtime expression of the behavior's contract — the caller (e.g.
+ * `createComposition`) uses them to know which signals to provide. The setup parameter type declares the _slot map_
+ * (per-slot `Signal<T>` vs `ReadonlySignal<T>`); together they form a complete contract.
  *
- * Manual `Behavior<>` literals (e.g. engine wrappers that forward keys
- * from a wrapped behavior, or pass-through behaviors like `shareSignals`)
- * opt out of exhaustiveness — the type alias is permissive (subset).
- * Source behaviors should use `defineBehavior` to get exhaustiveness
- * enforcement at the call site.
+ * Manual `Behavior<>` literals (e.g. engine wrappers that forward keys from a wrapped behavior, or pass-through
+ * behaviors like `shareSignals`) opt out of exhaustiveness — the type alias is permissive (subset). Source behaviors
+ * should use `defineBehavior` to get exhaustiveness enforcement at the call site.
  */
 export interface Behavior<
   StateMap extends AnySlotMap = Empty,
@@ -109,10 +96,9 @@ type DepsOf<B> = B extends { setup: (deps: infer D, ...args: any[]) => any } ? D
 /**
  * Empty-object fallback used when a behavior omits state, context, or config.
  *
- * Using `{}` rather than `object` is deliberate — `object & {x: T}` collapses
- * to `{x: never}` under TS's union-to-intersection conversion in some inference
- * contexts (likely a TS quirk around the `object` upper bound), whereas
- * `{} & {x: T}` simplifies cleanly to `{x: T}`.
+ * Using `{}` rather than `object` is deliberate — `object & {x: T}` collapses to `{x: never}` under TS's
+ * union-to-intersection conversion in some inference contexts (likely a TS quirk around the `object` upper bound),
+ * whereas `{} & {x: T}` simplifies cleanly to `{x: T}`.
  */
 // see comment above
 // oxlint-disable-next-line typescript/no-empty-object-type
@@ -121,9 +107,8 @@ type Empty = {};
 /**
  * Unwrap a signal map back to its state/context shape.
  *
- * Inferring through `{ get(): infer V }` rather than `Signal<infer V>`
- * sidesteps `Signal`'s nominal/invariance behaviour — the conditional
- * matches structurally on the read side, and `V` is inferred covariantly.
+ * Inferring through `{ get(): infer V }` rather than `Signal<infer V>` sidesteps `Signal`'s nominal/invariance
+ * behaviour — the conditional matches structurally on the read side, and `V` is inferred covariantly.
  */
 type UnwrapSignals<M> = M extends object ? { [K in keyof M]: M[K] extends { get(): infer V } ? V : never } : Empty;
 
@@ -139,10 +124,9 @@ export type InferBehaviorConfig<F> = DepsOf<F> extends { config: infer C extends
 /**
  * Recursively intersect a per-behavior projection across the tuple.
  *
- * Iterating over the tuple directly avoids `UnionToIntersection`'s
- * function-contravariance trick, which produces unstable intersections
- * (collapsing concrete fields to `never` or unrelated types) when one of the
- * union members is the empty `{}` fallback.
+ * Iterating over the tuple directly avoids `UnionToIntersection`'s function-contravariance trick, which produces
+ * unstable intersections (collapsing concrete fields to `never` or unrelated types) when one of the union members is
+ * the empty `{}` fallback.
  */
 type IntersectBehaviors<Behaviors extends readonly AnyBehavior[], Project extends object> = Behaviors extends readonly [
   infer First extends AnyBehavior,
@@ -152,9 +136,8 @@ type IntersectBehaviors<Behaviors extends readonly AnyBehavior[], Project extend
   : Empty;
 
 /**
- * Apply a projection (one of the marker types below) to a single behavior.
- * Encoded as a discriminated dispatch so the recursion above can stay generic
- * and we don't have to write three near-identical recursive types.
+ * Apply a projection (one of the marker types below) to a single behavior. Encoded as a discriminated dispatch so the
+ * recursion above can stay generic and we don't have to write three near-identical recursive types.
  */
 type Apply<Project extends object, F> = Project extends { kind: 'state' }
   ? InferBehaviorState<F>
@@ -181,8 +164,8 @@ export type ResolveBehaviorConfig<Behaviors extends readonly AnyBehavior[]> =
   IntersectBehaviors<Behaviors, ConfigProjection> extends infer R extends object ? R : Empty;
 
 /**
- * True if any property in `T` collapsed to `undefined` or `never` — indicating
- * a type conflict from intersecting incompatible behavior requirements.
+ * True if any property in `T` collapsed to `undefined` or `never` — indicating a type conflict from intersecting
+ * incompatible behavior requirements.
  *
  * - Required conflicts: `{ v: number } & { v: string }` → `{ v: never }` — caught via `[never] extends [undefined]`
  * - Optional conflicts: `{ v?: number } & { v?: string }` → `{ v?: undefined }` — caught directly
@@ -198,16 +181,14 @@ type HasConflict<T extends object> = true extends {
 // =============================================================================
 
 /**
- * Validate that a behavior composition has no type conflicts.
- * Returns the behaviors tuple if valid, or an error message type if conflicts are detected.
+ * Validate that a behavior composition has no type conflicts. Returns the behaviors tuple if valid, or an error message
+ * type if conflicts are detected.
  *
- * State, context, and config are all checked the same way — by intersecting
- * each behavior's requirement and looking for collapsed fields. The
- * intersection-based check applies the same rule to context as to state, so
- * two behaviors that disagree on a context field's type (e.g. `Surface` vs
- * `VideoSurface`) surface a conflict at compose time. The prior subtype-based
- * approach for owners is gone — the unified rule is simpler and catches the
- * cases where two behaviors silently agreed on a wider supertype.
+ * State, context, and config are all checked the same way — by intersecting each behavior's requirement and looking for
+ * collapsed fields. The intersection-based check applies the same rule to context as to state, so two behaviors that
+ * disagree on a context field's type (e.g. `Surface` vs `VideoSurface`) surface a conflict at compose time. The prior
+ * subtype-based approach for owners is gone — the unified rule is simpler and catches the cases where two behaviors
+ * silently agreed on a wider supertype.
  */
 type ValidateComposition<Behaviors extends readonly AnyBehavior[]> =
   HasConflict<ResolveBehaviorState<Behaviors>> extends true
@@ -222,9 +203,7 @@ type ValidateComposition<Behaviors extends readonly AnyBehavior[]> =
 // Composition
 // =============================================================================
 
-/**
- * A composition of behaviors with shared state and context signal maps.
- */
+/** A composition of behaviors with shared state and context signal maps. */
 export interface Composition<S extends object, C extends object> {
   state: StateSignals<S>;
   context: ContextSignals<C>;
@@ -234,10 +213,8 @@ export interface Composition<S extends object, C extends object> {
 /**
  * Options for `createComposition`.
  *
- * Composition derives the state and context signal maps from each
- * behavior's declared `stateKeys` / `contextKeys`; `initialState` and
- * `initialContext` seed those signals at creation time. Any unseeded
- * signal starts as `undefined`.
+ * Composition derives the state and context signal maps from each behavior's declared `stateKeys` / `contextKeys`;
+ * `initialState` and `initialContext` seed those signals at creation time. Any unseeded signal starts as `undefined`.
  */
 export interface CompositionOptions<S extends object, C extends object, Cfg extends object> {
   /** Static configuration passed to every behavior. */
@@ -251,47 +228,44 @@ export interface CompositionOptions<S extends object, C extends object, Cfg exte
 /**
  * Create a composition from a set of behaviors.
  *
- * Composition unions the behaviors' declared `stateKeys` / `contextKeys`
- * to know which signals to create. Each signal is seeded from
- * `initialState` / `initialContext` when supplied, defaulting to
- * `undefined`. Behaviors are responsible for writing their own slots
- * once their preconditions are met.
+ * Composition unions the behaviors' declared `stateKeys` / `contextKeys` to know which signals to create. Each signal
+ * is seeded from `initialState` / `initialContext` when supplied, defaulting to `undefined`. Behaviors are responsible
+ * for writing their own slots once their preconditions are met.
  *
- * Cross-behavior type conflicts (e.g. two behaviors disagreeing on a
- * field's type) surface as a compose-time type error via
- * `ValidateComposition`.
+ * Cross-behavior type conflicts (e.g. two behaviors disagreeing on a field's type) surface as a compose-time type error
+ * via `ValidateComposition`.
  *
  * @example
- * ```ts
- * const composition = createComposition([resolvePresentation, switchVideoTrack], {
+ *   ```ts
+ *   const composition = createComposition([resolvePresentation, switchVideoTrack], {
  *   config: { parsePresentation: parseMultivariantPlaylist, initialBandwidth: 2_000_000 },
  *   initialState: { bandwidthState: { fastEstimate: 0, ... } },
- * });
- * ```
+ *   });
+ *   ```;
  */
 /**
- * Create a typed signal map for a given set of keys, seeded from an
- * optional partial initial value.
+ * Create a typed signal map for a given set of keys, seeded from an optional partial initial value.
  *
- * Pipeline: `Set` dedupes the iterable (insertion order preserved, so
- * first occurrence wins) → `Object.fromEntries` materializes one
- * `signal()` per unique key, seeded from `initial[key]` or `undefined`.
+ * Pipeline: `Set` dedupes the iterable (insertion order preserved, so first occurrence wins) → `Object.fromEntries`
+ * materializes one `signal()` per unique key, seeded from `initial[key]` or `undefined`.
  *
- * Per-key value types live in TypeScript only — at runtime every signal
- * is `Signal<unknown>`. The boundary cast at the return narrows the wide
- * `Record<PropertyKey, Signal<unknown>>` shape to the caller's expected
- * per-key types from `S`.
+ * Per-key value types live in TypeScript only — at runtime every signal is `Signal<unknown>`. The boundary cast at the
+ * return narrows the wide `Record<PropertyKey, Signal<unknown>>` shape to the caller's expected per-key types from
+ * `S`.
  *
- * Used by `createComposition` to derive engine state/context maps from
- * the union of behaviors' declared `stateKeys` / `contextKeys`.
+ * Used by `createComposition` to derive engine state/context maps from the union of behaviors' declared `stateKeys` /
+ * `contextKeys`.
  *
  * @example
- * ```ts
- * interface State { count?: number; label?: string }
- * const state = buildSignalMap<State>(['count', 'label'], { count: 5 });
- * state.count.get(); // 5
- * state.label.get(); // undefined
- * ```
+ *   ```ts
+ *   interface State {
+ *     count?: number;
+ *     label?: string;
+ *   }
+ *   const state = buildSignalMap<State>(['count', 'label'], { count: 5 });
+ *   state.count.get(); // 5
+ *   state.label.get(); // undefined
+ *   ```;
  */
 export function buildSignalMap<S extends object>(
   keys: Iterable<PropertyKey>,
@@ -373,11 +347,9 @@ export function createComposition<const Behaviors extends readonly AnyBehavior[]
 /**
  * Compose-time exhaustiveness check.
  *
- * Adds a phantom error tag to the parameter shape when `Keys` does not
- * cover every key in `Slot`. The user's value won't satisfy the phantom
- * field requirement, so TS surfaces the failure at the call site with a
- * descriptive message. When exhaustive, the tag is `Empty` and adds no
- * constraint.
+ * Adds a phantom error tag to the parameter shape when `Keys` does not cover every key in `Slot`. The user's value
+ * won't satisfy the phantom field requirement, so TS surfaces the failure at the call site with a descriptive message.
+ * When exhaustive, the tag is `Empty` and adds no constraint.
  */
 type ExhaustiveKeys<Keys extends readonly PropertyKey[], Slot extends object, Name extends string> = [
   keyof Slot,
@@ -386,40 +358,33 @@ type ExhaustiveKeys<Keys extends readonly PropertyKey[], Slot extends object, Na
   : { [K in `Error: ${Name}Keys must list every key in the typed slice`]: Exclude<keyof Slot, Keys[number]> };
 
 /**
- * Typed factory for behaviors that enforces single-behavior key/param
- * consistency: declared `stateKeys` must equal `keyof S` (where `S` is
- * inferred from the setup's `state` parameter type), and same for
- * `contextKeys` / `C`.
+ * Typed factory for behaviors that enforces single-behavior key/param consistency: declared `stateKeys` must equal
+ * `keyof S` (where `S` is inferred from the setup's `state` parameter type), and same for `contextKeys` / `C`.
  *
- * The `const` modifier on `SK` / `CK` captures literal tuples so e.g.
- * `stateKeys: ['preload']` infers as `readonly ['preload']`, no `as
- * const` needed at the call site.
+ * The `const` modifier on `SK` / `CK` captures literal tuples so e.g. `stateKeys: ['preload']` infers as `readonly
+ * ['preload']`, no `as const` needed at the call site.
  *
- * Cross-behavior consistency at `createComposition` is unchanged — the
- * existing `IntersectBehaviors` machinery still runs over each
- * behavior's setup param type.
+ * Cross-behavior consistency at `createComposition` is unchanged — the existing `IntersectBehaviors` machinery still
+ * runs over each behavior's setup param type.
  *
  * @example
- * ```ts
- * export const syncPreload = defineBehavior({
+ *   ```ts
+ *   export const syncPreload = defineBehavior({
  *   stateKeys: ['preload'],
  *   contextKeys: ['mediaElement'],
  *   setup: ({ state, context }: {
- *     state: StateSignals<{ preload?: 'auto' | 'metadata' | 'none' }>;
- *     context: ContextSignals<{ mediaElement?: HTMLMediaElement | undefined }>;
+ *   state: StateSignals<{ preload?: 'auto' | 'metadata' | 'none' }>;
+ *   context: ContextSignals<{ mediaElement?: HTMLMediaElement | undefined }>;
  *   }) => { ... },
- * });
- * ```
+ *   });
+ *   ```;
  */
 /**
- * Deps shape for a behavior whose deps slot is empty (no keys). When a
- * slot is empty, the corresponding deps field is optional — callers
- * (typically tests) can omit it, and it defaults to `{}` at runtime via
- * `createComposition`.
+ * Deps shape for a behavior whose deps slot is empty (no keys). When a slot is empty, the corresponding deps field is
+ * optional — callers (typically tests) can omit it, and it defaults to `{}` at runtime via `createComposition`.
  *
- * When a slot has at least one key, the behavior reads `state.foo` /
- * `context.bar` / `config.baz` and we need the field to be required so
- * the access is type-safe.
+ * When a slot has at least one key, the behavior reads `state.foo` / `context.bar` / `config.baz` and we need the field
+ * to be required so the access is type-safe.
  */
 type RequireIfNonEmpty<Key extends string, T extends object> = keyof T extends never
   ? { [K in Key]?: T }

--- a/packages/spf/src/core/composition/share-signals.ts
+++ b/packages/spf/src/core/composition/share-signals.ts
@@ -3,40 +3,33 @@ import type { Behavior, ContextSignals, StateSignals } from './create-compositio
 /**
  * Config consumed by the `shareSignals` behavior.
  *
- * The callback fires once during composition setup with the composition's
- * state and context signal refs. Capture them to drive the composition
- * externally (writes) or observe its state (reads).
+ * The callback fires once during composition setup with the composition's state and context signal refs. Capture them
+ * to drive the composition externally (writes) or observe its state (reads).
  *
- * The callback runs while other behaviors are still in their setup phase —
- * for the typical "capture refs, use later" pattern this is fine (signal
- * refs are stable identities), but reading inside the callback may yield
- * only initial-seed values rather than what later behaviors write.
+ * The callback runs while other behaviors are still in their setup phase — for the typical "capture refs, use later"
+ * pattern this is fine (signal refs are stable identities), but reading inside the callback may yield only initial-seed
+ * values rather than what later behaviors write.
  */
 export interface ShareSignalsConfig<S extends object, C extends object> {
   onSignalsReady?: (signals: { state: StateSignals<S>; context: ContextSignals<C> }) => void;
 }
 
 /**
- * Behavior factory that hands the composition's signal refs to a
- * consumer-supplied callback (`config.onSignalsReady`) at setup time.
+ * Behavior factory that hands the composition's signal refs to a consumer-supplied callback (`config.onSignalsReady`)
+ * at setup time.
  *
- * Generic over `S` and `C` — the caller instantiates with their own
- * state/context types, and the callback's parameter shape is fully
- * type-driven from those. Suitable for both reads and writes (per-slot
- * intent can be expressed by typing captured refs as `Signal<T>` or
- * `ReadonlySignal<T>` at the call site).
+ * Generic over `S` and `C` — the caller instantiates with their own state/context types, and the callback's parameter
+ * shape is fully type-driven from those. Suitable for both reads and writes (per-slot intent can be expressed by typing
+ * captured refs as `Signal<T>` or `ReadonlySignal<T>` at the call site).
  *
- * By default declares no keys; the composition's state/context maps come from
- * other behaviors. Pass `inputStateKeys` / `inputContextKeys` to *materialize*
- * consumer-input slots that no other behavior produces — a slot the consumer
- * writes (e.g. `userAudioTrackSelection`) but only a rule reads. shareSignals
- * is the consumer boundary, so it's the natural place to bring those slots into
- * existence; readers then treat them as optional.
+ * By default declares no keys; the composition's state/context maps come from other behaviors. Pass `inputStateKeys` /
+ * `inputContextKeys` to _materialize_ consumer-input slots that no other behavior produces — a slot the consumer writes
+ * (e.g. `userAudioTrackSelection`) but only a rule reads. shareSignals is the consumer boundary, so it's the natural
+ * place to bring those slots into existence; readers then treat them as optional.
  *
- * Uses a `Behavior<>` literal (not `defineBehavior`) so its (possibly empty,
- * possibly partial) key arrays don't trip the exhaustiveness check — the
- * setup-param state/context shapes describe what the callback receives (the
- * full `S` / `C`), not the subset this behavior materializes.
+ * Uses a `Behavior<>` literal (not `defineBehavior`) so its (possibly empty, possibly partial) key arrays don't trip
+ * the exhaustiveness check — the setup-param state/context shapes describe what the callback receives (the full `S` /
+ * `C`), not the subset this behavior materializes.
  */
 export function makeShareSignals<S extends object, C extends object>(
   inputStateKeys: readonly (keyof S)[] = [],

--- a/packages/spf/src/core/index.ts
+++ b/packages/spf/src/core/index.ts
@@ -1,3 +1,1 @@
-/**
- * Core SPF logic (runtime-agnostic)
- */
+/** Core SPF logic (runtime-agnostic) */

--- a/packages/spf/src/core/machine.ts
+++ b/packages/spf/src/core/machine.ts
@@ -6,8 +6,8 @@ import { signal, untrack, update } from './signals/primitives';
 // =============================================================================
 
 /**
- * Base snapshot for all machine-like primitives (Actors and Reactors).
- * Carries only the finite state value. Actors extend this with `context`.
+ * Base snapshot for all machine-like primitives (Actors and Reactors). Carries only the finite state value. Actors
+ * extend this with `context`.
  */
 export interface MachineSnapshot<State extends string> {
   value: State;
@@ -18,8 +18,8 @@ export interface MachineSnapshot<State extends string> {
 // =============================================================================
 
 /**
- * Shared interface for all machine-like primitives.
- * Both Actors (message-driven) and Reactors (signal-driven) implement this.
+ * Shared interface for all machine-like primitives. Both Actors (message-driven) and Reactors (signal-driven) implement
+ * this.
  */
 export interface Machine<Snapshot extends MachineSnapshot<string>> {
   readonly snapshot: ReadonlySignal<Snapshot>;
@@ -31,11 +31,10 @@ export interface Machine<Snapshot extends MachineSnapshot<string>> {
 // =============================================================================
 
 /**
- * Provisions the shared mechanics for all machine-like primitives: a snapshot
- * signal, an untracked state reader, and a transition function.
+ * Provisions the shared mechanics for all machine-like primitives: a snapshot signal, an untracked state reader, and a
+ * transition function.
  *
- * Internal — consumed by `createMachineActor` and `createMachineReactor`. Not part of the
- * public API.
+ * Internal — consumed by `createMachineActor` and `createMachineReactor`. Not part of the public API.
  */
 export function createMachineCore<FullState extends string, Snapshot extends MachineSnapshot<FullState>>(
   initialSnapshot: Snapshot

--- a/packages/spf/src/core/reactors/create-machine-reactor.ts
+++ b/packages/spf/src/core/reactors/create-machine-reactor.ts
@@ -10,9 +10,8 @@ import { untrack } from '../signals/primitives';
 /**
  * A reactive state-deriving function used in the `monitor` field.
  *
- * Returns the target state the reactor should be in. Any signals read inside
- * the fn body create reactive dependencies — the framework re-evaluates it when
- * those signals change and automatically calls `transition()` when the returned
+ * Returns the target state the reactor should be in. Any signals read inside the fn body create reactive dependencies —
+ * the framework re-evaluates it when those signals change and automatically calls `transition()` when the returned
  * state differs from the current one.
  */
 export type ReactorDeriveFn<State extends string> = () => State;
@@ -20,20 +19,17 @@ export type ReactorDeriveFn<State extends string> = () => State;
 /**
  * An effect function used in reactor `entry` and `effects` blocks.
  *
- * May return a cleanup function that runs before each re-evaluation and on
- * state exit (including destroy).
+ * May return a cleanup function that runs before each re-evaluation and on state exit (including destroy).
  */
 export type ReactorEffectFn = () => (() => void) | { abort(): void } | void;
 
 /**
  * Per-state effect grouping for a single reactor state.
  *
- * - `entry` effects run once on state entry. The fn body is automatically
- *   untracked — no `untrack()` calls are needed inside. Use this for
- *   one-time setup: reading current values, attaching event listeners, etc.
- * - `effects` run on state entry and re-run whenever a signal read inside
- *   the fn body changes. Use `untrack()` for reads you do not want to track.
- *   Use this for work that must stay in sync with reactive state.
+ * - `entry` effects run once on state entry. The fn body is automatically untracked — no `untrack()` calls are needed
+ *   inside. Use this for one-time setup: reading current values, attaching event listeners, etc.
+ * - `effects` run on state entry and re-run whenever a signal read inside the fn body changes. Use `untrack()` for reads
+ *   you do not want to track. Use this for work that must stay in sync with reactive state.
  *
  * Both are optional; pass `{}` for states with no effects.
  */
@@ -45,23 +41,20 @@ export type ReactorStateDefinition = {
 /**
  * Full reactor definition passed to `createMachineReactor`.
  *
- * `State` is the set of domain-meaningful states. `'destroying'` and
- * `'destroyed'` are always added by the framework as implicit terminal states —
- * do not include them here.
+ * `State` is the set of domain-meaningful states. `'destroying'` and `'destroyed'` are always added by the framework as
+ * implicit terminal states — do not include them here.
  */
 export type ReactorDefinition<State extends string> = {
   /** Initial state. */
   initial: State;
   /**
-   * Reactive state derivation. Registered before per-state effects — the
-   * ordering guarantee ensures transitions fired here take effect before
-   * per-state effects re-evaluate in the same flush.
+   * Reactive state derivation. Registered before per-state effects — the ordering guarantee ensures transitions fired
+   * here take effect before per-state effects re-evaluate in the same flush.
    */
   monitor?: ReactorDeriveFn<State> | ReactorDeriveFn<State>[];
   /**
-   * Per-state effect groupings. Every valid state must be declared — pass `{}`
-   * for states with no effects. `entry` and `effects` each become independent
-   * `effect()` calls gated on that state, with their own cleanup lifecycles.
+   * Per-state effect groupings. Every valid state must be declared — pass `{}` for states with no effects. `entry` and
+   * `effects` each become independent `effect()` calls gated on that state, with their own cleanup lifecycles.
    */
   states: Record<State, ReactorStateDefinition>;
 };
@@ -86,30 +79,31 @@ const toArray = <T>(x: T | T[] | undefined): T[] => (x === undefined ? [] : Arra
 /**
  * Creates a reactive Reactor from a declarative definition.
  *
- * A Reactor is driven by subscriptions to external signals rather than
- * imperative messages. Each state holds an array of effect functions —
- * every element becomes one independent `effect()` call gated on that state,
- * with its own dependency tracking and cleanup lifecycle.
+ * A Reactor is driven by subscriptions to external signals rather than imperative messages. Each state holds an array
+ * of effect functions — every element becomes one independent `effect()` call gated on that state, with its own
+ * dependency tracking and cleanup lifecycle.
  *
- * `'destroying'` and `'destroyed'` are always implicit terminal states.
- * `destroy()` transitions through both in sequence: `'destroying'` first (for
- * potential async teardown in a future extension), then immediately `'destroyed'`
+ * `'destroying'` and `'destroyed'` are always implicit terminal states. `destroy()` transitions through both in
+ * sequence: `'destroying'` first (for potential async teardown in a future extension), then immediately `'destroyed'`
  * for the synchronous base case. Active effect cleanups fire via disposal.
  *
  * @example
- * const reactor = createMachineReactor({
- *   initial: 'waiting',
- *   monitor: () => srcSignal.get() ? 'active' : 'waiting',
- *   states: {
- *     active: {
- *       // entry: runs once on state entry; fn body is automatically untracked.
- *       entry: () => listen(el, 'play', handler),
- *       // effects: re-runs whenever tracked signals change.
- *       effects: () => { currentTimeSignal.get(); return cleanup; },
+ *   const reactor = createMachineReactor({
+ *     initial: 'waiting',
+ *     monitor: () => (srcSignal.get() ? 'active' : 'waiting'),
+ *     states: {
+ *       active: {
+ *         // entry: runs once on state entry; fn body is automatically untracked.
+ *         entry: () => listen(el, 'play', handler),
+ *         // effects: re-runs whenever tracked signals change.
+ *         effects: () => {
+ *           currentTimeSignal.get();
+ *           return cleanup;
+ *         },
+ *       },
+ *       waiting: {},
  *     },
- *     waiting: {},
- *   }
- * });
+ *   });
  */
 export function createMachineReactor<State extends string>(
   def: ReactorDefinition<State>

--- a/packages/spf/src/core/signals/effect.ts
+++ b/packages/spf/src/core/signals/effect.ts
@@ -24,23 +24,18 @@ function runPending() {
 /**
  * Recover an effect that wrote a signal one of its own dependencies reads.
  *
- * When an effect body writes a signal that an intermediate computed in its
- * own dependency graph consumes (e.g. a track-selection effect writing the
- * selection slot a candidate-set computed consults), the graph can't tell
- * the effect: the write marks the intermediate dirty, but the effect is the
- * in-flight consumer, so no watcher notification fires — and the effect
- * finishes the run *clean but stale*. Worse, every later external change
- * routed through that intermediate is deduped against its standing dirty
- * flag, so the effect never hears about those either (the lost-wakeup).
+ * When an effect body writes a signal that an intermediate computed in its own dependency graph consumes (e.g. a
+ * track-selection effect writing the selection slot a candidate-set computed consults), the graph can't tell the
+ * effect: the write marks the intermediate dirty, but the effect is the in-flight consumer, so no watcher notification
+ * fires — and the effect finishes the run _clean but stale_. Worse, every later external change routed through that
+ * intermediate is deduped against its standing dirty flag, so the effect never hears about those either (the
+ * lost-wakeup).
  *
- * Pulling each source once after the run closes the hole: a dirtied
- * intermediate recomputes and its dirty flag clears, so the *next* change
- * through it propagates and wakes the effect normally. The guarantee is
- * liveness, not immediacy — the effect is deliberately not re-run just
- * because it wrote into its own graph (that would double-run every writing
- * effect); it catches up on the next genuine change. Sources that are clean,
- * or whose recomputation is equals-gated to the same value, cost a cached
- * read and notify no one.
+ * Pulling each source once after the run closes the hole: a dirtied intermediate recomputes and its dirty flag clears,
+ * so the _next_ change through it propagates and wakes the effect normally. The guarantee is liveness, not immediacy —
+ * the effect is deliberately not re-run just because it wrote into its own graph (that would double-run every writing
+ * effect); it catches up on the next genuine change. Sources that are clean, or whose recomputation is equals-gated to
+ * the same value, cost a cached read and notify no one.
  */
 function revalidateSources(c: Signal.Computed<void>): void {
   for (const source of Signal.subtle.introspectSources(c)) {
@@ -51,10 +46,9 @@ function revalidateSources(c: Signal.Computed<void>): void {
 /**
  * Run a side effect whenever its signal dependencies change.
  *
- * Executes immediately (synchronous initial run), then re-runs on the next
- * microtask after any dependency changes. If the callback returns a function,
- * it is called before each re-run and when the effect is stopped — the same
- * cleanup contract as Preact Signals, Maverick Signals, and Svelte 5 $effect.
+ * Executes immediately (synchronous initial run), then re-runs on the next microtask after any dependency changes. If
+ * the callback returns a function, it is called before each re-run and when the effect is stopped — the same cleanup
+ * contract as Preact Signals, Maverick Signals, and Svelte 5 $effect.
  *
  * Returns a cleanup function that stops the effect.
  */

--- a/packages/spf/src/core/signals/primitives.ts
+++ b/packages/spf/src/core/signals/primitives.ts
@@ -4,18 +4,15 @@ import { Signal as SignalNS } from 'signal-polyfill';
 export const untrack: <T>(fn: () => T) => T = SignalNS.subtle.untrack;
 
 /**
- * Read a signal's current value without tracking it as a dependency. Sugar
- * for `untrack(() => signal.get())` to reduce boilerplate at single-read
- * sites. Structurally typed to accept any signal-like (Signal, Computed,
- * ReadonlySignal).
+ * Read a signal's current value without tracking it as a dependency. Sugar for `untrack(() => signal.get())` to reduce
+ * boilerplate at single-read sites. Structurally typed to accept any signal-like (Signal, Computed, ReadonlySignal).
  *
- * Accepts an optional `transform` to project the value in the same call;
- * the default is the identity function so the single-arg form returns `T`
- * unchanged.
+ * Accepts an optional `transform` to project the value in the same call; the default is the identity function so the
+ * single-arg form returns `T` unchanged.
  *
  * @example
- * const value = peek(someSignal);
- * const id = peek(presentationSignal, (p) => p?.id);
+ *   const value = peek(someSignal);
+ *   const id = peek(presentationSignal, (p) => p?.id);
  */
 export function peek<T, R = T>(source: { get(): T }, transform: (value: T) => R = (v: T) => v as unknown as R): R {
   return untrack(() => transform(source.get()));
@@ -47,15 +44,14 @@ export function computed<T>(fn: () => T, options?: SignalOptions<T>): Computed<T
 /**
  * Update a writable signal. Two forms:
  *
- * - **Updater function** `(current) => next`. Works for any signal type,
- *   including `Signal<T | undefined>` — handle undefined in the updater.
- * - **Partial object** to merge into the current state. Requires
- *   `T extends object`.
+ * - **Updater function** `(current) => next`. Works for any signal type, including `Signal<T | undefined>` — handle
+ *   undefined in the updater.
+ * - **Partial object** to merge into the current state. Requires `T extends object`.
  *
  * @example
- * update(state, { playbackRate: 2 });
- * update(state, (s) => ({ ...s, count: s.count + 1 }));
- * update(maybeUndefinedSignal, (current) => current ?? defaultValue);
+ *   update(state, { playbackRate: 2 });
+ *   update(state, (s) => ({ ...s, count: s.count + 1 }));
+ *   update(maybeUndefinedSignal, (current) => current ?? defaultValue);
  */
 export function update<T>(signal: Signal<T>, updater: (current: T) => T): void;
 export function update<T extends object>(signal: Signal<T>, updater: Partial<T>): void;
@@ -71,30 +67,27 @@ export function update<T>(signal: Signal<T>, updater: ((current: T) => T) | obje
 }
 
 /**
- * Equality comparator for objects with an optional `id` field. Designed for
- * use as a `computed` `equals` option when reacting to identity changes
- * (Ham-shaped objects, JSON-API-shaped resources) while filtering internal
- * updates that preserve the id.
+ * Equality comparator for objects with an optional `id` field. Designed for use as a `computed` `equals` option when
+ * reacting to identity changes (Ham-shaped objects, JSON-API-shaped resources) while filtering internal updates that
+ * preserve the id.
  *
- * Handles undefined inputs symmetrically: both undefined → equal; one
- * undefined → different.
+ * Handles undefined inputs symmetrically: both undefined → equal; one undefined → different.
  *
  * @example
- * const presentationById = computed(() => state.presentation.get(), {
- *   equals: equalsById,
- * });
+ *   const presentationById = computed(() => state.presentation.get(), {
+ *     equals: equalsById,
+ *   });
  */
 export function equalsById<T extends { id?: string }>(a: T | undefined, b: T | undefined): boolean {
   return a?.id === b?.id;
 }
 
 /**
- * Read every signal in a map and return a plain object snapshot. Each read
- * tracks in the surrounding Computed/Effect — equivalent to calling `.get()`
- * on a single `Signal<S>` over the merged shape.
+ * Read every signal in a map and return a plain object snapshot. Each read tracks in the surrounding Computed/Effect —
+ * equivalent to calling `.get()` on a single `Signal<S>` over the merged shape.
  *
- * Convenience for behaviors that pass whole state/context snapshots to pure
- * helpers; prefer per-field reads when only a few fields are needed.
+ * Convenience for behaviors that pass whole state/context snapshots to pure helpers; prefer per-field reads when only a
+ * few fields are needed.
  */
 export function snapshot<M extends Record<string, ReadonlySignal<unknown>>>(
   map: M

--- a/packages/spf/src/core/signals/when.ts
+++ b/packages/spf/src/core/signals/when.ts
@@ -1,15 +1,13 @@
 import { effect } from './effect';
 
 /**
- * Resolve once `condition` returns true. The condition is a tracked read — it
- * re-evaluates whenever a signal it read changes — so this is the promise
- * bridge from signal space into async task bodies (await a state condition
- * mid-task without polling).
+ * Resolve once `condition` returns true. The condition is a tracked read — it re-evaluates whenever a signal it read
+ * changes — so this is the promise bridge from signal space into async task bodies (await a state condition mid-task
+ * without polling).
  *
- * Settles synchronously when the condition already holds. Rejects with the
- * abort reason when `signal` aborts first (an already-aborted signal rejects
- * without evaluating the condition), so a task awaiting a condition dies with
- * its runner instead of leaking the subscription.
+ * Settles synchronously when the condition already holds. Rejects with the abort reason when `signal` aborts first (an
+ * already-aborted signal rejects without evaluating the condition), so a task awaiting a condition dies with its runner
+ * instead of leaking the subscription.
  */
 export function when(condition: () => boolean, options: { signal?: AbortSignal } = {}): Promise<void> {
   const { signal } = options;

--- a/packages/spf/src/core/tasks/delayed-reschedule.ts
+++ b/packages/spf/src/core/tasks/delayed-reschedule.ts
@@ -3,19 +3,15 @@ import { sleep } from '@videojs/utils/time';
 import type { Reschedule } from './task';
 
 /**
- * Build a {@link Reschedule} from a pure cadence function — the common
- * timer-based, *start-anchored* implementation.
+ * Build a {@link Reschedule} from a pure cadence function — the common timer-based, _start-anchored_ implementation.
  *
- * Invoked concurrently with the run, it observes the result, then waits
- * `cadence(current, previous)` milliseconds **measured from when it was invoked**
- * (≈ the run's start): it subtracts the run's own elapsed time, so consecutive
- * runs begin one cadence apart regardless of how long each run takes (per
- * RFC 8216 §6.3.4's "measured from the last time the client began loading"). If
- * the run takes longer than the cadence, the next run starts immediately.
+ * Invoked concurrently with the run, it observes the result, then waits `cadence(current, previous)` milliseconds
+ * **measured from when it was invoked** (≈ the run's start): it subtracts the run's own elapsed time, so consecutive
+ * runs begin one cadence apart regardless of how long each run takes (per RFC 8216 §6.3.4's "measured from the last
+ * time the client began loading"). If the run takes longer than the cadence, the next run starts immediately.
  *
- * A `null` cadence stops the recurrence. A rejected run rejects this reschedule,
- * which the `RecurringRunner` propagates as the recurrence's failure — error
- * recovery (e.g. retrying transient fetch failures) belongs below, at the fetch
+ * A `null` cadence stops the recurrence. A rejected run rejects this reschedule, which the `RecurringRunner` propagates
+ * as the recurrence's failure — error recovery (e.g. retrying transient fetch failures) belongs below, at the fetch
  * layer, not in the cadence.
  */
 export function delayedReschedule<TValue>(

--- a/packages/spf/src/core/tasks/task.ts
+++ b/packages/spf/src/core/tasks/task.ts
@@ -18,44 +18,35 @@ export type DeepReadonly<T> = T extends (infer U)[]
 
 export type TaskStatus = 'pending' | 'running' | 'done' | 'error';
 
-/**
- * Configuration for a Task.
- */
+/** Configuration for a Task. */
 export interface TaskConfig {
   /**
-   * Identifier for this task.
-   * - string: used as-is
-   * - () => string: called once at construction time
-   * - undefined: a unique ID is generated via generateId()
+   * Identifier for this task. - string: used as-is - () => string: called once at construction time - undefined: a
+   * unique ID is generated via generateId()
    */
   id?: string | (() => string);
 
   /**
-   * Optional external AbortSignal to compose with the task's internal one.
-   * The task's work is aborted when either the internal controller (via abort())
-   * or this external signal fires — whichever comes first.
+   * Optional external AbortSignal to compose with the task's internal one. The task's work is aborted when either the
+   * internal controller (via abort()) or this external signal fires — whichever comes first.
    */
   signal?: AbortSignal;
 }
 
-/**
- * Minimal contract for a schedulable unit of async work.
- */
+/** Minimal contract for a schedulable unit of async work. */
 export interface TaskLike<TValue = void, TError = unknown> {
   readonly id: string;
   readonly status: TaskStatus;
   readonly value: DeepReadonly<TValue> | undefined;
   readonly error: DeepReadonly<TError> | undefined;
   /**
-   * The last successful value carried forward from the run this was `clone()`d
-   * from — the prior cycle's result for a `RecurringRunner` (undefined for an
-   * original, or until the lineage has produced a success).
+   * The last successful value carried forward from the run this was `clone()`d from — the prior cycle's result for a
+   * `RecurringRunner` (undefined for an original, or until the lineage has produced a success).
    */
   readonly previous: DeepReadonly<TValue> | undefined;
   /**
-   * The signal this task's work runs under (its own abort composed with any
-   * external one). Aborting the task fires it — so a `reschedule` can wait on it
-   * to have its delay cancelled when the recurrence is aborted.
+   * The signal this task's work runs under (its own abort composed with any external one). Aborting the task fires it —
+   * so a `reschedule` can wait on it to have its delay cancelled when the recurrence is aborted.
    */
   readonly signal: AbortSignal;
   /** Run the work, memoized: repeated calls share one execution + result. */
@@ -68,19 +59,16 @@ export interface TaskLike<TValue = void, TError = unknown> {
 /**
  * Generic reusable task that wraps an async run function.
  *
- * Owns its own AbortController so it can always be aborted independently.
- * Optionally composes an external AbortSignal so that a parent's cancellation
- * propagates into the task's work without requiring the caller to track the
- * task separately.
+ * Owns its own AbortController so it can always be aborted independently. Optionally composes an external AbortSignal
+ * so that a parent's cancellation propagates into the task's work without requiring the caller to track the task
+ * separately.
  *
- * `run()` is memoized: the work runs at most once per instance, and every call
- * returns the same promise (so observers can `await run()` to read the result
- * without re-triggering the work). To re-run the *same* work, take a `clone()` —
- * a fresh instance with its own AbortController and a pending state.
+ * `run()` is memoized: the work runs at most once per instance, and every call returns the same promise (so observers
+ * can `await run()` to read the result without re-triggering the work). To re-run the _same_ work, take a `clone()` — a
+ * fresh instance with its own AbortController and a pending state.
  *
- * Ordering guarantee: `value` is written before `status` transitions to `'done'`;
- * `error` is written before `status` transitions to `'error'`. Any reader
- * observing `status === 'done'` is guaranteed `value` is already present.
+ * Ordering guarantee: `value` is written before `status` transitions to `'done'`; `error` is written before `status`
+ * transitions to `'error'`. Any reader observing `status === 'done'` is guaranteed `value` is already present.
  */
 export class Task<TValue = void, TError = unknown> implements TaskLike<TValue, TError> {
   readonly id: string;
@@ -156,14 +144,12 @@ export class Task<TValue = void, TError = unknown> implements TaskLike<TValue, T
   }
 
   /**
-   * A fresh task with the same work, id, and external signal, in a pending state
-   * (its own AbortController, no memoized result) — so it can be run again. Used
-   * to re-run structurally identical work (e.g. `RecurringRunner` reloads).
+   * A fresh task with the same work, id, and external signal, in a pending state (its own AbortController, no memoized
+   * result) — so it can be run again. Used to re-run structurally identical work (e.g. `RecurringRunner` reloads).
    *
-   * The clone inherits this run's value as its `previous` (or this run's own
-   * `previous` if it never produced one — e.g. it errored), so a recurrence's
-   * `previous` always tracks the last *successful* value across the lineage with
-   * no bookkeeping in the runner.
+   * The clone inherits this run's value as its `previous` (or this run's own `previous` if it never produced one — e.g.
+   * it errored), so a recurrence's `previous` always tracks the last _successful_ value across the lineage with no
+   * bookkeeping in the runner.
    */
   clone(): Task<TValue, TError> {
     const cloned = new Task<TValue, TError>(this.#runFn, { id: this.id, signal: this.#externalSignal });
@@ -180,9 +166,8 @@ export class Task<TValue = void, TError = unknown> implements TaskLike<TValue, T
 /**
  * Runs tasks concurrently, deduplicated by task id.
  *
- * If a task with a given id is already in flight, subsequent schedule() calls
- * for that id are silently ignored until the first completes. Tasks are stored
- * so abortAll() can cancel any in-flight work (e.g. on engine cleanup).
+ * If a task with a given id is already in flight, subsequent schedule() calls for that id are silently ignored until
+ * the first completes. Tasks are stored so abortAll() can cancel any in-flight work (e.g. on engine cleanup).
  */
 export class ConcurrentRunner {
   readonly #pending = new Map<string, { task: TaskLike<unknown, unknown>; promise: Promise<unknown> }>();
@@ -224,10 +209,9 @@ export class ConcurrentRunner {
   }
 
   /**
-   * Registers a callback to fire when all currently in-flight tasks settle.
-   * If the runner is already idle, the callback is never called. If abortAll()
-   * is called before the batch settles, the callback is superseded and silently
-   * dropped — no stale callbacks, no generation token required by the caller.
+   * Registers a callback to fire when all currently in-flight tasks settle. If the runner is already idle, the callback
+   * is never called. If abortAll() is called before the batch settles, the callback is superseded and silently dropped
+   * — no stale callbacks, no generation token required by the caller.
    */
   whenSettled(callback: () => void): void {
     if (this.#pending.size === 0) return;
@@ -269,16 +253,14 @@ export class ConcurrentRunner {
 /**
  * Runs tasks one at a time in submission order.
  *
- * Each schedule() call returns a Promise that resolves or rejects with the
- * task's result when it is eventually executed. Tasks wait in queue until the
- * prior task completes.
+ * Each schedule() call returns a Promise that resolves or rejects with the task's result when it is eventually
+ * executed. Tasks wait in queue until the prior task completes.
  *
- * Serialization is achieved by chaining each task's run() onto the tail of a
- * shared promise chain — no explicit queue or drain loop needed.
+ * Serialization is achieved by chaining each task's run() onto the tail of a shared promise chain — no explicit queue
+ * or drain loop needed.
  *
- * abortAll() aborts all pending (not yet started) tasks and the currently
- * in-flight task. Pending tasks still run briefly but receive an aborted
- * signal and are expected to exit early.
+ * AbortAll() aborts all pending (not yet started) tasks and the currently in-flight task. Pending tasks still run
+ * briefly but receive an aborted signal and are expected to exit early.
  */
 export class SerialRunner {
   #chain: Promise<unknown> = Promise.resolve();
@@ -313,21 +295,18 @@ export class SerialRunner {
   }
 
   /**
-   * A promise that resolves when all currently-scheduled tasks have settled.
-   * Use the reference as a generation token: capture it after scheduling a
-   * batch, then check identity in the resolution callback to detect whether
-   * a subsequent abortAll() + new batch has superseded this one.
+   * A promise that resolves when all currently-scheduled tasks have settled. Use the reference as a generation token:
+   * capture it after scheduling a batch, then check identity in the resolution callback to detect whether a subsequent
+   * abortAll() + new batch has superseded this one.
    */
   get settled(): Promise<void> {
     return this.#chain as Promise<void>;
   }
 
   /**
-   * Registers a callback to fire when all currently-pending tasks settle.
-   * If the runner is already idle (no pending or running tasks), the callback
-   * is never called. If new tasks are scheduled before the current batch
-   * settles, the callback is superseded and silently dropped — no stale
-   * callbacks, no generation token required by the caller.
+   * Registers a callback to fire when all currently-pending tasks settle. If the runner is already idle (no pending or
+   * running tasks), the callback is never called. If new tasks are scheduled before the current batch settles, the
+   * callback is superseded and silently dropped — no stale callbacks, no generation token required by the caller.
    */
   whenSettled(callback: () => void): void {
     if (this.#pending.size === 0 && this.#current === null) return;
@@ -367,59 +346,51 @@ export class SerialRunner {
 // =============================================================================
 
 /**
- * Decides whether — and *when* — a {@link RecurringRunner} re-runs its task.
- * Invoked **concurrently with the run** (so the inter-run interval can be
- * measured from when the run *started*, not when it finished) with the single
+ * Decides whether — and _when_ — a {@link RecurringRunner} re-runs its task. Invoked **concurrently with the run** (so
+ * the inter-run interval can be measured from when the run _started_, not when it finished) with the single
  * {@link TaskLike}, which carries everything a decision needs:
- * - `task.run()` — the in-flight run, observable via this memoized call (does
- *   not re-trigger work), e.g. to read its result for a cadence/stop decision.
- * - `task.previous` — the prior successful run's value (`undefined` on the
- *   first), for decisions that compare consecutive results.
+ *
+ * - `task.run()` — the in-flight run, observable via this memoized call (does not re-trigger work), e.g. to read its
+ *   result for a cadence/stop decision.
+ * - `task.previous` — the prior successful run's value (`undefined` on the first), for decisions that compare consecutive
+ *   results.
  * - `task.signal` — aborts the wait (and the recurrence) when the task is.
  *
- * Resolves `true` to re-run (after whatever delay it owns) or `false` to stop.
- * The runner deals only in this awaitable verdict — *how* the delay is produced
- * (a timer, a frame, an event) and *when* it's measured from live entirely in
- * the reschedule function, so the runner itself knows nothing about time. See
- * `delayedReschedule` for the common timer-based, start-anchored implementation.
+ * Resolves `true` to re-run (after whatever delay it owns) or `false` to stop. The runner deals only in this awaitable
+ * verdict — _how_ the delay is produced (a timer, a frame, an event) and _when_ it's measured from live entirely in the
+ * reschedule function, so the runner itself knows nothing about time. See `delayedReschedule` for the common
+ * timer-based, start-anchored implementation.
  */
 export type Reschedule<TValue> = (task: TaskLike<TValue>) => PromiseLike<boolean>;
 
 /**
- * A {@link Reschedule} that never recurs — the task runs exactly once. Pass it to
- * a {@link RecurringRunner} for non-recurring, run-once work (e.g. resolving a
- * complete VoD playlist that can never go stale).
+ * A {@link Reschedule} that never recurs — the task runs exactly once. Pass it to a {@link RecurringRunner} for
+ * non-recurring, run-once work (e.g. resolving a complete VoD playlist that can never go stale).
  */
 export const runOnce: Reschedule<unknown> = () => Promise.resolve(false);
 
 /**
- * Runs a task, then re-runs it whenever a {@link Reschedule} function says to,
- * until it says stop (or it's aborted) — the recurring sibling of
- * {@link ConcurrentRunner} / {@link SerialRunner}, and like them it's handed a
+ * Runs a task, then re-runs it whenever a {@link Reschedule} function says to, until it says stop (or it's aborted) —
+ * the recurring sibling of {@link ConcurrentRunner} / {@link SerialRunner}, and like them it's handed a
  * {@link TaskLike} to run.
  *
- * The runner has no notion of time: it just awaits whatever `reschedule`
- * returns (resolves `true` → re-run; `false` → stop). A `reschedule` is required;
- * pass {@link runOnce} for non-recurring, run-exactly-once work.
+ * The runner has no notion of time: it just awaits whatever `reschedule` returns (resolves `true` → re-run; `false` →
+ * stop). A `reschedule` is required; pass {@link runOnce} for non-recurring, run-exactly-once work.
  *
- * Single-slot, keyed by task **id**: there is always at most one identified
- * active task for re-running. Scheduling a task whose id matches the active one
- * is a no-op — the existing recurrence keeps running (dedup by id). Scheduling a
- * task with a *different* id aborts the prior task's in-flight run and pending
- * reschedule, then takes over the slot (abort-and-replace) — the right shape
- * when there's one logical unit of recurring work (e.g. reloading the *selected*
+ * Single-slot, keyed by task **id**: there is always at most one identified active task for re-running. Scheduling a
+ * task whose id matches the active one is a no-op — the existing recurrence keeps running (dedup by id). Scheduling a
+ * task with a _different_ id aborts the prior task's in-flight run and pending reschedule, then takes over the slot
+ * (abort-and-replace) — the right shape when there's one logical unit of recurring work (e.g. reloading the _selected_
  * track's media playlist).
  *
- * Each re-run is a fresh `clone()` of the task (since `Task.run()` is memoized —
- * the same instance won't re-execute), carrying the same id so the slot's
- * identity is stable across cycles. The clone also carries the prior cycle's
- * value forward as `task.previous`. The run function should read any inputs that
- * change between cycles at call time rather than capturing them once.
+ * Each re-run is a fresh `clone()` of the task (since `Task.run()` is memoized — the same instance won't re-execute),
+ * carrying the same id so the slot's identity is stable across cycles. The clone also carries the prior cycle's value
+ * forward as `task.previous`. The run function should read any inputs that change between cycles at call time rather
+ * than capturing them once.
  *
- * The task is the sole cancellation channel: `abortAll()` aborts the active task,
- * which fires `task.signal` — cancelling both its in-flight run and any pending
- * reschedule delay waiting on that signal. An aborted (or stopped) recurrence
- * frees the slot, so a later schedule of the same id starts fresh.
+ * The task is the sole cancellation channel: `abortAll()` aborts the active task, which fires `task.signal` —
+ * cancelling both its in-flight run and any pending reschedule delay waiting on that signal. An aborted (or stopped)
+ * recurrence frees the slot, so a later schedule of the same id starts fresh.
  */
 export class RecurringRunner<TValue = unknown> {
   readonly #reschedule: Reschedule<TValue>;
@@ -435,25 +406,21 @@ export class RecurringRunner<TValue = unknown> {
   }
 
   /**
-   * Run `task` and recur per the `reschedule` verdict, as a single promise.
-   * Resolves with the *final* cycle's value when the recurrence stops; **rejects**
-   * if a run (or reschedule) genuinely fails — the rejection propagates to the
-   * caller, who owns error handling; the runner only frees its slot (no
-   * swallowing). The runner's *own* cancellation (abort/supersede/destroy) is not
-   * a failure, so an aborted recurrence settles quietly rather than rejecting —
+   * Run `task` and recur per the `reschedule` verdict, as a single promise. Resolves with the _final_ cycle's value
+   * when the recurrence stops; **rejects** if a run (or reschedule) genuinely fails — the rejection propagates to the
+   * caller, who owns error handling; the runner only frees its slot (no swallowing). The runner's _own_ cancellation
+   * (abort/supersede/destroy) is not a failure, so an aborted recurrence settles quietly rather than rejecting —
    * callers don't have to `.catch` routine teardown.
    *
-   * Each cycle runs the task and consults `reschedule` concurrently (so the delay
-   * can be measured from the run's start); when both settle and this cycle still
-   * owns the slot, a `true` verdict re-schedules a `clone()` whose promise is
-   * *returned* — so the recurrence is the method calling itself, threaded into one
-   * promise, no separate loop. The clone shares the id, so the slot's identity is
-   * stable across cycles; it's released just before the re-schedule so the call
-   * advances rather than dedup-returning.
+   * Each cycle runs the task and consults `reschedule` concurrently (so the delay can be measured from the run's
+   * start); when both settle and this cycle still owns the slot, a `true` verdict re-schedules a `clone()` whose
+   * promise is _returned_ — so the recurrence is the method calling itself, threaded into one promise, no separate
+   * loop. The clone shares the id, so the slot's identity is stable across cycles; it's released just before the
+   * re-schedule so the call advances rather than dedup-returning.
    *
-   * Note: because each cycle's promise adopts the next, the chain retains every
-   * prior cycle for the life of the recurrence — bounded for finite recurrences,
-   * an unbounded (small per-cycle) cost for a long-lived one (e.g. live reload).
+   * Note: because each cycle's promise adopts the next, the chain retains every prior cycle for the life of the
+   * recurrence — bounded for finite recurrences, an unbounded (small per-cycle) cost for a long-lived one (e.g. live
+   * reload).
    */
   schedule(task: TaskLike<TValue, unknown>): Promise<TValue> {
     if (this.#destroyed) return Promise.resolve() as Promise<TValue>;

--- a/packages/spf/src/core/tasks/tests/delayed-reschedule.test.ts
+++ b/packages/spf/src/core/tasks/tests/delayed-reschedule.test.ts
@@ -8,8 +8,8 @@ afterEach(() => {
 });
 
 /**
- * A minimal {@link TaskLike} for exercising `delayedReschedule` in isolation:
- * the cadence only reads `run()`, `previous`, and `signal`.
+ * A minimal {@link TaskLike} for exercising `delayedReschedule` in isolation: the cadence only reads `run()`,
+ * `previous`, and `signal`.
  */
 function fakeTask(
   run: () => Promise<number>,

--- a/packages/spf/src/core/tasks/tests/task.test.ts
+++ b/packages/spf/src/core/tasks/tests/task.test.ts
@@ -688,8 +688,10 @@ describe('SerialRunner', () => {
 });
 
 describe('RecurringRunner', () => {
-  /** A reschedule that parks forever, rejecting only when its signal aborts — so a
-   *  recurrence stays "live" (awaiting) until superseded or aborted. */
+  /**
+   * A reschedule that parks forever, rejecting only when its signal aborts — so a recurrence stays "live" (awaiting)
+   * until superseded or aborted.
+   */
   const parkUntilAborted: Reschedule<number> = (task) =>
     new Promise<boolean>((_resolve, reject) => {
       task.signal.addEventListener('abort', () => reject(task.signal.reason), { once: true });

--- a/packages/spf/src/dom.ts
+++ b/packages/spf/src/dom.ts
@@ -1,9 +1,8 @@
 /**
  * DOM/Browser-specific SPF bindings
  *
- * This is a convenience aggregate of DOM-bound exports drawn from across
- * the package. The underlying pieces live alongside their DOM-free peers
- * in `behaviors/` (with `dom/` subdirs where applicable) and `media/dom/`.
+ * This is a convenience aggregate of DOM-bound exports drawn from across the package. The underlying pieces live
+ * alongside their DOM-free peers in `behaviors/` (with `dom/` subdirs where applicable) and `media/dom/`.
  */
 
 export { appendSegment } from './media/dom/mse/append-segment';

--- a/packages/spf/src/index.ts
+++ b/packages/spf/src/index.ts
@@ -1,9 +1,8 @@
 /**
  * Stream Processing Framework (SPF) for Video.js 10
  *
- * The compositional primitives: createComposition, signals, tasks, actors,
- * reactors. Media-domain helpers and the HLS playback engine live behind
- * the `./dom` and `./hls` subpaths.
+ * The compositional primitives: createComposition, signals, tasks, actors, reactors. Media-domain helpers and the HLS
+ * playback engine live behind the `./dom` and `./hls` subpaths.
  *
  * @packageDocumentation
  */

--- a/packages/spf/src/media/abr/quality-selection.ts
+++ b/packages/spf/src/media/abr/quality-selection.ts
@@ -1,10 +1,11 @@
 /**
  * Quality Selection Algorithm
  *
- * Selects optimal video track based on bandwidth estimate with safety margin.
- * Stateless selection - picks highest quality that fits bandwidth.
+ * Selects optimal video track based on bandwidth estimate with safety margin. Stateless selection - picks highest
+ * quality that fits bandwidth.
  *
  * Key concepts:
+ *
  * - **Safety margin** (0.85): Pick track where bandwidth >= track.bandwidth / 0.85
  * - This ensures 15% headroom to avoid buffering
  * - At same bandwidth, prefer higher resolution
@@ -12,78 +13,64 @@
 
 import type { PartiallyResolvedVideoTrack, VideoTrack } from '../types';
 
-/**
- * Quality selection configuration.
- */
+/** Quality selection configuration. */
 export interface QualityConfig {
   /**
-   * Safety margin (0-1).
-   * To select a track, need: currentBandwidth >= track.bandwidth / safetyMargin.
-   * Default 0.85 means track must use ≤85% of available bandwidth (15% headroom).
+   * Safety margin (0-1). To select a track, need: currentBandwidth >= track.bandwidth / safetyMargin. Default 0.85
+   * means track must use ≤85% of available bandwidth (15% headroom).
    */
   safetyMargin: number;
   /**
-   * Upgrade hysteresis ratio (>= 1). When `currentTrack` is supplied, an
-   * upgrade is applied only if `optimal.bandwidth >= currentTrack.bandwidth * upgradeMargin`.
-   * Downgrades are always applied. Default 1.15 means optimal must clear
-   * the current bandwidth by at least 15% to trigger an upgrade.
+   * Upgrade hysteresis ratio (>= 1). When `currentTrack` is supplied, an upgrade is applied only if `optimal.bandwidth
+   *
+   * > = currentTrack.bandwidth * upgradeMargin`. Downgrades are always applied. Default 1.15 means optimal must clear the
+   * > current bandwidth by at least 15% to trigger an upgrade.
    */
   upgradeMargin: number;
 }
 
-/**
- * Default quality selection configuration.
- * Values match Shaka Player upgrade threshold (0.85 = 15% headroom).
- */
+/** Default quality selection configuration. Values match Shaka Player upgrade threshold (0.85 = 15% headroom). */
 export const DEFAULT_QUALITY_CONFIG: QualityConfig = {
   safetyMargin: 0.85,
   upgradeMargin: 1.15,
 };
 
 /**
- * Selection context for `selectQuality`. The `bandwidth` field carries the
- * current network estimate; `safetyMargin` / `upgradeMargin` override the
- * defaults; `currentTrack` enables upgrade-vs-downgrade hysteresis.
+ * Selection context for `selectQuality`. The `bandwidth` field carries the current network estimate; `safetyMargin` /
+ * `upgradeMargin` override the defaults; `currentTrack` enables upgrade-vs-downgrade hysteresis.
  *
- * Shape matches the unified `selectOptimal` contract of
- * `setupTrackSwitching` (`playback/behaviors/track-switching.ts`) so the
- * function can be passed directly as a variant's `selectOptimal`.
+ * Shape matches the unified `selectOptimal` contract of `setupTrackSwitching` (`playback/behaviors/track-switching.ts`)
+ * so the function can be passed directly as a variant's `selectOptimal`.
  */
 export interface SelectQualityCtx<
   T extends { bandwidth: number } = PartiallyResolvedVideoTrack | VideoTrack,
 > extends Partial<QualityConfig> {
   bandwidth: number;
   /**
-   * Track currently selected. When supplied, `selectQuality` returns
-   * `currentTrack` (no change) for upgrades that don't clear the
-   * `upgradeMargin`. When omitted, no hysteresis is applied — the
-   * computed optimal is returned regardless.
+   * Track currently selected. When supplied, `selectQuality` returns `currentTrack` (no change) for upgrades that don't
+   * clear the `upgradeMargin`. When omitted, no hysteresis is applied — the computed optimal is returned regardless.
    */
   currentTrack?: T;
 }
 
 /**
- * Select the track to apply now, given a context that carries current
- * bandwidth, an optional `currentTrack`, and tuning overrides. Returns:
+ * Select the track to apply now, given a context that carries current bandwidth, an optional `currentTrack`, and tuning
+ * overrides. Returns:
  *
  * - The bandwidth-fitting optimal when no `currentTrack` is supplied.
- * - The optimal when it's a downgrade vs. `currentTrack` (downgrades
- *   apply immediately — no hysteresis).
- * - The optimal when it clears `currentTrack.bandwidth * upgradeMargin`
- *   (upgrade clears hysteresis).
- * - `currentTrack` itself when an upgrade doesn't clear the margin
- *   (stay put — caller checks identity to no-op).
+ * - The optimal when it's a downgrade vs. `currentTrack` (downgrades apply immediately — no hysteresis).
+ * - The optimal when it clears `currentTrack.bandwidth * upgradeMargin` (upgrade clears hysteresis).
+ * - `currentTrack` itself when an upgrade doesn't clear the margin (stay put — caller checks identity to no-op).
  *
- * "Optimal" is the highest-bandwidth track where the available bandwidth
- * meets the safety requirement (`bandwidth >= track.bandwidth / safetyMargin`).
- * Falls back to the lowest-bandwidth track when nothing fits the safety
- * margin (preserves a definitive pick under under-bandwidth conditions).
+ * "Optimal" is the highest-bandwidth track where the available bandwidth meets the safety requirement (`bandwidth >=
+ * track.bandwidth / safetyMargin`). Falls back to the lowest-bandwidth track when nothing fits the safety margin
+ * (preserves a definitive pick under under-bandwidth conditions).
  *
  * @example
- * const tracks = [low, mid, high];
- * selectQuality(tracks, { bandwidth: 5_000_000, currentTrack: low });
- * // Returns `high` if 5 Mbps clears safety AND high.bandwidth >= low.bandwidth * upgradeMargin.
- * // Returns `low` (no-op signal) otherwise.
+ *   const tracks = [low, mid, high];
+ *   selectQuality(tracks, { bandwidth: 5_000_000, currentTrack: low });
+ *   // Returns `high` if 5 Mbps clears safety AND high.bandwidth >= low.bandwidth * upgradeMargin.
+ *   // Returns `low` (no-op signal) otherwise.
  */
 export function selectQuality(
   tracks: readonly (PartiallyResolvedVideoTrack | VideoTrack)[],
@@ -141,17 +128,15 @@ export function selectQuality(
 /**
  * Select the lowest-bandwidth track from the candidate set.
  *
- * Used as a safety-net fallback by callers that need a definitive pick when
- * a primary selection algorithm declines to choose. Pairs naturally with
- * `selectQuality` — when ABR has no good answer (e.g., all candidates
- * exceed available bandwidth and the algorithm doesn't fall back
- * internally), the lowest bitrate is the safest default.
+ * Used as a safety-net fallback by callers that need a definitive pick when a primary selection algorithm declines to
+ * choose. Pairs naturally with `selectQuality` — when ABR has no good answer (e.g., all candidates exceed available
+ * bandwidth and the algorithm doesn't fall back internally), the lowest bitrate is the safest default.
+ *
+ * @example
+ *   const fallback = selectLowestQuality(tracks);
  *
  * @param tracks - Candidate tracks (can be unsorted)
  * @returns The lowest-bandwidth track, or `undefined` if `tracks` is empty
- *
- * @example
- * const fallback = selectLowestQuality(tracks);
  */
 export function selectLowestQuality<T extends { bandwidth: number }>(tracks: readonly T[]): T | undefined {
   if (tracks.length === 0) return undefined;
@@ -160,17 +145,15 @@ export function selectLowestQuality<T extends { bandwidth: number }>(tracks: rea
 }
 
 /**
- * Resolution as a total pixel count (`width × height`), the basis for
- * comparing two tracks at the same bitrate. Missing dimensions count as 0, so
- * tracks without resolution metadata (e.g. audio) area-compare equal.
+ * Resolution as a total pixel count (`width × height`), the basis for comparing two tracks at the same bitrate. Missing
+ * dimensions count as 0, so tracks without resolution metadata (e.g. audio) area-compare equal.
  */
 export function resolutionArea(track: { width?: number; height?: number }): number {
   return (track.width ?? 0) * (track.height ?? 0);
 }
 
 /**
- * Check if track A has higher resolution than track B.
- * Compares by total pixel count (width × height).
+ * Check if track A has higher resolution than track B. Compares by total pixel count (width × height).
  *
  * @param trackA - First track to compare
  * @param trackB - Second track to compare

--- a/packages/spf/src/media/buffer/back-buffer.ts
+++ b/packages/spf/src/media/buffer/back-buffer.ts
@@ -1,26 +1,18 @@
 /**
  * Back Buffer Strategy (Simple)
  *
- * Calculates flush points for back buffer management.
- * V1 uses simple "keep N segments" strategy.
+ * Calculates flush points for back buffer management. V1 uses simple "keep N segments" strategy.
  */
 
 import type { Segment } from '../types';
 
-/**
- * Back buffer configuration.
- */
+/** Back buffer configuration. */
 export interface BackBufferConfig {
-  /**
-   * Number of segments to keep behind current playback position.
-   * Default: 2 segments.
-   */
+  /** Number of segments to keep behind current playback position. Default: 2 segments. */
   keepSegments: number;
 }
 
-/**
- * Default back buffer configuration.
- */
+/** Default back buffer configuration. */
 export const DEFAULT_BACK_BUFFER_CONFIG: BackBufferConfig = {
   keepSegments: 2,
 };
@@ -28,30 +20,28 @@ export const DEFAULT_BACK_BUFFER_CONFIG: BackBufferConfig = {
 /**
  * Calculate back buffer flush point.
  *
- * Determines where to flush old segments from the back buffer.
- * Keeps a fixed number of segments behind the current playback position.
+ * Determines where to flush old segments from the back buffer. Keeps a fixed number of segments behind the current
+ * playback position.
  *
- * Algorithm:
- * 1. Find segments before currentTime
- * 2. Count back N segments (keepSegments)
- * 3. Return startTime of segment N+1 back (flush everything before this)
+ * Algorithm: 1. Find segments before currentTime 2. Count back N segments (keepSegments) 3. Return startTime of segment
+ * N+1 back (flush everything before this)
+ *
+ * @example
+ *   const segments = [
+ *   { startTime: 0, duration: 6, ... },
+ *   { startTime: 6, duration: 6, ... },
+ *   { startTime: 12, duration: 6, ... },
+ *   { startTime: 18, duration: 6, ... },
+ *   ];
+ *
+ *   // Playing at 18s, keep 2 segments
+ *   const flushEnd = calculateBackBufferFlushPoint(segments, 18);
+ *   // Returns 6 (flush [0, 6), keep [6-18))
  *
  * @param segments - Available segments (should be sorted by startTime)
  * @param currentTime - Current playback position in seconds
  * @param config - Optional back buffer configuration
  * @returns Time in seconds to flush up to (flush range: [0, flushEnd))
- *
- * @example
- * const segments = [
- *   { startTime: 0, duration: 6, ... },
- *   { startTime: 6, duration: 6, ... },
- *   { startTime: 12, duration: 6, ... },
- *   { startTime: 18, duration: 6, ... },
- * ];
- *
- * // Playing at 18s, keep 2 segments
- * const flushEnd = calculateBackBufferFlushPoint(segments, 18);
- * // Returns 6 (flush [0, 6), keep [6-18))
  */
 export function calculateBackBufferFlushPoint(
   segments: Segment[],

--- a/packages/spf/src/media/buffer/forward-buffer.ts
+++ b/packages/spf/src/media/buffer/forward-buffer.ts
@@ -1,8 +1,8 @@
 /**
  * Forward Buffer Strategy (Simple)
  *
- * Determines which segments to load for forward buffer management.
- * V1 uses simple fixed-duration strategy (buffer N seconds ahead).
+ * Determines which segments to load for forward buffer management. V1 uses simple fixed-duration strategy (buffer N
+ * seconds ahead).
  */
 
 import { SEGMENT_TIME_EPSILON, type Segment } from '../types';
@@ -14,8 +14,8 @@ export interface TimeRange {
 }
 
 /**
- * Merge intervals into sorted, disjoint ranges; touching or overlapping ranges
- * (gap ≤ `epsilon`) are joined. Empty/inverted ranges are dropped.
+ * Merge intervals into sorted, disjoint ranges; touching or overlapping ranges (gap ≤ `epsilon`) are joined.
+ * Empty/inverted ranges are dropped.
  */
 export function mergeTimeRanges(ranges: readonly TimeRange[], epsilon = SEGMENT_TIME_EPSILON): TimeRange[] {
   const sorted = ranges.filter((r) => r.end > r.start).sort((a, b) => a.start - b.start);
@@ -35,10 +35,9 @@ export function mergeTimeRanges(ranges: readonly TimeRange[], epsilon = SEGMENT_
 }
 
 /**
- * Whether `[start, end)` is fully covered by the union of `merged` ranges,
- * tolerating `epsilon` of overhang at each edge. `merged` must be disjoint and
- * sorted (as returned by `mergeTimeRanges`), so full coverage means a single
- * merged range contains the interval.
+ * Whether `[start, end)` is fully covered by the union of `merged` ranges, tolerating `epsilon` of overhang at each
+ * edge. `merged` must be disjoint and sorted (as returned by `mergeTimeRanges`), so full coverage means a single merged
+ * range contains the interval.
  */
 export function isTimeRangeCovered(
   start: number,
@@ -49,20 +48,13 @@ export function isTimeRangeCovered(
   return merged.some((r) => r.start <= start + epsilon && r.end >= end - epsilon);
 }
 
-/**
- * Forward buffer configuration.
- */
+/** Forward buffer configuration. */
 export interface ForwardBufferConfig {
-  /**
-   * Duration in seconds to buffer ahead of current playback position.
-   * Default: 30 seconds.
-   */
+  /** Duration in seconds to buffer ahead of current playback position. Default: 30 seconds. */
   bufferDuration: number;
 }
 
-/**
- * Default forward buffer configuration.
- */
+/** Default forward buffer configuration. */
 export const DEFAULT_FORWARD_BUFFER_CONFIG: ForwardBufferConfig = {
   bufferDuration: 30,
 };
@@ -70,48 +62,43 @@ export const DEFAULT_FORWARD_BUFFER_CONFIG: ForwardBufferConfig = {
 /**
  * Get segments that need to be loaded for forward buffer.
  *
- * Determines which segments to load to maintain target buffer duration.
- * Handles discontiguous buffering (gaps after seeks).
+ * Determines which segments to load to maintain target buffer duration. Handles discontiguous buffering (gaps after
+ * seeks).
  *
- * Algorithm:
- * 1. Calculate target time: currentTime + bufferDuration
- * 2. Find all segments in range [currentTime, targetTime)
- * 3. Filter out segments already buffered at that time position
- * 4. Return segments to load (fills gaps + extends to target)
+ * Algorithm: 1. Calculate target time: currentTime + bufferDuration 2. Find all segments in range [currentTime,
+ * targetTime) 3. Filter out segments already buffered at that time position 4. Return segments to load (fills gaps +
+ * extends to target)
+ *
+ * @example
+ *   // After seek: buffered [0-12, 18-30], playing at 7s
+ *   const toLoad = getSegmentsToLoad(segments, buffered, 7, { bufferDuration: 24 });
+ *   // Returns [seg-12, seg-30] (fills gap, extends to target 31s)
  *
  * @param segments - All available segments from playlist
  * @param bufferedSegments - Segments already buffered (ordered by startTime)
  * @param currentTime - Current playback position in seconds
  * @param config - Optional forward buffer configuration
  * @returns Array of segments to load (empty if buffer is sufficient)
- *
- * @example
- * // After seek: buffered [0-12, 18-30], playing at 7s
- * const toLoad = getSegmentsToLoad(segments, buffered, 7, { bufferDuration: 24 });
- * // Returns [seg-12, seg-30] (fills gap, extends to target 31s)
  */
 /**
  * Calculate the start time from which to flush forward buffer content.
  *
- * Content that starts at or beyond `currentTime + bufferDuration` is no
- * longer needed for the current playback position and should be removed
- * from the SourceBuffer. This prevents unbounded accumulation of scattered
- * SourceBuffer content after seeks, which can cause QuotaExceededError on
- * long-form content.
+ * Content that starts at or beyond `currentTime + bufferDuration` is no longer needed for the current playback position
+ * and should be removed from the SourceBuffer. This prevents unbounded accumulation of scattered SourceBuffer content
+ * after seeks, which can cause QuotaExceededError on long-form content.
  *
- * Returns `Infinity` when nothing needs flushing (no buffered segments
- * exist beyond the threshold).
+ * Returns `Infinity` when nothing needs flushing (no buffered segments exist beyond the threshold).
+ *
+ * @example
+ *   // Playing at 0s, buffered [0,6,12,18,24,30,36], bufferDuration=30
+ *   const flushStart = calculateForwardFlushPoint(segments, 0);
+ *   // Returns 30 — flush [30, Infinity), keep [0, 30)
  *
  * @param bufferedSegments - Segments currently tracked in the buffer model
  * @param currentTime - Current playback position in seconds
  * @param config - Optional forward buffer configuration
  * @returns Start time to flush from (flush range: [flushStart, Infinity)),
- *          or Infinity if no flush is needed
- *
- * @example
- * // Playing at 0s, buffered [0,6,12,18,24,30,36], bufferDuration=30
- * const flushStart = calculateForwardFlushPoint(segments, 0);
- * // Returns 30 — flush [30, Infinity), keep [0, 30)
+ * or Infinity if no flush is needed
  */
 export function calculateForwardFlushPoint(
   bufferedSegments: readonly Segment[],
@@ -132,12 +119,11 @@ export function calculateForwardFlushPoint(
 }
 
 /**
- * Find the start time of the segment containing `currentTime` (or the last
- * segment if `currentTime` is past the end). Returns `undefined` when
- * `currentTime` is undefined or when no segment matches.
+ * Find the start time of the segment containing `currentTime` (or the last segment if `currentTime` is past the end).
+ * Returns `undefined` when `currentTime` is undefined or when no segment matches.
  *
- * Used to detect "meaningful currentTime change" — two times that map to the
- * same segment start aren't a load-trigger; crossing a segment boundary is.
+ * Used to detect "meaningful currentTime change" — two times that map to the same segment start aren't a load-trigger;
+ * crossing a segment boundary is.
  */
 export function segmentStartForTime(
   currentTime: number | undefined,

--- a/packages/spf/src/media/dom/capabilities.ts
+++ b/packages/spf/src/media/dom/capabilities.ts
@@ -1,21 +1,17 @@
 /**
- * Capability probing — the engine's foundation for asking the browser what it
- * can actually decode before committing a rendition to the pipeline.
+ * Capability probing — the engine's foundation for asking the browser what it can actually decode before committing a
+ * rendition to the pipeline.
  *
- * Today this is the synchronous codec half: `canPlayTrack` answers "can this
- * environment play this track?" by building the track's MIME codec string and
- * passing it to `MediaSource.isTypeSupported` (via `isCodecSupported`). It's the
- * DOM implementation of the DOM-free `CanPlayTrack` predicate the
- * track-switching hard-constraint pre-pass consumes — injected through engine
- * config so the (DOM-free) behavior never imports a DOM API directly.
+ * Today this is the synchronous codec half: `canPlayTrack` answers "can this environment play this track?" by building
+ * the track's MIME codec string and passing it to `MediaSource.isTypeSupported` (via `isCodecSupported`). It's the DOM
+ * implementation of the DOM-free `CanPlayTrack` predicate the track-switching hard-constraint pre-pass consumes —
+ * injected through engine config so the (DOM-free) behavior never imports a DOM API directly.
  *
- * Results are memoized by built MIME string: codec support is a pure function
- * of (codec, environment) and never changes after load, so probing is lazy
- * (per candidate, at constraint-apply time) but each unique MIME is asked once.
+ * Results are memoized by built MIME string: codec support is a pure function of (codec, environment) and never changes
+ * after load, so probing is lazy (per candidate, at constraint-apply time) but each unique MIME is asked once.
  *
- * Future cluster-D phases (async `requestMediaKeySystemAccess` key-system
- * probing, `SourceBuffer.changeType()` availability) extend this surface; the
- * async ones land as a state-slot writer behavior rather than a config
+ * Future cluster-D phases (async `requestMediaKeySystemAccess` key-system probing, `SourceBuffer.changeType()`
+ * availability) extend this surface; the async ones land as a state-slot writer behavior rather than a config
  * predicate, since their verdict resolves asynchronously.
  */
 
@@ -26,31 +22,24 @@ import { buildMimeCodec, isCodecSupported } from './mse/mediasource-setup';
 const codecSupportCache = new Map<string, boolean>();
 
 /**
- * Whether the environment can decode `track`, by codec. Builds the track's
- * MIME codec string and checks `MediaSource.isTypeSupported`, memoized by MIME.
- * A track without enough to probe — no `mimeType`, or no declared `codecs`
- * (CODECS is optional per the HLS spec) — is unprobeable and passes through as
- * playable (`true`) rather than being dropped; the late `createSourceBuffer`
- * check stays as the backstop for those.
+ * Whether the environment can decode `track`, by codec. Builds the track's MIME codec string and checks
+ * `MediaSource.isTypeSupported`, memoized by MIME. A track without enough to probe — no `mimeType`, or no declared
+ * `codecs` (CODECS is optional per the HLS spec) — is unprobeable and passes through as playable (`true`) rather than
+ * being dropped; the late `createSourceBuffer` check stays as the backstop for those.
  *
- * Detected non-fMP4 containers (`video/mp2t`, `audio/aac`) are asserted
- * unsupported regardless of the probe, so they're pruned before selection
- * (the type makes no pick) instead of failing/stalling deep in the pipeline.
- * Two different reasons, neither UA-based:
+ * Detected non-fMP4 containers (`video/mp2t`, `audio/aac`) are asserted unsupported regardless of the probe, so they're
+ * pruned before selection (the type makes no pick) instead of failing/stalling deep in the pipeline. Two different
+ * reasons, neither UA-based:
  *
- * - **MPEG-TS** can't be played at all here: `isTypeSupported('video/mp2t…')` is
- *   a genuine false positive on Chromium (reports `true` but appends produce no
- *   buffered range), and this engine has no TS transmux pipeline.
- * - **Raw ADTS AAC** is a *temporary* limitation. The browser genuinely
- *   supports it (Chrome/Safari decode `audio/aac`; Firefox doesn't), so it could
- *   be made playable — but our segment actors / loading behaviors / append
- *   pipeline assume every rendition has an `EXT-X-MAP` init segment (e.g. an
- *   `append-init` task with an empty URL, fMP4-shaped append handling). Until
- *   that init-segment assumption is removed, ADTS would fetch but never buffer
- *   (a silent stall), so we assert it unplayable for now. FOLLOW-UP: drop the
- *   init-required assumption in the pipeline and switch this to a bare-MIME
- *   probe (`buildMimeCodec` would project `audio/aac` with no codecs) so it
- *   plays where the browser supports it.
+ * - **MPEG-TS** can't be played at all here: `isTypeSupported('video/mp2t…')` is a genuine false positive on Chromium
+ *   (reports `true` but appends produce no buffered range), and this engine has no TS transmux pipeline.
+ * - **Raw ADTS AAC** is a _temporary_ limitation. The browser genuinely supports it (Chrome/Safari decode `audio/aac`;
+ *   Firefox doesn't), so it could be made playable — but our segment actors / loading behaviors / append pipeline
+ *   assume every rendition has an `EXT-X-MAP` init segment (e.g. an `append-init` task with an empty URL, fMP4-shaped
+ *   append handling). Until that init-segment assumption is removed, ADTS would fetch but never buffer (a silent
+ *   stall), so we assert it unplayable for now. FOLLOW-UP: drop the init-required assumption in the pipeline and switch
+ *   this to a bare-MIME probe (`buildMimeCodec` would project `audio/aac` with no codecs) so it plays where the browser
+ *   supports it.
  *
  * Override via the engine's `canPlayTrack` config when those pipelines land.
  */

--- a/packages/spf/src/media/dom/mse/append-segment.ts
+++ b/packages/spf/src/media/dom/mse/append-segment.ts
@@ -1,9 +1,8 @@
 /**
  * Segment appender helper.
  *
- * Appends media data (ArrayBuffer or AsyncIterable<Uint8Array> stream) to a
- * SourceBuffer, waiting for `updateend` between calls so the browser can
- * process each append before the next one arrives.
+ * Appends media data (ArrayBuffer or AsyncIterable<Uint8Array> stream) to a SourceBuffer, waiting for `updateend`
+ * between calls so the browser can process each append before the next one arrives.
  */
 
 import type { SegmentData } from '../../types';
@@ -14,12 +13,10 @@ export type AppendData = SegmentData;
 /**
  * Append media data to a SourceBuffer.
  *
- * Accepts either a full ArrayBuffer (single append) or an AsyncIterable of
- * Uint8Array chunks (one append per chunk, in order). Waits for `updateend`
- * between each call so appends are serialized correctly.
+ * Accepts either a full ArrayBuffer (single append) or an AsyncIterable of Uint8Array chunks (one append per chunk, in
+ * order). Waits for `updateend` between each call so appends are serialized correctly.
  *
- * Errors from the SourceBuffer (`error` event) or from the iterable are
- * propagated as rejections.
+ * Errors from the SourceBuffer (`error` event) or from the iterable are propagated as rejections.
  */
 export async function appendSegment(sourceBuffer: SourceBuffer, data: AppendData, signal?: AbortSignal): Promise<void> {
   if (data instanceof ArrayBuffer) {

--- a/packages/spf/src/media/dom/mse/buffer-flusher.ts
+++ b/packages/spf/src/media/dom/mse/buffer-flusher.ts
@@ -7,16 +7,16 @@
 /**
  * Remove a time range from a SourceBuffer.
  *
- * Waits for the SourceBuffer to be ready (not updating), then removes
- * the specified range. Returns a promise that resolves when removal completes.
+ * Waits for the SourceBuffer to be ready (not updating), then removes the specified range. Returns a promise that
+ * resolves when removal completes.
+ *
+ * @example
+ *   await flushBuffer(videoSourceBuffer, 0, 30);
  *
  * @param sourceBuffer - The SourceBuffer to remove data from
  * @param start - Start of the time range to remove (seconds)
  * @param end - End of the time range to remove (seconds)
  * @returns Promise that resolves when removal completes
- *
- * @example
- * await flushBuffer(videoSourceBuffer, 0, 30);
  */
 export async function flushBuffer(sourceBuffer: SourceBuffer, start: number, end: number): Promise<void> {
   // Wait for SourceBuffer to be ready (not currently updating)

--- a/packages/spf/src/media/dom/mse/duration.ts
+++ b/packages/spf/src/media/dom/mse/duration.ts
@@ -1,21 +1,18 @@
 /**
  * MediaSource duration helpers.
  *
- * Predicates and async primitives for propagating a presentation's duration
- * to `mediaSource.duration` under the MSE spec's constraints:
+ * Predicates and async primitives for propagating a presentation's duration to `mediaSource.duration` under the MSE
+ * spec's constraints:
  *
  * - `duration` cannot be set while any attached SourceBuffer is `updating`.
  * - `duration` cannot be less than any buffered range's end time.
  *
- * The buffer-set helpers take a `SourceBufferList` (or any iterable of
- * `SourceBuffer`) — they operate uniformly across whatever buffers are
- * attached, so callers in audio-only, video-only, and mixed configurations
- * compose them without per-type plumbing. `mediaSource.sourceBuffers` is the
- * canonical aggregate.
+ * The buffer-set helpers take a `SourceBufferList` (or any iterable of `SourceBuffer`) — they operate uniformly across
+ * whatever buffers are attached, so callers in audio-only, video-only, and mixed configurations compose them without
+ * per-type plumbing. `mediaSource.sourceBuffers` is the canonical aggregate.
  *
- * Consumed by `updateMediaSourceDuration` (DOM behavior) — kept here so the layering
- * stays clean: the predicates and wait helper are pure DOM/MSE primitives
- * with no `core/` reactivity.
+ * Consumed by `updateMediaSourceDuration` (DOM behavior) — kept here so the layering stays clean: the predicates and
+ * wait helper are pure DOM/MSE primitives with no `core/` reactivity.
  */
 
 import type { MaybeResolvedPresentation } from '../../types';
@@ -24,8 +21,8 @@ import { hasPresentationDuration } from '../../types';
 type SourceBufferIterable = SourceBufferList | Iterable<SourceBuffer>;
 
 /**
- * Check if we have the basics to update MediaSource duration:
- * a `mediaSource` and a `presentation` with a numeric duration.
+ * Check if we have the basics to update MediaSource duration: a `mediaSource` and a `presentation` with a numeric
+ * duration.
  */
 export function canUpdateDuration(
   presentation: MaybeResolvedPresentation | undefined,
@@ -57,44 +54,37 @@ const isGreaterThan = (x: number, y: number) => x > y;
 const isLessThan = (x: number, y: number) => x < y;
 
 /**
- * Get the maximum buffered end time across an iterable of SourceBuffers
- * (typically `mediaSource.sourceBuffers`). Returns `0` when the collection is
- * empty or no buffer has any buffered ranges.
+ * Get the maximum buffered end time across an iterable of SourceBuffers (typically `mediaSource.sourceBuffers`).
+ * Returns `0` when the collection is empty or no buffer has any buffered ranges.
  */
 export function getMaxBufferedEnd(buffers: SourceBufferIterable): number {
   return getBufferedEnd(buffers, isGreaterThan);
 }
 
 /**
- * Get the reachable buffered end across an iterable of SourceBuffers (typically
- * `mediaSource.sourceBuffers`): the `min` of each buffer's last buffered-range end
- * — the furthest point every track can play to (the intersection end). Buffers with
- * no buffered ranges are skipped. Returns `0` when the collection is empty or no
- * buffer has any buffered ranges.
+ * Get the reachable buffered end across an iterable of SourceBuffers (typically `mediaSource.sourceBuffers`): the `min`
+ * of each buffer's last buffered-range end — the furthest point every track can play to (the intersection end). Buffers
+ * with no buffered ranges are skipped. Returns `0` when the collection is empty or no buffer has any buffered ranges.
  *
- * Counterpart to {@link getMaxBufferedEnd}: `max` bounds the overall presentation
- * end (e.g. for setting `duration`), `min` bounds where playback can actually reach
- * when tracks end at slightly different times (e.g. skewed A/V near end-of-stream).
+ * Counterpart to {@link getMaxBufferedEnd}: `max` bounds the overall presentation end (e.g. for setting `duration`),
+ * `min` bounds where playback can actually reach when tracks end at slightly different times (e.g. skewed A/V near
+ * end-of-stream).
  */
 export function getMinBufferedEnd(buffers: SourceBufferIterable): number {
   return getBufferedEnd(buffers, isLessThan);
 }
 
 /**
- * Check if the preconditions are met to *attempt* a `mediaSource.duration`
- * write: a `mediaSource` is in scope and the presentation has a valid
- * positive duration (or `Infinity` for live).
+ * Check if the preconditions are met to _attempt_ a `mediaSource.duration` write: a `mediaSource` is in scope and the
+ * presentation has a valid positive duration (or `Infinity` for live).
  *
- * Does **not** check `mediaSource.readyState` or `mediaSource.duration` —
- * those are DOM properties the caller resolves at write time (e.g., by
- * `await`ing `waitForMediaSourceOpen` and re-checking `readyState` after,
- * and guarding on the existing `mediaSource.duration` for idempotency).
- * Keeping these off the signal-driven predicate lets callers use this
- * inside reactor state derivation without smuggling non-reactive DOM
- * reads into `computed(...)`.
+ * Does **not** check `mediaSource.readyState` or `mediaSource.duration` — those are DOM properties the caller resolves
+ * at write time (e.g., by `await`ing `waitForMediaSourceOpen` and re-checking `readyState` after, and guarding on the
+ * existing `mediaSource.duration` for idempotency). Keeping these off the signal-driven predicate lets callers use this
+ * inside reactor state derivation without smuggling non-reactive DOM reads into `computed(...)`.
  *
- * `Infinity` is allowed — per the MSE spec, `mediaSource.duration = +Infinity`
- * is how live playback signals an indefinite duration.
+ * `Infinity` is allowed — per the MSE spec, `mediaSource.duration = +Infinity` is how live playback signals an
+ * indefinite duration.
  */
 export function shouldUpdateDuration(
   presentation: MaybeResolvedPresentation | undefined,
@@ -110,13 +100,12 @@ export function shouldUpdateDuration(
 }
 
 /**
- * Wait for all currently-updating SourceBuffers in `buffers` to finish, or
- * until `signal` aborts — whichever fires first.
+ * Wait for all currently-updating SourceBuffers in `buffers` to finish, or until `signal` aborts — whichever fires
+ * first.
  *
- * The MSE spec forbids setting `MediaSource.duration` while any attached
- * SourceBuffer has `updating === true`. This defers until all are idle.
- * Listeners are registered with `{ signal }` so an abort tears them down
- * up-front rather than leaving them dangling until the next `updateend`.
+ * The MSE spec forbids setting `MediaSource.duration` while any attached SourceBuffer has `updating === true`. This
+ * defers until all are idle. Listeners are registered with `{ signal }` so an abort tears them down up-front rather
+ * than leaving them dangling until the next `updateend`.
  */
 export function waitForSourceBuffersReady(buffers: SourceBufferIterable, signal: AbortSignal): Promise<void> {
   if (signal.aborted) return Promise.resolve();

--- a/packages/spf/src/media/dom/mse/end-of-stream.ts
+++ b/packages/spf/src/media/dom/mse/end-of-stream.ts
@@ -1,40 +1,34 @@
 /**
  * End-of-stream detection helpers.
  *
- * Pure predicate that compares a track's expected segment list against the
- * appended-segment list from an MSE SourceBufferActor's snapshot. Consumed
- * by the `endOfStream` playback behavior to decide when to call
+ * Pure predicate that compares a track's expected segment list against the appended-segment list from an MSE
+ * SourceBufferActor's snapshot. Consumed by the `endOfStream` playback behavior to decide when to call
  * `MediaSource.endOfStream()`.
  *
- * Kept here so the layering stays clean: predicate has no `core/`
- * reactivity and operates on plain segment lists extracted by the caller.
+ * Kept here so the layering stays clean: predicate has no `core/` reactivity and operates on plain segment lists
+ * extracted by the caller.
  */
 
 /**
- * Minimum information about an appended segment needed to decide whether
- * it counts toward end-of-stream readiness.
+ * Minimum information about an appended segment needed to decide whether it counts toward end-of-stream readiness.
  *
- * Matches the shape of `SourceBufferActor`'s context segments — callers
- * typically pass `actor.snapshot.get().context.segments` directly.
+ * Matches the shape of `SourceBufferActor`'s context segments — callers typically pass
+ * `actor.snapshot.get().context.segments` directly.
  */
 export interface AppendedSegment {
   id: string;
   /**
-   * True while a streaming append is in progress for this segment. A
-   * partial segment is still streaming — it does not count as the last
-   * segment being ready.
+   * True while a streaming append is in progress for this segment. A partial segment is still streaming — it does not
+   * count as the last segment being ready.
    */
   partial?: boolean;
 }
 
 /**
- * Check if the temporally last segment of `expectedSegments` is present in
- * `appendedSegments` and not marked partial.
+ * Check if the temporally last segment of `expectedSegments` is present in `appendedSegments` and not marked partial.
  *
- * Compares by segment ID rather than by a pipeline flag, so the result
- * stays correct across quality switches (different tracks have different
- * segment IDs) and back-buffer flushes (flushed segment IDs are removed
- * from the appended list).
+ * Compares by segment ID rather than by a pipeline flag, so the result stays correct across quality switches (different
+ * tracks have different segment IDs) and back-buffer flushes (flushed segment IDs are removed from the appended list).
  */
 export function isLastSegmentAppended(
   expectedSegments: readonly { id: string }[],

--- a/packages/spf/src/media/dom/mse/mediasource-setup.ts
+++ b/packages/spf/src/media/dom/mse/mediasource-setup.ts
@@ -1,30 +1,25 @@
 /**
  * MediaSource Setup
  *
- * Utilities for creating and configuring MediaSource/ManagedMediaSource
- * for MSE (Media Source Extensions) playback.
+ * Utilities for creating and configuring MediaSource/ManagedMediaSource for MSE (Media Source Extensions) playback.
  *
  * Global ManagedMediaSource types are defined in ./mediasource.d.ts
  */
 
-/**
- * Check if MediaSource API is supported.
- */
+/** Check if MediaSource API is supported. */
 export function supportsMediaSource(): boolean {
   return typeof MediaSource !== 'undefined';
 }
 
 /**
- * Check if ManagedMediaSource API is supported.
- * ManagedMediaSource is a newer Safari API with better lifecycle management.
+ * Check if ManagedMediaSource API is supported. ManagedMediaSource is a newer Safari API with better lifecycle
+ * management.
  */
 export function supportsManagedMediaSource(): boolean {
   return typeof ManagedMediaSource !== 'undefined';
 }
 
-/**
- * Options for creating a MediaSource.
- */
+/** Options for creating a MediaSource. */
 export interface CreateMediaSourceOptions {
   /** Prefer ManagedMediaSource when available (default: false for broader compatibility). */
   preferManaged?: boolean;
@@ -33,14 +28,14 @@ export interface CreateMediaSourceOptions {
 /**
  * Create a MediaSource or ManagedMediaSource instance.
  *
+ * @example
+ *   const mediaSource = createMediaSource();
+ *   const mediaElement = document.querySelector('video');
+ *   attachMediaSource(mediaSource, mediaElement);
+ *
  * @param options - Creation options
  * @returns A MediaSource or ManagedMediaSource instance
  * @throws Error if no MediaSource API is available
- *
- * @example
- * const mediaSource = createMediaSource();
- * const mediaElement = document.querySelector('video');
- * attachMediaSource(mediaSource, mediaElement);
  */
 export function createMediaSource(options: CreateMediaSourceOptions = {}): MediaSource {
   const { preferManaged = false } = options;
@@ -56,29 +51,23 @@ export function createMediaSource(options: CreateMediaSourceOptions = {}): Media
   throw new Error('MediaSource API is not supported');
 }
 
-/**
- * Options for `detach`.
- */
+/** Options for `detach`. */
 export interface DetachOptions {
   /**
    * Run the `load()` reset on the next microtask instead of synchronously.
    *
-   * Required whenever another owner contributes sibling `<source>` children to
-   * the same element and drops them from a signal effect: effects re-run on a
-   * microtask, so a synchronous reset would run resource selection while those
-   * siblings are still in the DOM and commit the element to one of them.
-   * Canonical caller: `setupMediaSource`, whose compositions may include
-   * `setupAirPlay`'s native-HLS fallback source.
+   * Required whenever another owner contributes sibling `<source>` children to the same element and drops them from a
+   * signal effect: effects re-run on a microtask, so a synchronous reset would run resource selection while those
+   * siblings are still in the DOM and commit the element to one of them. Canonical caller: `setupMediaSource`, whose
+   * compositions may include `setupAirPlay`'s native-HLS fallback source.
    *
-   * The ownership guard is evaluated when the reset actually fires, so a
-   * re-attach landing in the interim correctly suppresses it.
+   * The ownership guard is evaluated when the reset actually fires, so a re-attach landing in the interim correctly
+   * suppresses it.
    */
   deferReset?: boolean;
 }
 
-/**
- * Result of attaching a MediaSource to a media element.
- */
+/** Result of attaching a MediaSource to a media element. */
 export interface AttachMediaSourceResult {
   /** The object URL created for the MediaSource. */
   url: string;
@@ -89,20 +78,19 @@ export interface AttachMediaSourceResult {
 /**
  * Attach a MediaSource to an HTMLMediaElement via the `src` attribute.
  *
- * The object URL on the `src` attribute is the industry-hardened MSE attach
- * across the browser matrix, and works for ManagedMediaSource too (`srcObject`
- * buys nothing over it and forfeits the uniform URL lifecycle).
+ * The object URL on the `src` attribute is the industry-hardened MSE attach across the browser matrix, and works for
+ * ManagedMediaSource too (`srcObject` buys nothing over it and forfeits the uniform URL lifecycle).
+ *
+ * @example
+ *   const mediaSource = createMediaSource();
+ *   const { detach } = attachMediaSource(mediaSource, videoElement);
+ *   // Use mediaSource...
+ *   // Later, to clean up:
+ *   detach();
  *
  * @param mediaSource - The MediaSource to attach
  * @param mediaElement - The media element to attach to
  * @returns Object with URL and detach function
- *
- * @example
- * const mediaSource = createMediaSource();
- * const { detach } = attachMediaSource(mediaSource, videoElement);
- * // Use mediaSource...
- * // Later, to clean up:
- * detach();
  */
 export function attachMediaSource(mediaSource: MediaSource, mediaElement: HTMLMediaElement): AttachMediaSourceResult {
   // ManagedMediaSource requires disableRemotePlayback — without it Safari
@@ -128,14 +116,11 @@ export function attachMediaSource(mediaSource: MediaSource, mediaElement: HTMLMe
 /**
  * Attach a MediaSource as a `<source>` child element.
  *
- * The object URL rides a `<source type="video/mp4">` inserted as the
- * element's FIRST child (any bare `src` attribute is dropped; `load()`
- * re-runs resource selection). Unlike `srcObject`/`src` — which commit the
- * element to the MSE resource and ignore every `<source>` child — this
- * keeps sibling `<source>` alternatives part of resource selection, so a
- * composition can offer the element a natively-playable alternative next to
- * MSE. Canonical consumer: `setupAirPlay`'s native-HLS fallback source,
- * wired through `setupMediaSource`'s `attachMediaSource` config
+ * The object URL rides a `<source type="video/mp4">` inserted as the element's FIRST child (any bare `src` attribute is
+ * dropped; `load()` re-runs resource selection). Unlike `srcObject`/`src` — which commit the element to the MSE
+ * resource and ignore every `<source>` child — this keeps sibling `<source>` alternatives part of resource selection,
+ * so a composition can offer the element a natively-playable alternative next to MSE. Canonical consumer:
+ * `setupAirPlay`'s native-HLS fallback source, wired through `setupMediaSource`'s `attachMediaSource` config
  * (https://webkit.org/blog/15036/how-to-use-media-source-extensions-with-airplay/).
  */
 export function attachMediaSourceAsSourceElement(
@@ -170,14 +155,11 @@ export function attachMediaSourceAsSourceElement(
 }
 
 /**
- * Detach's `load()` reset, applied only when tearing down an **unclosed**
- * attachment the element is still committed to:
+ * Detach's `load()` reset, applied only when tearing down an **unclosed** attachment the element is still committed to:
  *
- * - **Closed MediaSource**: skip. The attachment is already dead, and the
- *   element deliberately keeps whatever playback state it carries for
- *   whatever attaches next — that attach's own `load()` performs the reset.
- * - **Element moved to another resource**: skip — resetting would rip that
- *   resource out from under its owner.
+ * - **Closed MediaSource**: skip. The attachment is already dead, and the element deliberately keeps whatever playback
+ *   state it carries for whatever attaches next — that attach's own `load()` performs the reset.
+ * - **Element moved to another resource**: skip — resetting would rip that resource out from under its owner.
  */
 function resetIfOwnedAndNotClosed(mediaSource: MediaSource, mediaElement: HTMLMediaElement, url: string): void {
   if (mediaSource.readyState !== 'closed' && mediaElement.currentSrc === url) {
@@ -186,12 +168,11 @@ function resetIfOwnedAndNotClosed(mediaSource: MediaSource, mediaElement: HTMLMe
 }
 
 /**
- * Run the reset now, or on the next microtask when the caller has sibling
- * `<source>` owners that clear on an effect (see {@link DetachOptions.deferReset}).
+ * Run the reset now, or on the next microtask when the caller has sibling `<source>` owners that clear on an effect
+ * (see {@link DetachOptions.deferReset}).
  *
- * Deferring is safe because removing this attachment's own source does not by
- * itself re-run resource selection: the element stays committed to the object
- * URL until something calls `load()`, so nothing starts playing in the gap.
+ * Deferring is safe because removing this attachment's own source does not by itself re-run resource selection: the
+ * element stays committed to the object URL until something calls `load()`, so nothing starts playing in the gap.
  */
 function scheduleReset(
   mediaSource: MediaSource,
@@ -210,13 +191,13 @@ function scheduleReset(
 /**
  * Create a SourceBuffer on a MediaSource.
  *
+ * @example
+ *   const buffer = createSourceBuffer(mediaSource, 'video/mp4; codecs="avc1.42E01E"');
+ *
  * @param mediaSource - The MediaSource (must be in 'open' state)
  * @param mimeCodec - MIME type with codecs (e.g., 'video/mp4; codecs="avc1.42E01E"')
  * @returns The created SourceBuffer
  * @throws Error if MediaSource is not open or codec is unsupported
- *
- * @example
- * const buffer = createSourceBuffer(mediaSource, 'video/mp4; codecs="avc1.42E01E"');
  */
 export function createSourceBuffer(mediaSource: MediaSource, mimeCodec: string): SourceBuffer {
   if (mediaSource.readyState !== 'open') {
@@ -231,16 +212,15 @@ export function createSourceBuffer(mediaSource: MediaSource, mimeCodec: string):
 }
 
 /**
- * Build a MIME codec string from a track's `mimeType` + `codecs`. Works
- * on partially-resolved tracks — both fields come from the multivariant
- * playlist and are available before media-playlist resolution.
+ * Build a MIME codec string from a track's `mimeType` + `codecs`. Works on partially-resolved tracks — both fields come
+ * from the multivariant playlist and are available before media-playlist resolution.
+ *
+ * @example
+ *   buildMimeCodec({ mimeType: 'video/mp4', codecs: ['avc1.42E01E'] });
+ *   // => 'video/mp4; codecs="avc1.42E01E"'
  *
  * @param track - Track carrying `mimeType` and `codecs`
  * @returns MIME codec string suitable for `MediaSource.addSourceBuffer`
- *
- * @example
- * buildMimeCodec({ mimeType: 'video/mp4', codecs: ['avc1.42E01E'] })
- * // => 'video/mp4; codecs="avc1.42E01E"'
  */
 export function buildMimeCodec(track: { mimeType: string; codecs?: string[] }): string {
   const codecString = track.codecs?.join(',') ?? '';
@@ -251,13 +231,13 @@ export function buildMimeCodec(track: { mimeType: string; codecs?: string[] }): 
 /**
  * Check if a codec is supported.
  *
+ * @example
+ *   if (isCodecSupported('video/mp4; codecs="avc1.42E01E"')) {
+ *     // Create source buffer
+ *   }
+ *
  * @param mimeCodec - MIME type with codecs string
  * @returns True if the codec is supported
- *
- * @example
- * if (isCodecSupported('video/mp4; codecs="avc1.42E01E"')) {
- *   // Create source buffer
- * }
  */
 export function isCodecSupported(mimeCodec: string): boolean {
   if (!supportsMediaSource()) {
@@ -270,20 +250,19 @@ export function isCodecSupported(mimeCodec: string): boolean {
 /**
  * Observe `mediaSource.readyState` changes via DOM events.
  *
- * Listens to `sourceopen`, `sourceended`, and `sourceclose` and invokes
- * `onChange` with the current `readyState` after each event. Listeners
- * are automatically removed when `abortSignal` is aborted.
+ * Listens to `sourceopen`, `sourceended`, and `sourceclose` and invokes `onChange` with the current `readyState` after
+ * each event. Listeners are automatically removed when `abortSignal` is aborted.
+ *
+ * @example
+ *   const controller = new AbortController();
+ *   onMediaSourceReadyStateChange(mediaSource, controller.signal, (state) => {
+ *   if (state === 'open') { ... }
+ *   });
+ *   // Later: controller.abort();
  *
  * @param mediaSource - The MediaSource to observe
  * @param abortSignal - AbortSignal that controls listener lifetime
  * @param onChange - Called with the current readyState after each change
- *
- * @example
- * const controller = new AbortController();
- * onMediaSourceReadyStateChange(mediaSource, controller.signal, (state) => {
- *   if (state === 'open') { ... }
- * });
- * // Later: controller.abort();
  */
 export function onMediaSourceReadyStateChange(
   mediaSource: MediaSource,
@@ -299,23 +278,20 @@ export function onMediaSourceReadyStateChange(
 }
 
 /**
- * Wait until `mediaSource.readyState` transitions away from `'closed'`
- * (the next `sourceopen`/`sourceended`/`sourceclose` event), or until
- * `signal` aborts — whichever fires first.
+ * Wait until `mediaSource.readyState` transitions away from `'closed'` (the next
+ * `sourceopen`/`sourceended`/`sourceclose` event), or until `signal` aborts — whichever fires first.
  *
- * Resolves immediately when `readyState` is already `'open'` or `'ended'`
- * (no further transition is coming, so there's nothing to wait for). The
- * caller is expected to re-check `readyState` after the await to
- * distinguish `'open'` from terminal states.
+ * Resolves immediately when `readyState` is already `'open'` or `'ended'` (no further transition is coming, so there's
+ * nothing to wait for). The caller is expected to re-check `readyState` after the await to distinguish `'open'` from
+ * terminal states.
  *
- * Companion to `onMediaSourceReadyStateChange` for one-shot use in async
- * sequences (e.g., a behavior's reactor entry that needs to wait for the
- * MediaSource to attach before performing a spec-conforming mutation).
+ * Companion to `onMediaSourceReadyStateChange` for one-shot use in async sequences (e.g., a behavior's reactor entry
+ * that needs to wait for the MediaSource to attach before performing a spec-conforming mutation).
  *
  * @example
- * await waitForMediaSourceOpen(mediaSource, signal);
- * if (signal.aborted || mediaSource.readyState !== 'open') return;
- * // safe to perform 'open'-state-only work
+ *   await waitForMediaSourceOpen(mediaSource, signal);
+ *   if (signal.aborted || mediaSource.readyState !== 'open') return;
+ *   // safe to perform 'open'-state-only work
  */
 export function waitForMediaSourceOpen(mediaSource: MediaSource, signal: AbortSignal): Promise<void> {
   if (signal.aborted) return Promise.resolve();

--- a/packages/spf/src/media/dom/mse/mediasource.d.ts
+++ b/packages/spf/src/media/dom/mse/mediasource.d.ts
@@ -1,10 +1,8 @@
-/**
- * Global type declarations for MediaSource APIs.
- */
+/** Global type declarations for MediaSource APIs. */
 
 /**
- * ManagedMediaSource is a newer Safari API not yet in standard DOM types.
- * Provides better lifecycle management for background tabs and picture-in-picture.
+ * ManagedMediaSource is a newer Safari API not yet in standard DOM types. Provides better lifecycle management for
+ * background tabs and picture-in-picture.
  */
 declare global {
   interface ManagedMediaSource extends MediaSource {

--- a/packages/spf/src/media/dom/screen.ts
+++ b/packages/spf/src/media/dom/screen.ts
@@ -1,19 +1,16 @@
 /**
  * Screen resolution, as the signal source for a screen-size rendition cap.
  *
- * Reported as a width and a height rather than a `"720p"`-style tier, because
- * the cap that consumes it compares against real track dimensions. A tier only
- * describes a track once you assume its aspect ratio, and that assumption
+ * Reported as a width and a height rather than a `"720p"`-style tier, because the cap that consumes it compares against
+ * real track dimensions. A tier only describes a track once you assume its aspect ratio, and that assumption
  * mis-measures an anamorphic or otherwise non-16:9 rendition.
  *
- * The signal source for the screen-size cap in
- * `internal/design/spf/features/rendition-selection-caps.md`.
+ * The signal source for the screen-size cap in `internal/design/spf/features/rendition-selection-caps.md`.
  *
- * The screen underneath a window is not stable: rotating a device swaps the axes,
- * and unplugging a monitor or dragging the window to another display changes the
- * numbers *and* which physical screen they describe. So `getScreenResolution`
- * reads at call time and caches nothing, and `watchScreenResolution` layers the
- * reacting on top rather than the reader holding state of its own.
+ * The screen underneath a window is not stable: rotating a device swaps the axes, and unplugging a monitor or dragging
+ * the window to another display changes the numbers _and_ which physical screen they describe. So `getScreenResolution`
+ * reads at call time and caches nothing, and `watchScreenResolution` layers the reacting on top rather than the reader
+ * holding state of its own.
  */
 
 import { getDevicePixelRatio, listen, watchDevicePixelRatio } from '@videojs/utils/dom';
@@ -27,18 +24,15 @@ export type ScreenResolution = Resolution;
 
 export interface ScreenResolutionOptions {
   /**
-   * Scale the reading from CSS pixels into device pixels. On by default, since
-   * device pixels are what the screen actually has, and a rendition's dimensions
-   * are in the same units.
+   * Scale the reading from CSS pixels into device pixels. On by default, since device pixels are what the screen
+   * actually has, and a rendition's dimensions are in the same units.
    *
-   * Opt out for CSS pixels. Note that derating — a 3x phone rarely wanting 3x the
-   * pixels of its layout — is a scale applied over this reading rather than a
-   * reason to turn it off.
+   * Opt out for CSS pixels. Note that derating — a 3x phone rarely wanting 3x the pixels of its layout — is a scale
+   * applied over this reading rather than a reason to turn it off.
    *
-   * ⚠️ Chromium and Gecko fold page zoom into `devicePixelRatio`, so with this on,
-   * zooming moves the reading even though the screen didn't change. WebKit holds
-   * the ratio independent of zoom and is unaffected. Whether a cap should track
-   * zoom is the cap's call; this flag is only what puts zoom in scope.
+   * ⚠️ Chromium and Gecko fold page zoom into `devicePixelRatio`, so with this on, zooming moves the reading even
+   * though the screen didn't change. WebKit holds the ratio independent of zoom and is unaffected. Whether a cap should
+   * track zoom is the cap's call; this flag is only what puts zoom in scope.
    */
   useDevicePixelRatio: boolean;
 }
@@ -46,16 +40,14 @@ export interface ScreenResolutionOptions {
 /**
  * Read the screen's resolution, or `undefined` where there isn't one to read.
  *
- * `undefined` means "unknown", which is the answer a cap needs in order to not
- * cap. `screenResolutionCap` reads it that way and declines to narrow, so an
- * unknown screen is "no cap" rather than a cap of zero — the reading a naive
- * `?? 0` would produce, which would pin every source to its smallest rendition on
- * exactly the environments we know least about.
+ * `undefined` means "unknown", which is the answer a cap needs in order to not cap. `screenResolutionCap` reads it that
+ * way and declines to narrow, so an unknown screen is "no cap" rather than a cap of zero — the reading a naive `?? 0`
+ * would produce, which would pin every source to its smallest rendition on exactly the environments we know least
+ * about.
  *
- * Dimensions are reported as-is, including the axis swap a rotated device
- * applies to them. Normalizing orientation away is a policy question — whether a
- * cap should flap on rotation, or hold the larger budget across both — and
- * belongs to the cap rather than to the reading.
+ * Dimensions are reported as-is, including the axis swap a rotated device applies to them. Normalizing orientation away
+ * is a policy question — whether a cap should flap on rotation, or hold the larger budget across both — and belongs to
+ * the cap rather than to the reading.
  */
 export function getScreenResolution(
   { useDevicePixelRatio }: ScreenResolutionOptions = { useDevicePixelRatio: true }
@@ -72,49 +64,37 @@ export function getScreenResolution(
 }
 
 /**
- * Call `onChange` whenever {@link getScreenResolution} would start answering
- * differently. Returns a function that stops watching.
+ * Call `onChange` whenever {@link getScreenResolution} would start answering differently. Returns a function that stops
+ * watching.
  *
- * There is no single event for "the screen changed", so this subscribes to every
- * signal that implies one and compares readings to decide whether anything
- * actually moved. Comparing is what makes that safe: the signals overlap and
- * `resize` in particular is noisy, so over-subscribing costs a discarded read
- * rather than a spurious call.
+ * There is no single event for "the screen changed", so this subscribes to every signal that implies one and compares
+ * readings to decide whether anything actually moved. Comparing is what makes that safe: the signals overlap and
+ * `resize` in particular is noisy, so over-subscribing costs a discarded read rather than a spurious call.
  *
- * `onChange` is called once on subscribe with the starting value — including
- * `undefined` where there is no screen — and after that only on a genuine change.
- * So a consumer gets its initial state from the watcher and never has to pair it
+ * `onChange` is called once on subscribe with the starting value — including `undefined` where there is no screen — and
+ * after that only on a genuine change. So a consumer gets its initial state from the watcher and never has to pair it
  * with a separate {@link getScreenResolution} call.
  *
  * The signals, and what each one is here for:
  *
- * - **`screen`'s own `change`** — the screen itself being reconfigured, or the
- *   window landing on a different one. The direct signal, and the only one that
- *   catches a window moving between two same-size, same-ratio displays. From the
- *   Window Management API, but on the base `Screen` rather than behind
- *   `getScreenDetails()`, so it needs no permission — only a secure context.
- *   Measured present in Chromium and absent in WebKit and Firefox, hence the
- *   three below rather than this alone.
- * - **`resize`** — the window changing size, which is also what the OS does to it
- *   when the display it was on goes away.
- * - **`screen.orientation` change** — rotation, which swaps the axes without
- *   necessarily resizing the window.
- * - **a `(resolution: <ratio>dppx)` media query** (`watchDevicePixelRatio`) — the
- *   device pixel ratio changing under a window that kept its size, which is the
- *   cross-display drag between displays of different density.
+ * - **`screen`'s own `change`** — the screen itself being reconfigured, or the window landing on a different one. The
+ *   direct signal, and the only one that catches a window moving between two same-size, same-ratio displays. From the
+ *   Window Management API, but on the base `Screen` rather than behind `getScreenDetails()`, so it needs no permission
+ *   — only a secure context. Measured present in Chromium and absent in WebKit and Firefox, hence the three below
+ *   rather than this alone.
+ * - **`resize`** — the window changing size, which is also what the OS does to it when the display it was on goes away.
+ * - **`screen.orientation` change** — rotation, which swaps the axes without necessarily resizing the window.
+ * - **a `(resolution: <ratio>dppx)` media query** (`watchDevicePixelRatio`) — the device pixel ratio changing under a
+ *   window that kept its size, which is the cross-display drag between displays of different density.
  *
- *   Worth keeping despite looking redundant, because it is the only coverage that
- *   case has in WebKit and Firefox: neither implements `screen`'s change event,
- *   and the drag doesn't resize the window. It is also a cleaner signal in Safari
- *   than elsewhere — WebKit holds `devicePixelRatio` independent of page zoom, so
- *   there it moves only on a real density change, where Chromium and Gecko fold
- *   zoom into it as well.
+ *   Worth keeping despite looking redundant, because it is the only coverage that case has in WebKit and Firefox: neither
+ *   implements `screen`'s change event, and the drag doesn't resize the window. It is also a cleaner signal in Safari
+ *   than elsewhere — WebKit holds `devicePixelRatio` independent of page zoom, so there it moves only on a real density
+ *   change, where Chromium and Gecko fold zoom into it as well.
  *
- * ⚠️ Known gap, on engines without `screen`'s change event: dragging a window
- * between two different-size displays that share a ratio, without the window
- * resizing, changes the reading with nothing firing. Closing it there would mean
- * polling, whose interval and battery cost are a policy decision this function
- * shouldn't be making.
+ * ⚠️ Known gap, on engines without `screen`'s change event: dragging a window between two different-size displays that
+ * share a ratio, without the window resizing, changes the reading with nothing firing. Closing it there would mean
+ * polling, whose interval and battery cost are a policy decision this function shouldn't be making.
  */
 export function watchScreenResolution(
   onChange: (resolution: ScreenResolution | undefined) => void,

--- a/packages/spf/src/media/dom/tests/screen.test.ts
+++ b/packages/spf/src/media/dom/tests/screen.test.ts
@@ -73,9 +73,8 @@ describe('getScreenResolution', () => {
 
 describe('watchScreenResolution', () => {
   /**
-   * A `matchMedia` stand-in whose queries can be told to fire. The real one only
-   * reports on ratios the environment actually has, so driving a ratio change
-   * means driving the query.
+   * A `matchMedia` stand-in whose queries can be told to fire. The real one only reports on ratios the environment
+   * actually has, so driving a ratio change means driving the query.
    */
   function stubMatchMedia() {
     const queries: Array<{ query: string; fire: () => void }> = [];
@@ -94,8 +93,8 @@ describe('watchScreenResolution', () => {
   }
 
   /**
-   * A mutable screen, so a test can move it the way the environment would. An
-   * `EventTarget` because the real one is: `screen` dispatches its own `change`.
+   * A mutable screen, so a test can move it the way the environment would. An `EventTarget` because the real one is:
+   * `screen` dispatches its own `change`.
    */
   function stubScreen(width: number, height: number, ratio = 1) {
     const screen = Object.assign(new EventTarget(), { width, height, orientation: new EventTarget() });
@@ -105,10 +104,7 @@ describe('watchScreenResolution', () => {
     return screen;
   }
 
-  /**
-   * Subscribe, then forget the call the subscribe itself makes, so a test can
-   * assert on changes alone.
-   */
+  /** Subscribe, then forget the call the subscribe itself makes, so a test can assert on changes alone. */
   function watchChanges(options?: ScreenResolutionOptions) {
     const onChange = vi.fn();
     const stop = watchScreenResolution(onChange, options);

--- a/packages/spf/src/media/dom/text/resolve-vtt-segment.ts
+++ b/packages/spf/src/media/dom/text/resolve-vtt-segment.ts
@@ -1,8 +1,8 @@
 /**
  * Parse a VTT segment using browser's native parser.
  *
- * Creates a dummy video element with a track element to leverage
- * the browser's optimized VTT parsing. Returns parsed VTTCue objects.
+ * Creates a dummy video element with a track element to leverage the browser's optimized VTT parsing. Returns parsed
+ * VTTCue objects.
  */
 
 import { resolveVttSegmentMetadata, type TextSegmentMetadata } from '../../text/resolve-vtt-metadata';
@@ -79,9 +79,8 @@ export function destroyVttResolver(): void {
 }
 
 /**
- * A resolved VTT segment paired with its header metadata — the shape used when a
- * caller needs the `X-TIMESTAMP-MAP` correlation (e.g. non-zero-PTS sources),
- * not just the cues.
+ * A resolved VTT segment paired with its header metadata — the shape used when a caller needs the `X-TIMESTAMP-MAP`
+ * correlation (e.g. non-zero-PTS sources), not just the cues.
  */
 export interface ResolvedVttSegment {
   cues: VTTCue[];
@@ -89,9 +88,8 @@ export interface ResolvedVttSegment {
 }
 
 /**
- * Resolve a VTT segment's cues and header metadata together. Cues still come
- * from the browser's native parser ({@link resolveVttSegment}); the header is
- * scraped in parallel ({@link resolveVttSegmentMetadata}).
+ * Resolve a VTT segment's cues and header metadata together. Cues still come from the browser's native parser ({@link
+ * resolveVttSegment}); the header is scraped in parallel ({@link resolveVttSegmentMetadata}).
  */
 export function resolveVttSegmentWithMetadata(url: string): Promise<ResolvedVttSegment> {
   return Promise.all([resolveVttSegment(url), resolveVttSegmentMetadata(url)]).then(([cues, metadata]) => ({

--- a/packages/spf/src/media/dom/text/tests/cue-persistence-investigation.test.ts
+++ b/packages/spf/src/media/dom/text/tests/cue-persistence-investigation.test.ts
@@ -1,9 +1,8 @@
 /**
  * Investigation: Do manually added TextTrack cues persist after async operations?
  *
- * This test file investigates whether cues added via TextTrack.addCue() persist
- * after async boundaries (setTimeout, Promise.resolve, etc.) in the vitest
- * browser test environment.
+ * This test file investigates whether cues added via TextTrack.addCue() persist after async boundaries (setTimeout,
+ * Promise.resolve, etc.) in the vitest browser test environment.
  */
 
 import { describe, expect, it } from 'vite-plus/test';

--- a/packages/spf/src/media/dom/text/text-track-slots.ts
+++ b/packages/spf/src/media/dom/text/text-track-slots.ts
@@ -3,21 +3,17 @@ import { isCaptionOrSubtitleTrack } from '@videojs/utils/dom';
 import type { PartiallyResolvedTextTrack, TextTrack } from '../../types';
 
 /**
- * SPF-owned `<track>` selector. Each slot created by
- * `addSubtitlesTracksToMedia` carries this attribute so reads and removals can
- * filter SPF-owned tracks from host-page-owned ones.
+ * SPF-owned `<track>` selector. Each slot created by `addSubtitlesTracksToMedia` carries this attribute so reads and
+ * removals can filter SPF-owned tracks from host-page-owned ones.
  */
 const SPF_TRACK_SELECTOR = 'track[data-src-track]';
 
 /**
- * Allocate text-track slots on `mediaElement` for each model track by creating
- * and appending `<track>` children. Marks each element with `data-src-track`
- * so it can be distinguished from `<track>` children the host page added
- * directly — used by `getShowingSubtitlesTrackFromMedia` and
- * `removeAllSubtitlesTracksFromMedia` to scope their reads/removals to
- * SPF-owned slots. The spec has no `removeTextTrack` API, so creating
- * `<track>` elements is the only mechanism for adding *and* removing entries
- * to `mediaElement.textTracks`.
+ * Allocate text-track slots on `mediaElement` for each model track by creating and appending `<track>` children. Marks
+ * each element with `data-src-track` so it can be distinguished from `<track>` children the host page added directly —
+ * used by `getShowingSubtitlesTrackFromMedia` and `removeAllSubtitlesTracksFromMedia` to scope their reads/removals to
+ * SPF-owned slots. The spec has no `removeTextTrack` API, so creating `<track>` elements is the only mechanism for
+ * adding _and_ removing entries to `mediaElement.textTracks`.
  */
 export function addSubtitlesTracksToMedia(
   mediaElement: HTMLMediaElement,
@@ -44,11 +40,9 @@ export function addSubtitlesTracksToMedia(
 }
 
 /**
- * Return the SPF-owned subtitle/caption `TextTrack` currently in `'showing'`
- * mode, or `undefined` if none. Restricts the search to slots created by
- * `addSubtitlesTracksToMedia` (via the `data-src-track` selector) so a showing
- * track that the host page added directly is ignored — SPF selection only
- * mirrors tracks it owns.
+ * Return the SPF-owned subtitle/caption `TextTrack` currently in `'showing'` mode, or `undefined` if none. Restricts
+ * the search to slots created by `addSubtitlesTracksToMedia` (via the `data-src-track` selector) so a showing track
+ * that the host page added directly is ignored — SPF selection only mirrors tracks it owns.
  */
 export function getShowingSubtitlesTrackFromMedia(mediaElement: HTMLMediaElement): globalThis.TextTrack | undefined {
   const elements = mediaElement.querySelectorAll<HTMLTrackElement>(SPF_TRACK_SELECTOR);
@@ -65,9 +59,8 @@ export function getShowingSubtitlesTrackFromMedia(mediaElement: HTMLMediaElement
 }
 
 /**
- * Remove every SPF-owned `<track>` child from `mediaElement` (those tagged
- * with `data-src-track` by `addSubtitlesTracksToMedia`). `<track>` elements
- * the host page added directly are left in place.
+ * Remove every SPF-owned `<track>` child from `mediaElement` (those tagged with `data-src-track` by
+ * `addSubtitlesTracksToMedia`). `<track>` elements the host page added directly are left in place.
  */
 export function removeAllSubtitlesTracksFromMedia(mediaElement: HTMLMediaElement): void {
   const elements = mediaElement.querySelectorAll<HTMLTrackElement>(SPF_TRACK_SELECTOR);
@@ -78,10 +71,9 @@ export function removeAllSubtitlesTracksFromMedia(mediaElement: HTMLMediaElement
 }
 
 /**
- * Apply a selection to a `TextTrackList` by setting each subtitle/caption
- * track's `mode` to `'showing'` if its `id` matches `selectedId` and
- * `'disabled'` otherwise. Tracks of other kinds (chapters, metadata,
- * descriptions) are left untouched — they may be owned by the host page.
+ * Apply a selection to a `TextTrackList` by setting each subtitle/caption track's `mode` to `'showing'` if its `id`
+ * matches `selectedId` and `'disabled'` otherwise. Tracks of other kinds (chapters, metadata, descriptions) are left
+ * untouched — they may be owned by the host page.
  */
 export function syncTextTrackModes(textTracks: TextTrackList, selectedId: string | undefined): void {
   for (let i = 0; i < textTracks.length; i++) {

--- a/packages/spf/src/media/errors.ts
+++ b/packages/spf/src/media/errors.ts
@@ -1,26 +1,19 @@
 /**
- * SVTA 2070 (Standardized Error Codes) — the vocabulary for identifying a
- * playback failure or notice, independent of how it's transported or who
- * decides what to do about it.
+ * SVTA 2070 (Standardized Error Codes) — the vocabulary for identifying a playback failure or notice, independent of
+ * how it's transported or who decides what to do about it.
  *
- * A code is a single integer: the leading digit(s) are the **category** (the
- * error's domain) and the trailing three are the **index** (the specific error
- * within it). Four digits for natively-defined errors, five when an external
- * standard is embedded — `"03404"` is an HTTP 404 under the network category.
- * Categories are `0` unknown, `1` media content, `2` playback, `3` network,
- * `4` content protection, `5` accessibility, `6` remote play, `7` advertising,
- * `99` custom.
+ * A code is a single integer: the leading digit(s) are the **category** (the error's domain) and the trailing three are
+ * the **index** (the specific error within it). Four digits for natively-defined errors, five when an external standard
+ * is embedded — `"03404"` is an HTTP 404 under the network category. Categories are `0` unknown, `1` media content, `2`
+ * playback, `3` network, `4` content protection, `5` accessibility, `6` remote play, `7` advertising, `99` custom.
  *
  * Two properties of the spec shape the types here:
  *
- * - **Severity is deliberately not part of a code.** Per §Approach, "impact
- *   varies with player implementation, breaking the consistency of a specific
- *   error mapping to single code." So an error carries no fatal flag — whether a
- *   condition is fatal depends on the composition observing it, and is decided
- *   downstream.
- * - **Reporting is partial and stacked** (Principles 5–6). Errors are reported
- *   as encountered, most of them non-fatal, and the *sequence* carries causation
- *   a single value can't.
+ * - **Severity is deliberately not part of a code.** Per §Approach, "impact varies with player implementation, breaking
+ *   the consistency of a specific error mapping to single code." So an error carries no fatal flag — whether a
+ *   condition is fatal depends on the composition observing it, and is decided downstream.
+ * - **Reporting is partial and stacked** (Principles 5–6). Errors are reported as encountered, most of them non-fatal,
+ *   and the _sequence_ carries causation a single value can't.
  *
  * See `internal/design/spf/features/errors.md`.
  */
@@ -28,10 +21,9 @@
 /**
  * A reported condition, identified by its SVTA code.
  *
- * Named for the spec rather than the engine because the vocabulary is
- * format- and player-neutral. Not `MediaError` — that name belongs to the
- * `@videojs/media` DOM-facing class this eventually maps *onto*, and the mapping
- * is the point at which severity and user-facing text get decided.
+ * Named for the spec rather than the engine because the vocabulary is format- and player-neutral. Not `MediaError` —
+ * that name belongs to the `@videojs/media` DOM-facing class this eventually maps _onto_, and the mapping is the point
+ * at which severity and user-facing text get decided.
  */
 export interface SvtaError {
   /** The SVTA code — see {@link svtaCategory} / {@link svtaIndex}. */
@@ -49,22 +41,19 @@ export const SVTA_UNSUPPORTED_VIDEO_FORMAT = 1004;
 export const SVTA_UNSUPPORTED_AUDIO_FORMAT = 1005;
 
 /**
- * SVTA 4 [Content Protection] 008 — unsupported or unavailable DRM system. Used
- * for "this source is encrypted and we have no decryption pipeline," which is
- * detection, not a license failure.
+ * SVTA 4 [Content Protection] 008 — unsupported or unavailable DRM system. Used for "this source is encrypted and we
+ * have no decryption pipeline," which is detection, not a license failure.
  */
 export const SVTA_UNSUPPORTED_DRM_SYSTEM = 4008;
 
 /**
  * SVTA 2 [Playback] 011 — no video track the environment can play.
  *
- * Covers both ways a composition can end up with nothing to select: renditions
- * that existed and were all excluded as unplayable, and — where the composition
- * composes `reportAbsentTrackType` to say it needs the type — a source carrying
- * none to begin with. Deliberately one code for both, because they are the same
- * answer to a viewer, and because the alternative is a code the SVTA spec doesn't
- * define. Whether an absent type is a failure is the composition's to state,
- * which is why it opts in rather than being read off the source.
+ * Covers both ways a composition can end up with nothing to select: renditions that existed and were all excluded as
+ * unplayable, and — where the composition composes `reportAbsentTrackType` to say it needs the type — a source carrying
+ * none to begin with. Deliberately one code for both, because they are the same answer to a viewer, and because the
+ * alternative is a code the SVTA spec doesn't define. Whether an absent type is a failure is the composition's to
+ * state, which is why it opts in rather than being read off the source.
  */
 export const SVTA_NO_SUPPORTED_VIDEO_TRACK = 2011;
 
@@ -72,43 +61,37 @@ export const SVTA_NO_SUPPORTED_VIDEO_TRACK = 2011;
 export const SVTA_NO_SUPPORTED_AUDIO_TRACK = 2012;
 
 /**
- * SVTA 99 [Custom] 001 — this engine has no pipeline for something the source
- * requires, so the source is unplayable *here* rather than broken.
+ * SVTA 99 [Custom] 001 — this engine has no pipeline for something the source requires, so the source is unplayable
+ * _here_ rather than broken.
  *
- * Custom rather than standard because the standard codes available describe
- * either narrower or wider things. The causes (1004/1005 unsupported format,
- * 4008 unsupported DRM) say what one rendition hit; the verdicts (2011/2012 no
- * supported track) say a type emptied without saying why it's unfixable. And
- * 2039 "Manifest feature unsupported" covers features that are unsupported but
- * still *playable* — LL-HLS degrading to standard live is a 2039 — so
- * overloading it for a fatal condition would make it useless for the notices it
- * belongs on.
+ * Custom rather than standard because the standard codes available describe either narrower or wider things. The causes
+ * (1004/1005 unsupported format, 4008 unsupported DRM) say what one rendition hit; the verdicts (2011/2012 no supported
+ * track) say a type emptied without saying why it's unfixable. And 2039 "Manifest feature unsupported" covers features
+ * that are unsupported but still _playable_ — LL-HLS degrading to standard live is a 2039 — so overloading it for a
+ * fatal condition would make it useless for the notices it belongs on.
  *
- * Index `001`: the spec defines only `99000` (Unknown) for the custom category
- * and leaves the rest to the publisher, so this is the first code we define.
+ * Index `001`: the spec defines only `99000` (Unknown) for the custom category and leaves the rest to the publisher, so
+ * this is the first code we define.
  *
- * Five digits, and deliberately not special-cased anywhere: {@link svtaCategory}
- * and {@link svtaIndex} decompose it correctly by arithmetic alone, because
- * every standard category is below `8000` and custom starts at `99000`.
+ * Five digits, and deliberately not special-cased anywhere: {@link svtaCategory} and {@link svtaIndex} decompose it
+ * correctly by arithmetic alone, because every standard category is below `8000` and custom starts at `99000`.
  */
 export const SVTA_UNSUPPORTED_PLAYBACK_FEATURE = 99001;
 
 /**
- * The error's domain — `code / 1000`, per the spec's "divide by one thousand to
- * obtain the error category". Works uniformly across the four-digit native form
- * and the five-digit form embedding an external standard: `"03404"` is
- * numerically 3404, which decomposes identically. That also makes a numeric code
- * immune to the spec's inconsistent zero-padding (§Approach writes a
- * category-unknown network error as `"0300"` where the error index implies
- * category 3 / index 000).
+ * The error's domain — `code / 1000`, per the spec's "divide by one thousand to obtain the error category". Works
+ * uniformly across the four-digit native form and the five-digit form embedding an external standard: `"03404"` is
+ * numerically 3404, which decomposes identically. That also makes a numeric code immune to the spec's inconsistent
+ * zero-padding (§Approach writes a category-unknown network error as `"0300"` where the error index implies category 3
+ * / index 000).
  */
 export function svtaCategory(code: number): number {
   return Math.floor(code / 1000);
 }
 
 /**
- * The specific error within its category — `code % 1000`. For a five-digit code
- * this is the embedded external value (an HTTP status, a VAST code).
+ * The specific error within its category — `code % 1000`. For a five-digit code this is the embedded external value (an
+ * HTTP status, a VAST code).
  */
 export function svtaIndex(code: number): number {
   return code % 1000;

--- a/packages/spf/src/media/hls/parse-attributes.ts
+++ b/packages/spf/src/media/hls/parse-attributes.ts
@@ -1,9 +1,6 @@
 import type { FrameRate } from '../types';
 
-/**
- * Parse HLS attribute list from a tag line.
- * Handles both quoted and unquoted values.
- */
+/** Parse HLS attribute list from a tag line. Handles both quoted and unquoted values. */
 export function parseAttributeList(line: string): Map<string, string> {
   const attributes = new Map<string, string>();
   const regex = /([A-Z0-9-]+)=(?:"([^"]*)"|([^,]*))/g;
@@ -20,9 +17,7 @@ export function parseAttributeList(line: string): Map<string, string> {
   return attributes;
 }
 
-/**
- * Parse RESOLUTION attribute value (WIDTHxHEIGHT).
- */
+/** Parse RESOLUTION attribute value (WIDTHxHEIGHT). */
 export function parseResolution(value: string): { width: number; height: number } | null {
   const match = /^(\d+)x(\d+)$/.exec(value);
 
@@ -34,9 +29,7 @@ export function parseResolution(value: string): { width: number; height: number 
   return { width, height };
 }
 
-/**
- * Parse FRAME-RATE attribute to rational frame rate.
- */
+/** Parse FRAME-RATE attribute to rational frame rate. */
 export function parseFrameRate(value: string): FrameRate | undefined {
   const fps = Number.parseFloat(value);
 
@@ -72,9 +65,7 @@ export function parseFrameRate(value: string): FrameRate | undefined {
 // treated as unprobeable, so it would never be pruned.
 const AUDIO_CODEC_PREFIXES = ['mp4a.', 'ac-3', 'ec-3', 'ac-4', 'opus', 'flac', 'dts', 'alac', 'vorbis'];
 
-/**
- * Parse CODECS attribute into separate video and audio codecs.
- */
+/** Parse CODECS attribute into separate video and audio codecs. */
 export function parseCodecs(codecs: string): { video?: string; audio?: string } {
   const parts = codecs.split(',').map((s) => s.trim());
   const result: { video?: string; audio?: string } = {};
@@ -92,9 +83,7 @@ export function parseCodecs(codecs: string): { video?: string; audio?: string } 
   return result;
 }
 
-/**
- * Parse #EXTINF duration value.
- */
+/** Parse #EXTINF duration value. */
 export function parseExtInfDuration(value: string): number {
   const durationPart = value.split(',')[0] ?? value;
   const duration = Number.parseFloat(durationPart);
@@ -103,9 +92,8 @@ export function parseExtInfDuration(value: string): number {
 }
 
 /**
- * Parse BYTERANGE attribute value.
- * Format: "length[@offset]"
- * If offset is omitted, it continues from the previous byte range end.
+ * Parse BYTERANGE attribute value. Format: "length[@offset]" If offset is omitted, it continues from the previous byte
+ * range end.
  */
 export function parseByteRange(value: string, previousEnd?: number): { start: number; end: number } | null {
   const match = /^(\d+)(?:@(\d+))?$/.exec(value);
@@ -131,9 +119,7 @@ export function parseByteRange(value: string, previousEnd?: number): { start: nu
   return { start, end: start + length - 1 };
 }
 
-/**
- * AttributeList - Typed attribute access wrapper.
- */
+/** AttributeList - Typed attribute access wrapper. */
 export interface AttributeList {
   get: (key: string) => string | undefined;
   getInt: (key: string, defaultValue?: number) => number | undefined;
@@ -143,9 +129,7 @@ export interface AttributeList {
   getFrameRate: (key: string) => FrameRate | undefined;
 }
 
-/**
- * Create AttributeList from raw attribute string.
- */
+/** Create AttributeList from raw attribute string. */
 export function createAttributeList(line: string): AttributeList {
   const map = parseAttributeList(line);
 
@@ -196,10 +180,7 @@ export function createAttributeList(line: string): AttributeList {
   };
 }
 
-/**
- * Match a tag and extract its attributes.
- * Returns null if the line doesn't match the tag.
- */
+/** Match a tag and extract its attributes. Returns null if the line doesn't match the tag. */
 export function matchTag(line: string, tag: string): AttributeList | null {
   const prefix = `#${tag}:`;
 

--- a/packages/spf/src/media/hls/parse-media-playlist.ts
+++ b/packages/spf/src/media/hls/parse-media-playlist.ts
@@ -18,7 +18,10 @@ import {
 import { matchTag, parseByteRange, parseExtInfDuration } from './parse-attributes';
 import { resolveUrl } from './resolve-url';
 
-/** MPEG-2 Transport Stream (IANA `video/MP2T`, lowercased for `isTypeSupported`). Video + audio TS — there is no `audio/mp2t`. */
+/**
+ * MPEG-2 Transport Stream (IANA `video/MP2T`, lowercased for `isTypeSupported`). Video + audio TS — there is no
+ * `audio/mp2t`.
+ */
 export const MPEG_TS_MIME = 'video/mp2t';
 /** Raw ADTS AAC packed-audio (HLS `.aac` segments; IANA `audio/aac`). */
 export const RAW_AAC_MIME = 'audio/aac';
@@ -36,8 +39,8 @@ const CONTAINER_MIME_BY_EXTENSION: Record<string, string> = {
 export const NON_FMP4_CONTAINER_MIMES = new Set(Object.values(CONTAINER_MIME_BY_EXTENSION));
 
 /**
- * Non-fMP4 container MIME for a (resolved, absolute) segment URL, by file
- * extension, ignoring the query string. `undefined` for fMP4 / unrecognized.
+ * Non-fMP4 container MIME for a (resolved, absolute) segment URL, by file extension, ignoring the query string.
+ * `undefined` for fMP4 / unrecognized.
  */
 function containerMimeFromSegment(url: string | undefined): string | undefined {
   if (!url) return undefined;
@@ -55,9 +58,7 @@ function containerMimeFromSegment(url: string | undefined): string | undefined {
   return dot === -1 ? undefined : CONTAINER_MIME_BY_EXTENSION[path.slice(dot)];
 }
 
-/**
- * Resolve unresolved track type to its resolved equivalent.
- */
+/** Resolve unresolved track type to its resolved equivalent. */
 type ResolveTrack<T> = T extends PartiallyResolvedVideoTrack
   ? VideoTrack
   : T extends PartiallyResolvedAudioTrack
@@ -67,23 +68,18 @@ type ResolveTrack<T> = T extends PartiallyResolvedVideoTrack
       : never;
 
 /**
- * Position a freshly-parsed window (whose segment `startTime`s are snapshot-
- * local, i.e. from 0) onto the timeline established by the previous resolved
- * snapshot. Carries the timeline forward using the media-sequence overlap and
- * the previous window's *actual* segment durations — see
- * `internal/design/spf/live-presentation-timeline-model.md`.
+ * Position a freshly-parsed window (whose segment `startTime`s are snapshot- local, i.e. from 0) onto the timeline
+ * established by the previous resolved snapshot. Carries the timeline forward using the media-sequence overlap and the
+ * previous window's _actual_ segment durations — see `internal/design/spf/live-presentation-timeline-model.md`.
  *
- * - **Overlap** (`0 <= offset < previous.segments.length`): the new window's
- *   first segment is the same segment as `previous.segments[offset]`; anchor to
- *   its start (URLs checked — a mismatch warns).
+ * - **Overlap** (`0 <= offset < previous.segments.length`): the new window's first segment is the same segment as
+ *   `previous.segments[offset]`; anchor to its start (URLs checked — a mismatch warns).
  * - **Sequence went backwards** (non-conformant): reset to the local base.
- * - **Full turnover** (no overlap): estimate forward from the previous window's
- *   end across the unseen gap. This is the *only* place EXT-X-TARGETDURATION is
- *   used for timing — an upper-bound estimate, since the actual rolled-off
+ * - **Full turnover** (no overlap): estimate forward from the previous window's end across the unseen gap. This is the
+ *   _only_ place EXT-X-TARGETDURATION is used for timing — an upper-bound estimate, since the actual rolled-off
  *   durations are gone (exact recovery is the deferred PDT decision).
  *
- * Returns the rebased segments (the window edge is `segments[0].startTime`,
- * derived — never stored on the track).
+ * Returns the rebased segments (the window edge is `segments[0].startTime`, derived — never stored on the track).
  */
 function placeOnPreviousTimeline(
   previous: ResolvedTrack,
@@ -142,17 +138,13 @@ function placeOnPreviousTimeline(
 }
 
 /**
- * Place a window on the frozen wall-clock anchor — the track's `startDate`
- * (wall clock at media-time 0). The anchoring PDT-bearing segment lands at
- * `segment.startDate − anchor`, so the window sits on the shared presentation
- * timeline rather than a local-from-zero one (the `startDate` recomputed
- * afterwards then reads back as the anchor — idempotent). This is the **main
- * live path on every parse**: first resolves place against the pre-stamped
- * shell anchor, and reloads re-place from PDT so drift can't accumulate and a
- * long-stall turnover re-places with no overlap bridging (the HLS authoring
- * spec's §8.1 EXTINF-accuracy rule bounds the per-reload correction to ~one
- * video frame). Falls back to the local base when no segment carries PDT —
- * there's nothing to anchor against (callers guard this for reloads, where the
+ * Place a window on the frozen wall-clock anchor — the track's `startDate` (wall clock at media-time 0). The anchoring
+ * PDT-bearing segment lands at `segment.startDate − anchor`, so the window sits on the shared presentation timeline
+ * rather than a local-from-zero one (the `startDate` recomputed afterwards then reads back as the anchor — idempotent).
+ * This is the **main live path on every parse**: first resolves place against the pre-stamped shell anchor, and reloads
+ * re-place from PDT so drift can't accumulate and a long-stall turnover re-places with no overlap bridging (the HLS
+ * authoring spec's §8.1 EXTINF-accuracy rule bounds the per-reload correction to ~one video frame). Falls back to the
+ * local base when no segment carries PDT — there's nothing to anchor against (callers guard this for reloads, where the
  * local base would reset the timeline).
  */
 function placeOnAnchor(segments: Segment[], anchor: number): Segment[] {
@@ -174,12 +166,10 @@ function placeOnAnchor(segments: Segment[], anchor: number): Segment[] {
 /**
  * Parse HLS media playlist and resolve track with segments.
  *
- * `previous` is what was known about this track before this parse: the
- * partially-resolved track from the multivariant playlist on the first resolve,
- * or the previously-resolved snapshot on a live reload. Its metadata is carried
- * onto the result either way; when it's already resolved (has segments), its
- * timeline is carried forward so the new window lands on a stable, advancing
- * timeline (see {@link placeOnPreviousTimeline}).
+ * `previous` is what was known about this track before this parse: the partially-resolved track from the multivariant
+ * playlist on the first resolve, or the previously-resolved snapshot on a live reload. Its metadata is carried onto the
+ * result either way; when it's already resolved (has segments), its timeline is carried forward so the new window lands
+ * on a stable, advancing timeline (see {@link placeOnPreviousTimeline}).
  *
  * @param text - Media playlist text content
  * @param previous - Prior track state (unresolved shell, or previous resolved snapshot)

--- a/packages/spf/src/media/hls/parse-multivariant.ts
+++ b/packages/spf/src/media/hls/parse-multivariant.ts
@@ -21,9 +21,9 @@ import { resolveUrl } from './resolve-url';
 /**
  * Parse HLS multivariant playlist into a Presentation.
  *
- * Returns Presentation with partially resolved tracks (no segment information).
- * Tracks contain metadata from multivariant playlist (bandwidth, resolution, codecs)
- * but segment information is added when media playlists are fetched.
+ * Returns Presentation with partially resolved tracks (no segment information). Tracks contain metadata from
+ * multivariant playlist (bandwidth, resolution, codecs) but segment information is added when media playlists are
+ * fetched.
  *
  * @param text - Raw playlist text content
  * @param unresolved - Unresolved presentation (contains URL for base URL resolution)

--- a/packages/spf/src/media/hls/reload-policy.ts
+++ b/packages/spf/src/media/hls/reload-policy.ts
@@ -11,8 +11,8 @@ import { findTrackById } from '../utils/tracks';
 const FALLBACK_TARGET_DURATION = 6;
 
 /**
- * Default `HOLD-BACK` as a multiple of the target duration when the playlist
- * declares none — the HLS spec default (RFC 8216bis `EXT-X-SERVER-CONTROL`).
+ * Default `HOLD-BACK` as a multiple of the target duration when the playlist declares none — the HLS spec default (RFC
+ * 8216bis `EXT-X-SERVER-CONTROL`).
  */
 const HOLD_BACK_TARGET_MULTIPLIER = 3;
 
@@ -26,21 +26,17 @@ function targetDurationOf(track: ResolvedTrack): number {
 }
 
 /**
- * Live media-playlist reload cadence, per RFC 8216bis §6.3.4 — a
- * {@link RecurrencePolicy} for a `RecurringRunner` re-resolving the selected
- * track. Structurally matches `RecurrencePolicy<ResolvedTrack>` without
- * importing it (media stays core-free): `current` is the freshly resolved track,
- * `previous` the prior resolved snapshot.
+ * Live media-playlist reload cadence, per RFC 8216bis §6.3.4 — a {@link RecurrencePolicy} for a `RecurringRunner`
+ * re-resolving the selected track. Structurally matches `RecurrencePolicy<ResolvedTrack>` without importing it (media
+ * stays core-free): `current` is the freshly resolved track, `previous` the prior resolved snapshot.
  *
- * - Complete playlist (VoD, or live that hit `#EXT-X-ENDLIST`) → `null`: stop.
- *   Keys off `Track.duration` (finite once complete), the single completeness
- *   source of truth.
- * - Unchanged window (same media sequence + segment count as `previous`) → poll
- *   at half the target duration; a moved/grown window (or the first reload) →
- *   full target duration.
+ * - Complete playlist (VoD, or live that hit `#EXT-X-ENDLIST`) → `null`: stop. Keys off `Track.duration` (finite once
+ *   complete), the single completeness source of truth.
+ * - Unchanged window (same media sequence + segment count as `previous`) → poll at half the target duration; a
+ *   moved/grown window (or the first reload) → full target duration.
  *
- * A failed reload doesn't reach here — the rejection propagates through the
- * `RecurringRunner`; transient-failure recovery belongs at the fetch layer.
+ * A failed reload doesn't reach here — the rejection propagates through the `RecurringRunner`; transient-failure
+ * recovery belongs at the fetch layer.
  *
  * Returned delays are milliseconds.
  */
@@ -54,25 +50,21 @@ export function mediaPlaylistReloadDelay(current: ResolvedTrack, previous: Resol
 }
 
 /**
- * Target live latency (seconds) for a resolved track — how far behind the live
- * edge the playhead should sit. Prefers the server's declared
- * `EXT-X-SERVER-CONTROL` `HOLD-BACK`, falling back to
- * {@link HOLD_BACK_TARGET_MULTIPLIER}× the target duration when absent (the
- * spec default). This is the HLS side of the format-neutral
- * `resolveLiveLatency` seam consumed by `seek-to-live-edge`; a DASH engine
- * supplies its own (`suggestedPresentationDelay`).
+ * Target live latency (seconds) for a resolved track — how far behind the live edge the playhead should sit. Prefers
+ * the server's declared `EXT-X-SERVER-CONTROL` `HOLD-BACK`, falling back to {@link HOLD_BACK_TARGET_MULTIPLIER}× the
+ * target duration when absent (the spec default). This is the HLS side of the format-neutral `resolveLiveLatency` seam
+ * consumed by `seek-to-live-edge`; a DASH engine supplies its own (`suggestedPresentationDelay`).
  *
- * Only `HOLD-BACK` — never `PART-HOLD-BACK`, which assumes partial-segment
- * playback. See {@link MediaPlaylistMetadata.holdBack}.
+ * Only `HOLD-BACK` — never `PART-HOLD-BACK`, which assumes partial-segment playback. See
+ * {@link MediaPlaylistMetadata.holdBack}.
  */
 export function liveLatencyFor(track: ResolvedTrack): number {
   return getMediaPlaylistMetadata(track)?.holdBack ?? HOLD_BACK_TARGET_MULTIPLIER * targetDurationOf(track);
 }
 
 /**
- * Resolve the target live latency for a presentation's timeline-bearing track —
- * the HLS engine injects this as `seekToLiveEdge`'s format-neutral
- * `resolveLiveLatency` seam. `0` when there is no resolved track to read (the
+ * Resolve the target live latency for a presentation's timeline-bearing track — the HLS engine injects this as
+ * `seekToLiveEdge`'s format-neutral `resolveLiveLatency` seam. `0` when there is no resolved track to read (the
  * behavior then seeks straight to the edge).
  */
 export function resolveLiveLatency(

--- a/packages/spf/src/media/hls/resolve-url.ts
+++ b/packages/spf/src/media/hls/resolve-url.ts
@@ -1,6 +1,4 @@
-/**
- * Resolve a potentially relative URL against a base URL using native URL API.
- */
+/** Resolve a potentially relative URL against a base URL using native URL API. */
 export function resolveUrl(url: string, baseUrl: string): string {
   return new URL(url, baseUrl).href;
 }

--- a/packages/spf/src/media/live-window.ts
+++ b/packages/spf/src/media/live-window.ts
@@ -1,19 +1,15 @@
 /**
- * Derive the live window of the track with the given id — the single source of
- * truth for "where is live," consumed (via `liveWindowFromState`) by the
- * seek-to-live-edge and live-seekable-range behaviors so neither re-derives (or
- * re-presumes) the window shape. Type-agnostic: the caller decides which track
- * bears the timeline (video when present, else audio).
+ * Derive the live window of the track with the given id — the single source of truth for "where is live," consumed (via
+ * `liveWindowFromState`) by the seek-to-live-edge and live-seekable-range behaviors so neither re-derives (or
+ * re-presumes) the window shape. Type-agnostic: the caller decides which track bears the timeline (video when present,
+ * else audio).
  *
- * The window is a **live read** over the current `segments` array — never
- * stored on the track. The anchor triple is frozen per source; per-segment
- * `startTime` values are re-derived against it on every reload, so the edge
- * here slides while the origin stays fixed (see
- * `internal/design/spf/live-presentation-timeline-model.md`).
+ * The window is a **live read** over the current `segments` array — never stored on the track. The anchor triple is
+ * frozen per source; per-segment `startTime` values are re-derived against it on every reload, so the edge here slides
+ * while the origin stays fixed (see `internal/design/spf/live-presentation-timeline-model.md`).
  *
- * Returns `null` when there is no live edge to track: an unresolved
- * presentation or track, a track with no segments, or a **complete** playlist
- * (VoD, or live that has ended — a finite `Track.duration`).
+ * Returns `null` when there is no live edge to track: an unresolved presentation or track, a track with no segments, or
+ * a **complete** playlist (VoD, or live that has ended — a finite `Track.duration`).
  */
 import { isResolvedPresentation, isResolvedTrack, type MaybeResolvedPresentation } from './types';
 import { findTrackById } from './utils/tracks';

--- a/packages/spf/src/media/media-tracks/index.ts
+++ b/packages/spf/src/media/media-tracks/index.ts
@@ -1,7 +1,6 @@
 /**
- * Media-track translation utilities — pure transforms from SPF's track model
- * onto the deduped video-rendition / audio-track lists a media-element adapter
- * exposes, plus the selection-criteria builders.
+ * Media-track translation utilities — pure transforms from SPF's track model onto the deduped video-rendition /
+ * audio-track lists a media-element adapter exposes, plus the selection-criteria builders.
  *
  * @packageDocumentation
  */

--- a/packages/spf/src/media/media-tracks/media-tracks.ts
+++ b/packages/spf/src/media/media-tracks/media-tracks.ts
@@ -1,21 +1,18 @@
 /**
  * Media-track translation utilities.
  *
- * Pure, DOM-free transforms from SPF's CMAF-HAM track model onto the deduped
- * lists a media-element adapter exposes (video renditions, audio tracks), plus
- * the selection-criteria builders that turn a chosen rendition/track back into a
+ * Pure, DOM-free transforms from SPF's CMAF-HAM track model onto the deduped lists a media-element adapter exposes
+ * (video renditions, audio tracks), plus the selection-criteria builders that turn a chosen rendition/track back into a
  * `user*TrackSelection` partial the engine's track-switching reads.
  *
- * These return SPF *model vocabulary* (`bandwidth`, `codecs: string[]`,
- * `frameRate` as a rational `FrameRate`); the consuming adapter owns the
- * mapping (e.g. for DOM `bandwidth` -> `bitrate`, `codecs.join(',')` -> `codec`,
- * `name` -> `label`).
+ * These return SPF _model vocabulary_ (`bandwidth`, `codecs: string[]`, `frameRate` as a rational `FrameRate`); the
+ * consuming adapter owns the mapping (e.g. for DOM `bandwidth` -> `bitrate`, `codecs.join(',')` -> `codec`, `name` ->
+ * `label`).
  *
- * Deduplication is by *properties*, never URL, so a multi-CDN source that lists
- * the same rendition on several hosts collapses to one entry: video renditions
- * by `width` + `height` + `bandwidth`, audio tracks by `language` + `name`.
- * The selection builders emit those same properties as the match criteria, so
- * selecting a collapsed entry re-selects, for example, every underlying per-CDN track.
+ * Deduplication is by _properties_, never URL, so a multi-CDN source that lists the same rendition on several hosts
+ * collapses to one entry: video renditions by `width` + `height` + `bandwidth`, audio tracks by `language` + `name`.
+ * The selection builders emit those same properties as the match criteria, so selecting a collapsed entry re-selects,
+ * for example, every underlying per-CDN track.
  */
 
 import type { AudioTrack, FrameRate, MaybeResolvedPresentation, VideoTrack } from '../types';
@@ -51,8 +48,8 @@ export function dedupedVideoTracks(presentation: MaybeResolvedPresentation | und
 }
 
 /**
- * The distinct audio tracks of a presentation, deduped by `language` + `name`
- * (first occurrence wins). Returns `[]` when the presentation is unresolved or has no audio tracks.
+ * The distinct audio tracks of a presentation, deduped by `language` + `name` (first occurrence wins). Returns `[]`
+ * when the presentation is unresolved or has no audio tracks.
  */
 export function dedupedAudioTracks(presentation: MaybeResolvedPresentation | undefined): AudioTrack[] {
   if (!presentation) return [];
@@ -64,11 +61,10 @@ export function dedupedAudioTracks(presentation: MaybeResolvedPresentation | und
 }
 
 /**
- * Find a video track by id, searching the same candidate set the engine resolves
- * against ({@link dedupedVideoTracks}'s pre-dedupe source). Returns `undefined`
- * when absent. Maps the engine's resolved `selectedVideoTrackId` back to its
- * properties for `active` reflection — the resolved id may be a per-CDN copy that
- * isn't the representative {@link dedupedVideoTracks} kept.
+ * Find a video track by id, searching the same candidate set the engine resolves against ({@link dedupedVideoTracks}'s
+ * pre-dedupe source). Returns `undefined` when absent. Maps the engine's resolved `selectedVideoTrackId` back to its
+ * properties for `active` reflection — the resolved id may be a per-CDN copy that isn't the representative
+ * {@link dedupedVideoTracks} kept.
  */
 export function findVideoTrackById(
   presentation: MaybeResolvedPresentation | undefined,
@@ -94,8 +90,8 @@ export function findAudioTrackById(
 }
 
 /**
- * Shallow-equal two key objects by their own properties. Both come from the same
- * key builder, so they carry the same keys — a one-directional scan suffices.
+ * Shallow-equal two key objects by their own properties. Both come from the same key builder, so they carry the same
+ * keys — a one-directional scan suffices.
  */
 function sameKey<K extends object>(a: K, b: K): boolean {
   for (const attr in a) {
@@ -106,8 +102,8 @@ function sameKey<K extends object>(a: K, b: K): boolean {
 }
 
 /**
- * Dedupe tracks by a key function, keeping the first occurrence of each key.
- * Keys are compared field-by-field ({@link sameKey}).
+ * Dedupe tracks by a key function, keeping the first occurrence of each key. Keys are compared field-by-field ({@link
+ * sameKey}).
  */
 function dedupe<T, K extends object>({
   tracks,
@@ -131,16 +127,12 @@ function dedupe<T, K extends object>({
   return kept;
 }
 
-/**
- * Build a partial video track that can be used as `userVideoTrackSelection`.
- */
+/** Build a partial video track that can be used as `userVideoTrackSelection`. */
 export function toUserVideoTrackSelection<T extends VideoDedupeKey>(rendition?: T): Partial<VideoTrack> | undefined {
   return rendition ? { width: rendition.width, height: rendition.height, bandwidth: rendition.bandwidth } : undefined;
 }
 
-/**
- * Build a partial audio track that can be used as a `userAudioTrackSelection`.
- */
+/** Build a partial audio track that can be used as a `userAudioTrackSelection`. */
 export function toUserAudioTrackSelection<T extends AudioDedupeKey>(track?: T): Partial<AudioTrack> | undefined {
   return track ? { language: track.language, name: track.name } : undefined;
 }

--- a/packages/spf/src/media/mp4/box.ts
+++ b/packages/spf/src/media/mp4/box.ts
@@ -1,14 +1,12 @@
 /**
  * Minimal ISO-BMFF (MP4/CMAF) box walker.
  *
- * Just enough to locate boxes by nested path — the framework needs a couple of
- * leaf fields (`mdhd` timescale, `tfdt` baseMediaDecodeTime) to derive a
- * segment's decode-time origin, not a full demuxer. DOM-free: operates on an
+ * Just enough to locate boxes by nested path — the framework needs a couple of leaf fields (`mdhd` timescale, `tfdt`
+ * baseMediaDecodeTime) to derive a segment's decode-time origin, not a full demuxer. DOM-free: operates on an
  * `ArrayBuffer` / `Uint8Array` via `DataView`.
  *
- * Box layout: `[u32 size][u32 type][payload]`. `size === 1` means a `u64
- * largesize` follows the type (payload after it); `size === 0` means the box
- * runs to the end of its container.
+ * Box layout: `[u32 size][u32 type][payload]`. `size === 1` means a `u64 largesize` follows the type (payload after
+ * it); `size === 0` means the box runs to the end of its container.
  */
 
 /** A located box: its 4-char type and byte offsets within the buffer. */
@@ -68,9 +66,8 @@ export function* iterateBoxesOfType(view: DataView, type: string, start = 0, end
 }
 
 /**
- * Depth-first descent to the first box matching a nested path, e.g.
- * `['moov', 'trak', 'mdia', 'mdhd']`. Returns `undefined` if any level is
- * absent.
+ * Depth-first descent to the first box matching a nested path, e.g. `['moov', 'trak', 'mdia', 'mdhd']`. Returns
+ * `undefined` if any level is absent.
  */
 export function findBox(view: DataView, path: readonly string[], start = 0, end = view.byteLength): Box | undefined {
   const [head, ...rest] = path;
@@ -89,8 +86,8 @@ export function findBox(view: DataView, path: readonly string[], start = 0, end 
 }
 
 /**
- * Read the version byte of a FullBox — the `version(1) + flags(3)` header at the
- * start of the payload of `mdhd` / `tkhd` / `tfdt` / `hdlr` / `elst` / etc.
+ * Read the version byte of a FullBox — the `version(1) + flags(3)` header at the start of the payload of `mdhd` /
+ * `tkhd` / `tfdt` / `hdlr` / `elst` / etc.
  */
 export function readFullBoxVersion(view: DataView, dataStart: number): number {
   return view.getUint8(dataStart);

--- a/packages/spf/src/media/mp4/tests/synthetic-boxes.ts
+++ b/packages/spf/src/media/mp4/tests/synthetic-boxes.ts
@@ -1,8 +1,7 @@
 /**
- * Hand-built ISO-BMFF boxes for unit tests — precise control over
- * version/field layout and multi-track muxing without committing binary
- * segment fixtures. Real-stream validation of the parsers lives in the
- * non-zero-PTS spike probes, not here.
+ * Hand-built ISO-BMFF boxes for unit tests — precise control over version/field layout and multi-track muxing without
+ * committing binary segment fixtures. Real-stream validation of the parsers lives in the non-zero-PTS spike probes, not
+ * here.
  */
 
 export function concat(...parts: Uint8Array[]): Uint8Array {

--- a/packages/spf/src/media/mp4/timestamp-origin.ts
+++ b/packages/spf/src/media/mp4/timestamp-origin.ts
@@ -1,49 +1,39 @@
 /**
  * Decode-time origin extraction from fMP4/CMAF segments.
  *
- * Non-zero-PTS sources encode media at a non-zero start time (an instant clip
- * starting at asset second 60, an Apple bipbop asset starting at 10s, …). To
- * relocate such a source onto a 0-based presentation timeline via
- * `SourceBuffer.timestampOffset`, the engine needs that start time — the
- * **decode-time origin** — read straight from the container:
+ * Non-zero-PTS sources encode media at a non-zero start time (an instant clip starting at asset second 60, an Apple
+ * bipbop asset starting at 10s, …). To relocate such a source onto a 0-based presentation timeline via
+ * `SourceBuffer.timestampOffset`, the engine needs that start time — the **decode-time origin** — read straight from
+ * the container:
  *
- * - `tfdt.baseMediaDecodeTime` (from a media segment's `moof`) — the decode
- *   time of the segment's first sample, in the track's media timescale. This is
- *   a DTS: relocating by `−(baseMediaDecodeTime / timescale)` lands the earliest
- *   DTS at exactly 0, so a negative-DTS append failure on Chromium is impossible
- *   by construction.
- * - `mdhd.timescale` (from the init segment's `moov`) — ticks per second for
- *   that track, needed to convert the raw tick count to seconds.
+ * - `tfdt.baseMediaDecodeTime` (from a media segment's `moof`) — the decode time of the segment's first sample, in the
+ *   track's media timescale. This is a DTS: relocating by `−(baseMediaDecodeTime / timescale)` lands the earliest DTS
+ *   at exactly 0, so a negative-DTS append failure on Chromium is impossible by construction.
+ * - `mdhd.timescale` (from the init segment's `moov`) — ticks per second for that track, needed to convert the raw tick
+ *   count to seconds.
  *
  * ## Presumptive vs. track-selected reads
  *
- * The two variants share only the leaf field-readers (`mdhd` timescale, `tfdt`
- * baseMediaDecodeTime) and the box walker. Everything else differs, and the
- * split is deliberate so the presumptive pair is *proportionally* smaller under
+ * The two variants share only the leaf field-readers (`mdhd` timescale, `tfdt` baseMediaDecodeTime) and the box walker.
+ * Everything else differs, and the split is deliberate so the presumptive pair is _proportionally_ smaller under
  * tree-shaking:
  *
- * - **Presumptive** — {@link readFirstMediaTimescale} / {@link readFirstBaseMediaDecodeTime}
- *   read the first `mdhd` timescale and first `tfdt` baseMediaDecodeTime. There's
- *   no `track_id` (nothing to match against) and no `trak`/`traf` iteration — a
- *   direct `findBox` to the first leaf. Correct when the init/segment holds a
- *   single media track (the common CMAF case). A caption-free platform imports
- *   only this pair and tree-shakes away all the matching machinery below.
- * - **Track-selected** — {@link findMediaTrack} / {@link readBaseMediaDecodeTime}.
- *   `findMediaTrack` returns `{ trackId, timescale }` for the `trak` whose `hdlr`
- *   handler matches; `readBaseMediaDecodeTime` takes that `trackId` and reads the
- *   `traf` whose `tfhd.track_id` matches. The `track_id` is the join that ties one
- *   track's timescale to the *same* track's baseMediaDecodeTime — required when a
- *   source muxes CEA-608/708 captions (a `clcp` track shares the same `moov` and
- *   `moof`, each track with its own timescale + baseMediaDecodeTime, so a
- *   presumptive read there risks `300000 / 6000 = 50s` instead of
- *   `60000 / 6000 = 10s`). This pair adds `trak`/`traf` iteration plus the handler
- *   and `track_id` reads. We only ever ask for buffered media handlers
- *   (`vide` / `soun`); the caption track is never selected — we read the origin,
- *   not the captions (caption *rendering* is out of scope).
+ * - **Presumptive** — {@link readFirstMediaTimescale} / {@link readFirstBaseMediaDecodeTime} read the first `mdhd`
+ *   timescale and first `tfdt` baseMediaDecodeTime. There's no `track_id` (nothing to match against) and no
+ *   `trak`/`traf` iteration — a direct `findBox` to the first leaf. Correct when the init/segment holds a single media
+ *   track (the common CMAF case). A caption-free platform imports only this pair and tree-shakes away all the matching
+ *   machinery below.
+ * - **Track-selected** — {@link findMediaTrack} / {@link readBaseMediaDecodeTime}. `findMediaTrack` returns `{ trackId,
+ *   timescale }` for the `trak` whose `hdlr` handler matches; `readBaseMediaDecodeTime` takes that `trackId` and reads
+ *   the `traf` whose `tfhd.track_id` matches. The `track_id` is the join that ties one track's timescale to the _same_
+ *   track's baseMediaDecodeTime — required when a source muxes CEA-608/708 captions (a `clcp` track shares the same
+ *   `moov` and `moof`, each track with its own timescale + baseMediaDecodeTime, so a presumptive read there risks
+ *   `300000 / 6000 = 50s` instead of `60000 / 6000 = 10s`). This pair adds `trak`/`traf` iteration plus the handler and
+ *   `track_id` reads. We only ever ask for buffered media handlers (`vide` / `soun`); the caption track is never
+ *   selected — we read the origin, not the captions (caption _rendering_ is out of scope).
  *
- * Both raw values are returned un-divided to leave room for an edit-list (`elst`)
- * presentation-time correction term if a source ever carries one — the validated
- * streams do not.
+ * Both raw values are returned un-divided to leave room for an edit-list (`elst`) presentation-time correction term if
+ * a source ever carries one — the validated streams do not.
  */
 import { type Box, findBox, iterateBoxesOfType, readFourCC, readFullBoxVersion, toDataView } from './box';
 
@@ -60,9 +50,8 @@ export interface MediaTrackInfo {
 // --- presumptive: first leaf, no track_id, no iteration -----------------------
 
 /**
- * Presumptive: the `timescale` of the **first** `mdhd` in an init segment.
- * Correct only for single-media-track inits — for muxed captions use
- * {@link findMediaTrack}. `undefined` if no `mdhd` exists.
+ * Presumptive: the `timescale` of the **first** `mdhd` in an init segment. Correct only for single-media-track inits —
+ * for muxed captions use {@link findMediaTrack}. `undefined` if no `mdhd` exists.
  */
 export function readFirstMediaTimescale(initSegment: ArrayBuffer | Uint8Array): number | undefined {
   const view = toDataView(initSegment);
@@ -72,9 +61,8 @@ export function readFirstMediaTimescale(initSegment: ArrayBuffer | Uint8Array): 
 }
 
 /**
- * Presumptive: `baseMediaDecodeTime` from the **first** `tfdt` of a media
- * segment. Correct only for single-`traf` segments — for muxed captions use
- * {@link readBaseMediaDecodeTime}. `undefined` if no `tfdt` exists.
+ * Presumptive: `baseMediaDecodeTime` from the **first** `tfdt` of a media segment. Correct only for single-`traf`
+ * segments — for muxed captions use {@link readBaseMediaDecodeTime}. `undefined` if no `tfdt` exists.
  */
 export function readFirstBaseMediaDecodeTime(mediaSegment: ArrayBuffer | Uint8Array): number | undefined {
   const view = toDataView(mediaSegment);
@@ -86,9 +74,8 @@ export function readFirstBaseMediaDecodeTime(mediaSegment: ArrayBuffer | Uint8Ar
 // --- track-selected: iterate + match by handler / track_id --------------------
 
 /**
- * The `track_ID` + timescale of the `trak` whose `mdhd` handler matches
- * `handlerType`, skipping a muxed `clcp` caption track. `undefined` if no
- * matching track exists.
+ * The `track_ID` + timescale of the `trak` whose `mdhd` handler matches `handlerType`, skipping a muxed `clcp` caption
+ * track. `undefined` if no matching track exists.
  */
 export function findMediaTrack(
   initSegment: ArrayBuffer | Uint8Array,
@@ -118,9 +105,8 @@ export function findMediaTrack(
 }
 
 /**
- * `baseMediaDecodeTime` (in the track's media timescale) from the `traf` matching
- * `trackId` (via `tfhd.track_id`) — required for muxed multi-`traf` segments.
- * `undefined` if no matching `tfdt` exists.
+ * `baseMediaDecodeTime` (in the track's media timescale) from the `traf` matching `trackId` (via `tfhd.track_id`) —
+ * required for muxed multi-`traf` segments. `undefined` if no matching `tfdt` exists.
  */
 export function readBaseMediaDecodeTime(mediaSegment: ArrayBuffer | Uint8Array, trackId: number): number | undefined {
   const view = toDataView(mediaSegment);

--- a/packages/spf/src/media/primitives/resolution.ts
+++ b/packages/spf/src/media/primitives/resolution.ts
@@ -1,19 +1,17 @@
 /**
  * Pixel dimensions, and the one projection every reader of them needs.
  *
- * Shared by the surfaces a rendition cap measures — a screen (`media/dom/screen`),
- * a player element (`behaviors/dom/track-player-resolution`) — and by the caps
- * that compare renditions against them. Lives outside the DOM layer because
- * scaling and rounding two numbers needs no DOM, which is also what lets the
- * DOM-free selection rules name the type they read instead of restating its shape.
+ * Shared by the surfaces a rendition cap measures — a screen (`media/dom/screen`), a player element
+ * (`behaviors/dom/track-player-resolution`) — and by the caps that compare renditions against them. Lives outside the
+ * DOM layer because scaling and rounding two numbers needs no DOM, which is also what lets the DOM-free selection rules
+ * name the type they read instead of restating its shape.
  */
 
 /**
  * A surface's pixel dimensions.
  *
- * A width and a height rather than a `"720p"`-style tier, because a tier only
- * describes a surface once you assume its aspect ratio — the assumption that
- * mis-measures an anamorphic or otherwise non-16:9 rendition.
+ * A width and a height rather than a `"720p"`-style tier, because a tier only describes a surface once you assume its
+ * aspect ratio — the assumption that mis-measures an anamorphic or otherwise non-16:9 rendition.
  */
 export interface Resolution {
   readonly width: number;
@@ -21,15 +19,12 @@ export interface Resolution {
 }
 
 /**
- * Apply `scale` to a size and normalize it to whole pixels, or `undefined` where
- * that leaves nothing to describe.
+ * Apply `scale` to a size and normalize it to whole pixels, or `undefined` where that leaves nothing to describe.
  *
- * Rounded because pixels are whole and a fractional scale doesn't divide a
- * surface evenly. A non-positive or non-finite axis yields `undefined` rather
- * than a zero-area reading: an element that isn't being rendered reports `0 × 0`
- * and a nonsense dimension reports `NaN`, and the caps consuming this read
- * absence as "unknown, don't cap" while an area of zero would read as a cap of
- * zero — pinning every source to its smallest rendition.
+ * Rounded because pixels are whole and a fractional scale doesn't divide a surface evenly. A non-positive or non-finite
+ * axis yields `undefined` rather than a zero-area reading: an element that isn't being rendered reports `0 × 0` and a
+ * nonsense dimension reports `NaN`, and the caps consuming this read absence as "unknown, don't cap" while an area of
+ * zero would read as a cap of zero — pinning every source to its smallest rendition.
  *
  * @param size - Dimensions to project, in the units `scale` converts from
  * @param scale - Multiplier for both axes, e.g. `devicePixelRatio`; defaults to 1

--- a/packages/spf/src/media/primitives/select-tracks.ts
+++ b/packages/spf/src/media/primitives/select-tracks.ts
@@ -1,8 +1,6 @@
 import type { MaybeResolvedPresentation, PartiallyResolvedTextTrack, TextTrack } from '../types';
 
-/**
- * State shape for track selection.
- */
+/** State shape for track selection. */
 export interface TrackSelectionState {
   presentation?: MaybeResolvedPresentation;
   selectedVideoTrackId?: string;
@@ -10,44 +8,31 @@ export interface TrackSelectionState {
   selectedTextTrackId?: string;
 }
 
-/**
- * Configuration for audio track selection.
- */
+/** Configuration for audio track selection. */
 export interface AudioSelectionConfig {
-  /**
-   * Preferred audio language (ISO 639 code, e.g., "en", "es").
-   * If not specified, selects first audio track.
-   */
+  /** Preferred audio language (ISO 639 code, e.g., "en", "es"). If not specified, selects first audio track. */
   preferredAudioLanguage?: string;
 }
 
-/**
- * Configuration for text track selection.
- */
+/** Configuration for text track selection. */
 export interface TextSelectionConfig {
-  /**
-   * Preferred subtitle language (ISO 639 code, e.g., "en", "es").
-   * If specified, selects matching track if available.
-   */
+  /** Preferred subtitle language (ISO 639 code, e.g., "en", "es"). If specified, selects matching track if available. */
   preferredSubtitleLanguage?: string;
 
   /**
-   * Include FORCED subtitle tracks in selection.
-   * Default: false (follows hls.js/http-streaming pattern)
+   * Include FORCED subtitle tracks in selection. Default: false (follows hls.js/http-streaming pattern)
    *
-   * Note: Per Apple's HLS spec, if content has forced and regular subtitles
-   * in the same language, the regular track MUST contain both forced and
-   * regular content. Therefore, forced-only tracks are redundant and excluded
-   * by default.
+   * Note: Per Apple's HLS spec, if content has forced and regular subtitles in the same language, the regular track
+   * MUST contain both forced and regular content. Therefore, forced-only tracks are redundant and excluded by default.
    */
   includeForcedTracks?: boolean;
 
   /**
-   * Auto-select DEFAULT track (requires DEFAULT=YES + AUTOSELECT=YES in HLS).
-   * Default: false (user opt-in, matches hls.js/http-streaming)
+   * Auto-select DEFAULT track (requires DEFAULT=YES + AUTOSELECT=YES in HLS). Default: false (user opt-in, matches
+   * hls.js/http-streaming)
    *
-   * When enabled, tracks marked with both DEFAULT=YES and AUTOSELECT=YES
-   * will be automatically selected if no user preference matches.
+   * When enabled, tracks marked with both DEFAULT=YES and AUTOSELECT=YES will be automatically selected if no user
+   * preference matches.
    */
   enableDefaultTrack?: boolean;
 }
@@ -63,10 +48,9 @@ export interface TextSelectionConfig {
 // =============================================================================
 
 /**
- * Test whether a track matches a partial-track description: every present,
- * defined field of `filter` equals the track's. Absent or `undefined` filter
- * fields don't constrain. Used to narrow candidates by a user selection
- * (`{ id }`, `{ language }`, `{ height }`, …).
+ * Test whether a track matches a partial-track description: every present, defined field of `filter` equals the
+ * track's. Absent or `undefined` filter fields don't constrain. Used to narrow candidates by a user selection (`{ id
+ * }`, `{ language }`, `{ height }`, …).
  *
  * @param track - The track to test
  * @param filter - Partial-track description; only present, defined fields constrain
@@ -90,16 +74,13 @@ function pixelArea(track: RankableTrack): number {
 }
 
 /**
- * Narrow to the tracks at or below `maxPixelArea`, and nothing else: no ordering,
- * no fallback. Survivors keep their incoming order, and an empty result is a real
- * answer — "none of these fit".
+ * Narrow to the tracks at or below `maxPixelArea`, and nothing else: no ordering, no fallback. Survivors keep their
+ * incoming order, and an empty result is a real answer — "none of these fit".
  *
- * Deliberately only the filter, because as a selection rule this composes under
- * `applyRules`, which already owns both halves a caller might expect here: an empty
- * result is skipped, so a preference can never narrow the candidate set to nothing;
- * and ordering the survivors is a separate rule's job
- * ({@link byDescendingResolution}, bandwidth ABR). Doing either here would duplicate
- * the composer and give one rule two responsibilities.
+ * Deliberately only the filter, because as a selection rule this composes under `applyRules`, which already owns both
+ * halves a caller might expect here: an empty result is skipped, so a preference can never narrow the candidate set to
+ * nothing; and ordering the survivors is a separate rule's job ({@link byDescendingResolution}, bandwidth ABR). Doing
+ * either here would duplicate the composer and give one rule two responsibilities.
  */
 export function tracksUnderPixelArea<T extends RankableTrack>(
   tracks: readonly T[],
@@ -109,16 +90,14 @@ export function tracksUnderPixelArea<T extends RankableTrack>(
 }
 
 /**
- * The smallest track area that still covers `minPixelArea`, or `undefined` when
- * no track reaches it.
+ * The smallest track area that still covers `minPixelArea`, or `undefined` when no track reaches it.
  *
- * The cap a surface-size rule wants when it should round *up* to the ladder: a
- * surface between two tiers is covered by the upper one, and capping at the
- * surface's own area instead would serve a picture smaller than the surface and
+ * The cap a surface-size rule wants when it should round _up_ to the ladder: a surface between two tiers is covered by
+ * the upper one, and capping at the surface's own area instead would serve a picture smaller than the surface and
  * upscale it.
  *
- * Tracks declaring no dimensions compare as area `0` and so never cover anything,
- * which keeps them out of the cap rather than pinning it to zero.
+ * Tracks declaring no dimensions compare as area `0` and so never cover anything, which keeps them out of the cap
+ * rather than pinning it to zero.
  */
 export function smallestCoveringPixelArea(tracks: readonly RankableTrack[], minPixelArea: number): number | undefined {
   const covering = tracks.map(pixelArea).filter((area) => area >= minPixelArea);
@@ -127,21 +106,19 @@ export function smallestCoveringPixelArea(tracks: readonly RankableTrack[], minP
 }
 
 /**
- * Compare two tracks by resolution, largest first, with bandwidth as the tiebreak
- * for renditions of identical dimensions. Missing dimensions are treated as area
- * `0`, so a track without them sorts last.
+ * Compare two tracks by resolution, largest first, with bandwidth as the tiebreak for renditions of identical
+ * dimensions. Missing dimensions are treated as area `0`, so a track without them sorts last.
  *
- * A comparator rather than a "highest track" function: the selection-rule chain
- * takes the head of the list it produces, so ranking never has to collapse to a
- * single track. `preferHighestResolution` is `sort` over this and nothing more.
+ * A comparator rather than a "highest track" function: the selection-rule chain takes the head of the list it produces,
+ * so ranking never has to collapse to a single track. `preferHighestResolution` is `sort` over this and nothing more.
  */
 export function byDescendingResolution(a: RankableTrack, b: RankableTrack): number {
   return pixelArea(b) - pixelArea(a) || (b.bandwidth ?? 0) - (a.bandwidth ?? 0);
 }
 
 /**
- * Default audio policy over a candidate list: the three-tier pick a selection-rule
- * chain applies once it has narrowed the candidates.
+ * Default audio policy over a candidate list: the three-tier pick a selection-rule chain applies once it has narrowed
+ * the candidates.
  *
  * Priority: `preferredAudioLanguage` match → `DEFAULT=YES` → first track.
  */
@@ -170,13 +147,11 @@ export function pickAudioTrackFromTracks(
 }
 
 /**
- * Default text-track policy over a candidate list: the opt-in three-tier pick
- * `switchTextTrack`'s terminal applies once it has narrowed the renditions to the
- * constrained, CDN-scoped set.
+ * Default text-track policy over a candidate list: the opt-in three-tier pick `switchTextTrack`'s terminal applies once
+ * it has narrowed the renditions to the constrained, CDN-scoped set.
  *
- * Priority: `preferredSubtitleLanguage` match → `DEFAULT=YES + AUTOSELECT=YES`
- * (only when `enableDefaultTrack`) → `undefined` (opt-in). FORCED tracks are
- * excluded unless `includeForcedTracks` (Apple-spec: a regular track must carry
+ * Priority: `preferredSubtitleLanguage` match → `DEFAULT=YES + AUTOSELECT=YES` (only when `enableDefaultTrack`) →
+ * `undefined` (opt-in). FORCED tracks are excluded unless `includeForcedTracks` (Apple-spec: a regular track must carry
  * forced content when both exist, so a forced-only track is redundant).
  */
 export function pickTextTrackFromTracks(

--- a/packages/spf/src/media/primitives/tests/select-tracks.test.ts
+++ b/packages/spf/src/media/primitives/tests/select-tracks.test.ts
@@ -1,11 +1,10 @@
 /**
  * Track geometry for the video selection rules: one filter, one comparator.
  *
- * The candidate-list policies alongside them (`pickAudioTrackFromTracks`,
- * `pickTextTrackFromTracks`) are covered through the behaviors that compose them —
- * `selectAudioTrack` in `playback/behaviors/tests/select-tracks.test.ts`, and
- * `switchTextTrack` in `playback/behaviors/tests/track-switching.test.ts` — since
- * the policy and its lifecycle are only meaningful together.
+ * The candidate-list policies alongside them (`pickAudioTrackFromTracks`, `pickTextTrackFromTracks`) are covered
+ * through the behaviors that compose them — `selectAudioTrack` in `playback/behaviors/tests/select-tracks.test.ts`, and
+ * `switchTextTrack` in `playback/behaviors/tests/track-switching.test.ts` — since the policy and its lifecycle are only
+ * meaningful together.
  */
 import { describe, expect, it } from 'vite-plus/test';
 

--- a/packages/spf/src/media/text/parse-vtt-timestamp-map.ts
+++ b/packages/spf/src/media/text/parse-vtt-timestamp-map.ts
@@ -1,9 +1,8 @@
 /**
- * WebVTT-in-HLS `X-TIMESTAMP-MAP`: correlates a cue's LOCAL (in-file) time with
- * an MPEG-2 presentation timestamp, so LOCAL-authored cues can be placed on the
- * media presentation timeline. Stored raw — the LOCAL→native correction is
- * `mpegts / 90000 - local` — so it stays independent of how (or whether) the
- * presentation is later re-origined. See the HLS spec, RFC 8216bis §3.5.
+ * WebVTT-in-HLS `X-TIMESTAMP-MAP`: correlates a cue's LOCAL (in-file) time with an MPEG-2 presentation timestamp, so
+ * LOCAL-authored cues can be placed on the media presentation timeline. Stored raw — the LOCAL→native correction is
+ * `mpegts / 90000 - local` — so it stays independent of how (or whether) the presentation is later re-origined. See the
+ * HLS spec, RFC 8216bis §3.5.
  */
 export interface TimestampMap {
   /** The MPEG-2 presentation timestamp, in 90 kHz ticks, as authored. */
@@ -15,15 +14,13 @@ export interface TimestampMap {
 const TIMESTAMP_MAP_PREFIX = 'X-TIMESTAMP-MAP=';
 
 /**
- * Scrape a WebVTT segment's `X-TIMESTAMP-MAP` header into a {@link TimestampMap}
- * — the only header line we need to correlate LOCAL cue times with the media
- * presentation timeline. Deliberately *not* a WebVTT parser: cue parsing stays
- * with the browser's native `<track>` parser (which drops this line); this reads
- * just the one header field the native path discards.
+ * Scrape a WebVTT segment's `X-TIMESTAMP-MAP` header into a {@link TimestampMap} — the only header line we need to
+ * correlate LOCAL cue times with the media presentation timeline. Deliberately _not_ a WebVTT parser: cue parsing stays
+ * with the browser's native `<track>` parser (which drops this line); this reads just the one header field the native
+ * path discards.
  *
- * Returns `undefined` when the segment carries no map (e.g. cues already in
- * absolute presentation time) — per the HLS spec that means LOCAL 0 maps to
- * MPEGTS 0. Tolerant of attribute order and `[HH:]MM:SS.mmm` LOCAL forms.
+ * Returns `undefined` when the segment carries no map (e.g. cues already in absolute presentation time) — per the HLS
+ * spec that means LOCAL 0 maps to MPEGTS 0. Tolerant of attribute order and `[HH:]MM:SS.mmm` LOCAL forms.
  */
 export function parseVttTimestampMap(text: string): TimestampMap | undefined {
   const timestampMapLine = text.split(/\r\n|\r|\n/).find((line) => line.startsWith(TIMESTAMP_MAP_PREFIX));

--- a/packages/spf/src/media/text/resolve-vtt-metadata.ts
+++ b/packages/spf/src/media/text/resolve-vtt-metadata.ts
@@ -1,14 +1,13 @@
 /**
- * Header-level text-segment metadata — the `X-TIMESTAMP-MAP` correlation scraped from
- * a VTT segment's raw bytes. DOM-free (a plain fetch + regex parse): the native
- * `<track>` parser in `media/dom/text` (`resolveVttSegment`) discards this header, so a
- * caller that needs it (e.g. non-zero-PTS relocation) fetches the bytes itself.
+ * Header-level text-segment metadata — the `X-TIMESTAMP-MAP` correlation scraped from a VTT segment's raw bytes.
+ * DOM-free (a plain fetch + regex parse): the native `<track>` parser in `media/dom/text` (`resolveVttSegment`)
+ * discards this header, so a caller that needs it (e.g. non-zero-PTS relocation) fetches the bytes itself.
  */
 import { parseVttTimestampMap, type TimestampMap } from './parse-vtt-timestamp-map';
 
 /**
- * Header-level metadata for a text segment, surfaced alongside its cues. Each
- * field is present only when the segment declared it.
+ * Header-level metadata for a text segment, surfaced alongside its cues. Each field is present only when the segment
+ * declared it.
  */
 export interface TextSegmentMetadata {
   timestampMap?: TimestampMap;
@@ -17,10 +16,9 @@ export interface TextSegmentMetadata {
 /**
  * Fetch a VTT segment and scrape only its header metadata (no cue parsing).
  *
- * The native `<track>` parser (`media/dom/text`'s `resolveVttSegment`) discards
- * `X-TIMESTAMP-MAP`, so reading it requires the raw bytes. This is a separate,
- * caller-controlled fetch — the caller decides *when* metadata is needed (e.g.
- * once per source) rather than paying for it on every segment.
+ * The native `<track>` parser (`media/dom/text`'s `resolveVttSegment`) discards `X-TIMESTAMP-MAP`, so reading it
+ * requires the raw bytes. This is a separate, caller-controlled fetch — the caller decides _when_ metadata is needed
+ * (e.g. once per source) rather than paying for it on every segment.
  */
 export async function resolveVttSegmentMetadata(url: string): Promise<TextSegmentMetadata> {
   const text = await fetch(url).then((response) => response.text());

--- a/packages/spf/src/media/types/index.ts
+++ b/packages/spf/src/media/types/index.ts
@@ -1,8 +1,8 @@
 /**
  * Core SPF Types
  *
- * Based on CMAF-HAM (Common Media Application Format - Hypothetical Application Model)
- * Protocol-agnostic representation of streaming media content.
+ * Based on CMAF-HAM (Common Media Application Format - Hypothetical Application Model) Protocol-agnostic representation
+ * of streaming media content.
  *
  * @see https://github.com/streaming-video-technology-alliance/common-media-library
  */
@@ -11,23 +11,18 @@
 // Base Types
 // =============================================================================
 
-/**
- * Base identifier type for all HAM objects.
- */
+/** Base identifier type for all HAM objects. */
 export interface Ham {
   id: string;
   /**
-   * Format-/protocol-specific values that aren't part of the generic CMAF-HAM
-   * model — kept in an open bag so the model stays format-neutral (mirrors how
-   * CMAF-HAM itself stashes protocol extras rather than growing the model).
-   * Typed reads go through dedicated accessors (e.g. `getMediaPlaylistMetadata`).
+   * Format-/protocol-specific values that aren't part of the generic CMAF-HAM model — kept in an open bag so the model
+   * stays format-neutral (mirrors how CMAF-HAM itself stashes protocol extras rather than growing the model). Typed
+   * reads go through dedicated accessors (e.g. `getMediaPlaylistMetadata`).
    */
   metadata?: Record<string, unknown>;
 }
 
-/**
- * Addressable resource with optional byte range.
- */
+/** Addressable resource with optional byte range. */
 export interface AddressableObject {
   url: string;
   byteRange?: {
@@ -41,8 +36,7 @@ export interface AddressableObject {
 // =============================================================================
 
 /**
- * Platform-agnostic media element interface.
- * Captures minimal shape needed for orchestration without DOM dependencies.
+ * Platform-agnostic media element interface. Captures minimal shape needed for orchestration without DOM dependencies.
  * HTMLMediaElement satisfies this interface.
  */
 export interface MediaElementLike {
@@ -53,10 +47,7 @@ export interface MediaElementLike {
 // Time and Duration
 // =============================================================================
 
-/**
- * Time span with start time and duration.
- * Used for segments and other timed ranges.
- */
+/** Time span with start time and duration. Used for segments and other timed ranges. */
 export interface TimeSpan {
   startTime: number;
   duration: number;
@@ -66,9 +57,7 @@ export interface TimeSpan {
 // Enums
 // =============================================================================
 
-/**
- * Track content type.
- */
+/** Track content type. */
 export type TrackType = 'video' | 'audio' | 'text';
 
 // =============================================================================
@@ -78,9 +67,7 @@ export type TrackType = 'video' | 'audio' | 'text';
 /**
  * Video frame rate expressed as numerator/denominator.
  *
- * Examples:
- * - 30 fps: { frameRateNumerator: 30 }
- * - 29.97 fps: { frameRateNumerator: 30000, frameRateDenominator: 1001 }
+ * Examples: - 30 fps: { frameRateNumerator: 30 } - 29.97 fps: { frameRateNumerator: 30000, frameRateDenominator: 1001 }
  */
 export interface FrameRate {
   frameRateNumerator: number;
@@ -92,8 +79,7 @@ export interface FrameRate {
 // =============================================================================
 
 /**
- * Generic type for partially resolved tracks.
- * Removes fields that come from media playlist parsing.
+ * Generic type for partially resolved tracks. Removes fields that come from media playlist parsing.
  *
  * @param T - Track type to make partially resolved (must extend Track)
  */
@@ -105,14 +91,14 @@ export type PartiallyResolved<T extends Track = Track> = Omit<T, 'segments' | 'i
 };
 
 /**
- * Partially resolved video track from multivariant playlist.
- * Has metadata but no segments or initialization yet (media playlist not fetched).
+ * Partially resolved video track from multivariant playlist. Has metadata but no segments or initialization yet (media
+ * playlist not fetched).
  */
 export type PartiallyResolvedVideoTrack = PartiallyResolved<VideoTrack>;
 
 /**
- * Partially resolved audio track from multivariant playlist.
- * Has metadata but no segments or initialization yet (media playlist not fetched).
+ * Partially resolved audio track from multivariant playlist. Has metadata but no segments or initialization yet (media
+ * playlist not fetched).
  */
 export type PartiallyResolvedAudioTrack = PartiallyResolved<AudioTrack>;
 
@@ -121,14 +107,12 @@ export type PartiallyResolvedAudioTrack = PartiallyResolved<AudioTrack>;
 // =============================================================================
 
 /**
- * Base track type containing common properties for all resolved tracks.
- * A resolved track has segments, duration, and initialization data.
- * All URLs are fully qualified (parsers resolve relative URLs).
+ * Base track type containing common properties for all resolved tracks. A resolved track has segments, duration, and
+ * initialization data. All URLs are fully qualified (parsers resolve relative URLs).
  */
 /**
- * Track startTime is always 0 — the presentation-timeline origin (and future
- * multi-period base). The live sliding-window edge is `segments[0].startTime`,
- * derived — never stored here.
+ * Track startTime is always 0 — the presentation-timeline origin (and future multi-period base). The live
+ * sliding-window edge is `segments[0].startTime`, derived — never stored here.
  */
 export type Track = Ham &
   AddressableObject &
@@ -141,52 +125,41 @@ export type Track = Ham &
     initialization?: AddressableObject;
     segments: Segment[];
     /**
-     * Media-timeline (decode/encode) coordinate of the track's timeline origin
-     * (presentation-0) — the media-time base value of the coordinate model, peer
-     * to `startTime` (presentation). Derived from the container
-     * (`tfdt.baseMediaDecodeTime ÷ mdhd.timescale`); the relocation offset is
-     * `−startMediaTime` (targets presentation-0 — `Track.startTime` plays no
-     * part), never stored.
+     * Media-timeline (decode/encode) coordinate of the track's timeline origin (presentation-0) — the media-time base
+     * value of the coordinate model, peer to `startTime` (presentation). Derived from the container
+     * (`tfdt.baseMediaDecodeTime ÷ mdhd.timescale`); the relocation offset is `−startMediaTime` (targets presentation-0
+     * — `Track.startTime` plays no part), never stored.
      *
-     * Optional: `undefined` means not yet established, or never establishable
-     * (e.g. text tracks carry no container origin); a near-zero/native origin is
-     * established as `0` (no relocation). Established once per source by the
-     * `establishStartMediaTime` reactor. See
-     * `internal/design/spf/presentation-timeline-model.md`.
+     * Optional: `undefined` means not yet established, or never establishable (e.g. text tracks carry no container
+     * origin); a near-zero/native origin is established as `0` (no relocation). Established once per source by the
+     * `establishStartMediaTime` reactor. See `internal/design/spf/presentation-timeline-model.md`.
      */
     startMediaTime?: number;
     /**
-     * Wall-clock time (epoch seconds) at the track's timeline origin
-     * (presentation-0) — pure playlist arithmetic over any PDT-bearing segment:
-     * `segment.startDate − segment.startTime`, invariant along a linear
-     * timeline. Optional: absent when no segment carries `startDate`.
+     * Wall-clock time (epoch seconds) at the track's timeline origin (presentation-0) — pure playlist arithmetic over
+     * any PDT-bearing segment: `segment.startDate − segment.startTime`, invariant along a linear timeline. Optional:
+     * absent when no segment carries `startDate`.
      *
-     * The wall-clock member of the coordinate triple (peer to `startTime` and
-     * `startMediaTime`). For live it is the anchor segments are PDT-placed
-     * against on every parse; equal `startDate` across tracks marks the same
-     * presentation instant. See
-     * `internal/design/spf/live-presentation-timeline-model.md`.
+     * The wall-clock member of the coordinate triple (peer to `startTime` and `startMediaTime`). For live it is the
+     * anchor segments are PDT-placed against on every parse; equal `startDate` across tracks marks the same
+     * presentation instant. See `internal/design/spf/live-presentation-timeline-model.md`.
      */
     startDate?: number;
   };
 
 /**
- * Per-track-type origin-establishment data, accumulated across appends (the media
- * track's `track_id` + `mdhd` timescale from the init, `tfdt` baseMediaDecodeTime of
- * that same track from the first media segment) — hence optional. The transient input
- * the `establishStartMediaTime` reactor reduces into `Track.startMediaTime`.
+ * Per-track-type origin-establishment data, accumulated across appends (the media track's `track_id` + `mdhd` timescale
+ * from the init, `tfdt` baseMediaDecodeTime of that same track from the first media segment) — hence optional. The
+ * transient input the `establishStartMediaTime` reactor reduces into `Track.startMediaTime`.
  *
- * `trackId` is the ISO-BMFF `track_ID` of the buffered media track (`vide`/`soun`),
- * read from the init's `tkhd`; it ties the timescale to the *same* track's
- * `baseMediaDecodeTime` (matched via `tfhd.track_id`) so a muxed segment carrying a
- * second track (e.g. `clcp` captions) reads the right `tfdt` rather than the first one.
+ * `trackId` is the ISO-BMFF `track_ID` of the buffered media track (`vide`/`soun`), read from the init's `tkhd`; it
+ * ties the timescale to the _same_ track's `baseMediaDecodeTime` (matched via `tfhd.track_id`) so a muxed segment
+ * carrying a second track (e.g. `clcp` captions) reads the right `tfdt` rather than the first one.
  *
- * `segmentStartTime` is the 0-based presentation start of the segment
- * `baseMediaDecodeTime` was read from — *not* a container value (it's the playlist
- * position), but co-located because the origin is `baseMediaDecodeTime/timescale −
- * segmentStartTime`: the first *loaded* segment isn't necessarily the 0th (a
- * non-zero initial `currentTime`, or live/DVR), so the decode time alone isn't the
- * stream origin.
+ * `segmentStartTime` is the 0-based presentation start of the segment `baseMediaDecodeTime` was read from — _not_ a
+ * container value (it's the playlist position), but co-located because the origin is `baseMediaDecodeTime/timescale −
+ * segmentStartTime`: the first _loaded_ segment isn't necessarily the 0th (a non-zero initial `currentTime`, or
+ * live/DVR), so the decode time alone isn't the stream origin.
  */
 export interface MediaContainerData {
   trackId?: number;
@@ -196,15 +169,13 @@ export interface MediaContainerData {
 }
 
 /**
- * Raw media-segment bytes — a complete buffer or a byte stream. The transport-neutral
- * payload the loader pipeline carries; `AppendData` (the MSE `SourceBuffer` append
- * input in `media/dom/mse`) is an alias of this at the DOM boundary.
+ * Raw media-segment bytes — a complete buffer or a byte stream. The transport-neutral payload the loader pipeline
+ * carries; `AppendData` (the MSE `SourceBuffer` append input in `media/dom/mse`) is an alias of this at the DOM
+ * boundary.
  */
 export type SegmentData = ArrayBuffer | AsyncIterable<Uint8Array>;
 
-/**
- * Resolved video track with segments.
- */
+/** Resolved video track with segments. */
 export type VideoTrack = Track &
   Required<Pick<Track, 'initialization' | 'codecs'>> & {
     type: 'video';
@@ -214,18 +185,14 @@ export type VideoTrack = Track &
     height?: number;
     frameRate?: FrameRate;
     /**
-     * Audio groups (`EXT-X-STREAM-INF:AUDIO`) this video rendition can pair
-     * with. A list because one rendition is typically listed across multiple
-     * `EXT-X-STREAM-INF` entries — one per audio group (the HLS cross-product) —
-     * which the parser collapses into a single track carrying every group it
-     * advertised.
+     * Audio groups (`EXT-X-STREAM-INF:AUDIO`) this video rendition can pair with. A list because one rendition is
+     * typically listed across multiple `EXT-X-STREAM-INF` entries — one per audio group (the HLS cross-product) — which
+     * the parser collapses into a single track carrying every group it advertised.
      */
     audioGroupIds?: string[];
   };
 
-/**
- * Resolved audio track with segments.
- */
+/** Resolved audio track with segments. */
 export type AudioTrack = Track &
   Required<Pick<Track, 'initialization' | 'codecs'>> & {
     type: 'audio';
@@ -237,9 +204,7 @@ export type AudioTrack = Track &
     autoselect?: boolean;
   };
 
-/**
- * Resolved text track with segments.
- */
+/** Resolved text track with segments. */
 export type TextTrack = Track & {
   type: 'text';
   groupId: string;
@@ -251,17 +216,13 @@ export type TextTrack = Track & {
 };
 
 /**
- * Predicate that answers "can this environment decode this track?" — the
- * capability-probing surface, read by the track-switching hard-constraint
- * pre-pass (`excludeUnplayableTracks`) to drop undecodable renditions before
- * selection. Kept DOM-free here (a plain function type over a minimal track
- * shape) so DOM-free behaviors can consume it; the DOM implementation
- * (`canPlayTrack` in `media/dom/capabilities.ts`) wraps
- * `MediaSource.isTypeSupported`.
+ * Predicate that answers "can this environment decode this track?" — the capability-probing surface, read by the
+ * track-switching hard-constraint pre-pass (`excludeUnplayableTracks`) to drop undecodable renditions before selection.
+ * Kept DOM-free here (a plain function type over a minimal track shape) so DOM-free behaviors can consume it; the DOM
+ * implementation (`canPlayTrack` in `media/dom/capabilities.ts`) wraps `MediaSource.isTypeSupported`.
  *
- * Takes the minimal codec-bearing shape both video and audio candidates
- * carry. `mimeType` is optional so unprobeable candidates (no MIME) can be
- * passed straight through as playable rather than dropped.
+ * Takes the minimal codec-bearing shape both video and audio candidates carry. `mimeType` is optional so unprobeable
+ * candidates (no MIME) can be passed straight through as playable rather than dropped.
  */
 export type CanPlayTrack = (track: {
   mimeType?: string;
@@ -272,10 +233,9 @@ export type CanPlayTrack = (track: {
 /**
  * Minimal text-track cue shape — start time, end time, and display text.
  *
- * Host-agnostic representation. `VTTCue` structurally satisfies this
- * interface, so DOM consumers pass `VTTCue` values directly. Non-DOM
- * hosts (workers, test fakes, non-browser engines) can satisfy the same
- * shape without pulling in DOM types.
+ * Host-agnostic representation. `VTTCue` structurally satisfies this interface, so DOM consumers pass `VTTCue` values
+ * directly. Non-DOM hosts (workers, test fakes, non-browser engines) can satisfy the same shape without pulling in DOM
+ * types.
  */
 export interface Cue {
   startTime: number;
@@ -286,29 +246,24 @@ export interface Cue {
 /**
  * Media element with an iterable text-track list, host-agnostic.
  *
- * Extends `MediaElementLike` with the minimum surface needed to observe
- * which text tracks are currently mounted on the media. `HTMLMediaElement`
- * structurally satisfies this (its `textTracks` is a `TextTrackList`,
- * which is iterable with `{ id }` items).
+ * Extends `MediaElementLike` with the minimum surface needed to observe which text tracks are currently mounted on the
+ * media. `HTMLMediaElement` structurally satisfies this (its `textTracks` is a `TextTrackList`, which is iterable with
+ * `{ id }` items).
  */
 export interface MediaElementWithTextTracks extends MediaElementLike {
   readonly textTracks: Iterable<{ readonly id: string }>;
 }
 
 /**
- * Partially resolved text track from multivariant playlist.
- * Has metadata but no segments or initialization yet (media playlist not fetched).
+ * Partially resolved text track from multivariant playlist. Has metadata but no segments or initialization yet (media
+ * playlist not fetched).
  */
 export type PartiallyResolvedTextTrack = PartiallyResolved<TextTrack>;
 
-/**
- * Union of all resolved track types.
- */
+/** Union of all resolved track types. */
 export type ResolvedTrack = VideoTrack | AudioTrack | TextTrack;
 
-/**
- * Union of all partially resolved track types.
- */
+/** Union of all partially resolved track types. */
 export type PartiallyResolvedTrack =
   | PartiallyResolvedVideoTrack
   | PartiallyResolvedAudioTrack
@@ -319,8 +274,7 @@ export type PartiallyResolvedTrack =
 // =============================================================================
 
 /**
- * Generic switching set type.
- * A group of tracks that can be switched between seamlessly.
+ * Generic switching set type. A group of tracks that can be switched between seamlessly.
  *
  * @param T - Track type (VideoTrack, AudioTrack, or TextTrack)
  */
@@ -329,30 +283,20 @@ export type SwitchingSetOf<T extends Track = Track> = Ham & {
   tracks: (PartiallyResolved<T> | T)[];
 };
 
-/**
- * Video switching set - contains only video tracks (partially resolved or fully resolved).
- */
+/** Video switching set - contains only video tracks (partially resolved or fully resolved). */
 export type VideoSwitchingSet = SwitchingSetOf<VideoTrack>;
 
-/**
- * Audio switching set - contains only audio tracks (partially resolved or fully resolved).
- */
+/** Audio switching set - contains only audio tracks (partially resolved or fully resolved). */
 export type AudioSwitchingSet = SwitchingSetOf<AudioTrack>;
 
-/**
- * Text switching set - contains only text tracks (partially resolved or fully resolved).
- */
+/** Text switching set - contains only text tracks (partially resolved or fully resolved). */
 export type TextSwitchingSet = SwitchingSetOf<TextTrack>;
 
-/**
- * Switching set - a group of tracks that can be switched between seamlessly.
- * Discriminated by track type.
- */
+/** Switching set - a group of tracks that can be switched between seamlessly. Discriminated by track type. */
 export type SwitchingSet = VideoSwitchingSet | AudioSwitchingSet | TextSwitchingSet;
 
 /**
- * Generic selection set type.
- * Groups switching sets by track type.
+ * Generic selection set type. Groups switching sets by track type.
  *
  * @param T - Track type (VideoTrack, AudioTrack, or TextTrack)
  */
@@ -361,25 +305,16 @@ export type SelectionSetOf<T extends Track = Track> = Ham & {
   switchingSets: SwitchingSetOf<T>[];
 };
 
-/**
- * Video selection set - contains only video switching sets.
- */
+/** Video selection set - contains only video switching sets. */
 export type VideoSelectionSet = SelectionSetOf<VideoTrack>;
 
-/**
- * Audio selection set - contains only audio switching sets.
- */
+/** Audio selection set - contains only audio switching sets. */
 export type AudioSelectionSet = SelectionSetOf<AudioTrack>;
 
-/**
- * Text selection set - contains only text switching sets.
- */
+/** Text selection set - contains only text switching sets. */
 export type TextSelectionSet = SelectionSetOf<TextTrack>;
 
-/**
- * Selection set - groups switching sets by track type.
- * Discriminated union ensures type-safe track access.
- */
+/** Selection set - groups switching sets by track type. Discriminated union ensures type-safe track access. */
 export type SelectionSet = VideoSelectionSet | AudioSelectionSet | TextSelectionSet;
 
 // =============================================================================
@@ -387,27 +322,21 @@ export type SelectionSet = VideoSelectionSet | AudioSelectionSet | TextSelection
 // =============================================================================
 
 /**
- * Media segment with timing information.
- * Follows CMAF-HAM composition pattern.
+ * Media segment with timing information. Follows CMAF-HAM composition pattern.
  *
- * `startDate` is the absolute wall-clock time of the segment's first
- * sample, in **epoch seconds** (unit-consistent with `startTime`/`duration`),
- * derived from `#EXT-X-PROGRAM-DATE-TIME` (explicit or interpolated forward via
- * `EXTINF`). Unlike the per-track-relative `startTime`, it is comparable across
- * tracks, so it is the cross-track sync anchor for demuxed audio/video and the
- * exact recovery value on a full live-window turnover. Optional: absent when the
- * source carries no PDT (allowed by RFC 8216, required by Apple's HLS authoring
- * spec — so present on conformant content).
+ * `startDate` is the absolute wall-clock time of the segment's first sample, in **epoch seconds** (unit-consistent with
+ * `startTime`/`duration`), derived from `#EXT-X-PROGRAM-DATE-TIME` (explicit or interpolated forward via `EXTINF`).
+ * Unlike the per-track-relative `startTime`, it is comparable across tracks, so it is the cross-track sync anchor for
+ * demuxed audio/video and the exact recovery value on a full live-window turnover. Optional: absent when the source
+ * carries no PDT (allowed by RFC 8216, required by Apple's HLS authoring spec — so present on conformant content).
  */
 export type Segment = Ham & AddressableObject & TimeSpan & { startDate?: number };
 
 /**
- * Floating-point tolerance for matching segments by `startTime`. Two
- * segments are considered the same position when
- * `Math.abs(a.startTime - b.startTime) < SEGMENT_TIME_EPSILON`. Used by
- * the source-buffer dedup and segment-loader quality-aware filter to
- * tolerate sub-millisecond drift in segment timestamps across multiple
- * playlists / quality levels.
+ * Floating-point tolerance for matching segments by `startTime`. Two segments are considered the same position when
+ * `Math.abs(a.startTime - b.startTime) < SEGMENT_TIME_EPSILON`. Used by the source-buffer dedup and segment-loader
+ * quality-aware filter to tolerate sub-millisecond drift in segment timestamps across multiple playlists / quality
+ * levels.
  */
 export const SEGMENT_TIME_EPSILON = 0.0001;
 
@@ -416,14 +345,13 @@ export const SEGMENT_TIME_EPSILON = 0.0001;
 // =============================================================================
 
 /**
- * Playlist-level metadata surfaced from a parsed media playlist. HLS delivery
- * specifics — not part of the generic CMAF-HAM model — so they live under
- * `Ham.metadata` (read via `getMediaPlaylistMetadata`) rather than as
- * first-class `Track` fields:
+ * Playlist-level metadata surfaced from a parsed media playlist. HLS delivery specifics — not part of the generic
+ * CMAF-HAM model — so they live under `Ham.metadata` (read via `getMediaPlaylistMetadata`) rather than as first-class
+ * `Track` fields:
  *
  * - `targetDuration` (`#EXT-X-TARGETDURATION`) — reload-cadence basis.
- * - `mediaSequence` (`#EXT-X-MEDIA-SEQUENCE`, default 0) — sequence number of
- *   `segments[0]`; the join key for merging successive reload snapshots.
+ * - `mediaSequence` (`#EXT-X-MEDIA-SEQUENCE`, default 0) — sequence number of `segments[0]`; the join key for merging
+ *   successive reload snapshots.
  * - `playlistType` (`#EXT-X-PLAYLIST-TYPE`) — `VOD` / `EVENT` / undefined.
  * - `endList` (`#EXT-X-ENDLIST`) — playlist is complete; stop reloading.
  */
@@ -433,47 +361,36 @@ export interface MediaPlaylistMetadata {
   playlistType?: 'VOD' | 'EVENT';
   endList: boolean;
   /**
-   * Whether this rendition carries encrypted segments — any `#EXT-X-KEY` whose
-   * `METHOD` isn't `NONE`. Detection only: enough to tell that playback needs
-   * decryption support, not enough to perform it.
+   * Whether this rendition carries encrypted segments — any `#EXT-X-KEY` whose `METHOD` isn't `NONE`. Detection only:
+   * enough to tell that playback needs decryption support, not enough to perform it.
    *
-   * Deliberately *not* a model-level `protection` shape. CMAF-HAM puts
-   * `protection` on `SwitchingSet`, but that can't express two real cases: a
-   * clear lead (`METHOD=NONE` segments followed by encrypted ones — protection
-   * varies along the timeline within one rendition) or key rotation (its single
-   * `defaultKid` can't represent a key changing over time). Modeling it properly
-   * belongs to DRM support; until then this records the one fact a playlist
-   * reliably gives us. Per-rendition because that's HLS's granularity —
-   * `EXT-X-KEY` is a media-playlist tag.
+   * Deliberately _not_ a model-level `protection` shape. CMAF-HAM puts `protection` on `SwitchingSet`, but that can't
+   * express two real cases: a clear lead (`METHOD=NONE` segments followed by encrypted ones — protection varies along
+   * the timeline within one rendition) or key rotation (its single `defaultKid` can't represent a key changing over
+   * time). Modeling it properly belongs to DRM support; until then this records the one fact a playlist reliably gives
+   * us. Per-rendition because that's HLS's granularity — `EXT-X-KEY` is a media-playlist tag.
    *
-   * Conservative for a clear lead: a rendition whose opening segments are clear
-   * still reads as encrypted, so it's judged unplayable rather than played until
-   * it breaks.
+   * Conservative for a clear lead: a rendition whose opening segments are clear still reads as encrypted, so it's
+   * judged unplayable rather than played until it breaks.
    */
   encrypted?: boolean;
   /**
-   * `EXT-X-SERVER-CONTROL` `HOLD-BACK` (seconds) — the server's declared distance
-   * from the live edge for clients playing *complete* segments. Absent when the
-   * server doesn't advertise it, in which case the spec default (3 × target
-   * duration) applies. Deliberately HLS vocabulary living in the playlist
-   * metadata rather than on `Track`: whether a wall-clock holdback generalizes
-   * across delivery formats is unresolved.
+   * `EXT-X-SERVER-CONTROL` `HOLD-BACK` (seconds) — the server's declared distance from the live edge for clients
+   * playing _complete_ segments. Absent when the server doesn't advertise it, in which case the spec default (3 ×
+   * target duration) applies. Deliberately HLS vocabulary living in the playlist metadata rather than on `Track`:
+   * whether a wall-clock holdback generalizes across delivery formats is unresolved.
    *
-   * `PART-HOLD-BACK` is **not** captured — it only applies to clients playing
-   * partial segments, and using it while fetching whole segments would put the
-   * playhead ahead of the last complete segment. Add it with LL-HLS support.
+   * `PART-HOLD-BACK` is **not** captured — it only applies to clients playing partial segments, and using it while
+   * fetching whole segments would put the playhead ahead of the last complete segment. Add it with LL-HLS support.
    */
   holdBack?: number;
   /**
-   * Whether the server is delivering this rendition as Low-Latency HLS — any of
-   * `#EXT-X-PART`, `#EXT-X-PART-INF`, or `EXT-X-SERVER-CONTROL`'s
-   * `PART-HOLD-BACK`.
+   * Whether the server is delivering this rendition as Low-Latency HLS — any of `#EXT-X-PART`, `#EXT-X-PART-INF`, or
+   * `EXT-X-SERVER-CONTROL`'s `PART-HOLD-BACK`.
    *
-   * Detection only, and deliberately so: partial segments are ignored by the
-   * parser and the loader fetches whole segments, so an LL-HLS playlist plays as
-   * standard live at standard latency. Recording the fact is what lets a
-   * composition *say* that rather than silently under-delivering the latency the
-   * publisher configured.
+   * Detection only, and deliberately so: partial segments are ignored by the parser and the loader fetches whole
+   * segments, so an LL-HLS playlist plays as standard live at standard latency. Recording the fact is what lets a
+   * composition _say_ that rather than silently under-delivering the latency the publisher configured.
    */
   lowLatency?: boolean;
 }
@@ -491,16 +408,14 @@ export function getMediaPlaylistMetadata(ham: Pick<Ham, 'metadata'>): MediaPlayl
 // =============================================================================
 
 /**
- * The source's semantic nature — live vs on-demand. A model concept
- * (consumer-facing), distinct from completeness / duration: a live stream that
- * has *ended* is still `'live'`.
+ * The source's semantic nature — live vs on-demand. A model concept (consumer-facing), distinct from completeness /
+ * duration: a live stream that has _ended_ is still `'live'`.
  */
 export type StreamType = 'live' | 'on-demand';
 
 /**
- * Derive {@link StreamType} from a media playlist's metadata. Per the model,
- * only `#EXT-X-PLAYLIST-TYPE:VOD` marks on-demand; everything else (EVENT, or
- * the tag absent) is live — completeness (`endList`) never factors in.
+ * Derive {@link StreamType} from a media playlist's metadata. Per the model, only `#EXT-X-PLAYLIST-TYPE:VOD` marks
+ * on-demand; everything else (EVENT, or the tag absent) is live — completeness (`endList`) never factors in.
  */
 export function deriveStreamType(metadata: MediaPlaylistMetadata | undefined): StreamType {
   return metadata?.playlistType === 'VOD' ? 'on-demand' : 'live';
@@ -510,10 +425,7 @@ export function deriveStreamType(metadata: MediaPlaylistMetadata | undefined): S
 // Media Playlist Info
 // =============================================================================
 
-/**
- * Intermediate representation of a parsed media playlist.
- * Used internally before assembling into full Track structure.
- */
+/** Intermediate representation of a parsed media playlist. Used internally before assembling into full Track structure. */
 export interface MediaPlaylistInfo {
   version: number;
   targetDuration: number;
@@ -529,20 +441,19 @@ export interface MediaPlaylistInfo {
 // =============================================================================
 
 /**
- * Presentation - a single playable period of content.
- * Uses TimeSpan fields (startTime always 0, duration optional until track resolved).
+ * Presentation - a single playable period of content. Uses TimeSpan fields (startTime always 0, duration optional until
+ * track resolved).
  *
- * Extends AddressableObject so `url` contains the original manifest URL.
- * All URLs are fully qualified (parsers resolve relative URLs).
+ * Extends AddressableObject so `url` contains the original manifest URL. All URLs are fully qualified (parsers resolve
+ * relative URLs).
  */
 export type Presentation = Ham &
   AddressableObject &
   Partial<TimeSpan> & {
     selectionSets: SelectionSet[];
     /**
-     * Live vs on-demand — the source's semantic nature. Populated once a media
-     * playlist is parsed (derived from `#EXT-X-PLAYLIST-TYPE` via
-     * `deriveStreamType`); orthogonal to duration / completeness.
+     * Live vs on-demand — the source's semantic nature. Populated once a media playlist is parsed (derived from
+     * `#EXT-X-PLAYLIST-TYPE` via `deriveStreamType`); orthogonal to duration / completeness.
      */
     streamType?: StreamType;
   };
@@ -550,9 +461,8 @@ export type Presentation = Ham &
 /**
  * State-shaped presentation that may or may not be resolved yet.
  *
- * The lifecycle is a single value: a caller writes `{ url }`, and the
- * resolver populates the rest in place. `url` is always present; resolved
- * fields (`id`, `selectionSets`, duration) appear once parsing succeeds.
+ * The lifecycle is a single value: a caller writes `{ url }`, and the resolver populates the rest in place. `url` is
+ * always present; resolved fields (`id`, `selectionSets`, duration) appear once parsing succeeds.
  *
  * Use `isResolvedPresentation` to narrow to `Presentation`.
  */
@@ -562,10 +472,7 @@ export type MaybeResolvedPresentation = AddressableObject & Partial<Omit<Present
 // Type Guards
 // =============================================================================
 
-/**
- * Check if a track is resolved (has segments).
- * Works for all track types with overloaded signatures for type narrowing.
- */
+/** Check if a track is resolved (has segments). Works for all track types with overloaded signatures for type narrowing. */
 export function isResolvedTrack(track: PartiallyResolvedVideoTrack | VideoTrack): track is VideoTrack;
 export function isResolvedTrack(track: PartiallyResolvedAudioTrack | AudioTrack): track is AudioTrack;
 export function isResolvedTrack(track: PartiallyResolvedTextTrack | TextTrack): track is TextTrack;
@@ -574,10 +481,7 @@ export function isResolvedTrack(track: PartiallyResolvedTrack | ResolvedTrack): 
   return 'segments' in track;
 }
 
-/**
- * Check if a presentation has duration (at least one track resolved).
- * Narrows type to include required duration.
- */
+/** Check if a presentation has duration (at least one track resolved). Narrows type to include required duration. */
 export function hasPresentationDuration(
   presentation: MaybeResolvedPresentation
 ): presentation is MaybeResolvedPresentation & { duration: number } {
@@ -587,11 +491,9 @@ export function hasPresentationDuration(
 /**
  * Narrows a `MaybeResolvedPresentation` to a fully resolved `Presentation`.
  *
- * A presentation is resolved once `resolvePresentation` has parsed the
- * manifest and populated both `id` and `selectionSets`. Both must be
- * present — a partial value with only one of them isn't usable, and
- * letting it through would have downstream behaviors crash when they
- * access `selectionSets`.
+ * A presentation is resolved once `resolvePresentation` has parsed the manifest and populated both `id` and
+ * `selectionSets`. Both must be present — a partial value with only one of them isn't usable, and letting it through
+ * would have downstream behaviors crash when they access `selectionSets`.
  */
 export function isResolvedPresentation(
   presentation: MaybeResolvedPresentation | undefined

--- a/packages/spf/src/media/utils/cdn.ts
+++ b/packages/spf/src/media/utils/cdn.ts
@@ -1,19 +1,16 @@
 import type { MaybeResolvedPresentation, TrackType } from '../types';
 
 /**
- * Derive a stable grouping key for the CDN a URL is served from. Synchronous and
- * pure (deliberately not a `resolve*` — no fetch). Consumers override the
- * default via the engine's `getCdnId` config (e.g. to key on Mux's `cdn=` query
- * param instead of the host); every CDN-identity site reads that same function
- * so keys stay comparable across `cdnPriority`, `failedCdns`, and the
- * track-switching constraint + scope.
+ * Derive a stable grouping key for the CDN a URL is served from. Synchronous and pure (deliberately not a `resolve*` —
+ * no fetch). Consumers override the default via the engine's `getCdnId` config (e.g. to key on Mux's `cdn=` query param
+ * instead of the host); every CDN-identity site reads that same function so keys stay comparable across `cdnPriority`,
+ * `failedCdns`, and the track-switching constraint + scope.
  */
 export type GetCdnId = (url: string) => string;
 
 /**
- * Default {@link GetCdnId}: the URL's origin (scheme + host + port); falls back
- * to the raw string when the URL can't be parsed, so the return value is always
- * a stable grouping key.
+ * Default {@link GetCdnId}: the URL's origin (scheme + host + port); falls back to the raw string when the URL can't be
+ * parsed, so the return value is always a stable grouping key.
  */
 export function getCdnId(url: string): string {
   try {
@@ -32,17 +29,13 @@ export function getCdnId(url: string): string {
 const CDN_TYPE_PRIORITY: Record<TrackType, number> = { video: 0, audio: 1, text: 2 };
 
 /**
- * The distinct CDNs a presentation's tracks are served from, ordered video CDNs
- * first, then audio, then text (manifest order within a type). The head is the
- * primary CDN — the one a sticky pick defaults to — and is always video-derived
- * when the source has video. Returns `[]` for an unresolved presentation with
- * no tracks.
+ * The distinct CDNs a presentation's tracks are served from, ordered video CDNs first, then audio, then text (manifest
+ * order within a type). The head is the primary CDN — the one a sticky pick defaults to — and is always video-derived
+ * when the source has video. Returns `[]` for an unresolved presentation with no tracks.
  *
- * Redundant-stream sources list the same content on multiple hosts (e.g. Mux's
- * `?redundant_streams=true`), so each host contributes its own candidate tracks;
- * this collapses them to the set of CDNs across every track type. The CDN-id
- * derivation defaults to {@link getCdnId}; pass a consumer-configured `getId` to
- * key on something other than origin.
+ * Redundant-stream sources list the same content on multiple hosts (e.g. Mux's `?redundant_streams=true`), so each host
+ * contributes its own candidate tracks; this collapses them to the set of CDNs across every track type. The CDN-id
+ * derivation defaults to {@link getCdnId}; pass a consumer-configured `getId` to key on something other than origin.
  */
 export function getOrderedCdnIds(presentation: MaybeResolvedPresentation, getId: GetCdnId = getCdnId): string[] {
   const seen = new Set<string>();
@@ -69,9 +62,8 @@ export function getOrderedCdnIds(presentation: MaybeResolvedPresentation, getId:
 }
 
 /**
- * Add a CDN id to a failed-CDN list, preserving order and ignoring duplicates.
- * Idempotent: re-adding an already-present id returns the same array reference
- * (so a no-op trip doesn't churn the `failedCdns` signal). The failover trip in
+ * Add a CDN id to a failed-CDN list, preserving order and ignoring duplicates. Idempotent: re-adding an already-present
+ * id returns the same array reference (so a no-op trip doesn't churn the `failedCdns` signal). The failover trip in
  * `resolve-track` and the segment loaders feed this into `failedCdns` via `update`.
  */
 export function addFailedCdn(failed: string[] | undefined, cdn: string): string[] {

--- a/packages/spf/src/media/utils/preload.ts
+++ b/packages/spf/src/media/utils/preload.ts
@@ -1,7 +1,6 @@
 /**
- * The W3C-standard set of `<video>`/`<audio>` `preload` attribute values.
- * SPF allows extended values (e.g. `'canplay'`) on `state.preload`, which
- * are *not* reflected to the DOM — predicate below is the discriminator.
+ * The W3C-standard set of `<video>`/`<audio>` `preload` attribute values. SPF allows extended values (e.g. `'canplay'`)
+ * on `state.preload`, which are _not_ reflected to the DOM — predicate below is the discriminator.
  */
 export type StandardPreload = 'auto' | 'metadata' | 'none';
 
@@ -10,16 +9,14 @@ export function isStandardPreload(value: unknown): value is StandardPreload {
 }
 
 /**
- * Default `preload` value used as the fallback across behaviors
- * (`syncPreload`, `resolvePresentation`, `isBlockingPreload`). Matches the
- * `<video>`/`<audio>` element's implicit default.
+ * Default `preload` value used as the fallback across behaviors (`syncPreload`, `resolvePresentation`,
+ * `isBlockingPreload`). Matches the `<video>`/`<audio>` element's implicit default.
  */
 export const DEFAULT_PRELOAD = 'metadata';
 
 /**
- * True when the preload value blocks initial resolution / loading.
- * Falsy values (undefined, empty) fall back to `defaultPreload` (default
- * `DEFAULT_PRELOAD`); the resolved value blocks iff it is `'none'`.
+ * True when the preload value blocks initial resolution / loading. Falsy values (undefined, empty) fall back to
+ * `defaultPreload` (default `DEFAULT_PRELOAD`); the resolved value blocks iff it is `'none'`.
  */
 export function isBlockingPreload(
   preload: string | undefined,

--- a/packages/spf/src/media/utils/track-selection.ts
+++ b/packages/spf/src/media/utils/track-selection.ts
@@ -10,10 +10,7 @@ import type {
 } from '../types';
 import { isResolvedTrack } from '../types';
 
-/**
- * State shape for track selection.
- * Minimal shape containing presentation and selected track IDs.
- */
+/** State shape for track selection. Minimal shape containing presentation and selected track IDs. */
 export interface TrackSelectionState {
   presentation?: MaybeResolvedPresentation;
   selectedVideoTrackId?: string | undefined;
@@ -21,9 +18,7 @@ export interface TrackSelectionState {
   selectedTextTrackId?: string | undefined;
 }
 
-/**
- * Map track type to selected track ID property key in state.
- */
+/** Map track type to selected track ID property key in state. */
 export const SelectedTrackIdKeyByType = {
   video: 'selectedVideoTrackId',
   audio: 'selectedAudioTrackId',
@@ -31,15 +26,14 @@ export const SelectedTrackIdKeyByType = {
 } as const;
 
 /**
- * Get selected track from state by type.
- * Returns properly typed track (partially or fully resolved) or undefined.
- * Type parameter T is inferred from the type argument.
+ * Get selected track from state by type. Returns properly typed track (partially or fully resolved) or undefined. Type
+ * parameter T is inferred from the type argument.
  *
  * @example
- * const videoTrack = getSelectedTrack(state, 'video');
- * if (videoTrack && isResolvedTrack(videoTrack)) {
- *   // videoTrack is VideoTrack
- * }
+ *   const videoTrack = getSelectedTrack(state, 'video');
+ *   if (videoTrack && isResolvedTrack(videoTrack)) {
+ *     // videoTrack is VideoTrack
+ *   }
  */
 export function getSelectedTrack<T extends TrackType>(
   state: TrackSelectionState,
@@ -65,10 +59,9 @@ export function getSelectedTrack<T extends TrackType>(
 }
 
 /**
- * Returns the duration of the first resolved selected track, preferring
- * video over audio. A track is "resolved" once its media playlist has been
- * parsed (per {@link isResolvedTrack}). Returns `undefined` if neither
- * selected track is resolved.
+ * Returns the duration of the first resolved selected track, preferring video over audio. A track is "resolved" once
+ * its media playlist has been parsed (per {@link isResolvedTrack}). Returns `undefined` if neither selected track is
+ * resolved.
  */
 export function getResolvedSelectedTrackDuration(state: TrackSelectionState): number | undefined {
   if (state.selectedVideoTrackId) {

--- a/packages/spf/src/media/utils/tracks.ts
+++ b/packages/spf/src/media/utils/tracks.ts
@@ -13,14 +13,12 @@ import { isResolvedTrack } from '../types';
 /**
  * Get the tracks of the given type from a presentation's first switching set.
  *
- * Returns `[]` when the presentation is unresolved, when no selection set of
- * `type` exists, or when its first switching set is empty. Returned tracks may
- * be partially resolved (URL only) or fully resolved (with segments) — callers
- * narrow as needed.
+ * Returns `[]` when the presentation is unresolved, when no selection set of `type` exists, or when its first switching
+ * set is empty. Returned tracks may be partially resolved (URL only) or fully resolved (with segments) — callers narrow
+ * as needed.
  *
- * The "first switching set" assumption matches the rest of the codebase
- * (HLS typically has one switching set per type); multi-group / multi-period
- * support would generalize this.
+ * The "first switching set" assumption matches the rest of the codebase (HLS typically has one switching set per type);
+ * multi-group / multi-period support would generalize this.
  */
 export function getTracksByType(
   presentation: MaybeResolvedPresentation,
@@ -32,10 +30,9 @@ export function getTracksByType(
 /**
  * Find a track of the given type and id within a presentation.
  *
- * Returns the matching track from the first switching set of the matching
- * selection set, or `undefined` if either is missing. The returned track may
- * be partially resolved (URL only) or fully resolved (with segments) — callers
- * narrow as needed.
+ * Returns the matching track from the first switching set of the matching selection set, or `undefined` if either is
+ * missing. The returned track may be partially resolved (URL only) or fully resolved (with segments) — callers narrow
+ * as needed.
  */
 export function findTrack(
   presentation: MaybeResolvedPresentation,
@@ -46,13 +43,11 @@ export function findTrack(
 }
 
 /**
- * Find a track by id across all selection sets in a presentation, without
- * knowing its type up front. Used when the caller has a track id obtained
- * from a downstream consumer (e.g. `SourceBufferActor.initTrackId`) and
- * needs to locate the corresponding track in the presentation.
+ * Find a track by id across all selection sets in a presentation, without knowing its type up front. Used when the
+ * caller has a track id obtained from a downstream consumer (e.g. `SourceBufferActor.initTrackId`) and needs to locate
+ * the corresponding track in the presentation.
  *
- * Track ids are unique within a presentation per the HLS spec; the first
- * match wins.
+ * Track ids are unique within a presentation per the HLS spec; the first match wins.
  */
 export function findTrackById(
   presentation: MaybeResolvedPresentation,
@@ -68,13 +63,12 @@ export function findTrackById(
 }
 
 /**
- * Find a text track of the given id within a presentation and narrow it to
- * the fully-resolved `TextTrack` shape (segments populated). Returns
- * `undefined` if no track matches the id, the matching track isn't a text
- * track, or it hasn't been resolved yet.
+ * Find a text track of the given id within a presentation and narrow it to the fully-resolved `TextTrack` shape
+ * (segments populated). Returns `undefined` if no track matches the id, the matching track isn't a text track, or it
+ * hasn't been resolved yet.
  *
- * The segments-non-empty check stays at the call site — a resolved track
- * with zero segments is a valid state, distinct from "ready to load."
+ * The segments-non-empty check stays at the call site — a resolved track with zero segments is a valid state, distinct
+ * from "ready to load."
  */
 export function findResolvedTextTrack(
   presentation: MaybeResolvedPresentation | undefined,
@@ -118,36 +112,31 @@ export function findResolvedAudioTrack(
 }
 
 /**
- * Whether a track carries a non-empty `codecs` array. Both partially-
- * resolved and fully-resolved tracks may carry codecs — they come from
- * the multivariant playlist's `EXT-X-STREAM-INF` line, not from the
- * per-type media playlist — so this works at either resolution stage.
+ * Whether a track carries a non-empty `codecs` array. Both partially- resolved and fully-resolved tracks may carry
+ * codecs — they come from the multivariant playlist's `EXT-X-STREAM-INF` line, not from the per-type media playlist —
+ * so this works at either resolution stage.
  *
- * `TextTrack` doesn't declare a `codecs` field; the `'codecs' in track`
- * check narrows it out for the false branch.
+ * `TextTrack` doesn't declare a `codecs` field; the `'codecs' in track` check narrows it out for the false branch.
  */
 export function hasCodecs(track: PartiallyResolvedTrack | ResolvedTrack | undefined): boolean {
   return !!track && 'codecs' in track && !!track.codecs?.length;
 }
 
 /**
- * The family (RFC 6381 4CC) of one codec string: `'avc1.640028'` → `'avc1'`,
- * `'mp4a.40.2'` → `'mp4a'`, dotless strings (`'ec-3'`) pass through whole.
- * Lowercased so families compare regardless of manifest casing.
+ * The family (RFC 6381 4CC) of one codec string: `'avc1.640028'` → `'avc1'`, `'mp4a.40.2'` → `'mp4a'`, dotless strings
+ * (`'ec-3'`) pass through whole. Lowercased so families compare regardless of manifest casing.
  *
- * The family is what a `SourceBuffer`'s bytestream is keyed on: renditions in
- * one family swap via a new init segment, while crossing families needs
- * `SourceBuffer.changeType()` (which SPF doesn't implement).
+ * The family is what a `SourceBuffer`'s bytestream is keyed on: renditions in one family swap via a new init segment,
+ * while crossing families needs `SourceBuffer.changeType()` (which SPF doesn't implement).
  */
 export function getCodecFamily(codec: string): string {
   return codec.trim().split('.', 1)[0]!.toLowerCase();
 }
 
 /**
- * The distinct codec families a track carries, or `undefined` when it carries
- * no codecs (unknowable, per `hasCodecs` — not "none"). A demuxed rendition
- * has one family; a muxed one (bipbop's `CODECS="hvc1…,mp4a…"`) has one per
- * elementary stream.
+ * The distinct codec families a track carries, or `undefined` when it carries no codecs (unknowable, per `hasCodecs` —
+ * not "none"). A demuxed rendition has one family; a muxed one (bipbop's `CODECS="hvc1…,mp4a…"`) has one per elementary
+ * stream.
  */
 export function getCodecFamilies(track: { codecs?: string[] }): readonly string[] | undefined {
   if (!track.codecs?.length) return undefined;
@@ -156,30 +145,24 @@ export function getCodecFamilies(track: { codecs?: string[] }): readonly string[
 }
 
 /**
- * Set `mimeType` on every track of one `type` (immutably). Used to propagate a
- * detected container across a type's renditions: an ABR ladder is the same
- * content at different bitrates, so one rendition's container holds for all of
- * them — capability probing + SourceBuffer setup then get the right MIME for the
- * whole type from a single resolved media playlist, without fetching the rest.
+ * Set `mimeType` on every track of one `type` (immutably). Used to propagate a detected container across a type's
+ * renditions: an ABR ladder is the same content at different bitrates, so one rendition's container holds for all of
+ * them — capability probing + SourceBuffer setup then get the right MIME for the whole type from a single resolved
+ * media playlist, without fetching the rest.
  *
- * Scoped to one type on purpose: propagating *across* audio/video would be wrong
- * for mixed-container sources (e.g. muxed-TS video + raw-`.aac` audio) and races
- * concurrent per-type resolution. Same-type writes are disjoint and safe.
+ * Scoped to one type on purpose: propagating _across_ audio/video would be wrong for mixed-container sources (e.g.
+ * muxed-TS video + raw-`.aac` audio) and races concurrent per-type resolution. Same-type writes are disjoint and safe.
  * Idempotent — tracks already at `mimeType` are left as-is.
  *
- * **Assumes one container per type, which the HLS specs don't guarantee.** Apple's
- * HLS Authoring Specification not only permits a mixed ladder, it produces one:
- * §1.5 requires HEVC in fMP4, while §9.22 says a 192 kbit/s H.264 variant
- * *packaged in a transport stream* SHOULD be provided for cellular — so a
- * conformant HEVC ladder with that fallback is necessarily mixed. RFC 8216 is
- * silent too (§6.2.4 constrains variant *content*, not container).
+ * **Assumes one container per type, which the HLS specs don't guarantee.** Apple's HLS Authoring Specification not only
+ * permits a mixed ladder, it produces one: §1.5 requires HEVC in fMP4, while §9.22 says a 192 kbit/s H.264 variant
+ * _packaged in a transport stream_ SHOULD be provided for cellular — so a conformant HEVC ladder with that fallback is
+ * necessarily mixed. RFC 8216 is silent too (§6.2.4 constrains variant _content_, not container).
  *
- * Where that happens, resolving the TS variant first relabels the whole type,
- * capability probing prunes all of it, and a source whose fMP4 variants were fine
- * reports as unplayable. Accepted because the current target is CMAF-compliant
- * single-container delivery (plus Apple's official fMP4 example); revisit by
- * narrowing the relabel to the resolved track, or gating propagation on config,
- * if mixed ladders come into scope.
+ * Where that happens, resolving the TS variant first relabels the whole type, capability probing prunes all of it, and
+ * a source whose fMP4 variants were fine reports as unplayable. Accepted because the current target is CMAF-compliant
+ * single-container delivery (plus Apple's official fMP4 example); revisit by narrowing the relabel to the resolved
+ * track, or gating propagation on config, if mixed ladders come into scope.
  */
 export function applyContainerMimeType(presentation: Presentation, type: TrackType, mimeType: string): Presentation {
   return {
@@ -200,10 +183,7 @@ export function applyContainerMimeType(presentation: Presentation, type: TrackTy
   } as Presentation;
 }
 
-/**
- * Updates a track within a presentation (immutably). Generic — works for
- * video, audio, or text tracks.
- */
+/** Updates a track within a presentation (immutably). Generic — works for video, audio, or text tracks. */
 export function updateTrackInPresentation<T extends ResolvedTrack>(
   presentation: Presentation,
   resolvedTrack: T

--- a/packages/spf/src/network/bandwidth-estimator.ts
+++ b/packages/spf/src/network/bandwidth-estimator.ts
@@ -1,15 +1,15 @@
 /**
  * Dual EWMA Bandwidth Estimator
  *
- * Estimates available bandwidth using two EWMA calculations with different
- * half-lives, taking the minimum of both. This approach (from Shaka Player):
+ * Estimates available bandwidth using two EWMA calculations with different half-lives, taking the minimum of both. This
+ * approach (from Shaka Player):
  *
  * - **Fast EWMA** (2s half-life): Reacts quickly to bandwidth drops
  * - **Slow EWMA** (5s half-life): Provides stability during fluctuations
  * - **min(fast, slow)**: Adapts down quickly, up slowly
  *
- * This naturally provides asymmetric behavior needed for good QoE:
- * avoiding stalls (quick downgrade) while preventing oscillation (slow upgrade).
+ * This naturally provides asymmetric behavior needed for good QoE: avoiding stalls (quick downgrade) while preventing
+ * oscillation (slow upgrade).
  */
 
 import { applyZeroFactor, calculateEwma } from './ewma';
@@ -17,8 +17,8 @@ import { applyZeroFactor, calculateEwma } from './ewma';
 /**
  * Bandwidth estimator state.
  *
- * This state structure will be managed by O1 (State Container).
- * Functions in this module operate on this state immutably.
+ * This state structure will be managed by O1 (State Container). Functions in this module operate on this state
+ * immutably.
  */
 export interface BandwidthState {
   /** Fast-moving EWMA estimate (raw, uncorrected). */
@@ -33,9 +33,7 @@ export interface BandwidthState {
   bytesSampled: number;
 }
 
-/**
- * Configuration for bandwidth estimation.
- */
+/** Configuration for bandwidth estimation. */
 export interface BandwidthConfig {
   /** Half-life for fast EWMA in seconds. */
   fastHalfLife: number;
@@ -65,22 +63,21 @@ export const DEFAULT_BANDWIDTH_CONFIG: BandwidthConfig = {
 /**
  * Add a bandwidth sample from a segment download.
  *
- * Samples are filtered based on:
- * - Minimum bytes (filters TTFB-dominated small segments)
- * - Minimum duration (filters cached responses)
+ * Samples are filtered based on: - Minimum bytes (filters TTFB-dominated small segments) - Minimum duration (filters
+ * cached responses)
  *
  * Valid samples update both fast and slow EWMA estimates.
+ *
+ * @example
+ *   let state = { fastEstimate: 0, fastTotalWeight: 0, ... };
+ *   // Sample: 1MB in 1 second
+ *   state = sampleBandwidth(state, 1000, 1_000_000);
  *
  * @param state - Current estimator state
  * @param durationMs - Download duration in milliseconds
  * @param numBytes - Number of bytes downloaded
  * @param config - Optional estimator configuration (uses defaults if not provided)
  * @returns New estimator state with sample incorporated (or unchanged if filtered)
- *
- * @example
- * let state = { fastEstimate: 0, fastTotalWeight: 0, ... };
- * // Sample: 1MB in 1 second
- * state = sampleBandwidth(state, 1000, 1_000_000);
  */
 export function sampleBandwidth(
   state: BandwidthState,
@@ -125,21 +122,21 @@ export function sampleBandwidth(
 /**
  * Get the current bandwidth estimate.
  *
- * Returns the **minimum** of the fast and slow EWMA estimates.
- * This provides the key asymmetric behavior:
+ * Returns the **minimum** of the fast and slow EWMA estimates. This provides the key asymmetric behavior:
+ *
  * - When bandwidth drops, fast EWMA reacts first and dominates (quick adaptation)
  * - When bandwidth rises, slow EWMA lags behind and dominates (slow adaptation)
  *
- * Uses default estimate until enough data has been sampled — and when no
- * estimator state exists at all (`state === undefined`).
+ * Uses default estimate until enough data has been sampled — and when no estimator state exists at all (`state ===
+ * undefined`).
+ *
+ * @example
+ *   const estimate = getBandwidthEstimate(state, 5_000_000); // 5 Mbps default
  *
  * @param state - Current estimator state, or `undefined` before any samples have been collected
  * @param defaultEstimate - Fallback estimate before sufficient samples (bps)
  * @param config - Optional estimator configuration (uses defaults if not provided)
  * @returns Bandwidth estimate in bits per second
- *
- * @example
- * const estimate = getBandwidthEstimate(state, 5_000_000); // 5 Mbps default
  */
 export function getBandwidthEstimate(
   state: BandwidthState | undefined,
@@ -164,18 +161,17 @@ export function getBandwidthEstimate(
 /**
  * Check if the estimator has enough data to provide a reliable estimate.
  *
- * Requires both:
- * - Enough total bytes sampled (minTotalBytes threshold)
- * - At least one valid EWMA sample (totalWeight > 0)
+ * Requires both: - Enough total bytes sampled (minTotalBytes threshold) - At least one valid EWMA sample (totalWeight >
+ * 0)
+ *
+ * @example
+ *   if (hasGoodEstimate(state)) {
+ *     const estimate = getBandwidthEstimate(state, 5_000_000);
+ *   }
  *
  * @param state - Current estimator state
  * @param config - Optional estimator configuration (uses defaults if not provided)
  * @returns True if we've sampled enough bytes to trust the estimate
- *
- * @example
- * if (hasGoodEstimate(state)) {
- *   const estimate = getBandwidthEstimate(state, 5_000_000);
- * }
  */
 export function hasGoodEstimate(state: BandwidthState, config: BandwidthConfig = DEFAULT_BANDWIDTH_CONFIG): boolean {
   // Need enough total bytes AND at least one valid EWMA sample

--- a/packages/spf/src/network/chunked-stream-iterable.ts
+++ b/packages/spf/src/network/chunked-stream-iterable.ts
@@ -5,13 +5,11 @@ export interface ChunkedStreamIterableOptions {
 }
 
 /**
- * Adapts a `ReadableStream<Uint8Array>` (e.g. `response.body`) into an
- * `AsyncIterable<Uint8Array>` that yields chunks no smaller than
- * `minChunkSize` bytes. Smaller network chunks are accumulated and yielded
- * together once the threshold is met. Any remainder is flushed on stream end.
+ * Adapts a `ReadableStream<Uint8Array>` (e.g. `response.body`) into an `AsyncIterable<Uint8Array>` that yields chunks
+ * no smaller than `minChunkSize` bytes. Smaller network chunks are accumulated and yielded together once the threshold
+ * is met. Any remainder is flushed on stream end.
  *
- * Errors from the underlying stream propagate naturally — the reader lock is
- * always released via `finally`.
+ * Errors from the underlying stream propagate naturally — the reader lock is always released via `finally`.
  */
 export class ChunkedStreamIterable implements AsyncIterable<Uint8Array> {
   readonly minChunkSize: number;

--- a/packages/spf/src/network/ewma.ts
+++ b/packages/spf/src/network/ewma.ts
@@ -1,23 +1,20 @@
 /**
  * Exponentially Weighted Moving Average (EWMA)
  *
- * Pure functional implementation of EWMA calculations.
- * Based on Shaka Player's EWMA algorithm.
+ * Pure functional implementation of EWMA calculations. Based on Shaka Player's EWMA algorithm.
  */
 
 /**
  * Calculate alpha (decay factor) from half-life.
  *
- * Alpha determines how quickly old data "expires":
- * - alpha close to 1 = slow decay (long memory)
- * - alpha close to 0 = fast decay (short memory)
- *
- * @param halfLife - The quantity of prior samples (by weight) that make up
- *   half of the new estimate. Must be positive.
- * @returns Alpha value between 0 and 1
+ * Alpha determines how quickly old data "expires": - alpha close to 1 = slow decay (long memory) - alpha close to 0 =
+ * fast decay (short memory)
  *
  * @example
- * const alpha = calculateAlpha(2); // ≈ 0.7071 for 2-second half-life
+ *   const alpha = calculateAlpha(2); // ≈ 0.7071 for 2-second half-life
+ *
+ * @param halfLife - The quantity of prior samples (by weight) that make up half of the new estimate. Must be positive.
+ * @returns Alpha value between 0 and 1
  */
 export function calculateAlpha(halfLife: number): number {
   return Math.exp(Math.log(0.5) / halfLife);
@@ -26,19 +23,19 @@ export function calculateAlpha(halfLife: number): number {
 /**
  * Calculate exponentially weighted moving average.
  *
- * Updates an estimate by blending a new value with the previous estimate,
- * weighted by the sample duration. Longer samples have more influence.
+ * Updates an estimate by blending a new value with the previous estimate, weighted by the sample duration. Longer
+ * samples have more influence.
+ *
+ * @example
+ *   let estimate = 0;
+ *   estimate = calculateEwma(estimate, 1_000_000, 1, 2); // First sample
+ *   estimate = calculateEwma(estimate, 2_000_000, 1, 2); // Second sample
  *
  * @param prevEstimate - Previous EWMA estimate
  * @param value - New sample value to incorporate
  * @param weight - Sample weight (typically duration in seconds)
  * @param halfLife - Half-life for decay (typically 2-5 seconds)
  * @returns Updated EWMA estimate
- *
- * @example
- * let estimate = 0;
- * estimate = calculateEwma(estimate, 1_000_000, 1, 2); // First sample
- * estimate = calculateEwma(estimate, 2_000_000, 1, 2); // Second sample
  */
 export function calculateEwma(prevEstimate: number, value: number, weight: number, halfLife: number): number {
   const alpha = calculateAlpha(halfLife);
@@ -50,20 +47,20 @@ export function calculateEwma(prevEstimate: number, value: number, weight: numbe
 /**
  * Apply zero-factor correction to EWMA estimate.
  *
- * The zero-factor correction compensates for bias when starting from zero.
- * Without this correction, early estimates would be artificially low.
+ * The zero-factor correction compensates for bias when starting from zero. Without this correction, early estimates
+ * would be artificially low.
  *
- * As totalWeight increases, the correction factor approaches 1, meaning
- * the estimate becomes more reliable and needs less correction.
+ * As totalWeight increases, the correction factor approaches 1, meaning the estimate becomes more reliable and needs
+ * less correction.
+ *
+ * @example
+ *   const raw = calculateEwma(0, 1_000_000, 1, 2);
+ *   const corrected = applyZeroFactor(raw, 1, 2); // ≈ 1_000_000
  *
  * @param estimate - Raw EWMA estimate (uncorrected)
  * @param totalWeight - Accumulated weight from all samples
  * @param halfLife - Half-life used in EWMA calculation
  * @returns Corrected estimate, or 0 if totalWeight is 0
- *
- * @example
- * const raw = calculateEwma(0, 1_000_000, 1, 2);
- * const corrected = applyZeroFactor(raw, 1, 2); // ≈ 1_000_000
  */
 export function applyZeroFactor(estimate: number, totalWeight: number, halfLife: number): number {
   if (totalWeight === 0) {

--- a/packages/spf/src/network/fetch.ts
+++ b/packages/spf/src/network/fetch.ts
@@ -1,33 +1,25 @@
 /**
  * HTTP Fetch Wrapper
  *
- * Composable building blocks:
- * - fetchResolvable() — fetch a Resource (handles byte ranges); returns Response
- * - getResponseText() — extract text from Response
- * - fetchResolvableStream() — single-stage async generator over body chunks
- * - fetchStream() — two-stage: await connection establishment, then lazily
- *   iterate body chunks. Use when timing the connection start independently
- *   of body consumption matters (e.g., observable fetch timing for ABR).
- * - createTrackedFetch() — factory for a fetchStream-shape function that
- *   samples bandwidth (via EWMA) per chunk and notifies via callback.
+ * Composable building blocks: - fetchResolvable() — fetch a Resource (handles byte ranges); returns Response -
+ * getResponseText() — extract text from Response - fetchResolvableStream() — single-stage async generator over body
+ * chunks - fetchStream() — two-stage: await connection establishment, then lazily iterate body chunks. Use when timing
+ * the connection start independently of body consumption matters (e.g., observable fetch timing for ABR). -
+ * createTrackedFetch() — factory for a fetchStream-shape function that samples bandwidth (via EWMA) per chunk and
+ * notifies via callback.
  */
 
 import { type BandwidthState, sampleBandwidth } from './bandwidth-estimator';
 import { ChunkedStreamIterable, type ChunkedStreamIterableOptions } from './chunked-stream-iterable';
 
-/**
- * Minimal Response-like interface for text extraction.
- * Allows testing without full Response object.
- */
+/** Minimal Response-like interface for text extraction. Allows testing without full Response object. */
 export interface ResponseLike {
   text(): Promise<string>;
 }
 
 /**
- * An HTTP-addressable resource — URL plus optional byte range.
- * Media's `AddressableObject` (and anything else with the same shape)
- * is structurally compatible; kept local so this module stays
- * domain-agnostic.
+ * An HTTP-addressable resource — URL plus optional byte range. Media's `AddressableObject` (and anything else with the
+ * same shape) is structurally compatible; kept local so this module stays domain-agnostic.
  */
 export interface Resource {
   url: string;
@@ -40,22 +32,22 @@ export interface Resource {
 /**
  * Fetch resolvable from a Resource.
  *
- * Handles byte range requests if byteRange is present.
- * Returns native fetch Response for composability (can extract text, stream, etc.).
+ * Handles byte range requests if byteRange is present. Returns native fetch Response for composability (can extract
+ * text, stream, etc.).
+ *
+ * @example
+ *   const response = await fetchResolvable({ url: 'https://example.com/segment.m4s' });
+ *   const text = await getResponseText(response);
+ *
+ * @example
+ *   // With byte range
+ *   const response = await fetchResolvable({
+ *     url: 'https://example.com/file.mp4',
+ *     byteRange: { start: 1000, end: 1999 },
+ *   });
  *
  * @param addressable - Resource to fetch (url + optional byteRange)
  * @returns Promise resolving to Response
- *
- * @example
- * const response = await fetchResolvable({ url: 'https://example.com/segment.m4s' });
- * const text = await getResponseText(response);
- *
- * @example
- * // With byte range
- * const response = await fetchResolvable({
- *   url: 'https://example.com/file.mp4',
- *   byteRange: { start: 1000, end: 1999 }
- * });
  */
 export async function fetchResolvable(addressable: Resource, options?: RequestInit): Promise<Response> {
   const headers = new Headers(options?.headers);
@@ -79,9 +71,8 @@ export async function fetchResolvable(addressable: Resource, options?: RequestIn
 /**
  * Fetch resolvable as bytes.
  *
- * Convenience wrapper around fetchResolvable that resolves the body as an
- * ArrayBuffer. Use this when you need the raw bytes (e.g. segment appends).
- * For text or streaming consumption, use fetchResolvable directly.
+ * Convenience wrapper around fetchResolvable that resolves the body as an ArrayBuffer. Use this when you need the raw
+ * bytes (e.g. segment appends). For text or streaming consumption, use fetchResolvable directly.
  */
 export async function fetchResolvableBytes(addressable: Resource, options?: RequestInit): Promise<ArrayBuffer> {
   const response = await fetchResolvable(addressable, options);
@@ -92,12 +83,11 @@ export async function fetchResolvableBytes(addressable: Resource, options?: Requ
 /**
  * Fetch resolvable as a stream of Uint8Array chunks.
  *
- * Convenience wrapper around fetchResolvable that yields the body as chunks
- * via ChunkedStreamIterable. Headers are awaited before the first chunk is
- * yielded (TTFB is accounted for before iteration begins).
+ * Convenience wrapper around fetchResolvable that yields the body as chunks via ChunkedStreamIterable. Headers are
+ * awaited before the first chunk is yielded (TTFB is accounted for before iteration begins).
  *
- * Throws if the response body is null (e.g. non-body HTTP status).
- * Errors from the underlying stream propagate naturally as thrown errors.
+ * Throws if the response body is null (e.g. non-body HTTP status). Errors from the underlying stream propagate
+ * naturally as thrown errors.
  */
 export async function* fetchResolvableStream(
   addressable: Resource,
@@ -114,25 +104,23 @@ export async function* fetchResolvableStream(
 /**
  * Extract text from Response.
  *
- * Accepts minimal Response-like object (just needs text() method).
- * Returns promise from response.text().
+ * Accepts minimal Response-like object (just needs text() method). Returns promise from response.text().
+ *
+ * @example
+ *   const response = await fetchResolvable(addressable);
+ *   const text = await getResponseText(response);
  *
  * @param response - Response-like object with text() method
  * @returns Promise resolving to text content
- *
- * @example
- * const response = await fetchResolvable(addressable);
- * const text = await getResponseText(response);
  */
 export function getResponseText(response: ResponseLike): Promise<string> {
   return response.text();
 }
 
 /**
- * Fetch a resource and resolve its text body — the text analog of
- * {@link FetchBytes}. A non-OK status rejects, so HTTP failures surface as
- * rejections that callers (and decorators like the failover tracker) handle
- * uniformly with network errors.
+ * Fetch a resource and resolve its text body — the text analog of {@link FetchBytes}. A non-OK status rejects, so HTTP
+ * failures surface as rejections that callers (and decorators like the failover tracker) handle uniformly with network
+ * errors.
  */
 export type FetchText = (addressable: Resource, options?: RequestInit) => Promise<string>;
 
@@ -148,15 +136,13 @@ export const fetchResolvableText: FetchText = async (addressable, options) => {
 };
 
 /**
- * Two-stage fetch helper: eagerly starts the HTTP request (TTFB is awaited),
- * then returns a lazy iterable over the response body. Separating connection
- * start from body iteration makes fetch timing predictable and observable
+ * Two-stage fetch helper: eagerly starts the HTTP request (TTFB is awaited), then returns a lazy iterable over the
+ * response body. Separating connection start from body iteration makes fetch timing predictable and observable
  * regardless of when downstream consumers begin pulling chunks.
  *
- * Sibling to {@link fetchResolvableStream}, which is single-stage (calls
- * `fetch` only when iteration starts). Pick `fetchStream` when "when did the
- * fetch start" needs to be observable separately from "when did the body
- * begin arriving."
+ * Sibling to {@link fetchResolvableStream}, which is single-stage (calls `fetch` only when iteration starts). Pick
+ * `fetchStream` when "when did the fetch start" needs to be observable separately from "when did the body begin
+ * arriving."
  */
 export type FetchOptions = RequestInit & ChunkedStreamIterableOptions;
 
@@ -172,18 +158,15 @@ export async function fetchStream(addressable: Resource, options?: FetchOptions)
 }
 
 /**
- * Returns a {@link FetchBytes} function that samples bandwidth via EWMA
- * per body chunk. The factory captures the running bandwidth state
- * internally; per chunk it computes the next state and notifies the
- * supplied `onSample` callback.
+ * Returns a {@link FetchBytes} function that samples bandwidth via EWMA per body chunk. The factory captures the
+ * running bandwidth state internally; per chunk it computes the next state and notifies the supplied `onSample`
+ * callback.
  *
- * The factory's internal accumulator is seeded from `initial` and updated
- * on every chunk; callers don't need to thread it back in. `onSample`
- * receives the *new* state after each chunk — typical use is to bridge
- * samples back into engine state for ABR consumers.
+ * The factory's internal accumulator is seeded from `initial` and updated on every chunk; callers don't need to thread
+ * it back in. `onSample` receives the _new_ state after each chunk — typical use is to bridge samples back into engine
+ * state for ABR consumers.
  *
- * @param initial - Starting `BandwidthState` (commonly zeros or the
- *   engine's current accumulator).
+ * @param initial - Starting `BandwidthState` (commonly zeros or the engine's current accumulator).
  * @param onSample - Called with the new `BandwidthState` after each chunk.
  */
 export function createTrackedFetch(initial: BandwidthState, onSample: (next: BandwidthState) => void): FetchBytes {

--- a/packages/spf/src/playback/actors/dom/segment-loader.ts
+++ b/packages/spf/src/playback/actors/dom/segment-loader.ts
@@ -30,10 +30,7 @@ import type { SourceBufferActor } from './source-buffer';
 // BUFFER STATE TYPES
 // ============================================================================
 
-/**
- * Buffer state for a single SourceBuffer.
- * Tracks which init segment and media segments are loaded.
- */
+/** Buffer state for a single SourceBuffer. Tracks which init segment and media segments are loaded. */
 export interface SourceBufferState {
   /** Track ID of the loaded init segment */
   initTrackId?: string;
@@ -41,9 +38,7 @@ export interface SourceBufferState {
   segments: Array<{ id: string; trackId: string }>;
 }
 
-/**
- * Buffer state for all SourceBuffers.
- */
+/** Buffer state for all SourceBuffers. */
 export interface BufferState {
   video?: SourceBufferState;
   audio?: SourceBufferState;
@@ -59,12 +54,10 @@ export type SegmentLoaderTrack = VideoTrack | AudioTrack;
 /**
  * Message sent to a SegmentLoaderActor.
  *
- * `range` is optional to distinguish loading modes:
- * - No range: load init segment only (metadata preload mode)
- * - With range: load init + all segments overlapping [start, end]
+ * `range` is optional to distinguish loading modes: - No range: load init segment only (metadata preload mode) - With
+ * range: load init + all segments overlapping [start, end]
  *
- * `start` and `end` are raw time values — no segment snapping.
- * The actor maps them onto segment boundaries internally.
+ * `start` and `end` are raw time values — no segment snapping. The actor maps them onto segment boundaries internally.
  */
 export type SegmentLoaderMessage = {
   type: 'load';
@@ -84,12 +77,10 @@ export interface SegmentLoaderActorContext {
   /** Track ID of the init segment currently being fetched/appended, or null. */
   inFlightInitTrackId: string | null;
   /**
-   * Identity of the segment currently being fetched/appended, or null. Tracks
-   * the `trackId` alongside the positional `id` because renditions number
-   * segments independently (`segment-N`): an in-flight LOW `segment-0` must not
-   * be mistaken for a needed HIGH `segment-0` on a switch (see the loading
-   * handler's continue/preempt decision). Mirrors the text-track loader, which
-   * already matches its in-flight segment on `(inFlightTrackId, inFlightSegmentId)`.
+   * Identity of the segment currently being fetched/appended, or null. Tracks the `trackId` alongside the positional
+   * `id` because renditions number segments independently (`segment-N`): an in-flight LOW `segment-0` must not be
+   * mistaken for a needed HIGH `segment-0` on a switch (see the loading handler's continue/preempt decision). Mirrors
+   * the text-track loader, which already matches its in-flight segment on `(inFlightTrackId, inFlightSegmentId)`.
    */
   inFlightSegment: { id: string; trackId: string } | null;
 }
@@ -97,9 +88,8 @@ export interface SegmentLoaderActorContext {
 export type SegmentLoaderActor = MessageActor<SegmentLoaderActorState, SegmentLoaderActorContext, SegmentLoaderMessage>;
 
 /**
- * Configuration for `createSegmentLoaderActor`. Each sub-config is
- * spread over the corresponding `DEFAULT_*_CONFIG` so callers can
- * override individual fields.
+ * Configuration for `createSegmentLoaderActor`. Each sub-config is spread over the corresponding `DEFAULT_*_CONFIG` so
+ * callers can override individual fields.
  */
 export interface SegmentLoaderActorConfig {
   forwardBuffer?: Partial<ForwardBufferConfig>;
@@ -120,11 +110,9 @@ interface LoadTaskOptions {
 }
 
 /**
- * Wraps a LoadTask descriptor into a Task that runs the op's message pipeline
- * (fetch/discover/stamp/dispatch, per the composition's `messagePipelines`).
- * Updates in-flight context around the async region so the loading handler can
- * make accurate continue/preempt decisions at any point, and checks the abort
- * signal before each step.
+ * Wraps a LoadTask descriptor into a Task that runs the op's message pipeline (fetch/discover/stamp/dispatch, per the
+ * composition's `messagePipelines`). Updates in-flight context around the async region so the loading handler can make
+ * accurate continue/preempt decisions at any point, and checks the abort signal before each step.
  */
 function makeLoadTask(op: LoadTask, { getContext, setContext, pipelines, deps }: LoadTaskOptions): Task<void> {
   return new Task(async (taskSignal) => {
@@ -158,25 +146,20 @@ function makeLoadTask(op: LoadTask, { getContext, setContext, pipelines, deps }:
 /**
  * Creates a SegmentLoaderActor for one track type (video or audio).
  *
- * Receives load assignments via `send()` and owns all execution: planning,
- * removes, fetches, and appends. Coordinates with the SourceBufferActor for
- * all physical SourceBuffer operations.
+ * Receives load assignments via `send()` and owns all execution: planning, removes, fetches, and appends. Coordinates
+ * with the SourceBufferActor for all physical SourceBuffer operations.
  *
- * Planning (Cases 1–3) happens in the `load` handler on every incoming
- * message, producing an ordered LoadTask list. The runner drains that list
- * sequentially via SerialRunner. When a new message arrives mid-run, the
- * handler replans and either continues the in-flight operation (abortPending
- * + schedule new remainder) or preempts it (abortAll + cancel SourceBuffer
- * if needed + schedule new plan).
+ * Planning (Cases 1–3) happens in the `load` handler on every incoming message, producing an ordered LoadTask list. The
+ * runner drains that list sequentially via SerialRunner. When a new message arrives mid-run, the handler replans and
+ * either continues the in-flight operation (abortPending + schedule new remainder) or preempts it (abortAll + cancel
+ * SourceBuffer if needed + schedule new plan).
  *
  * @param sourceBufferActor - Shared SourceBufferActor reference (not owned)
- * @param fetchBytes - Tracked fetch closure (owns throughput sampling for segments).
- *   Accepts an optional `minChunkSize` in options; init segments pass `Infinity`
- *   so the entire body accumulates as one chunk before appending.
- * @param compositionDeps - The composition's `state`/`context`/`config`, threaded
- *   opaquely into each step's {@link StepDeps} (the loader never reads them). Lets
- *   injected steps (relocation) read composition signals at call time. Defaults to
- *   empty for standalone / base-pipeline use.
+ * @param fetchBytes - Tracked fetch closure (owns throughput sampling for segments). Accepts an optional `minChunkSize`
+ *   in options; init segments pass `Infinity` so the entire body accumulates as one chunk before appending.
+ * @param compositionDeps - The composition's `state`/`context`/`config`, threaded opaquely into each step's
+ *   {@link StepDeps} (the loader never reads them). Lets injected steps (relocation) read composition signals at call
+ *   time. Defaults to empty for standalone / base-pipeline use.
  */
 export function createSegmentLoaderActor(
   sourceBufferActor: SourceBufferActor,
@@ -227,29 +210,19 @@ export function createSegmentLoaderActor(
   };
 
   /**
-   * Translate a load message into an ordered LoadTask list based on committed
-   * actor state. In-flight awareness is handled separately in the load handler.
+   * Translate a load message into an ordered LoadTask list based on committed actor state. In-flight awareness is
+   * handled separately in the load handler.
    *
-   * @todo Rename alongside LoadTask (e.g. planOps).
-   *
-   * Case 1 — Removes: forward and back buffer flush points, segment-aligned.
-   *   ABR-style track switches (same content, different bitrate) do not flush:
-   *   appending new content overwrites existing buffer ranges, and the actor's
-   *   time-aligned deduplication keeps the segment model accurate as new
-   *   segments arrive.
-   *
-   *   Cross-rendition track switches (audio language change, text language
-   *   change) do flush: the buffered content is semantically incompatible with
-   *   the newly-selected track, so overwrite-on-append would leave stale
-   *   content playing until each replacement segment lands. Today's predicate:
-   *   `actorCtx.initTrackLanguage !== track.language` — fires for language
-   *   changes, no-ops for video / same-language audio bitrate switches.
-   *   Future stage: pluggable predicate / strategy at actor construction time
-   *   for codec-change (5.1 surround) and other cross-rendition shapes.
-   *
-   * Case 2 — Init: schedule if not yet committed for this track.
-   *
-   * Case 3 — Segments: all segments in the load window not yet committed.
+   * @todo Rename alongside LoadTask (e.g. planOps). Case 1 — Removes: forward and back buffer flush points,
+   *   segment-aligned. ABR-style track switches (same content, different bitrate) do not flush: appending new content
+   *   overwrites existing buffer ranges, and the actor's time-aligned deduplication keeps the segment model accurate as
+   *   new segments arrive. Cross-rendition track switches (audio language change, text language change) do flush: the
+   *   buffered content is semantically incompatible with the newly-selected track, so overwrite-on-append would leave
+   *   stale content playing until each replacement segment lands. Today's predicate: `actorCtx.initTrackLanguage !==
+   *   track.language` — fires for language changes, no-ops for video / same-language audio bitrate switches. Future
+   *   stage: pluggable predicate / strategy at actor construction time for codec-change (5.1 surround) and other
+   *   cross-rendition shapes. Case 2 — Init: schedule if not yet committed for this track. Case 3 — Segments: all
+   *   segments in the load window not yet committed.
    */
   const planTasks = (message: SegmentLoaderMessage): LoadTask[] => {
     const { track, range } = message;

--- a/packages/spf/src/playback/actors/dom/source-buffer.ts
+++ b/packages/spf/src/playback/actors/dom/source-buffer.ts
@@ -34,10 +34,9 @@ export type SourceBufferActorState = 'idle' | 'updating' | 'destroyed';
 export interface SourceBufferActorContext {
   initTrackId?: string | undefined;
   /**
-   * Language of the most recently appended init segment's track (when
-   * present on the playlist). Used by the segment-loader's `planTasks`
-   * to detect cross-language switches and schedule ahead-buffer flush.
-   * Undefined for video and for language-less audio.
+   * Language of the most recently appended init segment's track (when present on the playlist). Used by the
+   * segment-loader's `planTasks` to detect cross-language switches and schedule ahead-buffer flush. Undefined for video
+   * and for language-less audio.
    */
   initTrackLanguage?: string | undefined;
   segments: Array<
@@ -45,9 +44,8 @@ export interface SourceBufferActorContext {
       trackId: Track['id'];
       trackBandwidth?: number;
       /**
-       * True while a streaming append is in progress for this segment.
-       * The segment's data is partially present in the SourceBuffer.
-       * Downstream code must not treat a partial segment as fully buffered.
+       * True while a streaming append is in progress for this segment. The segment's data is partially present in the
+       * SourceBuffer. Downstream code must not treat a partial segment as fully buffered.
        */
       partial?: boolean;
     }

--- a/packages/spf/src/playback/actors/dom/tests/source-buffer.test.ts
+++ b/packages/spf/src/playback/actors/dom/tests/source-buffer.test.ts
@@ -10,10 +10,9 @@ import { createSourceBufferActor } from '../source-buffer';
 /**
  * Creates a minimal SourceBuffer mock.
  *
- * Pass `appendRanges` to simulate realistic buffered state: each entry is
- * added to `buffered` in sequence as `appendBuffer` is called. `remove()`
- * clips the ranges to match what a real SourceBuffer would report, enabling
- * the midpoint-based segment model logic in removeTask to be tested correctly.
+ * Pass `appendRanges` to simulate realistic buffered state: each entry is added to `buffered` in sequence as
+ * `appendBuffer` is called. `remove()` clips the ranges to match what a real SourceBuffer would report, enabling the
+ * midpoint-based segment model logic in removeTask to be tested correctly.
  */
 function makeSourceBuffer(appendRanges: Array<[number, number]> = []): SourceBuffer {
   const listeners: Record<string, EventListener[]> = {};

--- a/packages/spf/src/playback/actors/dom/tests/text-track-mode-cue-preservation.test.ts
+++ b/packages/spf/src/playback/actors/dom/tests/text-track-mode-cue-preservation.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vite-plus/test';
 /**
  * Empirical tests for TextTrack cue preservation across mode transitions.
  *
- * Key question: does setting mode="disabled" permanently discard cues added
- * via addCue(), or are they preserved and accessible again after re-enabling?
+ * Key question: does setting mode="disabled" permanently discard cues added via addCue(), or are they preserved and
+ * accessible again after re-enabling?
  *
  * Tests run in real Chromium via @vitest/browser-playwright.
  */

--- a/packages/spf/src/playback/actors/text-track-segment-loader.ts
+++ b/packages/spf/src/playback/actors/text-track-segment-loader.ts
@@ -22,11 +22,9 @@ import type { TextTracksActor } from './text-tracks';
 // =============================================================================
 
 /**
- * Mirrors the v/a `SegmentLoaderMessage` shape. `range` carries the
- * forward-window anchor (`range.start` is treated as the load anchor;
- * the actor computes its own forward window internally via
- * `getSegmentsToLoad`). When `range` is omitted (metadata mode), this
- * actor is a no-op — text tracks have no init-segment concept.
+ * Mirrors the v/a `SegmentLoaderMessage` shape. `range` carries the forward-window anchor (`range.start` is treated as
+ * the load anchor; the actor computes its own forward window internally via `getSegmentsToLoad`). When `range` is
+ * omitted (metadata mode), this actor is a no-op — text tracks have no init-segment concept.
  */
 export type TextTrackSegmentLoaderMessage = {
   type: 'load';
@@ -40,15 +38,13 @@ export type TextTrackSegmentLoaderActorState = 'idle' | 'loading' | 'destroyed';
 /** Non-finite (extended) data managed by the actor. */
 export interface TextTrackSegmentLoaderActorContext {
   /**
-   * Track ID of the segment currently being fetched, or null. Paired
-   * with `inFlightSegmentId` so the continue-vs-preempt check survives
-   * cross-track segment-id collisions (e.g. each track starts at
-   * `seg-0`).
+   * Track ID of the segment currently being fetched, or null. Paired with `inFlightSegmentId` so the
+   * continue-vs-preempt check survives cross-track segment-id collisions (e.g. each track starts at `seg-0`).
    */
   inFlightTrackId: string | null;
   /**
-   * Segment ID currently being fetched, or null. Used together with
-   * `inFlightTrackId` by the `loading` state's `load` handler.
+   * Segment ID currently being fetched, or null. Used together with `inFlightTrackId` by the `loading` state's `load`
+   * handler.
    */
   inFlightSegmentId: string | null;
 }
@@ -60,11 +56,9 @@ export type TextTrackSegmentLoaderActor = MessageActor<
 >;
 
 /**
- * Configuration for `createTextTrackSegmentLoaderActor`. Spread over
- * `DEFAULT_FORWARD_BUFFER_CONFIG` to override individual forward-window
- * fields (e.g. `bufferDuration`). Text tracks don't have a back-buffer
- * concern — cues evict by their playhead-relative window at runtime —
- * so no `backBuffer` config field.
+ * Configuration for `createTextTrackSegmentLoaderActor`. Spread over `DEFAULT_FORWARD_BUFFER_CONFIG` to override
+ * individual forward-window fields (e.g. `bufferDuration`). Text tracks don't have a back-buffer concern — cues evict
+ * by their playhead-relative window at runtime — so no `backBuffer` config field.
  */
 export interface TextTrackSegmentLoaderActorConfig<C extends Cue = Cue> {
   forwardBuffer?: Partial<ForwardBufferConfig>;
@@ -77,31 +71,25 @@ export interface TextTrackSegmentLoaderActorConfig<C extends Cue = Cue> {
 // =============================================================================
 
 /**
- * Loads text-track segments for a track and delegates cue management
- * to a TextTracksActor. Mirrors the v/a `SegmentLoaderActor` shape (FSM
- * with `idle` / `loading` and `inFlight*` context for continue-vs-preempt),
- * adapted to text:
+ * Loads text-track segments for a track and delegates cue management to a TextTracksActor. Mirrors the v/a
+ * `SegmentLoaderActor` shape (FSM with `idle` / `loading` and `inFlight*` context for continue-vs-preempt), adapted to
+ * text:
  *
- * - No init segment, no flush ops (text cues don't need eviction — they're
- *   small and the playhead-relative window is enforced by the runtime).
- * - Single in-flight identity (`inFlightSegmentId`) — text has only the
- *   media-segment path, no init-segment path.
+ * - No init segment, no flush ops (text cues don't need eviction — they're small and the playhead-relative window is
+ *   enforced by the runtime).
+ * - Single in-flight identity (`inFlightSegmentId`) — text has only the media-segment path, no init-segment path.
  *
- * Planning is done in the load handler on every incoming message:
- * `getSegmentsToLoad` filters to the forward window, then the segments
- * not already in `TextTracksActor`'s context are scheduled. When a new
- * `load` arrives mid-run, the handler replans and either:
+ * Planning is done in the load handler on every incoming message: `getSegmentsToLoad` filters to the forward window,
+ * then the segments not already in `TextTracksActor`'s context are scheduled. When a new `load` arrives mid-run, the
+ * handler replans and either:
  *
- * - **Continues**: the in-flight segment is still in the new plan →
- *   `abortPending` only, schedule the rest of the plan (minus the
- *   in-flight item, which covers its slot).
- * - **Preempts**: in-flight segment is no longer wanted (track switch,
- *   large seek out of window) → `abortAll`, schedule the new plan
- *   from scratch.
+ * - **Continues**: the in-flight segment is still in the new plan → `abortPending` only, schedule the rest of the plan
+ *   (minus the in-flight item, which covers its slot).
+ * - **Preempts**: in-flight segment is no longer wanted (track switch, large seek out of window) → `abortAll`, schedule
+ *   the new plan from scratch.
  *
- * The cue parser is injected so this factory is host-agnostic. A DOM
- * host supplies a VTT parser backed by `<track>`/`TextTrack` APIs; a
- * non-DOM host (worker, test fake, alternate runtime) supplies its own.
+ * The cue parser is injected so this factory is host-agnostic. A DOM host supplies a VTT parser backed by
+ * `<track>`/`TextTrack` APIs; a non-DOM host (worker, test fake, alternate runtime) supplies its own.
  */
 export function createTextTrackSegmentLoaderActor<C extends Cue>(
   textTracksActor: TextTracksActor<C>,
@@ -128,13 +116,11 @@ export function createTextTrackSegmentLoaderActor<C extends Cue>(
   const pipeline = (config.messagePipelines ?? DEFAULT_TEXT_MESSAGE_PIPELINES)();
 
   /**
-   * Translate a load message into an ordered TextLoadTask list based on
-   * committed actor state. In-flight awareness is handled separately in
-   * the `loading` state's load handler.
+   * Translate a load message into an ordered TextLoadTask list based on committed actor state. In-flight awareness is
+   * handled separately in the `loading` state's load handler.
    *
-   * Metadata mode (no `range`) is a no-op for text — text tracks have
-   * no init-segment concept, so there's nothing to load until a range
-   * arrives via `'full-range'` dispatch.
+   * Metadata mode (no `range`) is a no-op for text — text tracks have no init-segment concept, so there's nothing to
+   * load until a range arrives via `'full-range'` dispatch.
    */
   const planTasks = (message: TextTrackSegmentLoaderMessage): TextLoadTask[] => {
     const { track, range } = message;
@@ -159,15 +145,12 @@ export function createTextTrackSegmentLoaderActor<C extends Cue>(
   };
 
   /**
-   * Wraps a TextLoadTask into a Task that runs the op's step pipeline
-   * (resolve/relocate/dispatch, per the composition's `messagePipelines`).
-   * Updates `inFlightSegmentId` around the async region so the load handler can
-   * make accurate continue/preempt decisions, and checks the abort signal before
-   * each step.
+   * Wraps a TextLoadTask into a Task that runs the op's step pipeline (resolve/relocate/dispatch, per the composition's
+   * `messagePipelines`). Updates `inFlightSegmentId` around the async region so the load handler can make accurate
+   * continue/preempt decisions, and checks the abort signal before each step.
    *
-   * Text degrades gracefully: a step throwing (e.g. a failed segment fetch) is
-   * logged and swallowed so the runner continues to the next segment — unlike the
-   * v/a loader, where a failed init must abort the remaining tasks.
+   * Text degrades gracefully: a step throwing (e.g. a failed segment fetch) is logged and swallowed so the runner
+   * continues to the next segment — unlike the v/a loader, where a failed init must abort the remaining tasks.
    */
   const makeLoadTask = (op: TextLoadTask, { getContext, setContext }: Ctx): Task<void> => {
     return new Task(async (signal) => {

--- a/packages/spf/src/playback/actors/text-tracks.ts
+++ b/packages/spf/src/playback/actors/text-tracks.ts
@@ -15,12 +15,9 @@ export interface TextTracksActorContext {
 }
 
 /**
- * Wipe the actor's `loaded` + `segments` context. Sent on source reset
- * (typically by `syncTextTracks` on state exit) so a subsequent
- * presentation starts with a fresh cue+segment cache. Without this, a
- * new presentation reusing trackIds from the prior source would have
- * `getSegmentsToLoad` treat its segments as already-buffered and skip
- * loading them.
+ * Wipe the actor's `loaded` + `segments` context. Sent on source reset (typically by `syncTextTracks` on state exit) so
+ * a subsequent presentation starts with a fresh cue+segment cache. Without this, a new presentation reusing trackIds
+ * from the prior source would have `getSegmentsToLoad` treat its segments as already-buffered and skip loading them.
  */
 export interface ClearMessage {
   type: 'clear';
@@ -31,7 +28,7 @@ export type TextTracksActorMessage<C extends Cue = Cue> = AddCuesMessage<C> | Cl
 /**
  * Host-agnostic text-track actor type.
  *
- * Generic over the concrete cue shape `C` so DOM hosts (using `VTTCue`)
- * and non-DOM hosts (custom cue representations) can both satisfy it.
+ * Generic over the concrete cue shape `C` so DOM hosts (using `VTTCue`) and non-DOM hosts (custom cue representations)
+ * can both satisfy it.
  */
 export type TextTracksActor<C extends Cue = Cue> = TransitionActor<TextTracksActorContext, TextTracksActorMessage<C>>;

--- a/packages/spf/src/playback/adapters/hls-audio/adapter.ts
+++ b/packages/spf/src/playback/adapters/hls-audio/adapter.ts
@@ -44,45 +44,40 @@ export interface HlsAudioMediaAPI extends HlsAudioMediaProps {
 }
 
 /**
- * Which reported conditions this composition treats as fatal. Only the audio
- * verdict: an audio-only engine composes no video selection, so
- * `SVTA_NO_SUPPORTED_VIDEO_TRACK` is never reported and surfacing it would
- * describe a track type this media doesn't have.
+ * Which reported conditions this composition treats as fatal. Only the audio verdict: an audio-only engine composes no
+ * video selection, so `SVTA_NO_SUPPORTED_VIDEO_TRACK` is never reported and surfacing it would describe a track type
+ * this media doesn't have.
  */
 const FATAL_SVTA_CODES: ReadonlySet<number> = new Set<number>([SVTA_NO_SUPPORTED_AUDIO_TRACK]);
 
 /**
  * Mixin that adds SPF audio-only HLS playback to any base class.
  *
+ * @example
+ *   class HlsAudioMedia extends HlsAudioMediaMixin(HTMLVideoElementHost) {}
+ *
+ *   const media = new HlsAudioMedia();
+ *   media.attach(document.querySelector('video'));
+ *   media.src = 'https://stream.mux.com/abc123.m3u8';
+ *
  * @fires error - Fired when a fatal condition is reported. Read `error` for it.
  *
- * Parallel to `HlsVideoMediaMixin` with one substantive difference: the
- * underlying engine is the audio-only variant (`createHlsAudioEngine`),
- * which omits video and text-track behaviors. The src / preload /
- * disableRemotePlayback / play() contract per the WHATWG HTML spec is identical
- * to the default adapter.
+ *   Parallel to `HlsVideoMediaMixin` with one substantive difference: the underlying engine is the audio-only variant
+ *   (`createHlsAudioEngine`), which omits video and text-track behaviors. The src / preload / disableRemotePlayback /
+ *   play() contract per the WHATWG HTML spec is identical to the default adapter.
  *
- * Selecting this adapter is the variant decision: instantiating
- * `HlsAudioMediaElement` opts the consumer into audio-only
- * delivery even when the source is a mixed-AV HLS manifest.
- *
- * @example
- * class HlsAudioMedia extends HlsAudioMediaMixin(HTMLVideoElementHost) {}
- *
- * const media = new HlsAudioMedia();
- * media.attach(document.querySelector('video'));
- * media.src = 'https://stream.mux.com/abc123.m3u8';
+ *   Selecting this adapter is the variant decision: instantiating `HlsAudioMediaElement` opts the consumer into
+ *   audio-only delivery even when the source is a mixed-AV HLS manifest.
  */
 export function HlsAudioMediaMixin<Base extends Constructor<any>>(BaseClass: Base) {
   class HlsAudioMediaImpl extends BaseClass {
     /**
-     * A complete sentence naming the Media to reach for when this one can't play
-     * a source. Appended to the copy this adapter logs.
+     * A complete sentence naming the Media to reach for when this one can't play a source. Appended to the copy this
+     * adapter logs.
      *
-     * Empty here, and overridden the same way as on the video adapter — see its
-     * note. `hls-audio` has no better-equipped sibling of its own; the
-     * Mux audio Media built on this engine does, and points at the hls.js-backed
-     * one.
+     * Empty here, and overridden the same way as on the video adapter — see its note. `hls-audio` has no
+     * better-equipped sibling of its own; the Mux audio Media built on this engine does, and points at the
+     * hls.js-backed one.
      */
     static get alternativeMediaSuggestion(): string | undefined {
       return undefined;
@@ -121,9 +116,8 @@ export function HlsAudioMediaMixin<Base extends Constructor<any>>(BaseClass: Bas
     }
 
     /**
-     * The current fatal error, or `null`. Only *fatal* conditions appear here —
-     * the engine reports non-fatal ones too, which stay in `engine.state.errors`.
-     * Resets per source. Fires `'error'` when set.
+     * The current fatal error, or `null`. Only _fatal_ conditions appear here — the engine reports non-fatal ones too,
+     * which stay in `engine.state.errors`. Resets per source. Fires `'error'` when set.
      */
     get error(): HlsVideoMediaError | null {
       return this.#error;
@@ -162,10 +156,8 @@ export function HlsAudioMediaMixin<Base extends Constructor<any>>(BaseClass: Bas
     }
 
     /**
-     * Underlying playback engine — the low-level SPF reactive composition that
-     * drives playback. An advanced escape hatch for direct engine access;
-     * normal playback is driven through this element's own properties and
-     * methods.
+     * Underlying playback engine — the low-level SPF reactive composition that drives playback. An advanced escape
+     * hatch for direct engine access; normal playback is driven through this element's own properties and methods.
      */
     get engine(): Composition<HlsAudioEngineState, HlsAudioEngineContext> {
       return this.#engine;

--- a/packages/spf/src/playback/adapters/hls-audio/index.ts
+++ b/packages/spf/src/playback/adapters/hls-audio/index.ts
@@ -1,7 +1,6 @@
 /**
- * The Media over the audio-only HLS engine. Sibling of
- * `@videojs/spf/hls-video`; see that entry point for why the Medias ship
- * separately from `@videojs/spf/hls`.
+ * The Media over the audio-only HLS engine. Sibling of `@videojs/spf/hls-video`; see that entry point for why the
+ * Medias ship separately from `@videojs/spf/hls`.
  */
 export type { HlsAudioMediaAPI, HlsAudioMediaProps } from './adapter';
 export { HlsAudioMediaElement, HlsAudioMediaMixin, hlsAudioMediaDefaultProps } from './adapter';

--- a/packages/spf/src/playback/adapters/hls-audio/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/hls-audio/tests/adapter.test.ts
@@ -1,10 +1,8 @@
 /**
  * HlsAudioMediaElement adapter tests.
  *
- * Covers the HTMLMediaElement-compatible contract for src and play(), per the
- * WHATWG HTML spec, for the audio-only HLS variant. Parallels
- * adapter.test.ts — semantics match (the variant differs in composition,
- * not in adapter contract).
+ * Covers the HTMLMediaElement-compatible contract for src and play(), per the WHATWG HTML spec, for the audio-only HLS
+ * variant. Parallels adapter.test.ts — semantics match (the variant differs in composition, not in adapter contract).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 

--- a/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
@@ -42,27 +42,22 @@ export interface HlsBackgroundVideoMediaAPI extends HlsBackgroundVideoMediaProps
 }
 
 /**
- * Which reported conditions this composition treats as **fatal** — the ones that
- * reach `error` and fire `'error'`. Severity isn't part of an SVTA code
- * (§Approach: "impact varies with player implementation"), so it's decided at
- * this boundary rather than by the reporter.
+ * Which reported conditions this composition treats as **fatal** — the ones that reach `error` and fire `'error'`.
+ * Severity isn't part of an SVTA code (§Approach: "impact varies with player implementation"), so it's decided at this
+ * boundary rather than by the reporter.
  *
- * **Causes are fatal here, unlike on the other two adapters.** There, a cause is
- * context — one unplayable rendition doesn't fail a source whose others still
- * play, and a verdict follows if the type empties. In the pinned variant a cause
- * *is* the verdict: only the pinned rendition's playlist is ever resolved, so a
- * cause can only be about the pick itself, and dropping that pick is final —
- * nothing here re-picks (that is what `switchVideoTrack` exists for, and this
- * engine doesn't compose it). Measured on Chromium: an MPEG-TS source reports
- * 1004 and an encrypted one 4008, each with no verdict behind it, and the element
- * then sits at `readyState 0` with `error` null forever.
+ * **Causes are fatal here, unlike on the other two adapters.** There, a cause is context — one unplayable rendition
+ * doesn't fail a source whose others still play, and a verdict follows if the type empties. In the pinned variant a
+ * cause _is_ the verdict: only the pinned rendition's playlist is ever resolved, so a cause can only be about the pick
+ * itself, and dropping that pick is final — nothing here re-picks (that is what `switchVideoTrack` exists for, and this
+ * engine doesn't compose it). Measured on Chromium: an MPEG-TS source reports 1004 and an encrypted one 4008, each with
+ * no verdict behind it, and the element then sits at `readyState 0` with `error` null forever.
  *
- * The verdict is still listed, for the shapes that report nothing else: no video
- * renditions at all, or a ladder pruned before anything resolves — both of which
- * `reportAbsentTrackType` covers from the tail of the constraint chain.
+ * The verdict is still listed, for the shapes that report nothing else: no video renditions at all, or a ladder pruned
+ * before anything resolves — both of which `reportAbsentTrackType` covers from the tail of the constraint chain.
  *
- * First-fatal-wins then surfaces the cause rather than the verdict when both are
- * present, which is the more specific of the two.
+ * First-fatal-wins then surfaces the cause rather than the verdict when both are present, which is the more specific of
+ * the two.
  */
 const FATAL_SVTA_CODES: ReadonlySet<number> = new Set<number>([
   SVTA_NO_SUPPORTED_VIDEO_TRACK,
@@ -71,55 +66,44 @@ const FATAL_SVTA_CODES: ReadonlySet<number> = new Set<number>([
 ]);
 
 /**
- * Mixin that adds the background-video SPF playback engine to any base class,
- * for an HLS URL.
+ * Mixin that adds the background-video SPF playback engine to any base class, for an HLS URL.
  *
- * `src` is the whole input surface, and `error` is the one output: nothing about
- * an unplayable source reaches the media element on its own here — an unsupported
- * container, encryption with no EME, and an undecodable codec all leave
- * `HTMLMediaElement.error` null with the element stalled at `readyState 0`
- * (measured on Chromium and WebKit) — so a consumer that watched only the
- * `<video>` would see a source that never appears and never says why. The engine
- * reports each condition onto `engine.state.errors` and logs it; this adapter
- * promotes the first fatal one, mapping it the same way the video and audio Medias
- * map theirs. See `internal/design/spf/features/errors.md`.
+ * `src` is the whole input surface, and `error` is the one output: nothing about an unplayable source reaches the media
+ * element on its own here — an unsupported container, encryption with no EME, and an undecodable codec all leave
+ * `HTMLMediaElement.error` null with the element stalled at `readyState 0` (measured on Chromium and WebKit) — so a
+ * consumer that watched only the `<video>` would see a source that never appears and never says why. The engine reports
+ * each condition onto `engine.state.errors` and logs it; this adapter promotes the first fatal one, mapping it the same
+ * way the video and audio Medias map theirs. See `internal/design/spf/features/errors.md`.
  *
- * Selection pins the largest rendition that *fits the screen*, and holds it for
- * the session. The manifest is still the better place to narrow further: a
- * delivery param — `?max_resolution=720p` on a Mux stream URL, for one — keeps
- * the renditions it excludes out of the manifest entirely, rather than
- * fetched-then-unpicked.
+ * Selection pins the largest rendition that _fits the screen_, and holds it for the session. The manifest is still the
+ * better place to narrow further: a delivery param — `?max_resolution=720p` on a Mux stream URL, for one — keeps the
+ * renditions it excludes out of the manifest entirely, rather than fetched-then-unpicked.
  *
- * The pin is given up, never moved, if the pick turns out to be unplayable: the
- * container is only known once a media playlist resolves, which is after the pick
- * is made, so the selection clears rather than quietly appending bytes nothing can
- * decode.
+ * The pin is given up, never moved, if the pick turns out to be unplayable: the container is only known once a media
+ * playlist resolves, which is after the pick is made, so the selection clears rather than quietly appending bytes
+ * nothing can decode.
  *
- * `@videojs/spf/mux-background-video` is this same Media under a Mux-flavored
- * name — an alias, not a variant. Nothing about the surface changes with the
- * import path.
+ * `@videojs/spf/mux-background-video` is this same Media under a Mux-flavored name — an alias, not a variant. Nothing
+ * about the surface changes with the import path.
  *
- * Everything else the use case fixes rather than exposes: video-only, looping,
- * muted, autoplaying, loading as soon as there is a source. `attach` writes that
- * onto the element and nothing here declares `loop` / `muted` / `autoplay` /
- * `preload` of its own — a host-bound Media inherits all four from the host
- * already, and shadowing them with fixed values would only make reads describe
- * an intention rather than what the element is doing.
+ * Everything else the use case fixes rather than exposes: video-only, looping, muted, autoplaying, loading as soon as
+ * there is a source. `attach` writes that onto the element and nothing here declares `loop` / `muted` / `autoplay` /
+ * `preload` of its own — a host-bound Media inherits all four from the host already, and shadowing them with fixed
+ * values would only make reads describe an intention rather than what the element is doing.
  *
- * A new src re-resolves the presentation, tearing down the state, SourceBuffers,
- * and in-flight requests the previous one built before the next begins. The
- * engine instance and the attached media element are both kept, so neither has to
+ * A new src re-resolves the presentation, tearing down the state, SourceBuffers, and in-flight requests the previous
+ * one built before the next begins. The engine instance and the attached media element are both kept, so neither has to
  * be rewired.
  *
- * @fires error - Fired when a fatal condition is reported. Read `error` for it.
- *
  * @example
- * class HlsBackgroundVideoMedia extends HlsBackgroundVideoMediaMixin(BackgroundVideoHost) {}
+ *   class HlsBackgroundVideoMedia extends HlsBackgroundVideoMediaMixin(BackgroundVideoHost) {}
  *
- * const media = new HlsBackgroundVideoMedia();
- * media.attach(document.querySelector('video'));
- * media.src = 'https://stream.mux.com/PLAYBACK_ID.m3u8?max_resolution=720p';
- * media.play();
+ *   const media = new HlsBackgroundVideoMedia();
+ *   media.attach(document.querySelector('video'));
+ *   media.src = 'https://stream.mux.com/PLAYBACK_ID.m3u8?max_resolution=720p';
+ *   media.play();
+ *
+ * @fires error - Fired when a fatal condition is reported. Read `error` for it.
  */
 export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(BaseClass: Base) {
   class HlsBackgroundVideoMediaImpl extends BaseClass {
@@ -128,9 +112,8 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
     #signals!: BackgroundVideoEngineSignals;
     #error: HlsVideoMediaError | null = null;
     /**
-     * The *reported* condition currently surfaced, which is what the re-fire latch
-     * keys on. Not `#error.code`: that's the code this adapter chose to surface,
-     * and the substitution below can make the two differ.
+     * The _reported_ condition currently surfaced, which is what the re-fire latch keys on. Not `#error.code`: that's
+     * the code this adapter chose to surface, and the substitution below can make the two differ.
      */
     #reportedCode: number | null = null;
     #stopErrorSync: () => void;
@@ -162,17 +145,14 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
     }
 
     /**
-     * The current fatal condition, or `null`. Only *fatal* ones appear here — the
-     * engine reports non-fatal ones too (they stay in `engine.state.errors`), and
-     * promoting them would say playback had failed when it hadn't. Which ones are
-     * fatal is wider here than on the video and audio Medias; see
-     * {@link FATAL_SVTA_CODES}. Resets per source. Fires `'error'` when set.
+     * The current fatal condition, or `null`. Only _fatal_ ones appear here — the engine reports non-fatal ones too
+     * (they stay in `engine.state.errors`), and promoting them would say playback had failed when it hadn't. Which ones
+     * are fatal is wider here than on the video and audio Medias; see {@link FATAL_SVTA_CODES}. Resets per source.
+     * Fires `'error'` when set.
      *
-     * Mapped the same way theirs are: a sequence holding an
-     * unimplemented-capability cause surfaces as
-     * {@link SVTA_UNSUPPORTED_PLAYBACK_FEATURE} (99001) with the specifics logged,
-     * because "this player can't play this source" is what a consumer can act on,
-     * where a raw container or DRM code only says what to go and look up.
+     * Mapped the same way theirs are: a sequence holding an unimplemented-capability cause surfaces as
+     * {@link SVTA_UNSUPPORTED_PLAYBACK_FEATURE} (99001) with the specifics logged, because "this player can't play this
+     * source" is what a consumer can act on, where a raw container or DRM code only says what to go and look up.
      */
     get error(): HlsVideoMediaError | null {
       return this.#error;

--- a/packages/spf/src/playback/adapters/hls-background-video/host.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/host.ts
@@ -1,23 +1,19 @@
 /**
- * The `<video>` binding a background video uses: somewhere to keep the attached
- * element, and the four properties the Media fixes on it.
+ * The `<video>` binding a background video uses: somewhere to keep the attached element, and the four properties the
+ * Media fixes on it.
  *
- * That is the whole surface anything here reaches. The engine drives playback,
- * the element exposes `src` and nothing else, and the background player
- * subscribes to no store features, so nothing asks a background video for
- * `currentTime`, `play()`, picture-in-picture, fullscreen, forwarded events, or
- * media components. Holding the host to what is reachable is what keeps this
- * entry free of `@videojs/media`, and small enough to suit a component whose
- * whole pitch is its size.
+ * That is the whole surface anything here reaches. The engine drives playback, the element exposes `src` and nothing
+ * else, and the background player subscribes to no store features, so nothing asks a background video for
+ * `currentTime`, `play()`, picture-in-picture, fullscreen, forwarded events, or media components. Holding the host to
+ * what is reachable is what keeps this entry free of `@videojs/media`, and small enough to suit a component whose whole
+ * pitch is its size.
  *
- * An `EventTarget`, because a Media is one: the store and the element layers
- * take anything they attach as an event source, and inheriting the three methods
- * satisfies that for free rather than by stubbing them.
+ * An `EventTarget`, because a Media is one: the store and the element layers take anything they attach as an event
+ * source, and inheriting the three methods satisfies that for free rather than by stubbing them.
  *
- * ⚠️ It still implements too little to carry the rest of the media surface, which
- * bounds what may consume it: a store feature reading a property outside this set
- * gets `undefined` rather than an error. A Media needing more of that surface
- * belongs on a host that provides it.
+ * ⚠️ It still implements too little to carry the rest of the media surface, which bounds what may consume it: a store
+ * feature reading a property outside this set gets `undefined` rather than an error. A Media needing more of that
+ * surface belongs on a host that provides it.
  */
 export class BackgroundVideoHost extends EventTarget {
   #target: HTMLVideoElement | null = null;

--- a/packages/spf/src/playback/adapters/hls-background-video/index.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/index.ts
@@ -1,21 +1,18 @@
 /**
- * The Media over the background-video engine — SPF's public playback surface for
- * the muted, looping, chrome-less case, from an HLS URL.
+ * The Media over the background-video engine — SPF's public playback surface for the muted, looping, chrome-less case,
+ * from an HLS URL.
  *
- * `src` is the whole input surface and `error` the one output; selection pins the
- * largest rendition that fits the screen and holds it for the session. Narrowing
- * further is a delivery concern rather than a property here — a Mux stream URL's
- * `?max_resolution=720p`, for one, keeps the renditions it excludes out of the
- * manifest instead of merely unpicked.
+ * `src` is the whole input surface and `error` the one output; selection pins the largest rendition that fits the
+ * screen and holds it for the session. Narrowing further is a delivery concern rather than a property here — a Mux
+ * stream URL's `?max_resolution=720p`, for one, keeps the renditions it excludes out of the manifest instead of merely
+ * unpicked.
  *
- * Separate from `@videojs/spf/hls`, where the engine itself ships beside the
- * other HLS engines, for the same reason the HLS Medias are: wiring an engine
- * directly shouldn't pull an adapter in with it. Its host is local and narrow, so
- * this entry carries no `@videojs/media` dependency either.
+ * Separate from `@videojs/spf/hls`, where the engine itself ships beside the other HLS engines, for the same reason the
+ * HLS Medias are: wiring an engine directly shouldn't pull an adapter in with it. Its host is local and narrow, so this
+ * entry carries no `@videojs/media` dependency either.
  *
- * `@videojs/spf/mux-background-video` re-exports everything here under
- * Mux-flavored names. Same classes, so the import path is a naming choice and
- * nothing more.
+ * `@videojs/spf/mux-background-video` re-exports everything here under Mux-flavored names. Same classes, so the import
+ * path is a naming choice and nothing more.
  */
 export type { HlsBackgroundVideoMediaAPI, HlsBackgroundVideoMediaProps, HlsVideoMediaError } from './adapter';
 export {

--- a/packages/spf/src/playback/adapters/hls-background-video/media.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/media.ts
@@ -4,15 +4,12 @@ import { BackgroundVideoHost } from './host';
 const HlsBackgroundVideoMediaBase = HlsBackgroundVideoMediaMixin(BackgroundVideoHost);
 
 /**
- * The background-video Media, bound to a `<video>` through
- * {@link BackgroundVideoHost}.
+ * The background-video Media, bound to a `<video>` through {@link BackgroundVideoHost}.
  *
- * That host carries the attached element and the four properties `attach` fixes,
- * which is all this Media's surface needs, and it is local — so this entry has
- * no `@videojs/media` dependency.
+ * That host carries the attached element and the four properties `attach` fixes, which is all this Media's surface
+ * needs, and it is local — so this entry has no `@videojs/media` dependency.
  *
- * No `MediaTracksMixin`, unlike `HlsVideoMedia`: the engine subtracts audio and
- * text entirely and pins one video rendition for the session, so there are no
- * track lists for a consumer to project or switch between.
+ * No `MediaTracksMixin`, unlike `HlsVideoMedia`: the engine subtracts audio and text entirely and pins one video
+ * rendition for the session, so there are no track lists for a consumer to project or switch between.
  */
 export class HlsBackgroundVideoMedia extends HlsBackgroundVideoMediaBase {}

--- a/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
@@ -1,14 +1,13 @@
 /**
  * HlsBackgroundVideoMediaElement adapter tests.
  *
- * Covers the HTMLMediaElement-compatible contract for `src` and `play()`.
- * Adapter-shape parallels `HlsVideoMediaElement`; the tests focus on what
- * diverges: silent autoplay-looping playback is fixed on the element at attach
- * rather than exposed, and the picker takes the largest rendition on offer,
- * since narrowing the set is the manifest's job rather than a property here.
+ * Covers the HTMLMediaElement-compatible contract for `src` and `play()`. Adapter-shape parallels
+ * `HlsVideoMediaElement`; the tests focus on what diverges: silent autoplay-looping playback is fixed on the element at
+ * attach rather than exposed, and the picker takes the largest rendition on offer, since narrowing the set is the
+ * manifest's job rather than a property here.
  *
- * `@videojs/spf/mux-background-video` re-exports these same classes, so its own
- * test asserts identity and leans on this file for behavior.
+ * `@videojs/spf/mux-background-video` re-exports these same classes, so its own test asserts identity and leans on this
+ * file for behavior.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 

--- a/packages/spf/src/playback/adapters/hls-background-video/tests/media.test.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/tests/media.test.ts
@@ -1,7 +1,6 @@
 /**
- * The host-bound Media, covering what binding to a host is what makes true: the
- * fixed behavior is readable back off the Media because the host forwards to the
- * element, not because the adapter keeps a parallel copy of it.
+ * The host-bound Media, covering what binding to a host is what makes true: the fixed behavior is readable back off the
+ * Media because the host forwards to the element, not because the adapter keeps a parallel copy of it.
  */
 import { describe, expect, it } from 'vite-plus/test';
 

--- a/packages/spf/src/playback/adapters/hls-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/hls-video/adapter.ts
@@ -39,9 +39,8 @@ import {
 } from './error-surface';
 
 /**
- * The media-level stream type: the engine's detected stream type (`'live'` /
- * `'on-demand'`) plus `'unknown'` for "no playlist parsed yet." `@videojs/media`'s
- * {@link MediaStreamType} itself, kept under its own name because that is what
+ * The media-level stream type: the engine's detected stream type (`'live'` / `'on-demand'`) plus `'unknown'` for "no
+ * playlist parsed yet." `@videojs/media`'s {@link MediaStreamType} itself, kept under its own name because that is what
  * this adapter's `streamType` property is documented against.
  */
 export type HlsVideoMediaStreamType = MediaStreamType;
@@ -74,9 +73,8 @@ export interface HlsVideoMediaAPI extends HlsVideoMediaProps {
 }
 
 /**
- * `targetLiveWindow` per the media-ui-extensions live-edge proposal: `NaN` for
- * on-demand (or nothing resolved yet), `0` for standard sliding-window live,
- * `Infinity` for DVR (`#EXT-X-PLAYLIST-TYPE:EVENT` — the window grows from the
+ * `targetLiveWindow` per the media-ui-extensions live-edge proposal: `NaN` for on-demand (or nothing resolved yet), `0`
+ * for standard sliding-window live, `Infinity` for DVR (`#EXT-X-PLAYLIST-TYPE:EVENT` — the window grows from the
  * start). Read from the timeline-bearing track's playlist metadata.
  */
 function deriveTargetLiveWindow(
@@ -103,15 +101,12 @@ function deriveTargetLiveWindow(
 // ============================================================================
 
 /**
- * Which reported conditions this composition treats as **fatal** — the ones that
- * reach `error` and fire `'error'`. Severity isn't part of an SVTA code
- * (§Approach: "impact varies with player implementation"), and here it also
- * varies by composition, so it's decided at this boundary rather than by the
- * reporter.
+ * Which reported conditions this composition treats as **fatal** — the ones that reach `error` and fire `'error'`.
+ * Severity isn't part of an SVTA code (§Approach: "impact varies with player implementation"), and here it also varies
+ * by composition, so it's decided at this boundary rather than by the reporter.
  *
- * An allow-list, deliberately: only *verdicts* are here. The per-rendition causes
- * `resolve-track` reports (unsupported format, unsupported DRM) stay in the
- * sequence as context — one unplayable rendition doesn't fail the source, and
+ * An allow-list, deliberately: only _verdicts_ are here. The per-rendition causes `resolve-track` reports (unsupported
+ * format, unsupported DRM) stay in the sequence as context — one unplayable rendition doesn't fail the source, and
  * promoting a cause would put a dialog over a mixed source that goes on to play.
  */
 const FATAL_SVTA_CODES: ReadonlySet<number> = new Set<number>([
@@ -122,36 +117,33 @@ const FATAL_SVTA_CODES: ReadonlySet<number> = new Set<number>([
 /**
  * Mixin that adds SPF playback engine behavior to any base class.
  *
- * Implements the src/play() contract per the WHATWG HTML spec so that SPF can
- * be used anywhere a media element API is expected.
+ * Implements the src/play() contract per the WHATWG HTML spec so that SPF can be used anywhere a media element API is
+ * expected.
  *
- * A single engine instance is created at construction and recycled across src
- * changes.
+ * A single engine instance is created at construction and recycled across src changes.
+ *
+ * @example
+ *   class HlsVideoMedia extends HlsVideoMediaMixin(HTMLVideoElementHost) {}
+ *
+ *   const media = new HlsVideoMedia();
+ *   media.attach(document.querySelector('video'));
+ *   media.src = 'https://stream.mux.com/abc123.m3u8';
  *
  * @fires streamtypechange - Fired when the detected stream type changes. Read `streamType` for the new value.
  * @fires targetlivewindowchange - Fired when the target live window changes. Read `targetLiveWindow` for the new value.
  * @fires error - Fired when a fatal condition is reported. Read `error` for it.
- *
- * @example
- * class HlsVideoMedia extends HlsVideoMediaMixin(HTMLVideoElementHost) {}
- *
- * const media = new HlsVideoMedia();
- * media.attach(document.querySelector('video'));
- * media.src = 'https://stream.mux.com/abc123.m3u8';
  */
 export function HlsVideoMediaMixin<Base extends Constructor<any>>(BaseClass: Base) {
   class HlsVideoMediaImpl extends BaseClass {
     /**
-     * A complete sentence naming the Media to reach for when this one can't play
-     * a source — `Try the hls.js-backed Mux media instead: import the hls-js
-     * flavor in place of the spf one.` Appended to the copy this adapter
-     * surfaces, and to the notices it logs. Name the flavor, not an import path:
-     * a Media is reached through several packages, each with its own counterpart.
+     * A complete sentence naming the Media to reach for when this one can't play a source — `Try the hls.js-backed Mux
+     * media instead: import the hls-js flavor in place of the spf one.` Appended to the copy this adapter surfaces, and
+     * to the notices it logs. Name the flavor, not an import path: a Media is reached through several packages, each
+     * with its own counterpart.
      *
-     * Empty here: `hls-video` has no better-equipped sibling to point at.
-     * A Media that does (a Mux Video built on this engine, whose hls.js-backed
-     * counterpart plays MPEG-TS and DRM) overrides this static, and its copy gains
-     * the second sentence with no other change.
+     * Empty here: `hls-video` has no better-equipped sibling to point at. A Media that does (a Mux Video built on this
+     * engine, whose hls.js-backed counterpart plays MPEG-TS and DRM) overrides this static, and its copy gains the
+     * second sentence with no other change.
      */
     static get alternativeMediaSuggestion(): string | undefined {
       return undefined;
@@ -167,9 +159,8 @@ export function HlsVideoMediaMixin<Base extends Constructor<any>>(BaseClass: Bas
     #targetLiveWindow = Number.NaN;
     #error: HlsVideoMediaError | null = null;
     /**
-     * The *reported* condition currently surfaced, which is what the re-fire
-     * latch keys on. Not `#error.code`: that's the code this adapter chose to
-     * surface, and a later cause can change the choice for a condition already
+     * The _reported_ condition currently surfaced, which is what the re-fire latch keys on. Not `#error.code`: that's
+     * the code this adapter chose to surface, and a later cause can change the choice for a condition already
      * announced.
      */
     #reportedCode: number | null = null;
@@ -214,10 +205,8 @@ export function HlsVideoMediaMixin<Base extends Constructor<any>>(BaseClass: Bas
     }
 
     /**
-     * Underlying playback engine — the low-level SPF reactive composition that
-     * drives playback. An advanced escape hatch for direct engine access;
-     * normal playback is driven through this element's own properties and
-     * methods.
+     * Underlying playback engine — the low-level SPF reactive composition that drives playback. An advanced escape
+     * hatch for direct engine access; normal playback is driven through this element's own properties and methods.
      */
     get engine(): Composition<HlsVideoEngineState, HlsVideoEngineContext> {
       return this.#engine;
@@ -230,9 +219,8 @@ export function HlsVideoMediaMixin<Base extends Constructor<any>>(BaseClass: Bas
     // -------------------------------------------------------------------------
 
     /**
-     * The current fatal error, or `null`. Only *fatal* conditions appear here —
-     * the engine reports non-fatal ones too (they stay in `engine.state.errors`),
-     * and promoting them would tell a consumer playback had failed when it
+     * The current fatal error, or `null`. Only _fatal_ conditions appear here — the engine reports non-fatal ones too
+     * (they stay in `engine.state.errors`), and promoting them would tell a consumer playback had failed when it
      * hadn't. Resets per source. Fires `'error'` when set.
      */
     get error(): HlsVideoMediaError | null {
@@ -240,9 +228,8 @@ export function HlsVideoMediaMixin<Base extends Constructor<any>>(BaseClass: Bas
     }
 
     /**
-     * The source's stream type — `'live'`, `'on-demand'`, or `'unknown'` until
-     * a media playlist has been parsed. Setting a non-`'unknown'` value pins a
-     * user override (detection stops updating it); setting `'unknown'` reverts
+     * The source's stream type — `'live'`, `'on-demand'`, or `'unknown'` until a media playlist has been parsed.
+     * Setting a non-`'unknown'` value pins a user override (detection stops updating it); setting `'unknown'` reverts
      * to the engine's detected value.
      */
     get streamType(): HlsVideoMediaStreamType {
@@ -261,12 +248,10 @@ export function HlsVideoMediaMixin<Base extends Constructor<any>>(BaseClass: Bas
     }
 
     /**
-     * Presentation time marking the start of the live-edge window — playback at
-     * `currentTime >= liveEdgeStart` counts as "at the live edge" (the same
-     * target the engine's `seekToLiveEdge` seeks to: window end − HOLD-BACK).
-     * `NaN` when the stream isn't live or nothing is resolved yet. Derived at
-     * read time from the engine's live window — no change event; re-read on
-     * `timeupdate`/`progress` (as the store's live feature does).
+     * Presentation time marking the start of the live-edge window — playback at `currentTime >= liveEdgeStart` counts
+     * as "at the live edge" (the same target the engine's `seekToLiveEdge` seeks to: window end − HOLD-BACK). `NaN`
+     * when the stream isn't live or nothing is resolved yet. Derived at read time from the engine's live window — no
+     * change event; re-read on `timeupdate`/`progress` (as the store's live feature does).
      */
     get liveEdgeStart(): number {
       const edge = getLiveEdge({
@@ -278,9 +263,8 @@ export function HlsVideoMediaMixin<Base extends Constructor<any>>(BaseClass: Bas
     }
 
     /**
-     * The target live window: `NaN` for on-demand (or unknown), `0` for
-     * standard sliding-window live, `Infinity` for DVR
-     * (`#EXT-X-PLAYLIST-TYPE:EVENT`). Fires `targetlivewindowchange` on change.
+     * The target live window: `NaN` for on-demand (or unknown), `0` for standard sliding-window live, `Infinity` for
+     * DVR (`#EXT-X-PLAYLIST-TYPE:EVENT`). Fires `targetlivewindowchange` on change.
      */
     get targetLiveWindow(): number {
       return this.#targetLiveWindow;
@@ -479,14 +463,12 @@ export function HlsVideoMediaMixin<Base extends Constructor<any>>(BaseClass: Bas
     }
 
     /**
-     * Log what this engine is delivering differently from what the playlist asked
-     * for. Neither condition stops playback, so neither is an error — they go to
-     * the console rather than the error surface.
+     * Log what this engine is delivering differently from what the playlist asked for. Neither condition stops
+     * playback, so neither is an error — they go to the console rather than the error surface.
      *
-     * Once per source, not per parse: a live playlist reloads every target
-     * duration, and the timeline track re-parses on each one. Keyed on the notice
-     * rather than latched with a boolean so the two are independent, and cleared
-     * when the presentation unresolves so the next source starts quiet.
+     * Once per source, not per parse: a live playlist reloads every target duration, and the timeline track re-parses
+     * on each one. Keyed on the notice rather than latched with a boolean so the two are independent, and cleared when
+     * the presentation unresolves so the next source starts quiet.
      */
     #reportDeliveryNotices(presentation: MaybeResolvedPresentation | undefined): void {
       if (!isResolvedPresentation(presentation)) {

--- a/packages/spf/src/playback/adapters/hls-video/error-surface.ts
+++ b/packages/spf/src/playback/adapters/hls-video/error-surface.ts
@@ -1,19 +1,15 @@
 /**
  * The shared half of promoting reported conditions onto a media surface.
  *
- * Every adapter that has one does the same things: pick the first condition it
- * treats as fatal, latch it so a later append doesn't re-fire, and name a
- * better-equipped Media when its own class points at one. Only the *policy*
- * differs — which codes are fatal, which the video, audio-only, and background
- * adapters each answer differently — so that stays with each adapter and
- * everything else lives here.
+ * Every adapter that has one does the same things: pick the first condition it treats as fatal, latch it so a later
+ * append doesn't re-fire, and name a better-equipped Media when its own class points at one. Only the _policy_ differs
+ * — which codes are fatal, which the video, audio-only, and background adapters each answer differently — so that stays
+ * with each adapter and everything else lives here.
  *
- * `firstFatal` is the part all three share. The `ErrorLike` mapping below it is
- * for the two that feed a store and a dialog; the background adapter surfaces the
- * reported condition unmapped, so it takes the picker and nothing else.
+ * `firstFatal` is the part all three share. The `ErrorLike` mapping below it is for the two that feed a store and a
+ * dialog; the background adapter surfaces the reported condition unmapped, so it takes the picker and nothing else.
  *
- * See `internal/design/spf/features/errors.md` for the causes-vs-verdicts split
- * this rests on.
+ * See `internal/design/spf/features/errors.md` for the causes-vs-verdicts split this rests on.
  */
 import type { ErrorLike } from '@videojs/media';
 
@@ -25,12 +21,11 @@ import {
 } from '../../../media/errors';
 
 /**
- * The error shape a media surface exposes: `@videojs/media`'s {@link ErrorLike}
- * plus the reporter context the engine carries alongside a condition.
+ * The error shape a media surface exposes: `@videojs/media`'s {@link ErrorLike} plus the reporter context the engine
+ * carries alongside a condition.
  *
- * `code` is the **SVTA code**, not a `MediaError.MEDIA_ERR_*` value. Consumers
- * that map codes to copy currently only know 1–5, so an SVTA code falls through
- * to showing `message`; an extensible code lookup above the engine is the
+ * `code` is the **SVTA code**, not a `MediaError.MEDIA_ERR_*` value. Consumers that map codes to copy currently only
+ * know 1–5, so an SVTA code falls through to showing `message`; an extensible code lookup above the engine is the
  * follow-up that fixes it.
  */
 export interface HlsVideoMediaError extends ErrorLike {
@@ -41,10 +36,9 @@ export interface HlsVideoMediaError extends ErrorLike {
 /**
  * `message`, plus the alternative-Media sentence when `media`'s class names one.
  *
- * Read off the class rather than passed in so a subclass can point at a
- * better-equipped sibling — the SPF Mux Medias name the hls.js-backed one, which
- * plays the MPEG-TS and DRM sources SPF doesn't — without either adapter knowing
- * that sibling exists.
+ * Read off the class rather than passed in so a subclass can point at a better-equipped sibling — the SPF Mux Medias
+ * name the hls.js-backed one, which plays the MPEG-TS and DRM sources SPF doesn't — without either adapter knowing that
+ * sibling exists.
  */
 export function withAlternativeMediaSuggestion(message: string, media: object): string {
   const { alternativeMediaSuggestion } = media.constructor as { alternativeMediaSuggestion?: string };
@@ -62,13 +56,12 @@ export function firstFatal(
 }
 
 /**
- * The causes that mean the engine has no pipeline for what the source delivers —
- * a container it can't append, or encryption it can't decrypt.
+ * The causes that mean the engine has no pipeline for what the source delivers — a container it can't append, or
+ * encryption it can't decrypt.
  *
- * What these have in common is that no retry, no other CDN, and no other
- * rendition of the same source fixes them: the source needs a capability this
- * engine doesn't have. That's the distinction the surfaced code exists to draw,
- * and it's why the set is these three rather than "every cause".
+ * What these have in common is that no retry, no other CDN, and no other rendition of the same source fixes them: the
+ * source needs a capability this engine doesn't have. That's the distinction the surfaced code exists to draw, and it's
+ * why the set is these three rather than "every cause".
  */
 const UNSUPPORTED_FEATURE_CAUSES: ReadonlySet<number> = new Set<number>([
   SVTA_UNSUPPORTED_VIDEO_FORMAT,
@@ -77,15 +70,12 @@ const UNSUPPORTED_FEATURE_CAUSES: ReadonlySet<number> = new Set<number>([
 ]);
 
 /**
- * Whether anything in the sequence is a cause of the "we don't implement this"
- * kind.
+ * Whether anything in the sequence is a cause of the "we don't implement this" kind.
  *
- * Deliberately `some` over the whole sequence rather than a per-type match
- * against the verdict. A verdict means one type's candidates emptied, but the
- * *reason* the source is unplayable can sit on another type — an audio-only
- * source whose sole rendition is encrypted empties the audio candidates, and a
- * video source with encrypted video empties the video ones. Both are the same
- * answer to the viewer, so both get the same code.
+ * Deliberately `some` over the whole sequence rather than a per-type match against the verdict. A verdict means one
+ * type's candidates emptied, but the _reason_ the source is unplayable can sit on another type — an audio-only source
+ * whose sole rendition is encrypted empties the audio candidates, and a video source with encrypted video empties the
+ * video ones. Both are the same answer to the viewer, so both get the same code.
  */
 export function hasUnsupportedFeatureCause(errors: readonly SvtaError[] | undefined): boolean {
   return errors?.some((error) => UNSUPPORTED_FEATURE_CAUSES.has(error.code)) ?? false;

--- a/packages/spf/src/playback/adapters/hls-video/index.ts
+++ b/packages/spf/src/playback/adapters/hls-video/index.ts
@@ -1,11 +1,9 @@
 /**
  * The Media over the HLS engine — SPF's public playback surface.
  *
- * SPF differs from engines like hls.js in that it exposes no engine-shaped API
- * of its own: the `@videojs/media` facade *is* how a composed engine is
- * consumed. `HlsVideoMedia` is that facade, and this entry point is separate
- * from `@videojs/spf/hls` so wiring the engine directly doesn't pull the Media
- * (or `@videojs/media`) in with it.
+ * SPF differs from engines like hls.js in that it exposes no engine-shaped API of its own: the `@videojs/media` facade
+ * _is_ how a composed engine is consumed. `HlsVideoMedia` is that facade, and this entry point is separate from
+ * `@videojs/spf/hls` so wiring the engine directly doesn't pull the Media (or `@videojs/media`) in with it.
  */
 export type { HlsVideoMediaAPI, HlsVideoMediaError, HlsVideoMediaProps, HlsVideoMediaStreamType } from './adapter';
 export { HlsVideoMediaElement, HlsVideoMediaMixin, hlsVideoMediaDefaultProps } from './adapter';

--- a/packages/spf/src/playback/adapters/hls-video/media-tracks.ts
+++ b/packages/spf/src/playback/adapters/hls-video/media-tracks.ts
@@ -49,12 +49,11 @@ const sameIds = (a: { id: string }[], b: { id: string }[]): boolean =>
   a.length === b.length && a.every((item, i) => item.id === b[i]!.id);
 
 /**
- * Projects the SPF engine's presentation onto the media element's
- * `videoRenditions` / `audioTracks` lists, and wires user selection back to the
- * engine's `userVideoTrackSelection` / `userAudioTrackSelection` signals.
+ * Projects the SPF engine's presentation onto the media element's `videoRenditions` / `audioTracks` lists, and wires
+ * user selection back to the engine's `userVideoTrackSelection` / `userAudioTrackSelection` signals.
  *
- * Requires the media-tracks mixin (track-list infrastructure) earlier in the
- * chain so the host exposes `addVideoTrack`, `videoRenditions`, and friends.
+ * Requires the media-tracks mixin (track-list infrastructure) earlier in the chain so the host exposes `addVideoTrack`,
+ * `videoRenditions`, and friends.
  */
 export function HlsVideoMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
   class HlsVideoMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {

--- a/packages/spf/src/playback/adapters/hls-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/hls-video/tests/adapter.test.ts
@@ -1,16 +1,14 @@
 /**
  * HlsVideoMediaElement adapter tests.
  *
- * Covers the HTMLMediaElement-compatible contract for src and play(), per the
- * WHATWG HTML spec (https://html.spec.whatwg.org/multipage/media.html).
+ * Covers the HTMLMediaElement-compatible contract for src and play(), per the WHATWG HTML spec
+ * (https://html.spec.whatwg.org/multipage/media.html).
  *
- * Notable spec anchors:
- * - src IDL attribute reflects synchronously (§4.8.11.2)
- * - Setting src invokes the load algorithm (§4.8.11.5)
- * - play() returns a Promise that resolves when playback starts (§4.8.11.8)
+ * Notable spec anchors: - src IDL attribute reflects synchronously (§4.8.11.2) - Setting src invokes the load algorithm
+ * (§4.8.11.5) - play() returns a Promise that resolves when playback starts (§4.8.11.8)
  *
- * Remote-source integration tests (e.g. full pipeline with Mux streams) are
- * intentionally deferred; see comments below for planned coverage.
+ * Remote-source integration tests (e.g. full pipeline with Mux streams) are intentionally deferred; see comments below
+ * for planned coverage.
  *
  * Future: consider web-platform-tests (wpt) fixtures for deeper spec coverage.
  */
@@ -457,8 +455,8 @@ describe('HlsVideoMediaElement', () => {
     class TestMedia extends HlsVideoMediaMixin(EventTarget) {}
 
     /**
-     * A resolved live presentation: one selected video track, 5×2s segments at
-     * [100, 110], targetDuration 2 (→ HOLD-BACK latency 6 → liveEdgeStart 104).
+     * A resolved live presentation: one selected video track, 5×2s segments at [100, 110], targetDuration 2 (→
+     * HOLD-BACK latency 6 → liveEdgeStart 104).
      */
     function liveVideoPresentation(playlistType?: 'VOD' | 'EVENT'): Presentation {
       const complete = playlistType === 'VOD';

--- a/packages/spf/src/playback/adapters/mux-audio/index.ts
+++ b/packages/spf/src/playback/adapters/mux-audio/index.ts
@@ -1,15 +1,13 @@
 /**
- * The Mux Media over the SPF audio-only HLS engine. Sibling of
- * `@videojs/spf/mux-video`; see that entry point for the three-import-paths
- * design the two share, and `@videojs/spf/hls-video` for why the Medias ship
- * separately from `@videojs/spf/hls`.
+ * The Mux Media over the SPF audio-only HLS engine. Sibling of `@videojs/spf/mux-video`; see that entry point for the
+ * three-import-paths design the two share, and `@videojs/spf/hls-video` for why the Medias ship separately from
+ * `@videojs/spf/hls`.
  *
- * Named for the flavor, not the composition underneath: the engine is the
- * audio-only variant, but `mux-audio` is what this plays and what the element
- * and component are called.
+ * Named for the flavor, not the composition underneath: the engine is the audio-only variant, but `mux-audio` is what
+ * this plays and what the element and component are called.
  *
- * `MuxMediaProps` and `muxMediaDefaultProps` are the same Mux identity both
- * flavors take, re-exported here so consuming this Media costs no second import.
+ * `MuxMediaProps` and `muxMediaDefaultProps` are the same Mux identity both flavors take, re-exported here so consuming
+ * this Media costs no second import.
  */
 export type { MuxContentData, MuxSourceBase } from '@videojs/media/dom/mux/source';
 export type { MuxMediaAPI, MuxMediaProps } from '../mux-video/adapter';

--- a/packages/spf/src/playback/adapters/mux-audio/media.ts
+++ b/packages/spf/src/playback/adapters/mux-audio/media.ts
@@ -12,18 +12,14 @@ const MuxAudioMediaBase = MuxMediaMixin(HlsAudioMedia);
 /**
  * The Mux Media over the SPF audio-only HLS engine.
  *
- * Same Mux surface as the video flavor — `src`, the structured `source`, and the
- * derived `contentData` all come from the shared mixin — over the subtractive
- * engine, so only the audio renditions of whatever the playback ID names are
- * fetched. That is the one place this diverges from the hls.js-backed
- * `<mux-audio>`, which runs the full engine and downloads video renditions it
- * never shows.
+ * Same Mux surface as the video flavor — `src`, the structured `source`, and the derived `contentData` all come from
+ * the shared mixin — over the subtractive engine, so only the audio renditions of whatever the playback ID names are
+ * fetched. That is the one place this diverges from the hls.js-backed `<mux-audio>`, which runs the full engine and
+ * downloads video renditions it never shows.
  *
- * `contentData` is kept rather than dropped, for the same reason its hls.js
- * counterpart has it: a playback ID played as audio is usually a *video* asset,
- * whose poster and storyboard exist and which an audio skin may well want. The
- * element ignores it either way. Mux publishes neither for a genuinely
- * audio-only asset, so those URLs 404 — see the known shortcoming on the video
- * flavor, which shares the derivation.
+ * `contentData` is kept rather than dropped, for the same reason its hls.js counterpart has it: a playback ID played as
+ * audio is usually a _video_ asset, whose poster and storyboard exist and which an audio skin may well want. The
+ * element ignores it either way. Mux publishes neither for a genuinely audio-only asset, so those URLs 404 — see the
+ * known shortcoming on the video flavor, which shares the derivation.
  */
 export class MuxAudioMedia extends MuxAudioMediaBase {}

--- a/packages/spf/src/playback/adapters/mux-audio/tests/media.test.ts
+++ b/packages/spf/src/playback/adapters/mux-audio/tests/media.test.ts
@@ -1,11 +1,9 @@
 /**
  * SPF-backed MuxAudioMedia tests.
  *
- * The Mux surface is the shared mixin's, covered against the video flavor in
- * `../../mux/tests/media.test.ts`. What's worth asserting here is that applying
- * it to the audio-only Media keeps that surface intact — the two extend different
- * bases, so nothing guarantees it but a test — plus the two things this flavor
- * decides for itself.
+ * The Mux surface is the shared mixin's, covered against the video flavor in `../../mux/tests/media.test.ts`. What's
+ * worth asserting here is that applying it to the audio-only Media keeps that surface intact — the two extend different
+ * bases, so nothing guarantees it but a test — plus the two things this flavor decides for itself.
  */
 import { describe, expect, it, vi } from 'vite-plus/test';
 

--- a/packages/spf/src/playback/adapters/mux-background-video/index.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/index.ts
@@ -1,17 +1,14 @@
 /**
- * The Mux-flavored name for `@videojs/spf/hls-background-video` — a muted,
- * looping, chrome-less video from a Mux stream URL.
+ * The Mux-flavored name for `@videojs/spf/hls-background-video` — a muted, looping, chrome-less video from a Mux stream
+ * URL.
  *
- * An alias, not a variant: every export below is the same class or value that
- * entry exposes, renamed. There is no Mux identity to carry, because there is no
- * Mux input to take — `src` is an HLS URL, and capping which rendition is fetched
- * is a param on it (`?max_resolution=720p`) rather than a property. Playback-ID
- * identity, poster, and storyboard belong to `@videojs/spf/mux-video`; none of
- * them mean anything without controls to hang them on.
+ * An alias, not a variant: every export below is the same class or value that entry exposes, renamed. There is no Mux
+ * identity to carry, because there is no Mux input to take — `src` is an HLS URL, and capping which rendition is
+ * fetched is a param on it (`?max_resolution=720p`) rather than a property. Playback-ID identity, poster, and
+ * storyboard belong to `@videojs/spf/mux-video`; none of them mean anything without controls to hang them on.
  *
- * So the import path is a naming choice and nothing more. Kept because
- * `<mux-background-video>` is what the standalone package this replaces was
- * called, and because a Mux-shaped app reads better importing a Mux-shaped name.
+ * So the import path is a naming choice and nothing more. Kept because `<mux-background-video>` is what the standalone
+ * package this replaces was called, and because a Mux-shaped app reads better importing a Mux-shaped name.
  */
 export type {
   HlsBackgroundVideoMediaAPI as MuxBackgroundVideoMediaAPI,

--- a/packages/spf/src/playback/adapters/mux-background-video/tests/index.test.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/tests/index.test.ts
@@ -1,7 +1,7 @@
 /**
- * The alias entry. Asserting identity rather than behavior is the point: if these
- * are the same classes, the behavior tests in `../../hls-background-video/tests`
- * already cover this entry, and there is no second implementation to drift.
+ * The alias entry. Asserting identity rather than behavior is the point: if these are the same classes, the behavior
+ * tests in `../../hls-background-video/tests` already cover this entry, and there is no second implementation to
+ * drift.
  */
 import { describe, expect, it } from 'vite-plus/test';
 

--- a/packages/spf/src/playback/adapters/mux-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/mux-video/adapter.ts
@@ -24,33 +24,29 @@ export interface MuxMediaAPI extends MuxMediaProps {
 }
 
 /**
- * Mux identity over any SPF Media: the structured `source`, the `src` derived
- * from it, and the image URLs it describes.
+ * Mux identity over any SPF Media: the structured `source`, the `src` derived from it, and the image URLs it describes.
  *
- * Everything here is Mux identity, so it carries no engine and both flavors get
- * it unchanged — the video Media over the full HLS engine, the audio-only Media
- * over the subtractive one. A mixin rather than a shared base class because each
- * flavor extends a different SPF Media, so there is no common class to put this
- * on, only a common `src` accessor to write through.
+ * Everything here is Mux identity, so it carries no engine and both flavors get it unchanged — the video Media over the
+ * full HLS engine, the audio-only Media over the subtractive one. A mixin rather than a shared base class because each
+ * flavor extends a different SPF Media, so there is no common class to put this on, only a common `src` accessor to
+ * write through.
  *
- * Unlike the hls.js-backed `MuxMedia`, there is no inherited `source` to
- * delegate to — the SPF Medias know only `src` — so this owns the structured
- * source and dispatches `sourcechange` itself.
+ * Unlike the hls.js-backed `MuxMedia`, there is no inherited `source` to delegate to — the SPF Medias know only `src` —
+ * so this owns the structured source and dispatches `sourcechange` itself.
  *
- * @fires sourcechange - Fired when `source` changes, either directly or by parsing a new `src`. Read `source` for the new value.
+ * @fires sourcechange - Fired when `source` changes, either directly or by parsing a new `src`. Read `source` for the
+ *   new value.
  * @fires contentdatachange - Fired when the derived `contentData` changes. Read `contentData` for the new value.
  */
 export function MuxMediaMixin<Base extends Constructor<any>>(BaseClass: Base) {
   class MuxMediaImpl extends BaseClass {
     /**
-     * Named on the error copy when this engine can't play a source: the
-     * hls.js-backed Mux Media plays the MPEG-TS and DRM-protected sources that
-     * SPF does not, and it backs both `<mux-video>` and `<mux-audio>`.
+     * Named on the error copy when this engine can't play a source: the hls.js-backed Mux Media plays the MPEG-TS and
+     * DRM-protected sources that SPF does not, and it backs both `<mux-video>` and `<mux-audio>`.
      *
-     * Names the flavor rather than an import path, because one Media is reached
-     * through three of them — `@videojs/html`, `@videojs/react`, and this package
-     * — and each has a different counterpart. The flavor suffix is the one thing
-     * common to the layers a consumer imports elements and components from.
+     * Names the flavor rather than an import path, because one Media is reached through three of them —
+     * `@videojs/html`, `@videojs/react`, and this package — and each has a different counterpart. The flavor suffix is
+     * the one thing common to the layers a consumer imports elements and components from.
      */
     static get alternativeMediaSuggestion(): string | undefined {
       return 'Try the hls.js-backed Mux media instead: import the `hls-js` flavor in place of the `spf` one.';
@@ -60,13 +56,11 @@ export function MuxMediaMixin<Base extends Constructor<any>>(BaseClass: Base) {
     #contentData: MuxContentData = {};
 
     /**
-     * Media source URL. Setting a Mux stream URL
-     * (`https://stream.mux.com/<playback-id>.m3u8?...`) extracts the playback ID
-     * and query params into `source`; other URLs are kept as a plain `source.src`.
+     * Media source URL. Setting a Mux stream URL (`https://stream.mux.com/<playback-id>.m3u8?...`) extracts the
+     * playback ID and query params into `source`; other URLs are kept as a plain `source.src`.
      *
-     * Only playback options carry over. Mux identity comes from the URL, and the
-     * signed `poster`, `storyboard`, and `drm` tokens are scoped to a playback ID,
-     * so carrying them onto a different source would build rejected URLs.
+     * Only playback options carry over. Mux identity comes from the URL, and the signed `poster`, `storyboard`, and
+     * `drm` tokens are scoped to a playback ID, so carrying them onto a different source would build rejected URLs.
      */
     get src(): string {
       return super.src;
@@ -82,10 +76,9 @@ export function MuxMediaMixin<Base extends Constructor<any>>(BaseClass: Base) {
     }
 
     /**
-     * Structured Mux source. Setting it derives `src` from the playback ID, custom
-     * domain, and `playback` params (appended as `snake_case` query params). A
-     * `playback.token` replaces all other params — signed URLs bake them into the
-     * token.
+     * Structured Mux source. Setting it derives `src` from the playback ID, custom domain, and `playback` params
+     * (appended as `snake_case` query params). A `playback.token` replaces all other params — signed URLs bake them
+     * into the token.
      */
     get source(): MuxSourceBase | null {
       return this.#source;
@@ -113,12 +106,11 @@ export function MuxMediaMixin<Base extends Constructor<any>>(BaseClass: Base) {
     }
 
     /**
-     * Image URLs `source` describes rather than plays: `poster` from its `poster`
-     * params, `storyboard` from its `storyboard` params.
+     * Image URLs `source` describes rather than plays: `poster` from its `poster` params, `storyboard` from its
+     * `storyboard` params.
      *
-     * Derived from `source` and nothing else. The same object is handed back
-     * until one of those URLs changes, and `contentdatachange` announces it when
-     * it does. Nothing here is applied for you.
+     * Derived from `source` and nothing else. The same object is handed back until one of those URLs changes, and
+     * `contentdatachange` announces it when it does. Nothing here is applied for you.
      */
     get contentData(): MuxContentData {
       return this.#contentData;

--- a/packages/spf/src/playback/adapters/mux-video/index.ts
+++ b/packages/spf/src/playback/adapters/mux-video/index.ts
@@ -1,15 +1,12 @@
 /**
  * The Mux Media over the SPF HLS engine — Mux identity in, playback out.
  *
- * The hls.js-backed counterpart lives at `@videojs/media/dom/mux`. That is the
- * PRD's three-import-paths design: the import path picks the engine, and nothing
- * else about the surface changes. The class is named for its flavor rather than
- * sharing that one's `MuxMedia`, so it stays symmetrical with
- * `@videojs/spf/mux-audio` — which needs a distinct name whatever this one is
- * called.
+ * The hls.js-backed counterpart lives at `@videojs/media/dom/mux`. That is the PRD's three-import-paths design: the
+ * import path picks the engine, and nothing else about the surface changes. The class is named for its flavor rather
+ * than sharing that one's `MuxMedia`, so it stays symmetrical with `@videojs/spf/mux-audio` — which needs a distinct
+ * name whatever this one is called.
  *
- * `MuxMediaMixin` and the `MuxMedia*` types are the Mux identity both flavors
- * share, so they keep the unqualified name.
+ * `MuxMediaMixin` and the `MuxMedia*` types are the Mux identity both flavors share, so they keep the unqualified name.
  */
 export type { MuxContentData, MuxSourceBase } from '@videojs/media/dom/mux/source';
 export type { MuxMediaAPI, MuxMediaProps } from './adapter';

--- a/packages/spf/src/playback/adapters/mux-video/media.ts
+++ b/packages/spf/src/playback/adapters/mux-video/media.ts
@@ -6,15 +6,13 @@ const MuxVideoMediaBase = MuxMediaMixin(HlsVideoMedia);
 /**
  * The Mux Media over the SPF HLS engine.
  *
- * Mirrors `@videojs/media/dom/mux`'s hls.js-backed `MuxMedia` — same class shape,
- * same `src`/`source` relationship, same derived `contentData` — over a different
- * engine, though named for the flavor rather than sharing that class's name. It
- * carries no `engine` or `preferPlayback`: SPF publishes no
- * engine-shaped config for a consumer to pass, so the source is Mux identity and
- * nothing else.
+ * Mirrors `@videojs/media/dom/mux`'s hls.js-backed `MuxMedia` — same class shape, same `src`/`source` relationship,
+ * same derived `contentData` — over a different engine, though named for the flavor rather than sharing that class's
+ * name. It carries no `engine` or `preferPlayback`: SPF publishes no engine-shaped config for a consumer to pass, so
+ * the source is Mux identity and nothing else.
  *
- * `source.drm` is accepted but inert. SPF prunes encrypted renditions and reports
- * unsupported DRM, and `alternativeMediaSuggestion` points at the hls.js-backed
- * import, so a protected source fails with copy that says where to go.
+ * `source.drm` is accepted but inert. SPF prunes encrypted renditions and reports unsupported DRM, and
+ * `alternativeMediaSuggestion` points at the hls.js-backed import, so a protected source fails with copy that says
+ * where to go.
  */
 export class MuxVideoMedia extends MuxVideoMediaBase {}

--- a/packages/spf/src/playback/adapters/mux-video/tests/media.test.ts
+++ b/packages/spf/src/playback/adapters/mux-video/tests/media.test.ts
@@ -1,10 +1,8 @@
 /**
  * SPF-backed MuxVideoMedia tests.
  *
- * Mirrors the coverage of the hls.js-backed `MuxMedia`
- * (`packages/media/src/dom/mux/tests/mux-media.test.ts`), minus everything that
- * flavor's `engine` / `preferPlayback` options carry — this source is Mux
- * identity and nothing else.
+ * Mirrors the coverage of the hls.js-backed `MuxMedia` (`packages/media/src/dom/mux/tests/mux-media.test.ts`), minus
+ * everything that flavor's `engine` / `preferPlayback` options carry — this source is Mux identity and nothing else.
  */
 import { describe, expect, it, vi } from 'vite-plus/test';
 

--- a/packages/spf/src/playback/behaviors/calculate-presentation-duration.ts
+++ b/packages/spf/src/playback/behaviors/calculate-presentation-duration.ts
@@ -1,31 +1,26 @@
 /**
  * **Populate presentation duration via a config-supplied resolver.**
  *
- * Once a presentation is in place and its `duration` is still undefined,
- * calls `config.resolveDuration(state)` whenever a tracked slot changes. The
- * resolver decides what counts as "duration is now derivable" for the variant
- * in play; the behavior itself stays variant-agnostic:
+ * Once a presentation is in place and its `duration` is still undefined, calls `config.resolveDuration(state)` whenever
+ * a tracked slot changes. The resolver decides what counts as "duration is now derivable" for the variant in play; the
+ * behavior itself stays variant-agnostic:
  *
- * - **VoD** — derive from the first resolved selected track's `duration`
- *   (video preferred, audio fallback). The HLS engine wires
- *   `getResolvedSelectedTrackDuration` from `media/utils/track-selection.ts`
- *   as the default. Audio-only falls out of the same resolver naturally
- *   (no video selected → audio is the first resolved track).
- * - **Live** — return `Number.POSITIVE_INFINITY` once the presentation is
- *   established as live. This is the MSE-spec value for `mediaSource.duration`
- *   under live playback; downstream `updateMediaSourceDuration` propagates it through.
+ * - **VoD** — derive from the first resolved selected track's `duration` (video preferred, audio fallback). The HLS
+ *   engine wires `getResolvedSelectedTrackDuration` from `media/utils/track-selection.ts` as the default. Audio-only
+ *   falls out of the same resolver naturally (no video selected → audio is the first resolved track).
+ * - **Live** — return `Number.POSITIVE_INFINITY` once the presentation is established as live. This is the MSE-spec value
+ *   for `mediaSource.duration` under live playback; downstream `updateMediaSourceDuration` propagates it through.
  *
- * Validation: writes whatever the resolver returns as long as it's a positive
- * number, including `Infinity`. `undefined` / `NaN` / `<= 0` are skipped.
+ * Validation: writes whatever the resolver returns as long as it's a positive number, including `Infinity`. `undefined`
+ * / `NaN` / `<= 0` are skipped.
  *
- * Fires at most once per presentation — an already-set `duration` is never
- * overwritten, and the next reset arrives structurally when a new
- * (unresolved) presentation replaces the current one. The resolver may
- * return `undefined` while duration is still indeterminate; subsequent
- * tracked-slot changes re-run the effect until the resolver commits a value.
+ * Fires at most once per presentation — an already-set `duration` is never overwritten, and the next reset arrives
+ * structurally when a new (unresolved) presentation replaces the current one. The resolver may return `undefined` while
+ * duration is still indeterminate; subsequent tracked-slot changes re-run the effect until the resolver commits a
+ * value.
  *
- * Downstream of `resolveVideoTrack` / `resolveAudioTrack`; upstream of
- * `updateMediaSourceDuration` (which writes the value through to `mediaSource.duration`).
+ * Downstream of `resolveVideoTrack` / `resolveAudioTrack`; upstream of `updateMediaSourceDuration` (which writes the
+ * value through to `mediaSource.duration`).
  */
 import type { Behavior } from '../../core/composition/create-composition';
 import { effect } from '../../core/signals/effect';
@@ -33,11 +28,9 @@ import { type ReadonlySignal, type Signal, untrack, update } from '../../core/si
 import type { MaybeResolvedPresentation } from '../../media/types';
 
 /**
- * Input shape passed to the duration resolver. Represents the union of
- * track-selection slots the default `getResolvedSelectedTrackDuration`
- * resolver inspects to pick a representative resolved track. Variants
- * that compose neither audio nor video selection still satisfy this
- * shape — the missing fields read as `undefined` and the resolver
+ * Input shape passed to the duration resolver. Represents the union of track-selection slots the default
+ * `getResolvedSelectedTrackDuration` resolver inspects to pick a representative resolved track. Variants that compose
+ * neither audio nor video selection still satisfy this shape — the missing fields read as `undefined` and the resolver
  * falls through.
  */
 export interface PresentationDurationState {
@@ -47,9 +40,8 @@ export interface PresentationDurationState {
 }
 
 /**
- * Resolver supplied via `config.resolveDuration`. Returns the duration to
- * write to `presentation.duration`, or `undefined` when it isn't yet
- * derivable. Positive `Infinity` is the canonical live value.
+ * Resolver supplied via `config.resolveDuration`. Returns the duration to write to `presentation.duration`, or
+ * `undefined` when it isn't yet derivable. Positive `Infinity` is the canonical live value.
  */
 export type PresentationDurationResolver = (state: PresentationDurationState) => number | undefined;
 
@@ -104,14 +96,11 @@ function calculatePresentationDurationSetup({
 }
 
 /**
- * `calculatePresentationDuration` uses a manual `Behavior<>` literal
- * (rather than `defineBehavior`) so it can declare just `presentation`
- * in its stateKeys while the typed setup-param shape includes the
- * optional `selectedVideoTrackId` / `selectedAudioTrackId` reads used
- * at runtime. Mirrors the pattern in `endOfStream` for the same
- * reason: the behavior is uniform-across-tracks and reads slots
- * contributed by other behaviors, so it shouldn't leak those slot
- * declarations into variants that don't compose the contributors.
+ * `calculatePresentationDuration` uses a manual `Behavior<>` literal (rather than `defineBehavior`) so it can declare
+ * just `presentation` in its stateKeys while the typed setup-param shape includes the optional `selectedVideoTrackId` /
+ * `selectedAudioTrackId` reads used at runtime. Mirrors the pattern in `endOfStream` for the same reason: the behavior
+ * is uniform-across-tracks and reads slots contributed by other behaviors, so it shouldn't leak those slot declarations
+ * into variants that don't compose the contributors.
  */
 export const calculatePresentationDuration: Behavior<
   { presentation: Signal<PresentationDurationState['presentation']> },

--- a/packages/spf/src/playback/behaviors/collect-errors.ts
+++ b/packages/spf/src/playback/behaviors/collect-errors.ts
@@ -1,26 +1,21 @@
 /**
- * **Owns the engine's error sequence.** Reporters append through
- * {@link emitError}; this behavior owns the slot and its per-source lifecycle,
- * clearing it on exit so a new source starts clean and the sequence can't grow
- * unbounded across a session.
+ * **Owns the engine's error sequence.** Reporters append through {@link emitError}; this behavior owns the slot and its
+ * per-source lifecycle, clearing it on exit so a new source starts clean and the sequence can't grow unbounded across a
+ * session.
  *
- * Same split as `setupFailoverMonitor` and `failedCdns`: writes come from
- * wherever the condition is detected, one behavior owns the slot. Deliberately
- * has no `effects` — it holds no policy and derives nothing. Severity is decided
- * at the adapter, not here (see `internal/design/spf/features/errors.md`), which
- * is why this is a lifecycle owner rather than an error *handler*.
+ * Same split as `setupFailoverMonitor` and `failedCdns`: writes come from wherever the condition is detected, one
+ * behavior owns the slot. Deliberately has no `effects` — it holds no policy and derives nothing. Severity is decided
+ * at the adapter, not here (see `internal/design/spf/features/errors.md`), which is why this is a lifecycle owner
+ * rather than an error _handler_.
  *
- * Clearing binds to *exit* of `presentation-resolved`, mirroring the sibling
- * mixins' clear-on-teardown (`emptied` / `MEDIA_DETACHED`). A live reload swaps
- * the presentation object without leaving the resolved state, so it doesn't
- * clear — only an actual source change or destroy does. Known gap: a
- * resolved→resolved source swap that never passes through unresolved carries the
- * prior source's errors forward; `resolve-track` guards the same transition with
- * a commit-time id check, and doing likewise here is a follow-up.
+ * Clearing binds to _exit_ of `presentation-resolved`, mirroring the sibling mixins' clear-on-teardown (`emptied` /
+ * `MEDIA_DETACHED`). A live reload swaps the presentation object without leaving the resolved state, so it doesn't
+ * clear — only an actual source change or destroy does. Known gap: a resolved→resolved source swap that never passes
+ * through unresolved carries the prior source's errors forward; `resolve-track` guards the same transition with a
+ * commit-time id check, and doing likewise here is a follow-up.
  *
- * The vocabulary itself ({@link SvtaError} and the codes) is DOM- and
- * signal-free in `media/errors`; only the write seam lives here, with the slot
- * it writes.
+ * The vocabulary itself ({@link SvtaError} and the codes) is DOM- and signal-free in `media/errors`; only the write
+ * seam lives here, with the slot it writes.
  */
 
 import { defineBehavior } from '../../core/composition/create-composition';
@@ -36,9 +31,8 @@ export interface CollectErrorsState {
 }
 
 /**
- * State an error reporter writes into. The slot is *optional*: a behavior reports
- * through this seam without declaring ownership in its own typed slice, and
- * emission no-ops when `collectErrors` isn't composed. Same contract as
+ * State an error reporter writes into. The slot is _optional_: a behavior reports through this seam without declaring
+ * ownership in its own typed slice, and emission no-ops when `collectErrors` isn't composed. Same contract as
  * `failedCdns` / `failoverFetch`.
  */
 export interface ErrorEmitterState {
@@ -46,22 +40,18 @@ export interface ErrorEmitterState {
 }
 
 /**
- * Append `error` to the engine's error sequence. No-op when no owner is
- * composed. Replaces the array rather than mutating it, so signal consumers
- * notify; duplicates are kept, since a repeated condition is a real observation.
- * Writes go through `update` so concurrent reporters can't lose each other's
- * appends.
+ * Append `error` to the engine's error sequence. No-op when no owner is composed. Replaces the array rather than
+ * mutating it, so signal consumers notify; duplicates are kept, since a repeated condition is a real observation.
+ * Writes go through `update` so concurrent reporters can't lose each other's appends.
  *
- * Every emission is logged, deliberately *before* the owner check. A condition
- * emitted with no `collectErrors` composed is dropped on the floor — that's the
- * case where a log is the only evidence it happened at all, so gating the log on
- * the same check would hide exactly what's worth seeing. Emissions that *are*
- * collected still get logged, because reaching `state.errors` is no guarantee of
- * reaching a person: only *verdicts* are promoted to the media surface, so every
- * cause (and any non-fatal notice) is otherwise invisible outside a debugger.
+ * Every emission is logged, deliberately _before_ the owner check. A condition emitted with no `collectErrors` composed
+ * is dropped on the floor — that's the case where a log is the only evidence it happened at all, so gating the log on
+ * the same check would hide exactly what's worth seeing. Emissions that _are_ collected still get logged, because
+ * reaching `state.errors` is no guarantee of reaching a person: only _verdicts_ are promoted to the media surface, so
+ * every cause (and any non-fatal notice) is otherwise invisible outside a debugger.
  *
- * Ungated rather than `__DEV__`-only, matching the other reporting paths in this
- * package (`resolve-presentation`, `track-switching`, the segment actors).
+ * Ungated rather than `__DEV__`-only, matching the other reporting paths in this package (`resolve-presentation`,
+ * `track-switching`, the segment actors).
  */
 export function emitError(state: ErrorEmitterState, error: SvtaError): void {
   console.error('[spf] reported condition', error);
@@ -72,31 +62,27 @@ export function emitError(state: ErrorEmitterState, error: SvtaError): void {
 }
 
 /**
- * A "constraint" that reports a type the source carries **no** renditions of, for
- * a composition that can't play without it.
+ * A "constraint" that reports a type the source carries **no** renditions of, for a composition that can't play without
+ * it.
  *
- * Strange on purpose, and the strangeness is the point: it never constrains
- * anything, always returning its input untouched. It is shaped as a rule so a
- * composition opts in by adding it to `constraints` — nothing to thread through
+ * Strange on purpose, and the strangeness is the point: it never constrains anything, always returning its input
+ * untouched. It is shaped as a rule so a composition opts in by adding it to `constraints` — nothing to thread through
  * config, and no cost at all to a composition that leaves it out.
  *
- * **Belongs last in the chain.** A constraint sees the list as it stands at its
- * own position, so only at the tail does an empty input mean "nothing playable
- * here" — none of this type offered, or the constraints ahead pruned them all.
+ * **Belongs last in the chain.** A constraint sees the list as it stands at its own position, so only at the tail does
+ * an empty input mean "nothing playable here" — none of this type offered, or the constraints ahead pruned them all.
  *
- * These are the failures no per-rendition cause can report: causes come from
- * `reportUnsupportedTrackConditions` as each media playlist resolves, and a
- * rendition pruned before selection never resolves. Container and encryption
- * aren't knowable until one does; CODECS is, so an undecodable ladder isn't.
+ * These are the failures no per-rendition cause can report: causes come from `reportUnsupportedTrackConditions` as each
+ * media playlist resolves, and a rendition pruned before selection never resolves. Container and encryption aren't
+ * knowable until one does; CODECS is, so an undecodable ladder isn't.
  *
- * Idempotent because the constraint chain runs inside a `computed` that re-derives
- * on every `presentation` write — segment appends and live reloads included — and
- * the sequence deliberately keeps duplicates. `peek` is what keeps that computed
- * from subscribing to the slot this writes.
+ * Idempotent because the constraint chain runs inside a `computed` that re-derives on every `presentation` write —
+ * segment appends and live reloads included — and the sequence deliberately keeps duplicates. `peek` is what keeps that
+ * computed from subscribing to the slot this writes.
  *
  * @example
- * // engine-background-video.ts — video-only, so a source with none can't play
- * constraints: [excludeUnplayableTracks, reportAbsentTrackType(SVTA_NO_SUPPORTED_VIDEO_TRACK)]
+ *   // engine-background-video.ts — video-only, so a source with none can't play
+ *   constraints: [excludeUnplayableTracks, reportAbsentTrackType(SVTA_NO_SUPPORTED_VIDEO_TRACK)];
  */
 export function reportAbsentTrackType<T>(code: number): SelectionRule<T, ErrorEmitterState> {
   return (tracks, { state }) => {
@@ -114,7 +100,7 @@ export function reportAbsentTrackType<T>(code: number): SelectionRule<T, ErrorEm
  * Own `errors` for the resolved source's lifetime.
  *
  * @example
- * const reactor = collectErrors.setup({ state });
+ *   const reactor = collectErrors.setup({ state });
  */
 export const collectErrors = defineBehavior({
   stateKeys: ['presentation', 'errors'],

--- a/packages/spf/src/playback/behaviors/derive-cdn-priority.ts
+++ b/packages/spf/src/playback/behaviors/derive-cdn-priority.ts
@@ -1,28 +1,22 @@
 /**
- * **Session-level CDN priority.** While a presentation is resolved, owns the
- * `cdnPriority` signal: the distinct CDNs the source is served from (origin of
- * each track's URL), in manifest priority order — most-preferred first. Cleared
- * on src unload. The name mirrors HLS content steering's `PATHWAY-PRIORITY`.
+ * **Session-level CDN priority.** While a presentation is resolved, owns the `cdnPriority` signal: the distinct CDNs
+ * the source is served from (origin of each track's URL), in manifest priority order — most-preferred first. Cleared on
+ * src unload. The name mirrors HLS content steering's `PATHWAY-PRIORITY`.
  *
- * Redundant-stream sources (e.g. Mux's `?redundant_streams=true`) list the same
- * content on multiple hosts, so the candidate tracks already include one variant
- * per CDN. This behavior publishes *which* CDNs exist and their priority; the
- * `preferActiveCdn` scope rule in `track-switching` reads `cdnPriority` and
- * narrows each type's candidates to the first CDN with surviving tracks — so
- * video / audio / text all resolve from one host (the shared list is the
+ * Redundant-stream sources (e.g. Mux's `?redundant_streams=true`) list the same content on multiple hosts, so the
+ * candidate tracks already include one variant per CDN. This behavior publishes _which_ CDNs exist and their priority;
+ * the `preferActiveCdn` scope rule in `track-switching` reads `cdnPriority` and narrows each type's candidates to the
+ * first CDN with surviving tracks — so video / audio / text all resolve from one host (the shared list is the
  * per-presentation coherence guarantee).
  *
- * The "active" CDN is not stored — it's derived by the scope as the
- * highest-priority entry in `cdnPriority` that still has tracks after the
- * constraints pre-pass. That makes failover a pure consequence of the (future)
- * failed-CDN constraint: when the primary's tracks are pruned during cooldown,
- * the scope falls to the next CDN; when the primary recovers, it snaps back.
- * Content steering, when it lands, reorders `cdnPriority` (pathway priority as a
- * sort key).
+ * The "active" CDN is not stored — it's derived by the scope as the highest-priority entry in `cdnPriority` that still
+ * has tracks after the constraints pre-pass. That makes failover a pure consequence of the (future) failed-CDN
+ * constraint: when the primary's tracks are pruned during cooldown, the scope falls to the next CDN; when the primary
+ * recovers, it snaps back. Content steering, when it lands, reorders `cdnPriority` (pathway priority as a sort key).
  *
- * Lifecycle: `'presentation-unresolved'` ↔ `'presentation-resolved'`, mirroring
- * `setupTrackSwitching`. The resolved state owns the signal; its entry-returned
- * cleanup clears it on exit (canonical cleanup-binds-to-setup per `reactors.md`).
+ * Lifecycle: `'presentation-unresolved'` ↔ `'presentation-resolved'`, mirroring `setupTrackSwitching`. The resolved
+ * state owns the signal; its entry-returned cleanup clears it on exit (canonical cleanup-binds-to-setup per
+ * `reactors.md`).
  */
 
 import { defineBehavior } from '../../core/composition/create-composition';
@@ -40,11 +34,10 @@ const samePriority = (a: string[] | undefined, b: string[]): boolean =>
   !!a && a.length === b.length && a.every((cdn, i) => cdn === b[i]);
 
 /**
- * Manage `cdnPriority`: publish the manifest-ordered CDN list on src load, clear
- * on src unload.
+ * Manage `cdnPriority`: publish the manifest-ordered CDN list on src load, clear on src unload.
  *
  * @example
- * const reactor = deriveCdnPriority.setup({ state });
+ *   const reactor = deriveCdnPriority.setup({ state });
  */
 export const deriveCdnPriority = defineBehavior({
   stateKeys: ['presentation', 'cdnPriority'],

--- a/packages/spf/src/playback/behaviors/dom/airplay.ts
+++ b/packages/spf/src/playback/behaviors/dom/airplay.ts
@@ -1,62 +1,43 @@
 /**
- * **Bridge MSE playback to AirPlay on WebKit.**
- * MSE streams can't be handed to an AirPlay receiver directly.
- * The WebKit-recommended workaround is to append a fallback
- * `<source type="application/x-mpegURL">` carrying the original manifest URL:
- * Safari exposes the AirPlay picker and, when a wireless target is selected,
- * plays that native-HLS source on the receiver. The session state (WebKit's
- * wireless flag, falling edge debounced — see `REMOTE_INACTIVE_SETTLE_MS`) is
- * written straight to its policy consequences, declared here so the
- * cause→policy mapping stays with the feature:
+ * **Bridge MSE playback to AirPlay on WebKit.** MSE streams can't be handed to an AirPlay receiver directly. The
+ * WebKit-recommended workaround is to append a fallback `<source type="application/x-mpegURL">` carrying the original
+ * manifest URL: Safari exposes the AirPlay picker and, when a wireless target is selected, plays that native-HLS source
+ * on the receiver. The session state (WebKit's wireless flag, falling edge debounced — see `REMOTE_INACTIVE_SETTLE_MS`)
+ * is written straight to its policy consequences, declared here so the cause→policy mapping stays with the feature:
  *
- * - `state.loadingSuspended` — held while the session is live. Observed by
- *   the `loadXSegments` dispatchers (no fetching alongside the receiver) and
- *   by `setupMediaSource` (its post-close rebuild waits — attaching runs
- *   `element.load()` under the live receiver, which destroys a session still
- *   being established). The suspension this behavior holds doubles as its own
- *   session fact — same writer, same edges.
- * - `state.startPosition` — one-shot command: the position is captured from
- *   the element at the session's settled end (still receiver-mirrored) and
- *   written once the rebuild's `load()` resets the element (its `'emptied'`),
- *   so `applyStartPosition` applies it to the rebuilt source — never to the
- *   pre-rebuild element — and starts it where the receiver left off. The
- *   playing state rides the same snapshot but stays behavior-local: this
- *   behavior itself calls `play()` once the command has been *consumed* — i.e.
- *   after the seek — when the receiver was playing at session end. The whole
- *   restore is bound to the presentation the session owned and retracted if
- *   that changes.
+ * - `state.loadingSuspended` — held while the session is live. Observed by the `loadXSegments` dispatchers (no fetching
+ *   alongside the receiver) and by `setupMediaSource` (its post-close rebuild waits — attaching runs `element.load()`
+ *   under the live receiver, which destroys a session still being established). The suspension this behavior holds
+ *   doubles as its own session fact — same writer, same edges.
+ * - `state.startPosition` — one-shot command: the position is captured from the element at the session's settled end
+ *   (still receiver-mirrored) and written once the rebuild's `load()` resets the element (its `'emptied'`), so
+ *   `applyStartPosition` applies it to the rebuilt source — never to the pre-rebuild element — and starts it where the
+ *   receiver left off. The playing state rides the same snapshot but stays behavior-local: this behavior itself calls
+ *   `play()` once the command has been _consumed_ — i.e. after the seek — when the receiver was playing at session end.
+ *   The whole restore is bound to the presentation the session owned and retracted if that changes.
  *
- * A source change during a live session releases the hold rather than deferring
- * until the session ends, so the rebuild runs and WebKit switches the receiver
- * to the newly-built AirPlay alternate. Measured, not contracted — see the
- * effect below.
- * https://webkit.org/blog/15036/how-to-use-media-source-extensions-with-airplay/
+ * A source change during a live session releases the hold rather than deferring until the session ends, so the rebuild
+ * runs and WebKit switches the receiver to the newly-built AirPlay alternate. Measured, not contracted — see the effect
+ * below. https://webkit.org/blog/15036/how-to-use-media-source-extensions-with-airplay/
  *
- * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'airplay-capable'`):
- * gated on a WebKit-AirPlay-capable media element being in scope. The entry —
- * gated on `context.mediaSource` — appends the fallback `<source>` (kept
- * current from `state.presentation`) and enables the AirPlay picker once the
- * MediaSource is open, removing the source the moment the MediaSource detaches
- * so it never survives an MSE teardown. State-exit cleanup (author opt-out,
- * detach, source reset, behavior destroy) removes the source and restores the
- * element's `disableRemotePlayback` default. No-op on non-WebKit platforms
- * (Chromium, Firefox) — `deriveState` never leaves `'preconditions-unmet'`.
+ * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'airplay-capable'`): gated on a WebKit-AirPlay-capable
+ * media element being in scope. The entry — gated on `context.mediaSource` — appends the fallback `<source>` (kept
+ * current from `state.presentation`) and enables the AirPlay picker once the MediaSource is open, removing the source
+ * the moment the MediaSource detaches so it never survives an MSE teardown. State-exit cleanup (author opt-out, detach,
+ * source reset, behavior destroy) removes the source and restores the element's `disableRemotePlayback` default. No-op
+ * on non-WebKit platforms (Chromium, Firefox) — `deriveState` never leaves `'preconditions-unmet'`.
  *
- * MMS and AirPlay want *opposite* values of `disableRemotePlayback` on the same
- * element, so it is **sequenced**:
+ * MMS and AirPlay want _opposite_ values of `disableRemotePlayback` on the same element, so it is **sequenced**:
  *
- * - **MMS needs `true` to open.** `setupMediaSource` sets
- *   `disableRemotePlayback = true` when it attaches a ManagedMediaSource —
- *   Safari won't fire `sourceopen` (and MSE playback never starts) otherwise.
- * - **AirPlay needs `false` to offer the picker.** Flipping to `false` *before*
- *   the source opens would prevent `sourceopen`, so the flip is gated on
- *   `context.mediaSource` — which `setupMediaSource` publishes exactly once the
+ * - **MMS needs `true` to open.** `setupMediaSource` sets `disableRemotePlayback = true` when it attaches a
+ *   ManagedMediaSource — Safari won't fire `sourceopen` (and MSE playback never starts) otherwise.
+ * - **AirPlay needs `false` to offer the picker.** Flipping to `false` _before_ the source opens would prevent
+ *   `sourceopen`, so the flip is gated on `context.mediaSource` — which `setupMediaSource` publishes exactly once the
  *   MS is open. Re-fires per source (the slot clears + republishes on reset).
- * - **Author opt-out wins.** `state.disableRemotePlayback` is the author's
- *   intent, written only by the media adapter's IDL property; MMS/programmatic
- *   code touch the element's own `disableRemotePlayback` instead. A `true`
- *   there is unambiguously the author's choice to disable remote playback, so
- *   it holds the machine in `'preconditions-unmet'` and nothing is set up.
+ * - **Author opt-out wins.** `state.disableRemotePlayback` is the author's intent, written only by the media adapter's
+ *   IDL property; MMS/programmatic code touch the element's own `disableRemotePlayback` instead. A `true` there is
+ *   unambiguously the author's choice to disable remote playback, so it holds the machine in `'preconditions-unmet'`
+ *   and nothing is set up.
  */
 
 import { isWebKitAirPlayCapable, listen, type WebKitVideoElement } from '@videojs/utils/dom';
@@ -71,16 +52,12 @@ import type { StartPositionState } from './apply-start-position';
 import type { SegmentLoadingState } from './load-segments';
 
 /**
- * How long WebKit's wireless flag must read *inactive* before the
- * session-driven `loadingSuspended` clears.
+ * How long WebKit's wireless flag must read _inactive_ before the session-driven `loadingSuspended` clears.
  *
- * Measured on Safari 26.4 (macOS): when an AirPlay session engages, Safari
- * closes the ManagedMediaSource and — while its pipeline switches to the
- * native-HLS fallback source — transiently reports
- * `webkitCurrentPlaybackTargetIsWireless === false`, firing the changed
- * event. Trusting an instantaneous inactive reading would release
- * `setupMediaSource`'s rebuild hold mid-handoff; its recovery `load()` then
- * destroys the very session being established. Rising edges apply
+ * Measured on Safari 26.4 (macOS): when an AirPlay session engages, Safari closes the ManagedMediaSource and — while
+ * its pipeline switches to the native-HLS fallback source — transiently reports `webkitCurrentPlaybackTargetIsWireless
+ * === false`, firing the changed event. Trusting an instantaneous inactive reading would release `setupMediaSource`'s
+ * rebuild hold mid-handoff; its recovery `load()` then destroys the very session being established. Rising edges apply
  * immediately; only the falling edge waits out this settle window.
  */
 const REMOTE_INACTIVE_SETTLE_MS = 1000;

--- a/packages/spf/src/playback/behaviors/dom/apply-start-position.ts
+++ b/packages/spf/src/playback/behaviors/dom/apply-start-position.ts
@@ -1,46 +1,34 @@
 /**
- * **Start playback of a source at a requested position.** `state.startPosition`
- * is a one-shot command — "when the current source can seek, start there" —
- * the SPF analogue of hls.js's `startPosition` (and the primitive `EXT-X-START`,
- * resume-where-you-left-off, and MediaSource-recovery restore build on).
- * Consumers (adapters, `setupAirPlay`'s session-end snapshot) write it;
- * this behavior is its sole consumer and clears it after applying, so a
- * stale position can never replay against a later source or rebuild.
+ * **Start playback of a source at a requested position.** `state.startPosition` is a one-shot command — "when the
+ * current source can seek, start there" — the SPF analogue of hls.js's `startPosition` (and the primitive
+ * `EXT-X-START`, resume-where-you-left-off, and MediaSource-recovery restore build on). Consumers (adapters,
+ * `setupAirPlay`'s session-end snapshot) write it; this behavior is its sole consumer and clears it after applying, so
+ * a stale position can never replay against a later source or rebuild.
  *
- * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'position-pending'`):
- * gated on `mediaElement + resolved presentation + startPosition` defined.
- * The entry applies the command in two steps:
+ * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'position-pending'`): gated on `mediaElement + resolved
+ * presentation + startPosition` defined. The entry applies the command in two steps:
  *
- * 1. **Seed `state.currentTime` immediately.** The segment loaders anchor
- *    their load window on `state.currentTime`; seeding points the *first*
- *    fetches at the requested position instead of 0. Multi-writer with
- *    `trackCurrentTime` (ongoing DOM mirror) — legitimate: different decision
- *    domains (element-derived mirror vs one-shot command), and before
- *    HAVE_METADATA no `timeupdate`/`seeking` fires to overwrite the seed.
- *    Compose this behavior *after* `trackCurrentTime` so the seed lands after
- *    the mirror's attach-time sync.
- * 2. **Seek the element at metadata.** `element.currentTime = position` once
- *    `readyState >= HAVE_METADATA` (immediately if already there, else on
- *    `loadedmetadata`), then clear `startPosition` (consume). The element
- *    clamps the seek to its seekable range per spec, and the resulting
- *    `seeking` event flows back through `trackCurrentTime` — from here the
+ * 1. **Seed `state.currentTime` immediately.** The segment loaders anchor their load window on `state.currentTime`;
+ *    seeding points the _first_ fetches at the requested position instead of 0. Multi-writer with `trackCurrentTime`
+ *    (ongoing DOM mirror) — legitimate: different decision domains (element-derived mirror vs one-shot command), and
+ *    before HAVE_METADATA no `timeupdate`/`seeking` fires to overwrite the seed. Compose this behavior _after_
+ *    `trackCurrentTime` so the seed lands after the mirror's attach-time sync.
+ * 2. **Seek the element at metadata.** `element.currentTime = position` once `readyState >= HAVE_METADATA` (immediately if
+ *    already there, else on `loadedmetadata`), then clear `startPosition` (consume). The element clamps the seek to its
+ *    seekable range per spec, and the resulting `seeking` event flows back through `trackCurrentTime` — from here the
  *    ordinary seek path owns the position.
  *
- * Position only — playing/paused is deliberately out of scope. The media
- * element load algorithm forces `paused = true`, so a source that was
- * playing before a rebuild comes back paused at the restored position;
- * resume intent belongs to whoever commands the start (e.g. `setupAirPlay`
- * restores its session-end playing state itself).
+ * Position only — playing/paused is deliberately out of scope. The media element load algorithm forces `paused = true`,
+ * so a source that was playing before a rebuild comes back paused at the restored position; resume intent belongs to
+ * whoever commands the start (e.g. `setupAirPlay` restores its session-end playing state itself).
  *
- * Deliberately NOT relying on the pre-metadata "default playback start
- * position" write (setting `currentTime` at HAVE_NOTHING): cross-browser MSE
- * behavior there is inconsistent; the explicit `loadedmetadata` sequencing is
+ * Deliberately NOT relying on the pre-metadata "default playback start position" write (setting `currentTime` at
+ * HAVE_NOTHING): cross-browser MSE behavior there is inconsistent; the explicit `loadedmetadata` sequencing is
  * deterministic everywhere.
  *
- * State-exit cleanup (source reset, element detach, destroy) drops the
- * pending `loadedmetadata` listener. An *unapplied* command survives a source
- * reset — "start the source I'm loading at P" holds while the presentation
- * routes through unresolved — but is consumed the moment it applies.
+ * State-exit cleanup (source reset, element detach, destroy) drops the pending `loadedmetadata` listener. An
+ * _unapplied_ command survives a source reset — "start the source I'm loading at P" holds while the presentation routes
+ * through unresolved — but is consumed the moment it applies.
  */
 
 import { listen } from '@videojs/utils/dom';
@@ -55,9 +43,8 @@ import { isResolvedPresentation, type MaybeResolvedPresentation } from '../../..
 export interface StartPositionState {
   presentation?: MaybeResolvedPresentation;
   /**
-   * One-shot start-position command in presentation-timeline seconds.
-   * Written by consumers (adapter, recovery snapshot); consumed (cleared)
-   * by `applyStartPosition` once the element seeks.
+   * One-shot start-position command in presentation-timeline seconds. Written by consumers (adapter, recovery
+   * snapshot); consumed (cleared) by `applyStartPosition` once the element seeks.
    */
   startPosition?: number;
   currentTime?: number;

--- a/packages/spf/src/playback/behaviors/dom/end-of-stream.ts
+++ b/packages/spf/src/playback/behaviors/dom/end-of-stream.ts
@@ -1,99 +1,75 @@
 /**
- * **Drive each `open → ended` transition of the MediaSource.** Calls
- * `MediaSource.endOfStream()` once every active buffer actor's
- * currently-loading track is *complete* (finite `Track.duration` — the parser's
- * completeness signal), its temporally last segments are fully appended, and
- * the user has reached them — letting the browser finalize duration and
- * fire `ended` on the media element. The completeness gate keeps it inert for
- * ongoing live (`Track.duration === Infinity`), whose "last segment" is only
- * the rolling edge; a live stream opts in when its duration turns finite.
+ * **Drive each `open → ended` transition of the MediaSource.** Calls `MediaSource.endOfStream()` once every active
+ * buffer actor's currently-loading track is _complete_ (finite `Track.duration` — the parser's completeness signal),
+ * its temporally last segments are fully appended, and the user has reached them — letting the browser finalize
+ * duration and fire `ended` on the media element. The completeness gate keeps it inert for ongoing live
+ * (`Track.duration === Infinity`), whose "last segment" is only the rolling edge; a live stream opts in when its
+ * duration turns finite.
  *
- * Re-fires on every subsequent `open → ended → open` cycle. Per the MSE
- * spec, `appendBuffer()` after `endOfStream()` transitions the MediaSource
- * back to `'open'`; seek-back replays and back-buffer refills that re-load
- * earlier segments take this path, so the behavior must call
- * `endOfStream()` again once the last segments are reappended. The reactor's
- * `'preconditions-unmet'` ↔ `'eos-ready'` cycle *is* the re-arm mechanism:
- * a successful `endOfStream()` flips `mediaSource.readyState` to `'ended'`,
- * which (via the local `msIsOpen` signal) exits `'eos-ready'`; the next
- * `'open'` re-evaluates preconditions and may re-enter.
+ * Re-fires on every subsequent `open → ended → open` cycle. Per the MSE spec, `appendBuffer()` after `endOfStream()`
+ * transitions the MediaSource back to `'open'`; seek-back replays and back-buffer refills that re-load earlier segments
+ * take this path, so the behavior must call `endOfStream()` again once the last segments are reappended. The reactor's
+ * `'preconditions-unmet'` ↔ `'eos-ready'` cycle _is_ the re-arm mechanism: a successful `endOfStream()` flips
+ * `mediaSource.readyState` to `'ended'`, which (via the local `msIsOpen` signal) exits `'eos-ready'`; the next `'open'`
+ * re-evaluates preconditions and may re-enter.
  *
  * # Tracking what's in the buffer
  *
- * Each `SourceBufferActor` knows which track it's currently loading via
- * `initTrackId` (set on the most recent `append-init` message) and which
- * segments it has appended. `deriveState` iterates over the available
- * buffer actors (`[videoBufferActor, audioBufferActor].filter(Boolean)`),
- * resolves each to its track via `findTrackById`, and checks that track's
- * last segment is appended. This means audio-only / video-only / mixed
- * configurations compose uniformly — the body iterates whatever's in
- * scope. No reliance on `selectedTrackId` slots: the actor's view IS the
- * source of truth for "what's being loaded into this buffer."
+ * Each `SourceBufferActor` knows which track it's currently loading via `initTrackId` (set on the most recent
+ * `append-init` message) and which segments it has appended. `deriveState` iterates over the available buffer actors
+ * (`[videoBufferActor, audioBufferActor].filter(Boolean)`), resolves each to its track via `findTrackById`, and checks
+ * that track's last segment is appended. This means audio-only / video-only / mixed configurations compose uniformly —
+ * the body iterates whatever's in scope. No reliance on `selectedTrackId` slots: the actor's view IS the source of
+ * truth for "what's being loaded into this buffer."
  *
- * **Two-fire on mid-end ABR switches**: when a quality switch occurs near
- * end-of-stream, the actor's `initTrackId` still reflects the *old* track
- * until the new init segment is appended. The reactor may fire
- * `endOfStream()` against the old track's last-segment-appended state,
- * then the new init's `appendBuffer()` re-opens the MS, which re-arms us
- * to fire again once the new track's last segment lands. Functionally
- * correct (the browser re-fires `ended` after the re-arm), at the cost of
- * one extra call. Accepted as the price of dropping `selectedTrackId`
- * dependence.
+ * **Two-fire on mid-end ABR switches**: when a quality switch occurs near end-of-stream, the actor's `initTrackId`
+ * still reflects the _old_ track until the new init segment is appended. The reactor may fire `endOfStream()` against
+ * the old track's last-segment-appended state, then the new init's `appendBuffer()` re-opens the MS, which re-arms us
+ * to fire again once the new track's last segment lands. Functionally correct (the browser re-fires `ended` after the
+ * re-arm), at the cost of one extra call. Accepted as the price of dropping `selectedTrackId` dependence.
  *
  * # Buffer-actor idle gate
  *
- * Each actor must be `'idle'` (no queued or in-flight tasks) before we
- * fire. `buffer.updating === false` alone is insufficient: for chunked
- * fMP4 streaming, `updateend` fires after each chunk while the actor's
- * for-await loop synchronously enqueues the next `appendBuffer()` — so
- * the buffer flips `!updating → updating` across a microtask boundary.
- * The actor's `'updating'` state spans the entire multi-chunk append, so
- * `actor.snapshot.value === 'idle'` is the canonical "no more pending or
- * in-flight work" oracle.
+ * Each actor must be `'idle'` (no queued or in-flight tasks) before we fire. `buffer.updating === false` alone is
+ * insufficient: for chunked fMP4 streaming, `updateend` fires after each chunk while the actor's for-await loop
+ * synchronously enqueues the next `appendBuffer()` — so the buffer flips `!updating → updating` across a microtask
+ * boundary. The actor's `'updating'` state spans the entire multi-chunk append, so `actor.snapshot.value === 'idle'` is
+ * the canonical "no more pending or in-flight work" oracle.
  *
- * This bet (actor models the pipeline; `mediaSource.sourceBuffers` models
- * DOM state) is durable as long as the segment loader is the sole writer
- * of `appendBuffer()` calls. A future loop-mode that auto-fetches earlier
- * segments mid-`ended` would require a broader coordination story
- * between SourceBuffers and the MediaSource — possibly via a
- * `MediaSourceActor` — and that's where this gate would want
- * re-evaluating.
+ * This bet (actor models the pipeline; `mediaSource.sourceBuffers` models DOM state) is durable as long as the segment
+ * loader is the sole writer of `appendBuffer()` calls. A future loop-mode that auto-fetches earlier segments
+ * mid-`ended` would require a broader coordination story between SourceBuffers and the MediaSource — possibly via a
+ * `MediaSourceActor` — and that's where this gate would want re-evaluating.
  *
  * # currentTime gate
  *
- * `currentTime` must have reached (within {@link LAST_SEGMENT_REACHED_SLACK})
- * at least one active track's last segment startTime. Prevents `'eos-ready'`
- * entry when a back-buffer `remove()` / `appendBuffer()` briefly re-opens the
- * MediaSource while the user is mid-stream. HLS rendition time-alignment means
- * any active track works as the reference. The slack absorbs the near-end
- * playhead freeze (see the constant) so a tiny final segment doesn't deadlock.
+ * `currentTime` must have reached (within {@link LAST_SEGMENT_REACHED_SLACK}) at least one active track's last segment
+ * startTime. Prevents `'eos-ready'` entry when a back-buffer `remove()` / `appendBuffer()` briefly re-opens the
+ * MediaSource while the user is mid-stream. HLS rendition time-alignment means any active track works as the reference.
+ * The slack absorbs the near-end playhead freeze (see the constant) so a tiny final segment doesn't deadlock.
  *
  * # MS readyState — local subscription
  *
- * The behavior subscribes to `mediaSource`'s readyState changes inside
- * its setup (via `onMediaSourceReadyStateChange`) and mirrors `'open'` to
- * a behavior-local `msIsOpen` signal that `deriveState` reads. No shared
- * `mediaSourceReadyState` slot dependency. Anticipates a future
- * `MediaSourceActor` whose snapshot would expose the same signal — the
- * consumer code wouldn't change.
+ * The behavior subscribes to `mediaSource`'s readyState changes inside its setup (via `onMediaSourceReadyStateChange`)
+ * and mirrors `'open'` to a behavior-local `msIsOpen` signal that `deriveState` reads. No shared
+ * `mediaSourceReadyState` slot dependency. Anticipates a future `MediaSourceActor` whose snapshot would expose the same
+ * signal — the consumer code wouldn't change.
  *
  * # `endOfStream` entry sequence
  *
- * 1. Wait for all SourceBuffers to be idle (DOM-level — defensive,
- *    should already hold given the actor-idle gate in `deriveState`).
- * 2. Set `mediaSource.duration` from `getMaxBufferedEnd` to match actual
- *    container timestamps (`endOfStream()` only clamps up implicitly;
- *    setting it explicitly here keeps the final value deterministic).
+ * 1. Wait for all SourceBuffers to be idle (DOM-level — defensive, should already hold given the actor-idle gate in
+ *    `deriveState`).
+ * 2. Set `mediaSource.duration` from `getMaxBufferedEnd` to match actual container timestamps (`endOfStream()` only clamps
+ *    up implicitly; setting it explicitly here keeps the final value deterministic).
  * 3. Call `mediaSource.endOfStream()`.
  *
- * State-exit cleanup (`controller.abort()`) cancels any in-flight wait
- * on source unload, presentation replace, or behavior destroy.
+ * State-exit cleanup (`controller.abort()`) cancels any in-flight wait on source unload, presentation replace, or
+ * behavior destroy.
  *
  * # Coordination with `updateMediaSourceDuration`
  *
- * `updateMediaSourceDuration` writes the initial `mediaSource.duration`
- * from `presentation.duration` once per source; this behavior writes the
- * final value from the buffered end. Decision domains don't overlap.
+ * `updateMediaSourceDuration` writes the initial `mediaSource.duration` from `presentation.duration` once per source;
+ * this behavior writes the final value from the buffered end. Decision domains don't overlap.
  */
 import type { Behavior } from '../../../core/composition/create-composition';
 import { createMachineReactor } from '../../../core/reactors/create-machine-reactor';
@@ -121,14 +97,12 @@ export interface EndOfStreamContext {
 type EndOfStreamFsmState = 'preconditions-unmet' | 'eos-ready';
 
 /**
- * Slack (seconds) on the "playhead has reached the last segment" gate. A tiny final
- * segment (e.g. Apple's ~44ms last segment) starts right at the buffered end, and the
- * browser freezes the playhead ~50–70ms short of that end (its render horizon), so a
- * strict `currentTime >= lastSegStart` would never open — deadlocking `endOfStream`
- * (the MediaSource stays `'open'`, so the browser keeps the playhead frozen waiting for
- * data/EOS that never comes). This slack lets a playhead stalled just short of the final
- * segment still finalize. Firing slightly early is harmless: the last segment is already
- * appended (the gate above), so no more data is expected.
+ * Slack (seconds) on the "playhead has reached the last segment" gate. A tiny final segment (e.g. Apple's ~44ms last
+ * segment) starts right at the buffered end, and the browser freezes the playhead ~50–70ms short of that end (its
+ * render horizon), so a strict `currentTime >= lastSegStart` would never open — deadlocking `endOfStream` (the
+ * MediaSource stays `'open'`, so the browser keeps the playhead frozen waiting for data/EOS that never comes). This
+ * slack lets a playhead stalled just short of the final segment still finalize. Firing slightly early is harmless: the
+ * last segment is already appended (the gate above), so no more data is expected.
  */
 const LAST_SEGMENT_REACHED_SLACK = 0.5;
 
@@ -290,14 +264,11 @@ function endOfStreamSetup({
 }
 
 /**
- * `endOfStream` uses a manual `Behavior<>` literal (rather than
- * `defineBehavior`) because it reads `videoBufferActor` /
- * `audioBufferActor` defensively without declaring them in its
- * contextKeys — those slots are contributed by other behaviors and
- * compose conditionally per engine variant. The `Behavior<>` literal
- * opts out of the exhaustiveness check so the typed context shape can
- * include the optional fields used at runtime. See the comment on
- * `endOfStreamSetup`'s context param for the discipline.
+ * `endOfStream` uses a manual `Behavior<>` literal (rather than `defineBehavior`) because it reads `videoBufferActor` /
+ * `audioBufferActor` defensively without declaring them in its contextKeys — those slots are contributed by other
+ * behaviors and compose conditionally per engine variant. The `Behavior<>` literal opts out of the exhaustiveness check
+ * so the typed context shape can include the optional fields used at runtime. See the comment on `endOfStreamSetup`'s
+ * context param for the discipline.
  */
 export const endOfStream: Behavior<
   {

--- a/packages/spf/src/playback/behaviors/dom/load-segments.ts
+++ b/packages/spf/src/playback/behaviors/dom/load-segments.ts
@@ -1,50 +1,41 @@
 /**
- * **Per-type segment loading dispatch.** Per available track type (video /
- * audio / text), reads the per-type segment-loader actor from context and
- * sends typed `'load'` messages whenever a meaningful loading condition
- * changes (selected track, current time crossing a segment boundary).
+ * **Per-type segment loading dispatch.** Per available track type (video / audio / text), reads the per-type
+ * segment-loader actor from context and sends typed `'load'` messages whenever a meaningful loading condition changes
+ * (selected track, current time crossing a segment boundary).
  *
  * Loader-actor lifecycle is owned upstream:
+ *
  * - Video: `setupVideoBufferActors`
  * - Audio: `setupAudioBufferActors`
  * - Text: `setupTextTrackActors`
  *
- * This behavior is pure-consumer: it reads `context[loaderKey]` and
- * dispatches typed messages via the variant's per-type `findResolvedTrack`
- * resolver.
+ * This behavior is pure-consumer: it reads `context[loaderKey]` and dispatches typed messages via the variant's
+ * per-type `findResolvedTrack` resolver.
  *
  * # Load modes as reactor states
  *
  * Four states encode the load-gating policy directly:
  *
- * - `'preconditions-unmet'` — no loader actor in context, or the selected
- *   track hasn't resolved.
- * - `'dormant'` — loading disabled by policy: an observed `loadingSuspended`
- *   (highest precedence) or `preload === 'none' && !loadActivated`. Nothing
- *   fires; already-queued loader work drains. Auto-resumes into the derived
- *   state when the policy lifts.
- * - `'metadata-only'` — `!loadActivated && preload !== 'auto' && preload !== 'none'`.
- *   Fires an init-segment-only `load` message **once on entry**. The
- *   variant's loader actor decides what to do — v/a's actor fetches the
- *   init segment; text's actor no-ops (no init concept).
- * - `'full-range'` — `loadActivated || preload === 'auto'`. Effect re-fires
- *   on selected-track change and on segment-boundary crossing.
+ * - `'preconditions-unmet'` — no loader actor in context, or the selected track hasn't resolved.
+ * - `'dormant'` — loading disabled by policy: an observed `loadingSuspended` (highest precedence) or `preload === 'none'
+ *   && !loadActivated`. Nothing fires; already-queued loader work drains. Auto-resumes into the derived state when the
+ *   policy lifts.
+ * - `'metadata-only'` — `!loadActivated && preload !== 'auto' && preload !== 'none'`. Fires an init-segment-only `load`
+ *   message **once on entry**. The variant's loader actor decides what to do — v/a's actor fetches the init segment;
+ *   text's actor no-ops (no init concept).
+ * - `'full-range'` — `loadActivated || preload === 'auto'`. Effect re-fires on selected-track change and on
+ *   segment-boundary crossing.
  *
  * # Per-type parameterization (inference-driven)
  *
- * The helper is generic over `Track` — the resolved-track type. Each
- * variant supplies its own `findResolvedTrack` resolver via config; TS
- * infers `Track` from the resolver's return type. The loader signal's
- * value type is constrained to `SegmentLoaderLike<Track>` — anything with
- * a `send` method accepting the `Track`-parameterized message. Concrete
- * actor types (`SegmentLoaderActor`, `TextTrackSegmentLoaderActor`)
- * satisfy this via function-parameter contravariance: an actor whose
- * `.send` accepts a wider track type is assignable to a slot expecting a
- * narrower track type.
+ * The helper is generic over `Track` — the resolved-track type. Each variant supplies its own `findResolvedTrack`
+ * resolver via config; TS infers `Track` from the resolver's return type. The loader signal's value type is constrained
+ * to `SegmentLoaderLike<Track>` — anything with a `send` method accepting the `Track`-parameterized message. Concrete
+ * actor types (`SegmentLoaderActor`, `TextTrackSegmentLoaderActor`) satisfy this via function-parameter contravariance:
+ * an actor whose `.send` accepts a wider track type is assignable to a slot expecting a narrower track type.
  *
- * No widening of actor message types is needed; no casts inside the
- * helper. Per-variant wiring (right loader paired with right resolver)
- * is enforced at the variant call site.
+ * No widening of actor message types is needed; no casts inside the helper. Per-variant wiring (right loader paired
+ * with right resolver) is enforced at the variant call site.
  */
 import { defineBehavior } from '../../../core/composition/create-composition';
 import type { Reactor } from '../../../core/reactors/create-machine-reactor';
@@ -77,14 +68,11 @@ export interface SegmentLoadingState {
   /** True once a preload-overriding event has fired for the current source. */
   loadActivated?: boolean;
   /**
-   * Intent-level policy input: initiate no new loading work while `true`.
-   * Read here by the `loadXSegments` dispatchers (park in `'dormant'`,
-   * highest precedence) and by `setupMediaSource` (a pending MediaSource
-   * rebuild waits — attach runs the element's load algorithm). **Observed,
-   * never declared**: no reader lists this key in `stateKeys`, so the slot
-   * exists only in compositions where a feature behavior declares and
-   * writes it (e.g. `setupAirPlay`, while a remote-playback session owns
-   * presentation). An absent slot means never suspended.
+   * Intent-level policy input: initiate no new loading work while `true`. Read here by the `loadXSegments` dispatchers
+   * (park in `'dormant'`, highest precedence) and by `setupMediaSource` (a pending MediaSource rebuild waits — attach
+   * runs the element's load algorithm). **Observed, never declared**: no reader lists this key in `stateKeys`, so the
+   * slot exists only in compositions where a feature behavior declares and writes it (e.g. `setupAirPlay`, while a
+   * remote-playback session owns presentation). An absent slot means never suspended.
    */
   loadingSuspended?: boolean;
   selectedVideoTrackId?: string;
@@ -128,15 +116,12 @@ interface SegmentLoaderLike<Track> {
 }
 
 /**
- * Specialization helper. Generic over `Track` (inferred from
- * `findResolvedTrack`'s return type). The loader value type is
- * constrained to `SegmentLoaderLike<Track>` — concrete actor types
- * (whose `.send` accepts a wider track union) satisfy this via
- * function-parameter contravariance.
+ * Specialization helper. Generic over `Track` (inferred from `findResolvedTrack`'s return type). The loader value type
+ * is constrained to `SegmentLoaderLike<Track>` — concrete actor types (whose `.send` accepts a wider track union)
+ * satisfy this via function-parameter contravariance.
  *
- * Tracks that the helper handles must have a `segments` field — used by
- * `segmentBoundarySignal` to compute the load-anchor boundary. Each
- * variant's resolver narrows to the right resolved-track shape.
+ * Tracks that the helper handles must have a `segments` field — used by `segmentBoundarySignal` to compute the
+ * load-anchor boundary. Each variant's resolver narrows to the right resolved-track shape.
  */
 function setupSegmentLoading<
   K extends SelectedTrackKey,

--- a/packages/spf/src/playback/behaviors/dom/recover-end-stall.ts
+++ b/packages/spf/src/playback/behaviors/dom/recover-end-stall.ts
@@ -1,29 +1,25 @@
 /**
- * Recover the end-of-stream stall that Chrome exhibits on skewed A/V. After
- * `endOfStream`, when the audio and video tracks end a few ms apart (e.g. a source
- * with an A/V PTS skew), Chrome's audio-clock-paced playback freezes the playhead
- * ~50–70ms short of the reachable buffered end and never fires `ended` — so playback
- * hangs at the very end and loop never re-triggers. This behavior watches for the
- * `waiting` event that fires at that freeze and, when the MediaSource is `ended` and
- * the playhead sits at the reachable buffered end, nudges `currentTime` to `duration`
- * to force the native `ended`.
+ * Recover the end-of-stream stall that Chrome exhibits on skewed A/V. After `endOfStream`, when the audio and video
+ * tracks end a few ms apart (e.g. a source with an A/V PTS skew), Chrome's audio-clock-paced playback freezes the
+ * playhead ~50–70ms short of the reachable buffered end and never fires `ended` — so playback hangs at the very end and
+ * loop never re-triggers. This behavior watches for the `waiting` event that fires at that freeze and, when the
+ * MediaSource is `ended` and the playhead sits at the reachable buffered end, nudges `currentTime` to `duration` to
+ * force the native `ended`.
  *
- * **Event-driven, no poll.** `waiting` fires at the instant the playhead stalls
- * (measured ~0ms latency), so there's nothing to gain from polling — and polling would
- * add its interval + a stall threshold before reacting.
+ * **Event-driven, no poll.** `waiting` fires at the instant the playhead stalls (measured ~0ms latency), so there's
+ * nothing to gain from polling — and polling would add its interval + a stall threshold before reacting.
  *
- * **Proximity to the *reachable* buffered end** is the discriminator. That end is
- * `getMinBufferedEnd(mediaSource.sourceBuffers)` — the `min` of the per-track (video/audio)
- * SourceBuffer ends, i.e. the furthest point playback can reach — read from the SourceBuffers
- * directly rather than the `mediaElement.buffered` aggregate. Once `endOfStream` is signalled
- * that's the true content end. Requiring the playhead within `endStallNudgeWindow` of it
- * distinguishes the real end-of-stream freeze from a mid-stream buffer-hole stall (which sits
- * far from the buffered end), so we never skip content. The window must exceed the freeze gap;
- * too small would miss the stall (a permanent hang), so the default is generous relative to the
- * measured gap and is config-tunable for empirical tuning.
+ * **Proximity to the _reachable_ buffered end** is the discriminator. That end is
+ * `getMinBufferedEnd(mediaSource.sourceBuffers)` — the `min` of the per-track (video/audio) SourceBuffer ends, i.e. the
+ * furthest point playback can reach — read from the SourceBuffers directly rather than the `mediaElement.buffered`
+ * aggregate. Once `endOfStream` is signalled that's the true content end. Requiring the playhead within
+ * `endStallNudgeWindow` of it distinguishes the real end-of-stream freeze from a mid-stream buffer-hole stall (which
+ * sits far from the buffered end), so we never skip content. The window must exceed the freeze gap; too small would
+ * miss the stall (a permanent hang), so the default is generous relative to the measured gap and is config-tunable for
+ * empirical tuning.
  *
- * Inert where it shouldn't act: live (the MediaSource never reaches `ended` while the
- * window grows; `duration` is `Infinity`) and streams that end cleanly (no `waiting`).
+ * Inert where it shouldn't act: live (the MediaSource never reaches `ended` while the window grows; `duration` is
+ * `Infinity`) and streams that end cleanly (no `waiting`).
  *
  * See `internal/decisions/spf/end-of-stream-av-skew-recovery.md`.
  */
@@ -41,10 +37,9 @@ export interface RecoverEndStallContext {
 
 export interface RecoverEndStallConfig {
   /**
-   * How close (seconds) the playhead must be to the reachable buffered end for a
-   * `waiting` to count as the end-of-stream freeze. Must exceed the audio-clock freeze
-   * gap (~50–70ms measured on Chrome); too small risks missing the stall (a permanent
-   * hang), so keep a margin. Default {@link DEFAULT_END_STALL_NUDGE_WINDOW}.
+   * How close (seconds) the playhead must be to the reachable buffered end for a `waiting` to count as the
+   * end-of-stream freeze. Must exceed the audio-clock freeze gap (~50–70ms measured on Chrome); too small risks missing
+   * the stall (a permanent hang), so keep a margin. Default {@link DEFAULT_END_STALL_NUDGE_WINDOW}.
    */
   endStallNudgeWindow?: number;
 }
@@ -53,10 +48,9 @@ export interface RecoverEndStallConfig {
 export const DEFAULT_END_STALL_NUDGE_WINDOW = 0.2;
 
 /**
- * Whether a `waiting` should be forced to `ended`: the MediaSource is `ended`, the
- * stream is finite (not live), playback is active (not paused/seeking/already-ended),
- * and the playhead sits within `nudgeWindow` of the reachable buffered end (so it's the
- * true end, not a mid-stream buffer hole). Pure — the behavior supplies the live values.
+ * Whether a `waiting` should be forced to `ended`: the MediaSource is `ended`, the stream is finite (not live),
+ * playback is active (not paused/seeking/already-ended), and the playhead sits within `nudgeWindow` of the reachable
+ * buffered end (so it's the true end, not a mid-stream buffer hole). Pure — the behavior supplies the live values.
  */
 export function shouldForceEnded(
   input: {

--- a/packages/spf/src/playback/behaviors/dom/seek-to-live-edge.ts
+++ b/packages/spf/src/playback/behaviors/dom/seek-to-live-edge.ts
@@ -1,51 +1,37 @@
 /**
- * Keep the playhead in the live window, via a two-state reactor gated on the
- * preconditions for "we know where live is":
+ * Keep the playhead in the live window, via a two-state reactor gated on the preconditions for "we know where live is":
  *
- * - **`inactive`** — no media element, or no live edge (`getLiveEdge` is `null`:
- *   VOD, ended, or unresolved). Idle.
- * - **`live`** — preconditions met. `entry` commands `state.startPosition` once
- *   to the target live latency behind the edge (clamped to the window start) so
- *   playback begins near the edge and the loader dispatches an in-window range;
+ * - **`inactive`** — no media element, or no live edge (`getLiveEdge` is `null`: VOD, ended, or unresolved). Idle.
+ * - **`live`** — preconditions met. `entry` commands `state.startPosition` once to the target live latency behind the
+ *   edge (clamped to the window start) so playback begins near the edge and the loader dispatches an in-window range;
  *   `effects` runs the window-exit guard.
  *
- * A derivable live edge is itself the establishment gate: segment placement is
- * settled at parse time — the reference track's local placement *is* the
- * presentation timeline, and every other track's first parse is held until the
- * anchor is stamped (`resolve-track`'s gate + `establishStartMediaTime`) — so
- * any window derived from resolved segments is already final, with no separate
- * anchor signal to wait on (see
+ * A derivable live edge is itself the establishment gate: segment placement is settled at parse time — the reference
+ * track's local placement _is_ the presentation timeline, and every other track's first parse is held until the anchor
+ * is stamped (`resolve-track`'s gate + `establishStartMediaTime`) — so any window derived from resolved segments is
+ * already final, with no separate anchor signal to wait on (see
  * `internal/design/spf/live-presentation-timeline-model.md`).
  *
- * The two pieces split along the axis a future DVR / EVENT mode will care about:
- * the **one-time start position** (`entry`) is the *live-specific* behavior — start
- * near the edge on load; a DVR mode makes it conditional (start in place). The
- * **window-exit guard** (`effects`) is the *general windowed-live* behavior —
- * applies to sliding-window live, DVR, and EVENT alike. Because the command is an
- * `entry`, it fires once per entry into `live`; a source change exits to
- * `inactive`, so the next source re-commands (no closure latch to reset). The
- * guard stays a direct seek — it is recurring, while `startPosition` is a
- * self-clearing one-shot.
+ * The two pieces split along the axis a future DVR / EVENT mode will care about: the **one-time start position**
+ * (`entry`) is the _live-specific_ behavior — start near the edge on load; a DVR mode makes it conditional (start in
+ * place). The **window-exit guard** (`effects`) is the _general windowed-live_ behavior — applies to sliding-window
+ * live, DVR, and EVENT alike. Because the command is an `entry`, it fires once per entry into `live`; a source change
+ * exits to `inactive`, so the next source re-commands (no closure latch to reset). The guard stays a direct seek — it
+ * is recurring, while `startPosition` is a self-clearing one-shot.
  *
- * Window-exit guard: while playing (not paused), reposition to the live edge
- * when the playhead has fallen behind the window start — including when a seek
- * to a now-evicted position has stranded the playhead (such a seek can never
- * settle, so we rescue rather than wait on it). Two triggers:
- * the **window-update re-fire** (the guard reads the live edge, so each reload /
- * slide re-runs it — this catches a stall, where `timeupdate` stops but the
- * playlist keeps reloading) and a **`play` listener** for immediate reactivity on
- * resume, since the reload interval can be seconds. `play`, not `playing`: after
- * a long pause the playhead sits behind the window at an unseekable position,
- * where the browser stalls and `playing` never fires; `play` fires on the
- * paused→false transition regardless, so we snap before the stall. In-window
- * pause / DVR scrub-back are left untouched.
+ * Window-exit guard: while playing (not paused), reposition to the live edge when the playhead has fallen behind the
+ * window start — including when a seek to a now-evicted position has stranded the playhead (such a seek can never
+ * settle, so we rescue rather than wait on it). Two triggers: the **window-update re-fire** (the guard reads the live
+ * edge, so each reload / slide re-runs it — this catches a stall, where `timeupdate` stops but the playlist keeps
+ * reloading) and a **`play` listener** for immediate reactivity on resume, since the reload interval can be seconds.
+ * `play`, not `playing`: after a long pause the playhead sits behind the window at an unseekable position, where the
+ * browser stalls and `playing` never fires; `play` fires on the paused→false transition regardless, so we snap before
+ * the stall. In-window pause / DVR scrub-back are left untouched.
  *
- * The latency comes from the injected `resolveLiveLatency` seam (HLS:
- * `HOLD-BACK`), so this behavior carries no delivery-format specifics.
- * `applyStartPosition` performs the seek, gated on `loadedmetadata` — which
- * implies an open MediaSource and hence a declared seekable range (a seek outside
- * `seekable` is clamped) — so this behavior needs no MediaSource precondition of
- * its own.
+ * The latency comes from the injected `resolveLiveLatency` seam (HLS: `HOLD-BACK`), so this behavior carries no
+ * delivery-format specifics. `applyStartPosition` performs the seek, gated on `loadedmetadata` — which implies an open
+ * MediaSource and hence a declared seekable range (a seek outside `seekable` is clamped) — so this behavior needs no
+ * MediaSource precondition of its own.
  */
 import { listen } from '@videojs/utils/dom';
 
@@ -56,16 +42,16 @@ import type { MaybeResolvedPresentation } from '../../../media/types';
 import { getLiveEdge, type LiveEdge, type ResolveLiveLatency } from '../../primitives/live-window';
 
 /**
- * Tolerance (seconds) around the window edges before the guard repositions, so
- * boundary / floating-point noise doesn't trigger a spurious seek.
+ * Tolerance (seconds) around the window edges before the guard repositions, so boundary / floating-point noise doesn't
+ * trigger a spurious seek.
  */
 const REPOSITION_TOLERANCE = 0.1;
 
 export interface SeekToLiveEdgeState {
   presentation?: MaybeResolvedPresentation;
   /**
-   * One-shot start-position command in presentation-timeline seconds. Written
-   * here on entry into `live`; consumed (cleared) by `applyStartPosition`.
+   * One-shot start-position command in presentation-timeline seconds. Written here on entry into `live`; consumed
+   * (cleared) by `applyStartPosition`.
    */
   startPosition?: number;
   selectedVideoTrackId?: string;
@@ -78,11 +64,10 @@ export interface SeekToLiveEdgeContext {
 
 export interface SeekToLiveEdgeConfig {
   /**
-   * Resolve the target live latency (seconds the playhead should trail the live
-   * edge) for the timeline-bearing track. Injected by the engine so the latency
-   * rule stays format-specific (HLS: `HOLD-BACK`, default 3× target duration;
-   * DASH would read `suggestedPresentationDelay`) while this behavior stays
-   * neutral. Absent → `0` (seek straight to the edge).
+   * Resolve the target live latency (seconds the playhead should trail the live edge) for the timeline-bearing track.
+   * Injected by the engine so the latency rule stays format-specific (HLS: `HOLD-BACK`, default 3× target duration;
+   * DASH would read `suggestedPresentationDelay`) while this behavior stays neutral. Absent → `0` (seek straight to the
+   * edge).
    */
   resolveLiveLatency?: ResolveLiveLatency;
 }
@@ -90,22 +75,18 @@ export interface SeekToLiveEdgeConfig {
 type SeekToLiveEdgeFsmState = 'inactive' | 'live';
 
 /**
- * `'live'` once the preconditions hold: a media element and a derivable live edge
- * (whose placement is final by construction — see the module docstring).
- * `'inactive'` otherwise.
+ * `'live'` once the preconditions hold: a media element and a derivable live edge (whose placement is final by
+ * construction — see the module docstring). `'inactive'` otherwise.
  *
- * Deliberately narrow: every signal here can flip the reactor out of and back into
- * `live`, re-firing `entry`. Neither blinks mid-source — the edge can't, because
- * `liveWindowForType` falls back to any resolved track of the type — so `entry`
- * fires once per source without a latch, and a live reload (same source, slid
- * window) correctly doesn't re-command.
+ * Deliberately narrow: every signal here can flip the reactor out of and back into `live`, re-firing `entry`. Neither
+ * blinks mid-source — the edge can't, because `liveWindowForType` falls back to any resolved track of the type — so
+ * `entry` fires once per source without a latch, and a live reload (same source, slid window) correctly doesn't
+ * re-command.
  *
- * The flip side: the presentation *url* is not part of this state, so replacing one
- * already-resolved live presentation with another would stay in `live` and never
- * command a start position for the new source. Unreachable today — every writer
- * sets `{ url }` (unresolved) or `undefined` first, so a source change always
- * transits `inactive`. Supporting a seeded pre-resolved presentation (via
- * `initialState`) that later changes would mean folding the url in here.
+ * The flip side: the presentation _url_ is not part of this state, so replacing one already-resolved live presentation
+ * with another would stay in `live` and never command a start position for the new source. Unreachable today — every
+ * writer sets `{ url }` (unresolved) or `undefined` first, so a source change always transits `inactive`. Supporting a
+ * seeded pre-resolved presentation (via `initialState`) that later changes would mean folding the url in here.
  */
 function deriveState(mediaElement: HTMLMediaElement | undefined, edge: LiveEdge | null): SeekToLiveEdgeFsmState {
   return mediaElement && edge ? 'live' : 'inactive';
@@ -195,10 +176,9 @@ function seekToLiveEdgeSetup({
 }
 
 /**
- * Manual `Behavior<>` literal (like `calculatePresentationDuration`): declares
- * only `presentation` + `startPosition` in stateKeys while reading
- * `selectedVideoTrackId` / `selectedAudioTrackId` defensively (contributed by the
- * switch* behaviors), so it composes without a stateKeys/type conflict.
+ * Manual `Behavior<>` literal (like `calculatePresentationDuration`): declares only `presentation` + `startPosition` in
+ * stateKeys while reading `selectedVideoTrackId` / `selectedAudioTrackId` defensively (contributed by the switch*
+ * behaviors), so it composes without a stateKeys/type conflict.
  */
 export const seekToLiveEdge: Behavior<
   {

--- a/packages/spf/src/playback/behaviors/dom/setup-buffer-actors.ts
+++ b/packages/spf/src/playback/behaviors/dom/setup-buffer-actors.ts
@@ -1,63 +1,43 @@
 /**
- * **Per-type buffer + segment-loader actor setup.** Per available track
- * type (video / audio), when `mediaSource` is attached and the selected
- * track of that type is present in the presentation with codecs (partial
- * resolution from the multivariant playlist is enough — codecs live on
- * the `EXT-X-STREAM-INF` line, not in the per-type media playlist),
- * creates a `SourceBuffer`, a `SourceBufferActor`, and a
- * `SegmentLoaderActor` bound to that buffer-actor; publishes the per-type
- * actor slots. On `mediaSource` detach or behavior destroy, destroys both
- * actors in reverse order and clears the per-type slots so the next
- * source starts fresh.
+ * **Per-type buffer + segment-loader actor setup.** Per available track type (video / audio), when `mediaSource` is
+ * attached and the selected track of that type is present in the presentation with codecs (partial resolution from the
+ * multivariant playlist is enough — codecs live on the `EXT-X-STREAM-INF` line, not in the per-type media playlist),
+ * creates a `SourceBuffer`, a `SourceBufferActor`, and a `SegmentLoaderActor` bound to that buffer-actor; publishes the
+ * per-type actor slots. On `mediaSource` detach or behavior destroy, destroys both actors in reverse order and clears
+ * the per-type slots so the next source starts fresh.
  *
- * Each per-type variant (`setupVideoBufferActors` /
- * `setupAudioBufferActors`) is a single-positive-state reactor
- * (`'preconditions-unmet'` ↔ `'buffer-ready'`) gating only on its own
- * type. No cross-type coupling in `stateKeys` —
- * `setupVideoBufferActors` carries only `selectedVideoTrackId` (plus
- * `bandwidthState`, written by its trackedFetch), and audio mirrors.
+ * Each per-type variant (`setupVideoBufferActors` / `setupAudioBufferActors`) is a single-positive-state reactor
+ * (`'preconditions-unmet'` ↔ `'buffer-ready'`) gating only on its own type. No cross-type coupling in `stateKeys` —
+ * `setupVideoBufferActors` carries only `selectedVideoTrackId` (plus `bandwidthState`, written by its trackedFetch),
+ * and audio mirrors.
  *
  * # Firefox `mozHasAudio` invariant
  *
- * Appending to a video `SourceBuffer` before the audio `SourceBuffer`
- * exists causes `mozHasAudio` to be permanently false in Firefox. With
- * the two per-type variants decoupled, the invariant is no longer
- * structural to a single `entry` body (as it was when both buffers were
- * created in one synchronous block inside a merged behavior). It's now
- * preserved by a chain of assumptions about how this behavior composes
- * with its upstream and downstream siblings:
+ * Appending to a video `SourceBuffer` before the audio `SourceBuffer` exists causes `mozHasAudio` to be permanently
+ * false in Firefox. With the two per-type variants decoupled, the invariant is no longer structural to a single `entry`
+ * body (as it was when both buffers were created in one synchronous block inside a merged behavior). It's now preserved
+ * by a chain of assumptions about how this behavior composes with its upstream and downstream siblings:
  *
- * 1. **Upstream — default selections land in one `runPending`.**
- *    `selectAudioTrack` (default audio) and `switchVideoTrack`
- *    (default video) both subscribe to `state.presentation` flipping to
- *    resolved; their effects run in the same `runPending` iteration and
- *    write `selectedAudioTrackId` + `selectedVideoTrackId` within it.
- * 2. **Self — both per-type monitors flip in one `runPending`.**
- *    After (1), both monitors re-evaluate and flip to `'buffer-ready'`
- *    in the next `runPending`. Both `entry` bodies run synchronously
- *    within that iteration — both `addSourceBuffer` calls land before
- *    the iteration ends.
- * 3. **Downstream — `appendBuffer` is async.** `loadVideoSegments` /
- *    `loadAudioSegments` read the per-type `xSegmentLoaderActor` slots;
- *    their effects fire in the *next* `runPending` and the actual
- *    `appendBuffer` requires a network round-trip via the
- *    `SegmentLoaderActor` — many microtasks past both `addSourceBuffer`
- *    calls.
+ * 1. **Upstream — default selections land in one `runPending`.** `selectAudioTrack` (default audio) and `switchVideoTrack`
+ *    (default video) both subscribe to `state.presentation` flipping to resolved; their effects run in the same
+ *    `runPending` iteration and write `selectedAudioTrackId` + `selectedVideoTrackId` within it.
+ * 2. **Self — both per-type monitors flip in one `runPending`.** After (1), both monitors re-evaluate and flip to
+ *    `'buffer-ready'` in the next `runPending`. Both `entry` bodies run synchronously within that iteration — both
+ *    `addSourceBuffer` calls land before the iteration ends.
+ * 3. **Downstream — `appendBuffer` is async.** `loadVideoSegments` / `loadAudioSegments` read the per-type
+ *    `xSegmentLoaderActor` slots; their effects fire in the _next_ `runPending` and the actual `appendBuffer` requires
+ *    a network round-trip via the `SegmentLoaderActor` — many microtasks past both `addSourceBuffer` calls.
  *
- * The cross-tick failure mode — a user-initiated audio track switch
- * *after* video segments have begun appending — is out of scope for
- * this behavior and would be addressed in the buffer/segment-loading
- * path via `changeType`-aware logic.
+ * The cross-tick failure mode — a user-initiated audio track switch _after_ video segments have begun appending — is
+ * out of scope for this behavior and would be addressed in the buffer/segment-loading path via `changeType`-aware
+ * logic.
  *
  * # Sole writer
  *
- * `setupVideoBufferActors` is sole writer of `videoBufferActor` +
- * `videoSegmentLoaderActor` (and `bandwidthState` via its
- * trackedFetch); `setupAudioBufferActors` is sole writer of
- * `audioBufferActor` + `audioSegmentLoaderActor`. Both read
- * `mediaSource` from `setupMediaSource`. Downstream MSE behaviors
- * (`loadVideoSegments`, `loadAudioSegments`, `endOfStream`,
- * `updateMediaSourceDuration`) only read these slots.
+ * `setupVideoBufferActors` is sole writer of `videoBufferActor` + `videoSegmentLoaderActor` (and `bandwidthState` via
+ * its trackedFetch); `setupAudioBufferActors` is sole writer of `audioBufferActor` + `audioSegmentLoaderActor`. Both
+ * read `mediaSource` from `setupMediaSource`. Downstream MSE behaviors (`loadVideoSegments`, `loadAudioSegments`,
+ * `endOfStream`, `updateMediaSourceDuration`) only read these slots.
  */
 import { listen } from '@videojs/utils/dom';
 
@@ -82,10 +62,7 @@ import { failoverFetch } from '../../primitives/failover-fetch';
 import type { MessagePipelines } from '../../primitives/segment-load-pipeline';
 import { AUDIO_TYPE_CONFIG, VIDEO_TYPE_CONFIG } from '../../primitives/track-types';
 
-/**
- * Media track type for MSE buffer setup.
- * Text tracks are excluded as they don't use MSE SourceBuffers.
- */
+/** Media track type for MSE buffer setup. Text tracks are excluded as they don't use MSE SourceBuffers. */
 export type MediaTrackType = 'video' | 'audio';
 
 export interface BufferActorsState {
@@ -228,11 +205,9 @@ function setupBufferActors<K extends SelectedTrackKey, A extends BufferActorKey,
 // ============================================================================
 
 /**
- * Set up the video `SourceBufferActor` + `SegmentLoaderActor`. Fires
- * when `mediaSource` is attached and the selected video track is
- * present in the presentation with codecs. Gates only on video state —
- * no cross-type coupling. Owns a bandwidth-sampling `trackedFetch` and
- * is sole writer of `state.bandwidthState`.
+ * Set up the video `SourceBufferActor` + `SegmentLoaderActor`. Fires when `mediaSource` is attached and the selected
+ * video track is present in the presentation with codecs. Gates only on video state — no cross-type coupling. Owns a
+ * bandwidth-sampling `trackedFetch` and is sole writer of `state.bandwidthState`.
  */
 export const setupVideoBufferActors = defineBehavior({
   stateKeys: ['presentation', 'selectedVideoTrackId', 'bandwidthState'] as const,
@@ -284,22 +259,16 @@ export const setupVideoBufferActors = defineBehavior({
 });
 
 /**
- * Set up the audio `SourceBufferActor` + `SegmentLoaderActor`. Same
- * shape as `setupVideoBufferActors`, narrowed to audio. Today supplies
- * a non-sampling `fetchStream` (no audio ABR); adding audio ABR is a
- * localized change to this setup body (swap `fetchStream` for a
- * `createTrackedFetch` call + declare `bandwidthState` writable here)
- * without touching the shared helper. See
- * `internal/design/spf/features/audio-abr.md` for the design surface
- * (bandwidth-state sharing, multi-writer coordination, EWMA mixed-
- * source sampling).
+ * Set up the audio `SourceBufferActor` + `SegmentLoaderActor`. Same shape as `setupVideoBufferActors`, narrowed to
+ * audio. Today supplies a non-sampling `fetchStream` (no audio ABR); adding audio ABR is a localized change to this
+ * setup body (swap `fetchStream` for a `createTrackedFetch` call + declare `bandwidthState` writable here) without
+ * touching the shared helper. See `internal/design/spf/features/audio-abr.md` for the design surface (bandwidth-state
+ * sharing, multi-writer coordination, EWMA mixed- source sampling).
  *
- * **Mid-stream audio track switching is NOT this behavior's concern.**
- * Slot writes to `selectedAudioTrackId` (default selection, programmatic
- * filter-driven, future ABR) are owned by `switchAudioTrack` / future
- * `switchAudioQuality` in `track-switching.ts`. Flush orchestration on
- * track change is dispatched from there via `audioBufferActor.send(...)`
- * — keeping this setup behavior focused on per-source actor lifecycle.
+ * **Mid-stream audio track switching is NOT this behavior's concern.** Slot writes to `selectedAudioTrackId` (default
+ * selection, programmatic filter-driven, future ABR) are owned by `switchAudioTrack` / future `switchAudioQuality` in
+ * `track-switching.ts`. Flush orchestration on track change is dispatched from there via `audioBufferActor.send(...)` —
+ * keeping this setup behavior focused on per-source actor lifecycle.
  */
 export const setupAudioBufferActors = defineBehavior({
   stateKeys: ['presentation', 'selectedAudioTrackId'] as const,

--- a/packages/spf/src/playback/behaviors/dom/setup-mediasource.ts
+++ b/packages/spf/src/playback/behaviors/dom/setup-mediasource.ts
@@ -1,56 +1,42 @@
 /**
- * **Own the MediaSource lifecycle for the current source.** When a resolved
- * presentation and a mediaElement are both in scope, creates a MediaSource,
- * attaches it to the element, waits for `'open'`, and publishes it on
- * `context.mediaSource`. On source change or behavior destroy, detaches the
- * MediaSource and clears the slot so the next source starts fresh.
+ * **Own the MediaSource lifecycle for the current source.** When a resolved presentation and a mediaElement are both in
+ * scope, creates a MediaSource, attaches it to the element, waits for `'open'`, and publishes it on
+ * `context.mediaSource`. On source change or behavior destroy, detaches the MediaSource and clears the slot so the next
+ * source starts fresh.
  *
- * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'mediasource-attached'`):
- * state derivation gates on `mediaElement + isResolvedPresentation`. Riding the
- * resolver's resolved/unresolved lifecycle makes direct URL replacement
- * structural — `resolvePresentation` routes the presentation back through
- * unresolved on URL change, which drives this reactor through
- * `'preconditions-unmet'` so the entry's state-exit cleanup detaches the old
- * MediaSource before the new one is built.
+ * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'mediasource-attached'`): state derivation gates on
+ * `mediaElement + isResolvedPresentation`. Riding the resolver's resolved/unresolved lifecycle makes direct URL
+ * replacement structural — `resolvePresentation` routes the presentation back through unresolved on URL change, which
+ * drives this reactor through `'preconditions-unmet'` so the entry's state-exit cleanup detaches the old MediaSource
+ * before the new one is built.
  *
  * The entry resolves preconditions in sequence before publishing:
  *
- * 1. **Create + attach** — `createMediaSource` + `attachMediaSource` run
- *    synchronously on entry. The `detach` closure returned by
- *    `attachMediaSource` is captured for state-exit cleanup, so the cleanup
- *    is always bound to its setup even if the wait below is aborted.
- * 2. **Wait for `'open'`** — `waitForMediaSourceOpen` defers until the first
- *    `sourceopen` event (or any readyState transition out of `'closed'`).
- * 3. **Publish on `'open'`** — re-check `readyState === 'open'` after the
- *    await (covers `'ended'` / `'closed'` race) before writing to
- *    `context.mediaSource`. Downstream `setupVideoBufferActors` /
- *    `setupAudioBufferActors` call `addSourceBuffer` directly, which
- *    throws on non-open, so publish-only-when-open is the load-bearing
- *    contract.
+ * 1. **Create + attach** — `createMediaSource` + `attachMediaSource` run synchronously on entry. The `detach` closure
+ *    returned by `attachMediaSource` is captured for state-exit cleanup, so the cleanup is always bound to its setup
+ *    even if the wait below is aborted.
+ * 2. **Wait for `'open'`** — `waitForMediaSourceOpen` defers until the first `sourceopen` event (or any readyState
+ *    transition out of `'closed'`).
+ * 3. **Publish on `'open'`** — re-check `readyState === 'open'` after the await (covers `'ended'` / `'closed'` race)
+ *    before writing to `context.mediaSource`. Downstream `setupVideoBufferActors` / `setupAudioBufferActors` call
+ *    `addSourceBuffer` directly, which throws on non-open, so publish-only-when-open is the load-bearing contract.
  *
- * State-exit cleanup aborts the in-flight wait, detaches the MediaSource,
- * and clears `context.mediaSource`. Order: abort first (prevents a late
- * publish racing the slot clear), then detach, then clear.
+ * State-exit cleanup aborts the in-flight wait, detaches the MediaSource, and clears `context.mediaSource`. Order:
+ * abort first (prevents a late publish racing the slot clear), then detach, then clear.
  *
  * # Sourceclose recovery
  *
- * The behavior owns one **unclosed** MediaSource per source identity. The UA can
- * close the attached MediaSource out from under the engine (Safari on an
- * AirPlay handoff — see `setupAirPlay` — or a ManagedMediaSource evicted
- * under memory pressure), and a closed MediaSource can never reopen. The
- * `sourceclose` listener tears the attachment down synchronously; every
- * teardown records a local close-fact, which holds the machine out until
- * the fact is consumed — then the re-derive comes back in with a fresh
- * MediaSource for the *same* source. Cause-agnostic. Consumption honors an
- * observed `loadingSuspended` (attaching runs `element.load()` — new loading
- * work, e.g. resource selection under an active AirPlay receiver), and
- * happens only while the machine is out, so a suspension can never tear
- * down an existing attachment.
+ * The behavior owns one **unclosed** MediaSource per source identity. The UA can close the attached MediaSource out
+ * from under the engine (Safari on an AirPlay handoff — see `setupAirPlay` — or a ManagedMediaSource evicted under
+ * memory pressure), and a closed MediaSource can never reopen. The `sourceclose` listener tears the attachment down
+ * synchronously; every teardown records a local close-fact, which holds the machine out until the fact is consumed —
+ * then the re-derive comes back in with a fresh MediaSource for the _same_ source. Cause-agnostic. Consumption honors
+ * an observed `loadingSuspended` (attaching runs `element.load()` — new loading work, e.g. resource selection under an
+ * active AirPlay receiver), and happens only while the machine is out, so a suspension can never tear down an existing
+ * attachment.
  *
- * Sole writer of `context.mediaSource`; other MSE behaviors
- * (`setupVideoBufferActors`, `setupAudioBufferActors`,
- * `updateMediaSourceDuration`, `endOfStream`, `loadVideoSegments`) only
- * read.
+ * Sole writer of `context.mediaSource`; other MSE behaviors (`setupVideoBufferActors`, `setupAudioBufferActors`,
+ * `updateMediaSourceDuration`, `endOfStream`, `loadVideoSegments`) only read.
  */
 import { listen } from '@videojs/utils/dom';
 
@@ -61,31 +47,23 @@ import { computed, type ReadonlySignal, type Signal, signal } from '../../../cor
 import { attachMediaSource, createMediaSource, waitForMediaSourceOpen } from '../../../media/dom/mse/mediasource-setup';
 import { isResolvedPresentation, type MaybeResolvedPresentation } from '../../../media/types';
 
-/**
- * State shape required for MediaSource setup.
- */
+/** State shape required for MediaSource setup. */
 export interface MediaSourceState {
   presentation?: MaybeResolvedPresentation;
 }
 
-/**
- * Context shape for MediaSource setup.
- */
+/** Context shape for MediaSource setup. */
 export interface MediaSourceContext {
   mediaElement?: HTMLMediaElement | undefined;
   mediaSource?: MediaSource;
 }
 
-/**
- * Config for MediaSource setup.
- */
+/** Config for MediaSource setup. */
 export interface MediaSourceSetupConfig {
   /**
-   * Attach strategy — a composition-supplied implementation. Defaults to
-   * `attachMediaSource` (object URL on the `src` attribute). Compositions
-   * that pair MSE with sibling `<source>` alternatives wire
-   * `attachMediaSourceAsSourceElement` (e.g. the HLS engine, for
-   * `setupAirPlay`'s native fallback source).
+   * Attach strategy — a composition-supplied implementation. Defaults to `attachMediaSource` (object URL on the `src`
+   * attribute). Compositions that pair MSE with sibling `<source>` alternatives wire `attachMediaSourceAsSourceElement`
+   * (e.g. the HLS engine, for `setupAirPlay`'s native fallback source).
    */
   attachMediaSource?: typeof attachMediaSource;
 }

--- a/packages/spf/src/playback/behaviors/dom/setup-text-track-actors.ts
+++ b/packages/spf/src/playback/behaviors/dom/setup-text-track-actors.ts
@@ -1,22 +1,16 @@
 /**
- * **Own the TextTracks actor pair for the current `mediaElement`.** When a
- * `mediaElement` is in scope, creates the `TextTracksActor` (bound to the
- * element's `textTracks`) and the `TextTrackSegmentLoaderActor` (bound to
- * that actor + the injected cue resolver), and publishes both on
- * `context`. On element identity change or behavior destroy, destroys both
- * actors and clears the slots.
+ * **Own the TextTracks actor pair for the current `mediaElement`.** When a `mediaElement` is in scope, creates the
+ * `TextTracksActor` (bound to the element's `textTracks`) and the `TextTrackSegmentLoaderActor` (bound to that actor +
+ * the injected cue resolver), and publishes both on `context`. On element identity change or behavior destroy, destroys
+ * both actors and clears the slots.
  *
- * Single-resource synchronous create/destroy driven by one signal — the
- * simple-effect form is the right shape (per `behaviors.md` → "Where both
- * shapes are legitimate": criterion 4b applies; sole writer of
- * `textTracksActor` / `textTrackSegmentLoaderActor`, the effect's cleanup
- * return handles destroy + slot clear structurally).
+ * Single-resource synchronous create/destroy driven by one signal — the simple-effect form is the right shape (per
+ * `behaviors.md` → "Where both shapes are legitimate": criterion 4b applies; sole writer of `textTracksActor` /
+ * `textTrackSegmentLoaderActor`, the effect's cleanup return handles destroy + slot clear structurally).
  *
- * Pairs with the `loadTextTrackSegments` behavior (a per-type variant of
- * `setupSegmentLoading` in `load-segments.ts`), which only reads
- * `textTrackSegmentLoaderActor`. The cue resolver is injected via
- * `config` so this behavior owns the DOM-bound part of the text-track
- * pipeline.
+ * Pairs with the `loadTextTrackSegments` behavior (a per-type variant of `setupSegmentLoading` in `load-segments.ts`),
+ * which only reads `textTrackSegmentLoaderActor`. The cue resolver is injected via `config` so this behavior owns the
+ * DOM-bound part of the text-track pipeline.
  */
 import type { AnySlotMap, Behavior } from '../../../core/composition/create-composition';
 import { effect } from '../../../core/signals/effect';
@@ -39,9 +33,9 @@ export interface TextTrackActorsContext {
 export interface TextTrackActorsConfig extends Pick<TextTrackSegmentLoaderActorConfig<VTTCue>, 'forwardBuffer'> {
   resolveTextTrackSegment: TextTrackSegmentResolver<VTTCue>;
   /**
-   * Ordered text step pipeline, mapped to the loader's `messagePipelines`. Named
-   * with the `text` domain prefix to mirror the v/a `video`/`audioMessagePipelines`
-   * composition-config slots. Defaults (in the loader) to `resolveCues → dispatchCues`.
+   * Ordered text step pipeline, mapped to the loader's `messagePipelines`. Named with the `text` domain prefix to
+   * mirror the v/a `video`/`audioMessagePipelines` composition-config slots. Defaults (in the loader) to `resolveCues →
+   * dispatchCues`.
    */
   textMessagePipelines?: TextMessagePipelines<VTTCue>;
 }

--- a/packages/spf/src/playback/behaviors/dom/sync-live-seekable-range.ts
+++ b/packages/spf/src/playback/behaviors/dom/sync-live-seekable-range.ts
@@ -1,29 +1,22 @@
 /**
- * Mirror the live window into the MediaSource's seekable range. On every
- * window update — **including while paused** (the seekable range must stay
- * current as the window slides, regardless of play state) — declare
- * `setLiveSeekableRange(start, end)` so the browser's `HTMLMediaElement.seekable`
- * reflects the live window (without it, `seekable` is empty under
- * `duration === Infinity`).
+ * Mirror the live window into the MediaSource's seekable range. On every window update — **including while paused**
+ * (the seekable range must stay current as the window slides, regardless of play state) — declare
+ * `setLiveSeekableRange(start, end)` so the browser's `HTMLMediaElement.seekable` reflects the live window (without it,
+ * `seekable` is empty under `duration === Infinity`).
  *
- * The live window comes from `liveWindowFromState` (the shared derivation —
- * the intersection over the selected A/V tracks' windows); inert when it
- * returns `null` (VoD / ended live). Composed *before* `seekToLiveEdge`
- * so the range is declared before that behavior seeks the playhead into it (a
- * seek outside `seekable` is clamped).
+ * The live window comes from `liveWindowFromState` (the shared derivation — the intersection over the selected A/V
+ * tracks' windows); inert when it returns `null` (VoD / ended live). Composed _before_ `seekToLiveEdge` so the range is
+ * declared before that behavior seeks the playhead into it (a seek outside `seekable` is clamped).
  *
- * Duration is owned solely by `updateMediaSourceDuration`; this behavior only
- * declares the seekable range (`setLiveSeekableRange` requires only
- * `readyState === 'open'` per the W3C MSE spec, not a set `duration`).
+ * Duration is owned solely by `updateMediaSourceDuration`; this behavior only declares the seekable range
+ * (`setLiveSeekableRange` requires only `readyState === 'open'` per the W3C MSE spec, not a set `duration`).
  *
- * No `clearLiveSeekableRange()` on termination, by design: the MSE spec consults
- * the live seekable range *only* while `duration === Infinity`. When a live
- * stream ends, `endOfStream()` sets a finite duration and the UA derives
- * `seekable` from buffered + duration, ignoring the live range — so clearing is
- * unnecessary. Clearing on the `ENDLIST`→finite-`Track.duration` transition
- * (when the window goes `null`) would also be premature: `duration` is still
- * `Infinity` until `endOfStream`, so clearing would shrink `seekable` to
- * buffered-only while the stream is still effectively live.
+ * No `clearLiveSeekableRange()` on termination, by design: the MSE spec consults the live seekable range _only_ while
+ * `duration === Infinity`. When a live stream ends, `endOfStream()` sets a finite duration and the UA derives
+ * `seekable` from buffered + duration, ignoring the live range — so clearing is unnecessary. Clearing on the
+ * `ENDLIST`→finite-`Track.duration` transition (when the window goes `null`) would also be premature: `duration` is
+ * still `Infinity` until `endOfStream`, so clearing would shrink `seekable` to buffered-only while the stream is still
+ * effectively live.
  */
 import type { Behavior } from '../../../core/composition/create-composition';
 import { effect } from '../../../core/signals/effect';
@@ -74,10 +67,9 @@ function syncLiveSeekableRangeSetup({
 }
 
 /**
- * Manual `Behavior<>` literal (like `seekToLiveEdge`): declares only
- * `presentation` in stateKeys while reading `selectedVideoTrackId` /
- * `selectedAudioTrackId` defensively (contributed by the switch* behaviors), so
- * it composes without a stateKeys/type conflict.
+ * Manual `Behavior<>` literal (like `seekToLiveEdge`): declares only `presentation` in stateKeys while reading
+ * `selectedVideoTrackId` / `selectedAudioTrackId` defensively (contributed by the switch* behaviors), so it composes
+ * without a stateKeys/type conflict.
  */
 export const syncLiveSeekableRange: Behavior<
   { presentation: ReadonlySignal<SyncLiveSeekableRangeState['presentation']> },

--- a/packages/spf/src/playback/behaviors/dom/sync-text-tracks.ts
+++ b/packages/spf/src/playback/behaviors/dom/sync-text-tracks.ts
@@ -1,49 +1,34 @@
 /**
- * **Own the text-track slots on the host media element, mirroring the SPF
- * model.** When a presentation is resolved and a media element is
- * available, allocate one slot in `mediaElement.textTracks` per model text
- * track — via creating `<track>` children, since that's the only spec
- * mechanism for adding *and* removing entries to `textTracks` (no
- * `removeTextTrack` API exists). Once slots are provisioned, mirror the
- * resolved `selectedTextTrackId` into their `mode`s (one-way: state → DOM),
- * and propagate user-initiated DOM `change` events back to
- * `userTextTrackSelection` — the standing *intent* (a language-based partial,
- * or `'off'`) that `switchTextTrack` resolves into `selectedTextTrackId`. So
- * non-SPF consumers (host-page captions buttons, browser native UI, video.js
- * store) drive selection by expressing intent, not by writing the resolved id.
+ * **Own the text-track slots on the host media element, mirroring the SPF model.** When a presentation is resolved and
+ * a media element is available, allocate one slot in `mediaElement.textTracks` per model text track — via creating
+ * `<track>` children, since that's the only spec mechanism for adding _and_ removing entries to `textTracks` (no
+ * `removeTextTrack` API exists). Once slots are provisioned, mirror the resolved `selectedTextTrackId` into their
+ * `mode`s (one-way: state → DOM), and propagate user-initiated DOM `change` events back to `userTextTrackSelection` —
+ * the standing _intent_ (a language-based partial, or `'off'`) that `switchTextTrack` resolves into
+ * `selectedTextTrackId`. So non-SPF consumers (host-page captions buttons, browser native UI, video.js store) drive
+ * selection by expressing intent, not by writing the resolved id.
  *
- * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'sync-active'`):
- * the entry allocates the slots, applies the initial selection, attaches
- * the `change` listener, and opens a brief Chromium settling-window guard —
- * all transition-driven, fire-once on state entry, with paired cleanup on
- * state exit. A single `effects:` mirrors subsequent
- * `selectedTextTrackId` changes into `mode`s; that's the only
- * continuous-reactivity concern.
+ * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'sync-active'`): the entry allocates the slots, applies the
+ * initial selection, attaches the `change` listener, and opens a brief Chromium settling-window guard — all
+ * transition-driven, fire-once on state entry, with paired cleanup on state exit. A single `effects:` mirrors
+ * subsequent `selectedTextTrackId` changes into `mode`s; that's the only continuous-reactivity concern.
  *
- * State-exit cleanup also sends a `'clear'` message to the
- * `TextTracksActor` so its cue+segment cache (keyed by trackId) is
- * dropped alongside the DOM `<track>` slots. The actor itself is owned
- * by `setupTextTrackActors` and bound to mediaElement, not presentation,
- * so it survives source resets; clearing its context here keeps the
- * cache consistent with the DOM. Without this, a subsequent
- * presentation reusing a trackId would have `getSegmentsToLoad` treat
- * its segments as already-buffered and skip loading them.
+ * State-exit cleanup also sends a `'clear'` message to the `TextTracksActor` so its cue+segment cache (keyed by
+ * trackId) is dropped alongside the DOM `<track>` slots. The actor itself is owned by `setupTextTrackActors` and bound
+ * to mediaElement, not presentation, so it survives source resets; clearing its context here keeps the cache consistent
+ * with the DOM. Without this, a subsequent presentation reusing a trackId would have `getSegmentsToLoad` treat its
+ * segments as already-buffered and skip loading them.
  *
- * Single-writer separation: `selectedTextTrackId` is the resolved *output*
- * owned solely by `switchTextTrack`; this behavior only reads it (to mirror
- * modes). The write path here is `userTextTrackSelection` — the user-intent
- * *input* — so DOM action and the resolver never contend for one slot. The
- * intent isn't cleared on source unload (it's a standing preference, like
- * `userAudioTrackSelection`); `'off'` is written when the user disables all
- * tracks via native UI.
+ * Single-writer separation: `selectedTextTrackId` is the resolved _output_ owned solely by `switchTextTrack`; this
+ * behavior only reads it (to mirror modes). The write path here is `userTextTrackSelection` — the user-intent _input_ —
+ * so DOM action and the resolver never contend for one slot. The intent isn't cleared on source unload (it's a standing
+ * preference, like `userAudioTrackSelection`); `'off'` is written when the user disables all tracks via native UI.
  *
- * Echo guard: `selectedTextTrackId` is exactly the id this behavior last drove
- * into the DOM, so a `change` event still showing it is our own echo (or a
- * resolver-driven correction — e.g. the picked track's CDN failed and the
- * resolver disabled it) and is ignored, never written back as a spurious user
- * action. Only a showing id that *differs* from the resolved id is a real user
- * pick. The settling-window guard additionally swallows Chromium's init-time
- * auto-selection before the resolved selection has settled.
+ * Echo guard: `selectedTextTrackId` is exactly the id this behavior last drove into the DOM, so a `change` event still
+ * showing it is our own echo (or a resolver-driven correction — e.g. the picked track's CDN failed and the resolver
+ * disabled it) and is ignored, never written back as a spurious user action. Only a showing id that _differs_ from the
+ * resolved id is a real user pick. The settling-window guard additionally swallows Chromium's init-time auto-selection
+ * before the resolved selection has settled.
  */
 
 import { listen } from '@videojs/utils/dom';
@@ -61,24 +46,22 @@ type SyncTextTracksFsmState = 'preconditions-unmet' | 'sync-active';
 
 export interface SyncTextTracksConfig {
   /**
-   * Create and append SPF-owned `<track>` slots on `mediaElement`, one per
-   * model text track. Implementation tags each element so the read/remove
-   * helpers can scope to SPF-owned slots. **Required** — the behavior is
-   * DOM-binding-neutral and the composing engine supplies the integration.
+   * Create and append SPF-owned `<track>` slots on `mediaElement`, one per model text track. Implementation tags each
+   * element so the read/remove helpers can scope to SPF-owned slots. **Required** — the behavior is DOM-binding-neutral
+   * and the composing engine supplies the integration.
    */
   addSubtitlesTracksToMedia: (
     mediaElement: HTMLMediaElement,
     modelTextTracks: readonly (PartiallyResolvedTextTrack | TextTrack)[]
   ) => void;
   /**
-   * Return the SPF-owned subtitle/caption `TextTrack` currently in `'showing'`
-   * mode, or `undefined` if none. Used by the DOM `change` bridge to mirror
-   * native-UI selection back into `selectedTextTrackId`.
+   * Return the SPF-owned subtitle/caption `TextTrack` currently in `'showing'` mode, or `undefined` if none. Used by
+   * the DOM `change` bridge to mirror native-UI selection back into `selectedTextTrackId`.
    */
   getShowingSubtitlesTrackFromMedia: (mediaElement: HTMLMediaElement) => globalThis.TextTrack | undefined;
   /**
-   * Remove every SPF-owned `<track>` child from `mediaElement`. Called on
-   * state exit (source unload, behavior destroy) to evict slots.
+   * Remove every SPF-owned `<track>` child from `mediaElement`. Called on state exit (source unload, behavior destroy)
+   * to evict slots.
    */
   removeAllSubtitlesTracksFromMedia: (mediaElement: HTMLMediaElement) => void;
 }
@@ -93,9 +76,8 @@ function deriveState(
 }
 
 /**
- * Map the DOM-showing track back to standing user intent. No showing track is an
- * explicit `'off'`. Otherwise prefer a language-based partial (so the pick
- * persists across source changes); fall back to `{ id }` for a track without a
+ * Map the DOM-showing track back to standing user intent. No showing track is an explicit `'off'`. Otherwise prefer a
+ * language-based partial (so the pick persists across source changes); fall back to `{ id }` for a track without a
  * language (precise within a source, just not portable).
  */
 function deriveTextTrackIntent(

--- a/packages/spf/src/playback/behaviors/dom/tests/airplay.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/airplay.test.ts
@@ -24,8 +24,8 @@ interface WebKitVideoLike extends HTMLVideoElement {
 }
 
 /**
- * A real `<video>` decorated with the WebKit AirPlay flag so
- * `isWebKitAirPlayCapable` recognizes it (`'…IsWireless' in media`).
+ * A real `<video>` decorated with the WebKit AirPlay flag so `isWebKitAirPlayCapable` recognizes it (`'…IsWireless' in
+ * media`).
  */
 function makeWebKitVideo(opts: { wireless?: boolean; disableRemotePlayback?: boolean } = {}): WebKitVideoLike {
   const video = document.createElement('video') as WebKitVideoLike;

--- a/packages/spf/src/playback/behaviors/dom/tests/apply-start-position.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/apply-start-position.test.ts
@@ -11,9 +11,8 @@ function makeResolvedPresentation(url = 'https://example.com/a.m3u8'): Presentat
 }
 
 /**
- * A real `<video>` with controllable `currentTime` / `readyState` — no media
- * is loaded in tests, so both are stubbed the way `track-current-time.test.ts`
- * stubs `currentTime`.
+ * A real `<video>` with controllable `currentTime` / `readyState` — no media is loaded in tests, so both are stubbed
+ * the way `track-current-time.test.ts` stubs `currentTime`.
  */
 function makeVideo(opts: { readyState?: number } = {}): HTMLVideoElement {
   const video = document.createElement('video');

--- a/packages/spf/src/playback/behaviors/dom/tests/end-of-stream.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/end-of-stream.test.ts
@@ -54,8 +54,8 @@ function setupEndOfStream(initialState: EndOfStreamState, initialContext: EndOfS
 // ============================================================================
 
 /**
- * Back the mock with a real EventTarget so tests can dispatch sourceopen /
- * sourceended to exercise the behavior's local readyState subscription.
+ * Back the mock with a real EventTarget so tests can dispatch sourceopen / sourceended to exercise the behavior's local
+ * readyState subscription.
  */
 function makeMediaSource(
   overrides: { readyState?: MediaSource['readyState']; duration?: number; sourceBuffers?: SourceBuffer[] } = {}

--- a/packages/spf/src/playback/behaviors/dom/tests/load-segments.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/load-segments.test.ts
@@ -1,6 +1,4 @@
-/**
- * Tests for segment loading orchestration (F4 + F5)
- */
+/** Tests for segment loading orchestration (F4 + F5) */
 
 import { describe, expect, it, vi } from 'vite-plus/test';
 
@@ -81,12 +79,10 @@ function makeResolvedVideoTrack(segments: Segment[]) {
 /**
  * Creates a minimal SourceBuffer mock.
  *
- * `appendRanges` — added to `buffered` in sequence as `appendBuffer` is called
- *   (for testing the live append path).
- * `startingRanges` — present in `buffered` from the start, before any appends
- *   (for pre-seeded actor context tests where no appendBuffer calls are made).
- * `remove()` clips the current ranges to match real SourceBuffer behaviour,
- * enabling the midpoint-based segment model logic in removeTask.
+ * `appendRanges` — added to `buffered` in sequence as `appendBuffer` is called (for testing the live append path).
+ * `startingRanges` — present in `buffered` from the start, before any appends (for pre-seeded actor context tests where
+ * no appendBuffer calls are made). `remove()` clips the current ranges to match real SourceBuffer behaviour, enabling
+ * the midpoint-based segment model logic in removeTask.
  */
 function makeSourceBuffer(
   appendRanges: Array<[number, number]> = [],
@@ -155,10 +151,9 @@ function makeSourceBuffer(
 /**
  * Creates a SourceBuffer + SourceBufferActor pair.
  *
- * `preloadedRanges` — initial `buffered` ranges (present before any appends).
- *   Use when the actor context is pre-seeded with segments that are already
- *   "in" the SourceBuffer without going through the append path.
- * `initialSegments` — seeds the actor context with pre-existing segments.
+ * `preloadedRanges` — initial `buffered` ranges (present before any appends). Use when the actor context is pre-seeded
+ * with segments that are already "in" the SourceBuffer without going through the append path. `initialSegments` — seeds
+ * the actor context with pre-existing segments.
  */
 function makeSourceBufferWithActor(
   preloadedRanges: Array<[number, number]> = [],
@@ -175,11 +170,9 @@ function makeSourceBufferWithActor(
 }
 
 /**
- * Test driver: composes a per-type segment-loader-actor against the
- * supplied SourceBufferActor and wires it to the per-type
- * `load{Video,Audio}Segments` dispatcher. Production code creates the
- * loader inside `setup{Video,Audio}BufferActors`; tests do the wiring
- * directly to keep the dispatcher under test isolated.
+ * Test driver: composes a per-type segment-loader-actor against the supplied SourceBufferActor and wires it to the
+ * per-type `load{Video,Audio}Segments` dispatcher. Production code creates the loader inside
+ * `setup{Video,Audio}BufferActors`; tests do the wiring directly to keep the dispatcher under test isolated.
  */
 function setupLoadSegments(
   initialState: SegmentLoadingState,

--- a/packages/spf/src/playback/behaviors/dom/tests/seek-to-live-edge.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/seek-to-live-edge.test.ts
@@ -10,9 +10,8 @@ import {
 import { type SeekToLiveEdgeConfig, seekToLiveEdge } from '../seek-to-live-edge';
 
 /**
- * 5-segment, 2s window sliding at `[windowStart, windowStart + 10]`.
- * With the injected 6s live latency, the live-edge start is
- * `(windowStart + 10) − 6 = windowStart + 4` (104 for the default 100).
+ * 5-segment, 2s window sliding at `[windowStart, windowStart + 10]`. With the injected 6s live latency, the live-edge
+ * start is `(windowStart + 10) − 6 = windowStart + 4` (104 for the default 100).
  */
 function makePresentation(windowStart = 100, mediaSequence = 50): Presentation {
   const video: VideoTrack = {
@@ -51,9 +50,8 @@ type FakeMediaElement = HTMLMediaElement & {
 };
 
 /**
- * Event-capable fake: `seekToLiveEdge` attaches a `play` listener, so the
- * element must be a real `EventTarget`. Defaults to paused + `readyState`
- * HAVE_ENOUGH_DATA (the post-initial-seek resting state).
+ * Event-capable fake: `seekToLiveEdge` attaches a `play` listener, so the element must be a real `EventTarget`.
+ * Defaults to paused + `readyState` HAVE_ENOUGH_DATA (the post-initial-seek resting state).
  */
 function fakeMediaElement(
   init: Partial<Pick<FakeMediaElement, 'currentTime' | 'paused' | 'seeking' | 'readyState'>> = {}

--- a/packages/spf/src/playback/behaviors/dom/tests/setup-mediasource.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/setup-mediasource.test.ts
@@ -382,10 +382,9 @@ describe('setupMediaSource', () => {
     }
 
     /**
-     * Composes both behaviors, attaches, and arms detach's reset: waits for
-     * both `<source>` children, stages the element as committed to the MSE
-     * object URL (real resource selection is async), and records whether the
-     * fallback was still in the DOM when the reset `load()` ran.
+     * Composes both behaviors, attaches, and arms detach's reset: waits for both `<source>` children, stages the
+     * element as committed to the MSE object URL (real resource selection is async), and records whether the fallback
+     * was still in the DOM when the reset `load()` ran.
      */
     async function arrangeAttached() {
       const { createMediaSource } = await import('../../../../media/dom/mse/mediasource-setup');

--- a/packages/spf/src/playback/behaviors/dom/tests/track-player-resolution.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/track-player-resolution.test.ts
@@ -12,9 +12,8 @@ import {
 const elements: HTMLElement[] = [];
 
 /**
- * A laid-out `<video>`. Size has to come from a real box in a real document — an
- * element that isn't being rendered reports a `0 × 0` box, which is exactly the
- * "nothing to measure" case one of the tests covers.
+ * A laid-out `<video>`. Size has to come from a real box in a real document — an element that isn't being rendered
+ * reports a `0 × 0` box, which is exactly the "nothing to measure" case one of the tests covers.
  */
 function makeVideo(width: number, height: number): HTMLVideoElement {
   const element = document.createElement('video');
@@ -51,9 +50,8 @@ function setupTrackPlayerResolution(
 }
 
 /**
- * Device-pixel scaling is environment-dependent (headless Chromium reports 1, a
- * retina run reports 2), so a test asserting an exact reading either stubs the
- * ratio or opts out of it.
+ * Device-pixel scaling is environment-dependent (headless Chromium reports 1, a retina run reports 2), so a test
+ * asserting an exact reading either stubs the ratio or opts out of it.
  */
 const CSS_PIXELS: TrackPlayerResolutionConfig = { useDevicePixelRatio: false };
 

--- a/packages/spf/src/playback/behaviors/dom/track-current-time.ts
+++ b/packages/spf/src/playback/behaviors/dom/track-current-time.ts
@@ -1,20 +1,18 @@
 /**
  * Mirror `mediaElement.currentTime` into reactive state. Listens for:
+ *
  * - `timeupdate` — fires during playback (~4 Hz)
- * - `seeking` — fires when a seek begins; per spec, `currentTime` is already
- *   at the new position when this event dispatches, so buffer management can
- *   react immediately rather than waiting for `timeupdate`, which does not
- *   fire while paused.
- * - `emptied` — fires when the resource selection algorithm tears down the
- *   current media (e.g. a new `src` is set on the same element). Re-syncs so
- *   downstream state doesn't retain the stale playback position from the
- *   previous source when the engine is reused across src changes.
+ * - `seeking` — fires when a seek begins; per spec, `currentTime` is already at the new position when this event
+ *   dispatches, so buffer management can react immediately rather than waiting for `timeupdate`, which does not fire
+ *   while paused.
+ * - `emptied` — fires when the resource selection algorithm tears down the current media (e.g. a new `src` is set on the
+ *   same element). Re-syncs so downstream state doesn't retain the stale playback position from the previous source
+ *   when the engine is reused across src changes.
  *
  * Also syncs immediately when a media element becomes available.
  *
- * When no media element is attached, writes `config.defaultCurrentTime`
- * (default-default `0`, matching the HTMLMediaElement spec) so consumers
- * always see a defined position. Read-only mirror; does not push
+ * When no media element is attached, writes `config.defaultCurrentTime` (default-default `0`, matching the
+ * HTMLMediaElement spec) so consumers always see a defined position. Read-only mirror; does not push
  * `state.currentTime` back to the element.
  */
 import { listen } from '@videojs/utils/dom';
@@ -33,8 +31,8 @@ export interface CurrentTimeContext {
 
 export interface TrackCurrentTimeConfig {
   /**
-   * Value written to `state.currentTime` when no media element is attached.
-   * Defaults to `0` — the HTMLMediaElement spec default.
+   * Value written to `state.currentTime` when no media element is attached. Defaults to `0` — the HTMLMediaElement spec
+   * default.
    */
   defaultCurrentTime?: number;
 }

--- a/packages/spf/src/playback/behaviors/dom/track-load-triggers.ts
+++ b/packages/spf/src/playback/behaviors/dom/track-load-triggers.ts
@@ -6,27 +6,21 @@ import { createMachineReactor } from '../../../core/reactors/create-machine-reac
 import { computed, type ReadonlySignal, type Signal } from '../../../core/signals/primitives';
 import type { MaybeResolvedPresentation } from '../../../media/types';
 
-/**
- * State shape for load-trigger tracking.
- */
+/** State shape for load-trigger tracking. */
 export interface LoadTriggersState {
   /**
-   * Sticky-true per source. Flips to `true` the first time an event occurs
-   * that should switch loading behavior from preload-based to standard load
-   * (currently DOM `play` / `seeking`). Reset to `false` on source change.
+   * Sticky-true per source. Flips to `true` the first time an event occurs that should switch loading behavior from
+   * preload-based to standard load (currently DOM `play` / `seeking`). Reset to `false` on source change.
    *
-   * Read by `resolvePresentation` and `loadVideoSegments` / `loadAudioSegments`
-   * to mirror native `HTMLMediaElement` preload semantics — only meaningful
-   * when `preload !== 'auto'`, which already loads fully regardless.
+   * Read by `resolvePresentation` and `loadVideoSegments` / `loadAudioSegments` to mirror native `HTMLMediaElement`
+   * preload semantics — only meaningful when `preload !== 'auto'`, which already loads fully regardless.
    */
   loadActivated?: boolean;
   /** Current presentation — URL is used to detect source changes. */
   presentation?: MaybeResolvedPresentation;
 }
 
-/**
- * Context shape for load-trigger tracking.
- */
+/** Context shape for load-trigger tracking. */
 export interface LoadTriggersContext {
   mediaElement?: HTMLMediaElement | undefined;
 }
@@ -34,23 +28,20 @@ export interface LoadTriggersContext {
 type LoadTriggersFsmState = 'preconditions-unmet' | 'monitoring' | 'load-active';
 
 /**
- * Slot-driven FSM. The slot `loadActivated` is the canonical externally-
- * observable state; `deriveState` reads it (and the preconditions) to
- * derive the local FSM state. The slot is *both* the state and the data —
- * no separate internal bookkeeping.
+ * Slot-driven FSM. The slot `loadActivated` is the canonical externally- observable state; `deriveState` reads it (and
+ * the preconditions) to derive the local FSM state. The slot is _both_ the state and the data — no separate internal
+ * bookkeeping.
  *
- * ```
- * 'preconditions-unmet' ⟷ 'monitoring' ⟷ 'load-active'
+ *     'preconditions-unmet' ⟷ 'monitoring' ⟷ 'load-active'
  *
- * preconditions-unmet → monitoring        element + URL appear
- * monitoring          → load-active       slot flips true (listener fires
- *                                         or external write)
- * load-active         → monitoring        within-state cleanup resets slot
- *                                         (URL or element identity change)
- * any                 → preconditions-unmet  element or URL → undefined
+ *     preconditions-unmet → monitoring        element + URL appear
+ *     monitoring          → load-active       slot flips true (listener fires
+ *                                             or external write)
+ *     load-active         → monitoring        within-state cleanup resets slot
+ *                                             (URL or element identity change)
+ *     any                 → preconditions-unmet  element or URL → undefined
  *
- * any state → destroying → destroyed       on destroy()
- * ```
+ *     any state → destroying → destroyed       on destroy()
  */
 function deriveState(
   presentation: MaybeResolvedPresentation | undefined,
@@ -67,28 +58,23 @@ function deriveState(
 /**
  * Track preload-overriding events per source.
  *
- * Writes `state.loadActivated = true` the first time a `play` or `seeking`
- * event fires on the attached media element for the current source — or
- * immediately on entry if the element is already committed to loading
- * (`el.autoplay`, `!el.paused`, or `el.seeking`), covering autoplay,
- * native-controls, and direct-DOM-`play()` scenarios.
+ * Writes `state.loadActivated = true` the first time a `play` or `seeking` event fires on the attached media element
+ * for the current source — or immediately on entry if the element is already committed to loading (`el.autoplay`,
+ * `!el.paused`, or `el.seeking`), covering autoplay, native-controls, and direct-DOM-`play()` scenarios.
  *
- * Sticky-true *within a source identity*: subsequent play/pause/seek
- * cycles don't flip back. Source identity = (mediaElement, presentation
- * URL). Either changing — including direct in-place swap with no
- * `undefined` intermediate — resets the slot to `false`.
+ * Sticky-true _within a source identity_: subsequent play/pause/seek cycles don't flip back. Source identity =
+ * (mediaElement, presentation URL). Either changing — including direct in-place swap with no `undefined` intermediate —
+ * resets the slot to `false`.
  *
- * Multi-writer with `hls/adapter.ts:play()` (which writes `true` directly
- * on programmatic play) is intentional — different domains. The adapter
- * records programmatic intent; this behavior is the DOM-side observer.
- * Pre-existing `true` writes are honored because `deriveState` reads the
- * slot — a `true` value routes directly to `'load-active'` without
- * entering `'monitoring'`.
+ * Multi-writer with `hls/adapter.ts:play()` (which writes `true` directly on programmatic play) is intentional —
+ * different domains. The adapter records programmatic intent; this behavior is the DOM-side observer. Pre-existing
+ * `true` writes are honored because `deriveState` reads the slot — a `true` value routes directly to `'load-active'`
+ * without entering `'monitoring'`.
  *
  * @example
- * const reactor = trackLoadTriggers.setup({ state, context });
- * // later:
- * reactor.destroy();
+ *   const reactor = trackLoadTriggers.setup({ state, context });
+ *   // later:
+ *   reactor.destroy();
  */
 function trackLoadTriggersSetup({
   state,

--- a/packages/spf/src/playback/behaviors/dom/track-playback-rate.ts
+++ b/packages/spf/src/playback/behaviors/dom/track-playback-rate.ts
@@ -1,13 +1,11 @@
 /**
- * Mirror `mediaElement.playbackRate` into reactive state. On each `ratechange`
- * event, write the new value to `state.playbackRate`. Also syncs immediately
- * when a media element becomes available so consumers don't wait for the first
- * event.
+ * Mirror `mediaElement.playbackRate` into reactive state. On each `ratechange` event, write the new value to
+ * `state.playbackRate`. Also syncs immediately when a media element becomes available so consumers don't wait for the
+ * first event.
  *
- * When no media element is attached, writes `config.defaultPlaybackRate`
- * (default-default `1`, matching the HTMLMediaElement spec) so consumers
- * always see the rate a freshly attached element would have. Read-only mirror;
- * does not push `state.playbackRate` back to the element.
+ * When no media element is attached, writes `config.defaultPlaybackRate` (default-default `1`, matching the
+ * HTMLMediaElement spec) so consumers always see the rate a freshly attached element would have. Read-only mirror; does
+ * not push `state.playbackRate` back to the element.
  */
 import { listen } from '@videojs/utils/dom';
 
@@ -25,8 +23,8 @@ export interface PlaybackRateContext {
 
 export interface TrackPlaybackRateConfig {
   /**
-   * Value written to `state.playbackRate` when no media element is attached.
-   * Defaults to `1` — the HTMLMediaElement spec default.
+   * Value written to `state.playbackRate` when no media element is attached. Defaults to `1` — the HTMLMediaElement
+   * spec default.
    */
   defaultPlaybackRate?: number;
 }

--- a/packages/spf/src/playback/behaviors/dom/track-player-resolution.ts
+++ b/packages/spf/src/playback/behaviors/dom/track-player-resolution.ts
@@ -1,22 +1,18 @@
 /**
- * Mirror the player element's rendered pixel dimensions into reactive state, so
- * a rendition cap can narrow candidates to what the element can actually show
- * without reading the DOM at pick time — which would make the picker impure, and
+ * Mirror the player element's rendered pixel dimensions into reactive state, so a rendition cap can narrow candidates
+ * to what the element can actually show without reading the DOM at pick time — which would make the picker impure, and
  * would never re-pick when the element resized.
  *
- * The player-element half of the caps in
- * `internal/design/spf/features/rendition-selection-caps.md`, and the tighter
- * half: a small embed on a large display is capped by its own box rather than by
- * the screen behind it (`trackScreenResolution`).
+ * The player-element half of the caps in `internal/design/spf/features/rendition-selection-caps.md`, and the tighter
+ * half: a small embed on a large display is capped by its own box rather than by the screen behind it
+ * (`trackScreenResolution`).
  *
- * Reported as a width and a height in device pixels — the same units, and for the
- * same reason, as `media/dom/screen`'s reading: the cap compares against real
- * track dimensions, and a `"720p"`-style tier only describes a track once you
+ * Reported as a width and a height in device pixels — the same units, and for the same reason, as `media/dom/screen`'s
+ * reading: the cap compares against real track dimensions, and a `"720p"`-style tier only describes a track once you
  * assume its aspect ratio.
  *
- * `undefined` where there is nothing to measure — no element attached, or one
- * that isn't being rendered (detached, `display: none`, not yet laid out) — which
- * is the value the cap reads as "don't cap".
+ * `undefined` where there is nothing to measure — no element attached, or one that isn't being rendered (detached,
+ * `display: none`, not yet laid out) — which is the value the cap reads as "don't cap".
  */
 
 import { type ElementSize, observeElementSize, observeRenderedSize } from '@videojs/utils/dom';
@@ -40,19 +36,17 @@ export interface PlayerResolutionContext {
 
 export interface TrackPlayerResolutionConfig {
   /**
-   * Whether to cap renditions to the player's rendered size at all. `false`
-   * measures nothing, which leaves `state.playerResolution` unset and the cap
-   * inert. Defaults to `true`.
+   * Whether to cap renditions to the player's rendered size at all. `false` measures nothing, which leaves
+   * `state.playerResolution` unset and the cap inert. Defaults to `true`.
    *
-   * Named for the policy rather than the measurement because it is the public
-   * switch for the feature — the same one hls.js spells `capLevelToPlayerSize`
-   * and the Mux Video element spells `cap-rendition-to-player-size`.
+   * Named for the policy rather than the measurement because it is the public switch for the feature — the same one
+   * hls.js spells `capLevelToPlayerSize` and the Mux Video element spells `cap-rendition-to-player-size`.
    */
   capRenditionToPlayerSize?: boolean;
   /**
    * Whether the reading is scaled into device pixels. Defaults to `true` — see
-   * `ScreenResolutionOptions.useDevicePixelRatio` in `media/dom/screen.ts`,
-   * including its note on page zoom being folded into the ratio outside WebKit.
+   * `ScreenResolutionOptions.useDevicePixelRatio` in `media/dom/screen.ts`, including its note on page zoom being
+   * folded into the ratio outside WebKit.
    */
   useDevicePixelRatio?: boolean;
 }
@@ -99,7 +93,7 @@ function trackPlayerResolutionSetup({
  * Track the player element's rendered resolution in `state.playerResolution`.
  *
  * @example
- * const cleanup = trackPlayerResolution.setup({ state, context });
+ *   const cleanup = trackPlayerResolution.setup({ state, context });
  */
 export const trackPlayerResolution = defineBehavior({
   stateKeys: ['playerResolution'],

--- a/packages/spf/src/playback/behaviors/dom/track-screen-resolution.ts
+++ b/packages/spf/src/playback/behaviors/dom/track-screen-resolution.ts
@@ -1,16 +1,14 @@
 /**
- * Mirror the screen's pixel dimensions into reactive state, so a rendition cap
- * can narrow candidates to what the screen can actually show without reading the
- * environment at pick time — which would make the picker impure, and would never
+ * Mirror the screen's pixel dimensions into reactive state, so a rendition cap can narrow candidates to what the screen
+ * can actually show without reading the environment at pick time — which would make the picker impure, and would never
  * re-pick when the screen changed.
  *
- * Populated at setup rather than on the first change: `watchScreenResolution`
- * reports its starting value, so nothing downstream waits on a screen that may
- * never move. `undefined` where there is no screen to read, which is the value a
+ * Populated at setup rather than on the first change: `watchScreenResolution` reports its starting value, so nothing
+ * downstream waits on a screen that may never move. `undefined` where there is no screen to read, which is the value a
  * cap reads as "no cap" — see `getScreenResolution` on why that beats a zero.
  *
- * Reads no other slot, and has no source-identity reset: the screen is
- * independent of the presentation, so a new `src` doesn't invalidate the reading.
+ * Reads no other slot, and has no source-identity reset: the screen is independent of the presentation, so a new `src`
+ * doesn't invalidate the reading.
  */
 import { defineBehavior } from '../../../core/composition/create-composition';
 import type { Signal } from '../../../core/signals/primitives';
@@ -23,8 +21,8 @@ export interface ScreenResolutionState {
 export interface TrackScreenResolutionConfig {
   /**
    * Whether the reading is scaled into device pixels. Defaults to `true` — see
-   * `ScreenResolutionOptions.useDevicePixelRatio`, including its note on page
-   * zoom being folded into the ratio outside WebKit.
+   * `ScreenResolutionOptions.useDevicePixelRatio`, including its note on page zoom being folded into the ratio outside
+   * WebKit.
    */
   useDevicePixelRatio?: boolean;
 }

--- a/packages/spf/src/playback/behaviors/dom/update-mediasource-duration.ts
+++ b/packages/spf/src/playback/behaviors/dom/update-mediasource-duration.ts
@@ -1,56 +1,41 @@
 /**
- * **Propagate `presentation.duration` to `mediaSource.duration` — exactly
- * once per MediaSource.**
+ * **Propagate `presentation.duration` to `mediaSource.duration` — exactly once per MediaSource.**
  *
  * Two paths, by whether the presentation is live:
  *
- * - **Live** (`presentation.duration === Infinity`): write `Infinity` once the
- *   MediaSource is open and no SourceBuffer is mid-append. No buffered clamp is
- *   needed (`Infinity` ≥ any range) and — unlike the finite case — it needn't
- *   precede the first append: `Infinity` overrides whatever finite live-edge
- *   value an append may have pinned (a finite duration would otherwise stall
- *   the stream once the window slides past it). The wait-for-idle is required
- *   because the MSE spec forbids setting `duration` while a buffer is
- *   `updating`; both waits resolve immediately when already open / idle.
- *
- * - **VoD** (finite): the value is written once, after `mediaSource` is open and
- *   all SourceBuffers are idle, clamped to be ≥ the highest buffered range (MSE
- *   spec). Written only while `mediaSource.duration` is still `NaN`; once any
- *   non-NaN value is present (us on a prior entry, or `endOfStream` from the
- *   buffered end), the property is left alone — re-syncing would race
- *   concurrent `appendBuffer()` calls.
+ * - **Live** (`presentation.duration === Infinity`): write `Infinity` once the MediaSource is open and no SourceBuffer is
+ *   mid-append. No buffered clamp is needed (`Infinity` ≥ any range) and — unlike the finite case — it needn't precede
+ *   the first append: `Infinity` overrides whatever finite live-edge value an append may have pinned (a finite duration
+ *   would otherwise stall the stream once the window slides past it). The wait-for-idle is required because the MSE
+ *   spec forbids setting `duration` while a buffer is `updating`; both waits resolve immediately when already open /
+ *   idle.
+ * - **VoD** (finite): the value is written once, after `mediaSource` is open and all SourceBuffers are idle, clamped to
+ *   be ≥ the highest buffered range (MSE spec). Written only while `mediaSource.duration` is still `NaN`; once any
+ *   non-NaN value is present (us on a prior entry, or `endOfStream` from the buffered end), the property is left alone
+ *   — re-syncing would race concurrent `appendBuffer()` calls.
  *
  * The entry resolves three async preconditions in order before writing:
  *
- * 1. **MediaSource open** — `waitForMediaSourceOpen` defers until the first
- *    `sourceopen` event (or any readyState transition, since `'ended'` /
- *    `'closed'` mean we've missed the window and should bail).
- * 2. **All SourceBuffers idle** — `waitForSourceBuffersReady` defers per
- *    the MSE-spec rule that `duration` cannot be set while any buffer has
- *    `updating === true`.
- * 3. **Buffered-range clamp** — `getMaxBufferedEnd` ensures the written
- *    duration is at least the highest buffered end (MSE spec disallows
- *    a smaller `duration` than any buffered range).
+ * 1. **MediaSource open** — `waitForMediaSourceOpen` defers until the first `sourceopen` event (or any readyState
+ *    transition, since `'ended'` / `'closed'` mean we've missed the window and should bail).
+ * 2. **All SourceBuffers idle** — `waitForSourceBuffersReady` defers per the MSE-spec rule that `duration` cannot be set
+ *    while any buffer has `updating === true`.
+ * 3. **Buffered-range clamp** — `getMaxBufferedEnd` ensures the written duration is at least the highest buffered end (MSE
+ *    spec disallows a smaller `duration` than any buffered range).
  *
- * The buffer-set helpers operate across `mediaSource.sourceBuffers` (the
- * canonical aggregate), so the behavior composes uniformly across
- * audio-only, video-only, and mixed configurations.
+ * The buffer-set helpers operate across `mediaSource.sourceBuffers` (the canonical aggregate), so the behavior composes
+ * uniformly across audio-only, video-only, and mixed configurations.
  *
- * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'duration-writable'`):
- * state derivation is purely signal-driven (presentation validity +
- * mediaSource existence). MediaSource lifecycle state (`readyState`) and
- * the `duration` itself are non-signal DOM properties resolved inside the
- * entry's async sequence. The state-exit cleanup aborts the in-flight
- * wait, so source resets and behavior destroy structurally cancel the
- * pending write. A post-await re-check of `mediaSource.readyState ===
- * 'open'` covers the narrow race where `endOfStream()` synchronously
- * transitions readyState to `'ended'` between our `waitForMediaSourceOpen`
- * resolution and the `mediaSource.duration` write.
+ * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'duration-writable'`): state derivation is purely
+ * signal-driven (presentation validity + mediaSource existence). MediaSource lifecycle state (`readyState`) and the
+ * `duration` itself are non-signal DOM properties resolved inside the entry's async sequence. The state-exit cleanup
+ * aborts the in-flight wait, so source resets and behavior destroy structurally cancel the pending write. A post-await
+ * re-check of `mediaSource.readyState === 'open'` covers the narrow race where `endOfStream()` synchronously
+ * transitions readyState to `'ended'` between our `waitForMediaSourceOpen` resolution and the `mediaSource.duration`
+ * write.
  *
- * Downstream of `calculatePresentationDuration` (which writes
- * `presentation.duration`); concurrent with `endOfStream` (which may later
- * write `mediaSource.duration` — the "exactly once" contract keeps us out
- * of that path).
+ * Downstream of `calculatePresentationDuration` (which writes `presentation.duration`); concurrent with `endOfStream`
+ * (which may later write `mediaSource.duration` — the "exactly once" contract keeps us out of that path).
  */
 import { defineBehavior } from '../../../core/composition/create-composition';
 import type { Reactor } from '../../../core/reactors/create-machine-reactor';

--- a/packages/spf/src/playback/behaviors/establish-start-media-time.ts
+++ b/packages/spf/src/playback/behaviors/establish-start-media-time.ts
@@ -1,29 +1,22 @@
 /**
- * Establish the presentation's coordinate origin — the `startTime` /
- * `startMediaTime` / `startDate` triple — once per source, so every track lands
- * on one 0-based presentation timeline. One establishment unit with an internal
- * order: the wall-clock **anchor** settles (live PDT sources), gated parses
- * align to it, then `startMediaTime` latches — see
+ * Establish the presentation's coordinate origin — the `startTime` / `startMediaTime` / `startDate` triple — once per
+ * source, so every track lands on one 0-based presentation timeline. One establishment unit with an internal order: the
+ * wall-clock **anchor** settles (live PDT sources), gated parses align to it, then `startMediaTime` latches — see
  * `internal/design/spf/live-presentation-timeline-model.md`.
  *
  * The two coordinate stamps it owns:
- * - **`startDate` (wall-clock anchor).** The designated *reference track*
- *   (selected video, else audio) resolves first; its parser-computed
- *   `startDate` — PDT at presentation-0 — is frozen as the anchor and stamped
- *   onto every other track that lacks one, so their first parses place via
- *   `placeOnAnchor` (the pre-applied-anchor path in `parse-media-playlist`)
- *   and later-selected renditions resolve already aligned. Ordering is
- *   enforced by {@link gateFirstParseOnAnchor}, which `resolve-track` awaits
- *   through its injected gate seam. Absent PDT (ordinary VOD), no anchor is
- *   stamped and local-from-0 placement is already correct.
- * - **`startMediaTime` (decode origin).** Runs the injected
- *   {@link DeriveStartMediaTime} seam over the transient `mediaContainerData`
- *   slot (owned here; `inactive` clears it per source) and stamps the settled
- *   value onto the model until `established`. The byte-level discover/stamp
- *   steps that fill the slot are a separate, config `messagePipelines` array
- *   (`primitives/relocation-pipelines`); the two coordinate only through the
- *   shared `state.mediaContainerData` slot, never by import. See
- *   `internal/design/spf/presentation-timeline-model.md`.
+ *
+ * - **`startDate` (wall-clock anchor).** The designated _reference track_ (selected video, else audio) resolves first;
+ *   its parser-computed `startDate` — PDT at presentation-0 — is frozen as the anchor and stamped onto every other
+ *   track that lacks one, so their first parses place via `placeOnAnchor` (the pre-applied-anchor path in
+ *   `parse-media-playlist`) and later-selected renditions resolve already aligned. Ordering is enforced by
+ *   {@link gateFirstParseOnAnchor}, which `resolve-track` awaits through its injected gate seam. Absent PDT (ordinary
+ *   VOD), no anchor is stamped and local-from-0 placement is already correct.
+ * - **`startMediaTime` (decode origin).** Runs the injected {@link DeriveStartMediaTime} seam over the transient
+ *   `mediaContainerData` slot (owned here; `inactive` clears it per source) and stamps the settled value onto the model
+ *   until `established`. The byte-level discover/stamp steps that fill the slot are a separate, config
+ *   `messagePipelines` array (`primitives/relocation-pipelines`); the two coordinate only through the shared
+ *   `state.mediaContainerData` slot, never by import. See `internal/design/spf/presentation-timeline-model.md`.
  *
  * DOM-free reactor; sticky per source (`inactive → monitoring → established`).
  */
@@ -50,11 +43,9 @@ export type { DeriveStartMediaTime, DeriveStartMediaTimeContext, GateFirstParse,
 export interface EstablishStartMediaTimeState {
   presentation?: MaybeResolvedPresentation;
   /**
-   * Transient origin-establishment data, keyed by **track type** (`'video'` /
-   * `'audio'`) — per spec one init+media pair per type suffices, and ABR rungs of
-   * a type share the origin. Filled by the discover steps across appends, reset
-   * per source. Never the model — the churn stays here; only the settled
-   * `startMediaTime` reaches `Track`.
+   * Transient origin-establishment data, keyed by **track type** (`'video'` / `'audio'`) — per spec one init+media pair
+   * per type suffices, and ABR rungs of a type share the origin. Filled by the discover steps across appends, reset per
+   * source. Never the model — the churn stays here; only the settled `startMediaTime` reaches `Track`.
    */
   mediaContainerData?: Record<string, MediaContainerData>;
   selectedVideoTrackId?: string;
@@ -62,10 +53,9 @@ export interface EstablishStartMediaTimeState {
 }
 
 /**
- * A single type's own media-timeline origin:
- * `baseMediaDecodeTime/timescale − segmentStartTime` (the `segmentStartTime` term
- * makes it the stream origin even when the first loaded segment isn't the 0th).
- * `undefined` until timescale + baseMediaDecodeTime + segmentStartTime are all present.
+ * A single type's own media-timeline origin: `baseMediaDecodeTime/timescale − segmentStartTime` (the `segmentStartTime`
+ * term makes it the stream origin even when the first loaded segment isn't the 0th). `undefined` until timescale +
+ * baseMediaDecodeTime + segmentStartTime are all present.
  */
 function ownOrigin(data: MediaContainerData | undefined): number | undefined {
   const { timescale, baseMediaDecodeTime, segmentStartTime } = data ?? {};
@@ -76,16 +66,15 @@ function ownOrigin(data: MediaContainerData | undefined): number | undefined {
 }
 
 /**
- * Origins below this magnitude (seconds) are treated as `0` — the derive returns `0`, so
- * the presentation is left on its native (~0-based) timeline and no `timestampOffset` is
- * set (the loader stamp no-ops on a derived `0`). Ordinary VOD carries a small nonzero
- * encode origin (audio priming, first-frame CTS, edit lists); relocating by a sub-second
- * amount is pointless, and setting `timestampOffset` at all can ripple edge segments.
- * Relocation targets streams with an intentional large origin (instant clips, bipbop @10s).
+ * Origins below this magnitude (seconds) are treated as `0` — the derive returns `0`, so the presentation is left on
+ * its native (~0-based) timeline and no `timestampOffset` is set (the loader stamp no-ops on a derived `0`). Ordinary
+ * VOD carries a small nonzero encode origin (audio priming, first-frame CTS, edit lists); relocating by a sub-second
+ * amount is pointless, and setting `timestampOffset` at all can ripple edge segments. Relocation targets streams with
+ * an intentional large origin (instant clips, bipbop @10s).
  *
- * Absolute basis, not proportional: the DTS-below-zero / ripple risk scales with the
- * origin's absolute size, not with the presentation's duration. Also snaps negatives to
- * `0` — a negative origin would relocate *forward*, which is never the intent.
+ * Absolute basis, not proportional: the DTS-below-zero / ripple risk scales with the origin's absolute size, not with
+ * the presentation's duration. Also snaps negatives to `0` — a negative origin would relocate _forward_, which is never
+ * the intent.
  */
 export const NEAR_ZERO_ORIGIN_THRESHOLD = 1;
 
@@ -95,20 +84,18 @@ function thresholdOrigin(origin: number): number {
 }
 
 /**
- * The **default** — relocate the whole presentation by one shared origin: the `min`
- * across the *selected* A/V tracks' own origins, denormalized onto every type. This
- * single reduce subsumes the "per-type" and "shared" tiers:
+ * The **default** — relocate the whole presentation by one shared origin: the `min` across the _selected_ A/V tracks'
+ * own origins, denormalized onto every type. This single reduce subsumes the "per-type" and "shared" tiers:
+ *
  * - **aligned A/V** — `min` equals each origin (they're equal), so it matches per-type;
- * - **skewed A/V** (e.g. Apple's 44ms audio-lead) — `min` keeps every track's earliest
- *   DTS ≥ 0 (relocating by ≤ each own origin never drives one negative) *and* preserves
- *   the real skew (per-type would flatten it, desyncing A/V);
+ * - **skewed A/V** (e.g. Apple's 44ms audio-lead) — `min` keeps every track's earliest DTS ≥ 0 (relocating by ≤ each own
+ *   origin never drives one negative) _and_ preserves the real skew (per-type would flatten it, desyncing A/V);
  * - **single type / muxed** — `min` of the one origin is that origin.
  *
- * Returns `undefined` for every type until all *selected* types have a complete origin
- * (the shared-`min` barrier). Which types must contribute is read from `ctx` (the
- * selected v/a ids); with no selection context it coordinates across whatever types
- * have data. A shared origin below {@link NEAR_ZERO_ORIGIN_THRESHOLD} is returned as `0`
- * (native — ordinary ~0-PTS VOD isn't relocated).
+ * Returns `undefined` for every type until all _selected_ types have a complete origin (the shared-`min` barrier).
+ * Which types must contribute is read from `ctx` (the selected v/a ids); with no selection context it coordinates
+ * across whatever types have data. A shared origin below {@link NEAR_ZERO_ORIGIN_THRESHOLD} is returned as `0` (native
+ * — ordinary ~0-PTS VOD isn't relocated).
  */
 export const deriveSharedMinStartMediaTime: DeriveStartMediaTime = (containerData, ctx) => {
   const contributingTypes: string[] = [];
@@ -133,15 +120,13 @@ export const deriveSharedMinStartMediaTime: DeriveStartMediaTime = (containerDat
 };
 
 /**
- * Coordination-axis *off* — each type relocates by its own origin, independently. Not
- * the default: it flattens real A/V skew (see {@link deriveSharedMinStartMediaTime}).
- * Kept as an opt-in for compositions that know their A/V is aligned and want to skip
- * the shared-`min` barrier (each type stamps as soon as its own origin is discovered).
+ * Coordination-axis _off_ — each type relocates by its own origin, independently. Not the default: it flattens real A/V
+ * skew (see {@link deriveSharedMinStartMediaTime}). Kept as an opt-in for compositions that know their A/V is aligned
+ * and want to skip the shared-`min` barrier (each type stamps as soon as its own origin is discovered).
  *
- * Caution: {@link NEAR_ZERO_ORIGIN_THRESHOLD} applies independently per type here — if
- * two types' origins straddle it, one snaps to `0` and the other doesn't, injecting up
- * to a threshold's worth of A/V offset. Safe for the intended aligned-A/V opt-in; see
- * `internal/design/spf/live-presentation-timeline-model.md` (collision 5).
+ * Caution: {@link NEAR_ZERO_ORIGIN_THRESHOLD} applies independently per type here — if two types' origins straddle it,
+ * one snaps to `0` and the other doesn't, injecting up to a threshold's worth of A/V offset. Safe for the intended
+ * aligned-A/V opt-in; see `internal/design/spf/live-presentation-timeline-model.md` (collision 5).
  */
 export const derivePerTypeStartMediaTime: DeriveStartMediaTime = (containerData) => {
   const out: Record<string, number | undefined> = {};
@@ -156,26 +141,23 @@ export const derivePerTypeStartMediaTime: DeriveStartMediaTime = (containerData)
 };
 
 /**
- * The anchor-source track: the selected video track, falling back to audio
- * (audio-only). Deterministic — never "first resolved", which is race-dependent
- * under concurrent resolves.
+ * The anchor-source track: the selected video track, falling back to audio (audio-only). Deterministic — never "first
+ * resolved", which is race-dependent under concurrent resolves.
  */
 function referenceTrackId(ctx: GateFirstParseContext): string | undefined {
   return ctx.selectedVideoTrackId ?? ctx.selectedAudioTrackId;
 }
 
 /**
- * The live-anchor first-parse gate (the "parses align" step of the establishment
- * order). Open for the reference track itself — its local-from-0 placement *is*
- * the presentation timeline (presentation-0 = the join point). Every other track
- * holds until the reference's first parse settles the anchor question: no PDT →
- * local placement is already correct, proceed; PDT anchor → hold until the
- * establishment reactor stamps it onto this track, so the parse takes the
- * `placeOnAnchor` path. Establishment is sticky-once, so an unanchored first
- * parse would be permanently misaligned — that's the race this gate closes.
+ * The live-anchor first-parse gate (the "parses align" step of the establishment order). Open for the reference track
+ * itself — its local-from-0 placement _is_ the presentation timeline (presentation-0 = the join point). Every other
+ * track holds until the reference's first parse settles the anchor question: no PDT → local placement is already
+ * correct, proceed; PDT anchor → hold until the establishment reactor stamps it onto this track, so the parse takes the
+ * `placeOnAnchor` path. Establishment is sticky-once, so an unanchored first parse would be permanently misaligned —
+ * that's the race this gate closes.
  *
- * Pairs with the {@link establishStartMediaTime} reactor (the stamp that opens
- * the anchored branch); wire both or neither.
+ * Pairs with the {@link establishStartMediaTime} reactor (the stamp that opens the anchored branch); wire both or
+ * neither.
  */
 export const gateFirstParseOnAnchor: GateFirstParse = (presentation, ctx, trackId) => {
   const referenceId = referenceTrackId(ctx);
@@ -206,12 +188,10 @@ export interface EstablishStartMediaTimeConfig {
 // ============================================================================
 
 /**
- * Stamp the frozen wall-clock anchor as `startDate` onto every track that lacks
- * one (idempotent — same reference when nothing moved). Unresolved shells pick
- * it up as the `placeOnAnchor` preset; covering *all* tracks in one pass means
- * any track selected later — an ABR rung, another audio language, late captions
- * — resolves already anchored. The reference track's own parser-computed
- * `startDate` reads back as the anchor, so it's naturally left untouched.
+ * Stamp the frozen wall-clock anchor as `startDate` onto every track that lacks one (idempotent — same reference when
+ * nothing moved). Unresolved shells pick it up as the `placeOnAnchor` preset; covering _all_ tracks in one pass means
+ * any track selected later — an ABR rung, another audio language, late captions — resolves already anchored. The
+ * reference track's own parser-computed `startDate` reads back as the anchor, so it's naturally left untouched.
  */
 function stampStartDates(presentation: Presentation, anchor: number): Presentation {
   let changed = false;

--- a/packages/spf/src/playback/behaviors/resolve-presentation.ts
+++ b/packages/spf/src/playback/behaviors/resolve-presentation.ts
@@ -1,36 +1,27 @@
 /**
  * **Resolve an unresolved presentation by fetching and parsing its manifest.**
  *
- * Reads `state.presentation`; when it holds `{ url }` (unresolved) and the
- * preload / load-activation gate is met, fetches the manifest, parses it via
- * the **required** `config.parsePresentation`, and writes the resolved
- * `Presentation` back to the same slot. The behavior is format-neutral: the
- * composing engine wires in its parser (e.g. the HLS engine supplies the
- * multivariant-playlist parser).
+ * Reads `state.presentation`; when it holds `{ url }` (unresolved) and the preload / load-activation gate is met,
+ * fetches the manifest, parses it via the **required** `config.parsePresentation`, and writes the resolved
+ * `Presentation` back to the same slot. The behavior is format-neutral: the composing engine wires in its parser (e.g.
+ * the HLS engine supplies the multivariant-playlist parser).
  *
  * Source-identity-driven, expressed as a 4-state machine:
  *
- * ```
- * 'preconditions-unmet' → 'idle' → 'resolving' → 'resolved'
- * ```
+ *     'preconditions-unmet' → 'idle' → 'resolving' → 'resolved'
  *
  * - `'preconditions-unmet'`: no presentation, or presentation has no URL.
- * - `'idle'`: URL present, unresolved, gate unmet (blocking preload + no
- *   load-activation). Waits for the gate to open.
- * - `'resolving'`: URL present, unresolved, gate met. Entry starts the fetch
- *   and returns the AbortController — the reactor calls `.abort()` on state
- *   exit, so source change / gate-close / destroy all cancel cleanly.
+ * - `'idle'`: URL present, unresolved, gate unmet (blocking preload + no load-activation). Waits for the gate to open.
+ * - `'resolving'`: URL present, unresolved, gate met. Entry starts the fetch and returns the AbortController — the
+ *   reactor calls `.abort()` on state exit, so source change / gate-close / destroy all cancel cleanly.
  * - `'resolved'`: `state.presentation` holds a resolved `Presentation`.
  *
- * Gate semantics: `state.preload` (or `config.defaultPreload`, default
- * `'metadata'`, when state.preload is unset) blocks resolution when its
- * value is `'none'` (see `isBlockingPreload` in `media/utils/preload`).
- * `state.loadActivated` is an override — true bypasses the preload gate
- * entirely.
+ * Gate semantics: `state.preload` (or `config.defaultPreload`, default `'metadata'`, when state.preload is unset)
+ * blocks resolution when its value is `'none'` (see `isBlockingPreload` in `media/utils/preload`).
+ * `state.loadActivated` is an override — true bypasses the preload gate entirely.
  *
- * Multi-writer with the engine adapter, which writes the initial unresolved
- * `{ url }` to `state.presentation` from src input. Different domains
- * (config-input vs. derived state via fetch) — legitimate multi-writer.
+ * Multi-writer with the engine adapter, which writes the initial unresolved `{ url }` to `state.presentation` from src
+ * input. Different domains (config-input vs. derived state via fetch) — legitimate multi-writer.
  */
 import { defineBehavior } from '../../core/composition/create-composition';
 import type { Reactor } from '../../core/reactors/create-machine-reactor';
@@ -51,15 +42,13 @@ export type ParsePresentation = (text: string, presentation: MaybeResolvedPresen
 
 export interface ResolvePresentationConfig {
   /**
-   * Parses a manifest body into a resolved `Presentation`. **Required** —
-   * the behavior is format-neutral and the composing engine supplies its
-   * own parser (HLS, DASH, etc.).
+   * Parses a manifest body into a resolved `Presentation`. **Required** — the behavior is format-neutral and the
+   * composing engine supplies its own parser (HLS, DASH, etc.).
    */
   parsePresentation: ParsePresentation;
   /**
-   * Fallback used when `state.preload` is unset (undefined / empty) for the
-   * resolution-gate decision. Defaults to `'metadata'`, matching
-   * `syncPreload`'s own `defaultPreload`.
+   * Fallback used when `state.preload` is unset (undefined / empty) for the resolution-gate decision. Defaults to
+   * `'metadata'`, matching `syncPreload`'s own `defaultPreload`.
    */
   defaultPreload?: StandardPreload;
 }

--- a/packages/spf/src/playback/behaviors/resolve-track.ts
+++ b/packages/spf/src/playback/behaviors/resolve-track.ts
@@ -27,8 +27,8 @@ import { type ErrorEmitterState, emitError } from './collect-errors';
 // ============================================================================
 
 /**
- * State shape for track resolution. Uses `MaybeResolvedPresentation` so it
- * matches the engine's slot type; resolution narrows internally.
+ * State shape for track resolution. Uses `MaybeResolvedPresentation` so it matches the engine's slot type; resolution
+ * narrows internally.
  */
 export interface ResolveTrackState {
   presentation?: MaybeResolvedPresentation;
@@ -45,10 +45,9 @@ type ResolveTrackStateMap<K extends SelectedTrackKey> = {
 } & { [P in K]: ReadonlySignal<ResolveTrackState[P]> };
 
 /**
- * Sibling-owned A/V selection signals, present at runtime iff a sibling
- * behavior owns them. Deliberately not in the typed slice / `stateKeys`
- * (declaring them would force every composition to carry both selections);
- * read only to build the injected first-parse gate's selection context.
+ * Sibling-owned A/V selection signals, present at runtime iff a sibling behavior owns them. Deliberately not in the
+ * typed slice / `stateKeys` (declaring them would force every composition to carry both selections); read only to build
+ * the injected first-parse gate's selection context.
  */
 type SiblingSelectionSignals = {
   selectedVideoTrackId?: ReadonlySignal<ResolveTrackState['selectedVideoTrackId']>;
@@ -67,17 +66,11 @@ interface TrackResolutionConfig<K extends SelectedTrackKey> {
   gateFirstParse?: GateFirstParse;
   /** Live re-run policy for the `RecurringRunner`; absent → resolve once (VOD). */
   reschedule?: Reschedule<ResolvedTrack>;
-  /**
-   * Report conditions found in the parsed playlist (see
-   * `primitives/report-track-conditions`); absent → report nothing.
-   */
+  /** Report conditions found in the parsed playlist (see `primitives/report-track-conditions`); absent → report nothing. */
   reportUnsupportedTrackConditions?: ReportUnsupportedTrackConditions;
 }
 
-/**
- * Engine-config slice each `resolve*` behavior reads to build its failover-
- * decorated playlist fetch.
- */
+/** Engine-config slice each `resolve*` behavior reads to build its failover- decorated playlist fetch. */
 interface ResolveTrackConfig {
   /** CDN-id derivation for the failover trip; defaults to origin-based `getCdnId`. */
   getCdnId?: GetCdnId;
@@ -304,9 +297,8 @@ const TEXT_TRACK_RESOLUTION_CONFIG = {
 // ============================================================================
 
 /**
- * Resolve unresolved video tracks. Schedules a fetch task whenever the
- * selected video track is partially resolved, parses the manifest, and
- * writes the resolved track back into `state.presentation`.
+ * Resolve unresolved video tracks. Schedules a fetch task whenever the selected video track is partially resolved,
+ * parses the manifest, and writes the resolved track back into `state.presentation`.
  */
 export const resolveVideoTrack = defineBehavior({
   stateKeys: ['presentation', 'selectedVideoTrackId'],
@@ -332,10 +324,7 @@ export const resolveVideoTrack = defineBehavior({
   },
 });
 
-/**
- * Resolve unresolved audio tracks. Same shape as `resolveVideoTrack`,
- * narrowed to audio.
- */
+/** Resolve unresolved audio tracks. Same shape as `resolveVideoTrack`, narrowed to audio. */
 export const resolveAudioTrack = defineBehavior({
   stateKeys: ['presentation', 'selectedAudioTrackId'],
   contextKeys: [],
@@ -356,10 +345,7 @@ export const resolveAudioTrack = defineBehavior({
   },
 });
 
-/**
- * Resolve unresolved text tracks. Same shape as `resolveVideoTrack`,
- * narrowed to text.
- */
+/** Resolve unresolved text tracks. Same shape as `resolveVideoTrack`, narrowed to text. */
 export const resolveTextTrack = defineBehavior({
   stateKeys: ['presentation', 'selectedTextTrackId'],
   contextKeys: [],

--- a/packages/spf/src/playback/behaviors/select-tracks.ts
+++ b/packages/spf/src/playback/behaviors/select-tracks.ts
@@ -1,54 +1,42 @@
 /**
- * **Default audio/video track selection on src load / unselect on src unload.**
- * When a presentation is resolved, sets `selectedVideoTrackId` /
- * `selectedAudioTrackId` from a per-type default rule chain if no selection
- * already exists. When the presentation is unset/reset (transitions back to unresolved),
- * clears the selection so a stale id from the previous source doesn't persist.
+ * **Default audio/video track selection on src load / unselect on src unload.** When a presentation is resolved, sets
+ * `selectedVideoTrackId` / `selectedAudioTrackId` from a per-type default rule chain if no selection already exists.
+ * When the presentation is unset/reset (transitions back to unresolved), clears the selection so a stale id from the
+ * previous source doesn't persist.
  *
- * Lifecycle-driven: the pick fires once per transition, and nothing re-picks —
- * that is what separates these from the `switch*` variants. External writes (user
- * picks, ABR, programmatic filter-driven re-picks) are left alone, including a
- * write naming a track the manifest never offered.
+ * Lifecycle-driven: the pick fires once per transition, and nothing re-picks — that is what separates these from the
+ * `switch*` variants. External writes (user picks, ABR, programmatic filter-driven re-picks) are left alone, including
+ * a write naming a track the manifest never offered.
  *
- * The one thing policed between transitions is a pick the *constraints* turn
- * against: a rendition's container and encryption are only known once its media
- * playlist resolves, which is after the pick was made, so a selection that becomes
- * unplayable is dropped. Dropped, never moved — re-picking is exactly the behavior
- * `switchVideoTrack` exists to provide. Dropping reports nothing on its own, since
- * whatever made the pick unplayable already reported its own, more specific cause.
+ * The one thing policed between transitions is a pick the _constraints_ turn against: a rendition's container and
+ * encryption are only known once its media playlist resolves, which is after the pick was made, so a selection that
+ * becomes unplayable is dropped. Dropped, never moved — re-picking is exactly the behavior `switchVideoTrack` exists to
+ * provide. Dropping reports nothing on its own, since whatever made the pick unplayable already reported its own, more
+ * specific cause.
  *
- * Selection runs the same rule model `switchVideoTrack` does — a hard
- * `constraints` pre-pass, then an ordered `rules` chain, with the pick as the
- * head (see `internal/design/spf/track-switching-model.md`). What differs is
- * reactivity, not the rules: this evaluates the chain once on resolve and pins
- * the result, where `switchVideoTrack` re-evaluates inside an effect so its rules
- * subscribe to bandwidth and user selection. A rule written for one therefore
- * composes into the other unchanged.
+ * Selection runs the same rule model `switchVideoTrack` does — a hard `constraints` pre-pass, then an ordered `rules`
+ * chain, with the pick as the head (see `internal/design/spf/track-switching-model.md`). What differs is reactivity,
+ * not the rules: this evaluates the chain once on resolve and pins the result, where `switchVideoTrack` re-evaluates
+ * inside an effect so its rules subscribe to bandwidth and user selection. A rule written for one therefore composes
+ * into the other unchanged.
  *
- * Both are config-driven, each per-type export wiring a sensible default: audio's
- * three-tier language policy, and for video the *empty* chain — with nothing
- * narrowing or reordering, the head is the first candidate. The behavior's
- * `config` is forwarded to the rules, so options like `preferredAudioLanguage`
- * reach them without an intermediate layer.
+ * Both are config-driven, each per-type export wiring a sensible default: audio's three-tier language policy, and for
+ * video the _empty_ chain — with nothing narrowing or reordering, the head is the first candidate. The behavior's
+ * `config` is forwarded to the rules, so options like `preferredAudioLanguage` reach them without an intermediate
+ * layer.
  *
- * Note a rule can only pick among real candidates, where the picker it replaced
- * could return any id at all. An id absent from the manifest was never
- * selectable, so that narrowing is the point rather than a limitation.
+ * Note a rule can only pick among real candidates, where the picker it replaced could return any id at all. An id
+ * absent from the manifest was never selectable, so that narrowing is the point rather than a limitation.
  *
- * Compose `selectVideoTrack` for the simple "pick a default video track"
- * behavior, or `switchVideoTrack` (`./track-switching.ts`) for the
- * ABR-driven variant. Compose `selectAudioTrack` for the simple default
- * pick, or `switchAudioTrack` (`./track-switching.ts`) for the
- * filter-reactive + mid-stream-flush slot-owner variant — when audio-abr
- * lands, `switchAudioTrack` extends into `switchAudioQuality`. Compose
- * only one per type — they're alternatives, not stackable (each writes
- * the same `selected*TrackId` slot). The simple variants tree-shake out
- * the heavier machinery (bandwidth estimator, quality selection, flush
- * orchestration).
+ * Compose `selectVideoTrack` for the simple "pick a default video track" behavior, or `switchVideoTrack`
+ * (`./track-switching.ts`) for the ABR-driven variant. Compose `selectAudioTrack` for the simple default pick, or
+ * `switchAudioTrack` (`./track-switching.ts`) for the filter-reactive + mid-stream-flush slot-owner variant — when
+ * audio-abr lands, `switchAudioTrack` extends into `switchAudioQuality`. Compose only one per type — they're
+ * alternatives, not stackable (each writes the same `selected*TrackId` slot). The simple variants tree-shake out the
+ * heavier machinery (bandwidth estimator, quality selection, flush orchestration).
  *
- * Text selection has no simple variant here — it's owned by `switchTextTrack`
- * (`./track-switching.ts`), which resolves standing `userTextTrackSelection`
- * intent against the constrained, CDN-scoped renditions.
+ * Text selection has no simple variant here — it's owned by `switchTextTrack` (`./track-switching.ts`), which resolves
+ * standing `userTextTrackSelection` intent against the constrained, CDN-scoped renditions.
  */
 
 import { defineBehavior } from '../../core/composition/create-composition';
@@ -234,10 +222,9 @@ function setupTrackSelection<K extends SelectedTrackKey, RuleConfig>({
 const DEFAULT_VIDEO_RULES: readonly SelectTrackRule<SelectVideoTrackConfig>[] = [];
 
 /**
- * Default audio chain: the three-tier policy (`preferredAudioLanguage` →
- * `DEFAULT=YES` → first) as a single narrowing rule. Returning `[]` when nothing
- * is picked lets `applyRules` fall through to the unnarrowed candidates, so the
- * head stays the first track — the same last tier the policy itself ends on.
+ * Default audio chain: the three-tier policy (`preferredAudioLanguage` → `DEFAULT=YES` → first) as a single narrowing
+ * rule. Returning `[]` when nothing is picked lets `applyRules` fall through to the unnarrowed candidates, so the head
+ * stays the first track — the same last tier the policy itself ends on.
  */
 const preferAudioPolicy: SelectTrackRule<SelectAudioTrackConfig> = (tracks, { config }) => {
   const id = pickAudioTrackFromTracks(tracks as readonly { id: string }[], config);
@@ -249,18 +236,16 @@ const preferAudioPolicy: SelectTrackRule<SelectAudioTrackConfig> = (tracks, { co
 const DEFAULT_AUDIO_RULES: readonly SelectTrackRule<SelectAudioTrackConfig>[] = [preferAudioPolicy];
 
 /**
- * Order the candidates by resolution, largest first, with bandwidth breaking ties
- * between renditions of identical dimensions. The background-video default — that
- * variant pins one rendition for the session, and absent a cap the largest is the
- * head.
+ * Order the candidates by resolution, largest first, with bandwidth breaking ties between renditions of identical
+ * dimensions. The background-video default — that variant pins one rendition for the session, and absent a cap the
+ * largest is the head.
  *
- * A ranker, so it reorders rather than narrowing: the chain's pick is the head of
- * what it returns, which means ranking never has to collapse to one track. Belongs
- * last in a chain — a sort only reorders what survived the filters ahead of it, and
- * leaving it last is what lets `applyRules` early-bail before it runs.
+ * A ranker, so it reorders rather than narrowing: the chain's pick is the head of what it returns, which means ranking
+ * never has to collapse to one track. Belongs last in a chain — a sort only reorders what survived the filters ahead of
+ * it, and leaving it last is what lets `applyRules` early-bail before it runs.
  *
- * Exported because it is a *rule*, not a variant's private policy: the same one
- * composes into `switchVideoTrack`'s chain when a ranker is wanted there.
+ * Exported because it is a _rule_, not a variant's private policy: the same one composes into `switchVideoTrack`'s
+ * chain when a ranker is wanted there.
  */
 export const preferHighestResolution: SelectTrackRule<unknown> = (tracks) => [...tracks].sort(byDescendingResolution);
 
@@ -270,38 +255,30 @@ type ScreenResolutionRuleState = {
 };
 
 /**
- * Narrow to the renditions that fit the screen, by pixel area — the screen-size
- * cap from `internal/design/spf/features/rendition-selection-caps.md`, as a scope
- * (soft filter) rather than a constraint: an over-cap rendition is wasteful, not
- * unplayable, so nothing here may make a source unplayable.
+ * Narrow to the renditions that fit the screen, by pixel area — the screen-size cap from
+ * `internal/design/spf/features/rendition-selection-caps.md`, as a scope (soft filter) rather than a constraint: an
+ * over-cap rendition is wasteful, not unplayable, so nothing here may make a source unplayable.
  *
- * Narrows only — it neither orders the survivors nor resolves the case where none
- * survive, because `applyRules` owns both. So it needs a ranker behind it to pick
- * within the cap: `[screenResolutionCap, preferHighestResolution]` yields the
- * largest rendition that fits. Composed *last*, the pick would instead be whichever
- * fitting rendition the manifest happened to list first.
+ * Narrows only — it neither orders the survivors nor resolves the case where none survive, because `applyRules` owns
+ * both. So it needs a ranker behind it to pick within the cap: `[screenResolutionCap, preferHighestResolution]` yields
+ * the largest rendition that fits. Composed _last_, the pick would instead be whichever fitting rendition the manifest
+ * happened to list first.
  *
- * Reading `state.screenResolution` through its signal is what subscribes a
- * re-evaluating chain (`switchVideoTrack`) to screen changes; `selectVideoTrack`
- * pins the first answer instead, by design.
+ * Reading `state.screenResolution` through its signal is what subscribes a re-evaluating chain (`switchVideoTrack`) to
+ * screen changes; `selectVideoTrack` pins the first answer instead, by design.
  *
- * Compares areas rather than matching a `"1080p"`-style tier because a tier only
- * describes a rendition once you assume its aspect ratio — the assumption that
- * mis-measures an anamorphic ladder. See `media/dom/screen.ts`.
+ * Compares areas rather than matching a `"1080p"`-style tier because a tier only describes a rendition once you assume
+ * its aspect ratio — the assumption that mis-measures an anamorphic ladder. See `media/dom/screen.ts`.
  *
  * Three ways the cap ends up not applying, all of them fall-through:
  *
- * - **No `screenResolution` signal at all**, because the composition omits
- *   `trackScreenResolution`. So composing the cap without its signal source is
- *   inert rather than broken.
- * - **A `screenResolution` of `undefined`**, meaning no screen to read. "Unknown"
- *   has to mean "don't cap": treating it as an area of zero would pin every source
- *   to its smallest rendition on exactly the environments we know least about.
- * - **No rendition fits**, on a screen smaller than the whole ladder. `applyRules`
- *   skips the empty result and the chain proceeds unnarrowed, so the ranker behind
- *   the cap decides — for `preferHighestResolution`, the largest rendition. A floor
- *   is the fix if that ever matters (`rendition-selection-caps.md` carries one), not
- *   a special case here.
+ * - **No `screenResolution` signal at all**, because the composition omits `trackScreenResolution`. So composing the cap
+ *   without its signal source is inert rather than broken.
+ * - **A `screenResolution` of `undefined`**, meaning no screen to read. "Unknown" has to mean "don't cap": treating it as
+ *   an area of zero would pin every source to its smallest rendition on exactly the environments we know least about.
+ * - **No rendition fits**, on a screen smaller than the whole ladder. `applyRules` skips the empty result and the chain
+ *   proceeds unnarrowed, so the ranker behind the cap decides — for `preferHighestResolution`, the largest rendition. A
+ *   floor is the fix if that ever matters (`rendition-selection-caps.md` carries one), not a special case here.
  */
 export const screenResolutionCap: SelectTrackRule<unknown> = (tracks, { state }) => {
   const screenResolution = (state as ScreenResolutionRuleState | undefined)?.screenResolution?.get();
@@ -316,9 +293,8 @@ export const screenResolutionCap: SelectTrackRule<unknown> = (tracks, { state })
 // ============================================================================
 
 /**
- * Config for `selectVideoTrack`. Pass `rules` to replace the selection chain, or
- * `constraints` to replace the capability pre-pass; otherwise the chain is empty
- * and the first playable candidate is the pick.
+ * Config for `selectVideoTrack`. Pass `rules` to replace the selection chain, or `constraints` to replace the
+ * capability pre-pass; otherwise the chain is empty and the first playable candidate is the pick.
  */
 export interface SelectVideoTrackConfig extends CapabilityConstraintConfig {
   constraints?: readonly SelectTrackRule<SelectVideoTrackConfig>[];
@@ -326,25 +302,21 @@ export interface SelectVideoTrackConfig extends CapabilityConstraintConfig {
 }
 
 /**
- * Default video constraints: the capability pre-pass alone. No
- * `excludeFailedCdns` — this variant's compositions run no failover monitor, so
- * `failedCdns` has no writer and the constraint would always pass through.
+ * Default video constraints: the capability pre-pass alone. No `excludeFailedCdns` — this variant's compositions run no
+ * failover monitor, so `failedCdns` has no writer and the constraint would always pass through.
  */
 const DEFAULT_VIDEO_CONSTRAINTS: readonly SelectTrackRule<SelectVideoTrackConfig>[] = [excludeUnplayableTracks];
 
 /**
- * Select a video track when a presentation loads. Clears the selection on
- * src unload.
+ * Select a video track when a presentation loads. Clears the selection on src unload.
  *
- * This is the simple, non-ABR counterpart to `switchVideoTrack` — compose
- * one or the other, not both (both write `selectedVideoTrackId`). Composing
- * `selectVideoTrack` alone tree-shakes out the ABR code path
- * (bandwidth-estimator, quality-selection); use it for sources without
- * meaningful quality variants, test setups, or players that intentionally
- * pin a quality.
+ * This is the simple, non-ABR counterpart to `switchVideoTrack` — compose one or the other, not both (both write
+ * `selectedVideoTrackId`). Composing `selectVideoTrack` alone tree-shakes out the ABR code path (bandwidth-estimator,
+ * quality-selection); use it for sources without meaningful quality variants, test setups, or players that
+ * intentionally pin a quality.
  *
  * @example
- * const reactor = selectVideoTrack.setup({ state });
+ *   const reactor = selectVideoTrack.setup({ state });
  */
 export const selectVideoTrack = defineBehavior({
   stateKeys: ['presentation', 'selectedVideoTrackId'],
@@ -363,9 +335,8 @@ export const selectVideoTrack = defineBehavior({
 });
 
 /**
- * Config for `selectAudioTrack`. Pass `rules` to replace the selection chain, or
- * `constraints` to prune candidates before it runs; otherwise the default
- * three-tier policy applies (`preferredAudioLanguage` → `DEFAULT=YES` → first).
+ * Config for `selectAudioTrack`. Pass `rules` to replace the selection chain, or `constraints` to prune candidates
+ * before it runs; otherwise the default three-tier policy applies (`preferredAudioLanguage` → `DEFAULT=YES` → first).
  */
 export interface SelectAudioTrackConfig extends AudioSelectionConfig {
   constraints?: readonly SelectTrackRule<SelectAudioTrackConfig>[];
@@ -373,27 +344,23 @@ export interface SelectAudioTrackConfig extends AudioSelectionConfig {
 }
 
 /**
- * Select an audio track when a presentation loads. Clears the selection
- * on src unload.
+ * Select an audio track when a presentation loads. Clears the selection on src unload.
  *
- * This is the simple, lifecycle-only counterpart to `switchAudioTrack`
- * (in `./track-switching.ts`) — compose one or the other, not both
- * (both write `selectedAudioTrackId`). `switchAudioTrack` adds
- * filter-reactivity (`userAudioTrackSelection`) and mid-stream-flush
- * orchestration; `selectAudioTrack` covers the default-on-load case
- * without those. Use this variant for test setups, audio-only flows
- * that don't expose language switching, or composition variants that
- * intentionally pin a track.
+ * This is the simple, lifecycle-only counterpart to `switchAudioTrack` (in `./track-switching.ts`) — compose one or the
+ * other, not both (both write `selectedAudioTrackId`). `switchAudioTrack` adds filter-reactivity
+ * (`userAudioTrackSelection`) and mid-stream-flush orchestration; `selectAudioTrack` covers the default-on-load case
+ * without those. Use this variant for test setups, audio-only flows that don't expose language switching, or
+ * composition variants that intentionally pin a track.
  *
  * @example
- * const reactor = selectAudioTrack.setup({ state });
+ *   const reactor = selectAudioTrack.setup({ state });
  *
  * @example
- * // Language preference, honored by the default audio policy rule
- * const reactor = selectAudioTrack.setup({
- *   state,
- *   config: { preferredAudioLanguage: 'en' },
- * });
+ *   // Language preference, honored by the default audio policy rule
+ *   const reactor = selectAudioTrack.setup({
+ *     state,
+ *     config: { preferredAudioLanguage: 'en' },
+ *   });
  */
 export const selectAudioTrack = defineBehavior({
   stateKeys: ['presentation', 'selectedAudioTrackId'],

--- a/packages/spf/src/playback/behaviors/setup-failover-monitor.ts
+++ b/packages/spf/src/playback/behaviors/setup-failover-monitor.ts
@@ -1,18 +1,14 @@
 /**
- * **CDN failover cooldown.** The expiry half of multi-CDN failover. Fetch sites
- * own the *trip*: on a failed fetch they add the failing CDN (origin) to the
- * `failedCdns` state signal directly. This behavior owns the *expiry*: while a
- * presentation is resolved, it watches `failedCdns` and, for each CDN that
- * appears, schedules a timer to remove it once its cooldown lapses.
- * `track-switching`'s `excludeFailedCdns` constraint prunes a failed CDN's
- * tracks and the active-CDN scope falls to the next one — and back, once the
- * cooldown removes it here.
+ * **CDN failover cooldown.** The expiry half of multi-CDN failover. Fetch sites own the _trip_: on a failed fetch they
+ * add the failing CDN (origin) to the `failedCdns` state signal directly. This behavior owns the _expiry_: while a
+ * presentation is resolved, it watches `failedCdns` and, for each CDN that appears, schedules a timer to remove it once
+ * its cooldown lapses. `track-switching`'s `excludeFailedCdns` constraint prunes a failed CDN's tracks and the
+ * active-CDN scope falls to the next one — and back, once the cooldown removes it here.
  *
- * Lifecycle is per-source: timers + `failedCdns` are cleared on exit (a new
- * source starts with a clean slate). Policy (cooldown) is engine config. This is
- * the minimal `network-resilience` slice — a single failure trips a CDN, since
- * transient blips are the retry layer's job (it sits below the fetch sites, so
- * anything that reaches `failedCdns` is already terminal).
+ * Lifecycle is per-source: timers + `failedCdns` are cleared on exit (a new source starts with a clean slate). Policy
+ * (cooldown) is engine config. This is the minimal `network-resilience` slice — a single failure trips a CDN, since
+ * transient blips are the retry layer's job (it sits below the fetch sites, so anything that reaches `failedCdns` is
+ * already terminal).
  */
 
 import { defineBehavior } from '../../core/composition/create-composition';
@@ -20,10 +16,7 @@ import { createMachineReactor } from '../../core/reactors/create-machine-reactor
 import { computed, type ReadonlySignal, type Signal, update } from '../../core/signals/primitives';
 import { isResolvedPresentation, type MaybeResolvedPresentation } from '../../media/types';
 
-/**
- * Failover policy: how long a CDN stays excluded after a failed fetch trips it.
- * Supplied via engine config.
- */
+/** Failover policy: how long a CDN stays excluded after a failed fetch trips it. Supplied via engine config. */
 export interface FailoverMonitorConfig {
   /** How long a tripped CDN stays excluded, in milliseconds. */
   cooldownMs: number;
@@ -48,11 +41,10 @@ export interface SetupFailoverMonitorConfig {
 }
 
 /**
- * Expire failed CDNs from `failedCdns` once their cooldown lapses, for the
- * resolved source.
+ * Expire failed CDNs from `failedCdns` once their cooldown lapses, for the resolved source.
  *
  * @example
- * const reactor = setupFailoverMonitor.setup({ state });
+ *   const reactor = setupFailoverMonitor.setup({ state });
  */
 export const setupFailoverMonitor = defineBehavior({
   stateKeys: ['presentation', 'failedCdns'],

--- a/packages/spf/src/playback/behaviors/sync-preload.ts
+++ b/packages/spf/src/playback/behaviors/sync-preload.ts
@@ -2,21 +2,17 @@
  * **Bidirectional sync between `state.preload` and `mediaElement.preload`.**
  *
  * Two effects:
- * - **Read (DOM → state)** — on `context.mediaElement` swap or
- *   `state.presentation.url` change, copies `mediaElement.preload` into
- *   `state.preload` if it's a W3C value and `state.preload` isn't holding
- *   an extended (non-W3C) value. When the DOM has no W3C opinion and
- *   `state.preload` is undefined, backfills from `config.defaultPreload`
- *   (default-default `'metadata'`) so `state.preload` is never undefined
- *   in steady state.
- * - **Write (state → DOM)** — on `state.preload` change or
- *   `context.mediaElement` swap, writes `state.preload` back to
+ *
+ * - **Read (DOM → state)** — on `context.mediaElement` swap or `state.presentation.url` change, copies
+ *   `mediaElement.preload` into `state.preload` if it's a W3C value and `state.preload` isn't holding an extended
+ *   (non-W3C) value. When the DOM has no W3C opinion and `state.preload` is undefined, backfills from
+ *   `config.defaultPreload` (default-default `'metadata'`) so `state.preload` is never undefined in steady state.
+ * - **Write (state → DOM)** — on `state.preload` change or `context.mediaElement` swap, writes `state.preload` back to
  *   `mediaElement.preload` if the value is W3C.
  *
- * Extended values (e.g. `'canplay'`) written externally to `state.preload`
- * are sticky: read won't overwrite them, write won't push them to the DOM.
- * All writes are deduped to break echo loops and avoid spurious re-triggers
- * downstream (notably `resolvePresentation`, which reads `state.preload`).
+ * Extended values (e.g. `'canplay'`) written externally to `state.preload` are sticky: read won't overwrite them, write
+ * won't push them to the DOM. All writes are deduped to break echo loops and avoid spurious re-triggers downstream
+ * (notably `resolvePresentation`, which reads `state.preload`).
  */
 import { defineBehavior } from '../../core/composition/create-composition';
 import { effect } from '../../core/signals/effect';
@@ -27,8 +23,8 @@ import type { PresentationState } from './resolve-presentation';
 
 export interface SyncPreloadConfig {
   /**
-   * Backfill applied to `state.preload` when neither the host element nor
-   * external code has supplied a W3C value. Defaults to `'metadata'`.
+   * Backfill applied to `state.preload` when neither the host element nor external code has supplied a W3C value.
+   * Defaults to `'metadata'`.
    */
   defaultPreload?: StandardPreload;
 }

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -1,79 +1,58 @@
 /**
- * **Per-type track selection as a rule chain.** While a presentation is
- * resolved, owns that type's `selected{Video,Audio,Text}TrackId` signal: pick a
- * default, react to user intent and algorithmic ranking, and clear it on src
- * unload.
+ * **Per-type track selection as a rule chain.** While a presentation is resolved, owns that type's
+ * `selected{Video,Audio,Text}TrackId` signal: pick a default, react to user intent and algorithmic ranking, and clear
+ * it on src unload.
  *
- * Selection runs in two stages. First a **hard-constraints pre-pass**
- * (`applyConstraints`) prunes the unplayable from the candidate set — the
- * failed-CDN constraint (`excludeFailedCdns`, failover cooldown), the
- * capability constraint (`excludeUnplayableTracks`, codec support), and the
- * codec-family sticky constraint (`stickToSelectedCodecs`, no
- * `SourceBuffer.changeType()` — see its note). Then a small
- * ordered chain of rules (`applyRules`) picks among the survivors. Each constraint/rule reads the signals it needs at apply
- * time, so the effect subscribes to exactly what was consulted. The chain runs
- * most authoritative first:
+ * Selection runs in two stages. First a **hard-constraints pre-pass** (`applyConstraints`) prunes the unplayable from
+ * the candidate set — the failed-CDN constraint (`excludeFailedCdns`, failover cooldown), the capability constraint
+ * (`excludeUnplayableTracks`, codec support), and the codec-family sticky constraint (`stickToSelectedCodecs`, no
+ * `SourceBuffer.changeType()` — see its note). Then a small ordered chain of rules (`applyRules`) picks among the
+ * survivors. Each constraint/rule reads the signals it needs at apply time, so the effect subscribes to exactly what
+ * was consulted. The chain runs most authoritative first:
  *
- *   1. **user intent** — a soft filter on `user*TrackSelection`: narrow to the
- *      partial-track match; an empty match falls through to the full set.
- *   2. **codec-family preference** — a soft filter on `preferredCodecs`
- *      (`preferCodecFamilies`, default AVC/AAC): on a mixed-codec source,
- *      narrow which family the *initial* pick — the one the sticky constraint
- *      then holds — lands in. Behind user intent so an explicit initial pick
- *      may land anywhere; inert once the constraint narrows to a
- *      non-preferred family.
- *   3. **active CDN** — a soft filter on `cdnPriority` (`preferActiveCdn`):
- *      narrow to the highest-priority CDN that still has tracks; an empty match
- *      falls through. Shared by video and audio, so every type stays on one CDN
- *      (`deriveCdnPriority` owns the list). No-op for non-redundant sources.
- *   4. **player resolution** — a soft filter on `playerResolution`
- *      (`playerResolutionCap`, video only): narrow to the smallest rendition
- *      tier covering the player element, plus everything below it. No-op
- *      without a measurement. Ahead of the ranker but behind the CDN scope, so
- *      the cap chooses *within* a host rather than between hosts.
- *   5. **ranking** — the terminal sort: `rankByBandwidth`, shared by video and
- *      audio. Fitting tracks (within the throughput threshold) first, highest
- *      bitrate first; over-throughput tracks after, least-over first. Hysteresis
- *      via boosting the current track's sort weight by `upgradeMargin`.
+ * 1. **user intent** — a soft filter on `user*TrackSelection`: narrow to the partial-track match; an empty match falls
+ *    through to the full set.
+ * 2. **codec-family preference** — a soft filter on `preferredCodecs` (`preferCodecFamilies`, default AVC/AAC): on a
+ *    mixed-codec source, narrow which family the _initial_ pick — the one the sticky constraint then holds — lands in.
+ *    Behind user intent so an explicit initial pick may land anywhere; inert once the constraint narrows to a
+ *    non-preferred family.
+ * 3. **active CDN** — a soft filter on `cdnPriority` (`preferActiveCdn`): narrow to the highest-priority CDN that still
+ *    has tracks; an empty match falls through. Shared by video and audio, so every type stays on one CDN
+ *    (`deriveCdnPriority` owns the list). No-op for non-redundant sources.
+ * 4. **player resolution** — a soft filter on `playerResolution` (`playerResolutionCap`, video only): narrow to the
+ *    smallest rendition tier covering the player element, plus everything below it. No-op without a measurement. Ahead
+ *    of the ranker but behind the CDN scope, so the cap chooses _within_ a host rather than between hosts.
+ * 5. **ranking** — the terminal sort: `rankByBandwidth`, shared by video and audio. Fitting tracks (within the throughput
+ *    threshold) first, highest bitrate first; over-throughput tracks after, least-over first. Hysteresis via boosting
+ *    the current track's sort weight by `upgradeMargin`.
  *
- * The composer's early-bail (one survivor → stop) is load-bearing: a user
- * selection that narrows to a single track is the pick without the ranker
- * running, so the bandwidth estimate is never read and the effect doesn't
- * re-fire on bandwidth while that choice holds.
+ * The composer's early-bail (one survivor → stop) is load-bearing: a user selection that narrows to a single track is
+ * the pick without the ranker running, so the bandwidth estimate is never read and the effect doesn't re-fire on
+ * bandwidth while that choice holds.
  *
- * Lifecycle: `'presentation-unresolved'` ↔ `'presentation-resolved'`. The
- * resolved state owns the signal; its entry-returned cleanup clears it on exit
- * (canonical cleanup-binds-to-setup per `reactors.md`).
+ * Lifecycle: `'presentation-unresolved'` ↔ `'presentation-resolved'`. The resolved state owns the signal; its
+ * entry-returned cleanup clears it on exit (canonical cleanup-binds-to-setup per `reactors.md`).
  *
- * The pick is the chain's result mapped to a slot value by `resolveSelection`
- * (default: the head, `applyRules(...)[0]`). Each variant supplies its
- * **constraints + rule chain (+ optional resolveSelection)** via config;
- * `setupTrackSwitching` owns only the lifecycle and runs what it's given. Video
- * and audio run constraints `[excludeFailedCdns, excludeUnplayableTracks,
- * stickToSelectedCodecs]` then rules `[filterByUserSelection,
- * preferCodecFamilies, preferActiveCdn, rankByBandwidth]` and take the head;
- * video inserts
- * `playerResolutionCap` after the active-CDN scope, and `switchVideoTrack` also
- * accepts ABR tuning config, `switchAudioTrack` takes none.
- * `switchTextTrack` differs — selection is *optional* (captions are
- * opt-in / off-able), so it runs `[excludeFailedCdns]` + `[preferActiveCdn]` and
- * supplies a text terminal (`pickResolvedTextTrack`) that resolves standing user
- * intent (`userTextTrackSelection`, incl. `'off'`) and may yield no selection.
- * (The active-CDN *scope* is the sticky-pick half of multi-CDN; the failed-CDN
- * *constraint* is the failover half — prune the cooled-down CDN, the scope falls
- * to the next.)
+ * The pick is the chain's result mapped to a slot value by `resolveSelection` (default: the head,
+ * `applyRules(...)[0]`). Each variant supplies its **constraints + rule chain (+ optional resolveSelection)** via
+ * config; `setupTrackSwitching` owns only the lifecycle and runs what it's given. Video and audio run constraints
+ * `[excludeFailedCdns, excludeUnplayableTracks, stickToSelectedCodecs]` then rules `[filterByUserSelection,
+ * preferCodecFamilies, preferActiveCdn, rankByBandwidth]` and take the head; video inserts `playerResolutionCap` after
+ * the active-CDN scope, and `switchVideoTrack` also accepts ABR tuning config, `switchAudioTrack` takes none.
+ * `switchTextTrack` differs — selection is _optional_ (captions are opt-in / off-able), so it runs
+ * `[excludeFailedCdns]` + `[preferActiveCdn]` and supplies a text terminal (`pickResolvedTextTrack`) that resolves
+ * standing user intent (`userTextTrackSelection`, incl. `'off'`) and may yield no selection. (The active-CDN _scope_ is
+ * the sticky-pick half of multi-CDN; the failed-CDN _constraint_ is the failover half — prune the cooled-down CDN, the
+ * scope falls to the next.)
  *
- * When the pre-pass prunes a type that *has* tracks to empty, the behavior
- * clears the selection (so a now-unplayable pick can't linger and stall) and
- * reports the type's `noSupportedTrackCode`. Which constraint emptied the set is
- * deliberately not consulted — the behavior reads no constraint's state, so the
- * chain stays composable. A type with no tracks at all is left alone; that's a
- * legitimate source shape, not a failure. The late `createSourceBuffer` check
+ * When the pre-pass prunes a type that _has_ tracks to empty, the behavior clears the selection (so a now-unplayable
+ * pick can't linger and stall) and reports the type's `noSupportedTrackCode`. Which constraint emptied the set is
+ * deliberately not consulted — the behavior reads no constraint's state, so the chain stays composable. A type with no
+ * tracks at all is left alone; that's a legitimate source shape, not a failure. The late `createSourceBuffer` check
  * stays as the structural backstop.
  *
- * Deferred: audio's preferred-language / default-track selection as standing
- * soft-filter rules (previously the empty-slot picker, dropped in the move to
- * the rule chain).
+ * Deferred: audio's preferred-language / default-track selection as standing soft-filter rules (previously the
+ * empty-slot picker, dropped in the move to the rule chain).
  */
 
 import { type AnySlotMap, defineBehavior } from '../../core/composition/create-composition';
@@ -119,12 +98,10 @@ import { type ErrorEmitterState, emitError } from './collect-errors';
 // ============================================================================
 
 /**
- * The slots `setupTrackSwitching` itself owns: the `presentation` gate it reads
- * and the per-type `selected*TrackId` it writes. Rule-only inputs are
- * deliberately absent — `user*TrackSelection` and `bandwidthState` belong to
- * whoever materializes them (the embedder via `shareSignals`, the buffer-actor
- * sampler), and each rule declares the signal it consults as an optional slot
- * on its own deps map, so the behavior never assumes a rule's signal exists.
+ * The slots `setupTrackSwitching` itself owns: the `presentation` gate it reads and the per-type `selected*TrackId` it
+ * writes. Rule-only inputs are deliberately absent — `user*TrackSelection` and `bandwidthState` belong to whoever
+ * materializes them (the embedder via `shareSignals`, the buffer-actor sampler), and each rule declares the signal it
+ * consults as an optional slot on its own deps map, so the behavior never assumes a rule's signal exists.
  */
 export interface TrackSwitchingState {
   presentation?: MaybeResolvedPresentation;
@@ -134,11 +111,9 @@ export interface TrackSwitchingState {
 }
 
 /**
- * Config for `switchVideoTrack` — the ABR tuning read by its ranker rule
- * (`rankByBandwidth`). `quality.safetyMargin` is the bandwidth-headroom
- * multiplier; `quality.upgradeMargin` the hysteresis ratio gating upgrades;
- * `bandwidth` tunes the estimator; `initialBandwidth` is the pre-sample
- * fallback. Defaults: `DEFAULT_QUALITY_CONFIG` (0.85 / 1.15),
+ * Config for `switchVideoTrack` — the ABR tuning read by its ranker rule (`rankByBandwidth`). `quality.safetyMargin` is
+ * the bandwidth-headroom multiplier; `quality.upgradeMargin` the hysteresis ratio gating upgrades; `bandwidth` tunes
+ * the estimator; `initialBandwidth` is the pre-sample fallback. Defaults: `DEFAULT_QUALITY_CONFIG` (0.85 / 1.15),
  * `DEFAULT_BANDWIDTH_CONFIG`, `DEFAULT_INITIAL_BANDWIDTH` (5 Mbps).
  */
 export interface SwitchVideoTrackConfig {
@@ -148,23 +123,18 @@ export interface SwitchVideoTrackConfig {
   /** Override CDN-id derivation (shared by the CDN scope + failover constraint). */
   getCdnId?: GetCdnId;
   /**
-   * Codec capability probe read by the `excludeUnplayableTracks` hard
-   * constraint — drops renditions this environment can't decode before
-   * selection runs. Injected (rather than imported) so the DOM-free behavior
-   * never reaches a DOM API directly; the engine defaults it to the
-   * `MediaSource.isTypeSupported`-backed `canPlayTrack`. Absent → no codec
+   * Codec capability probe read by the `excludeUnplayableTracks` hard constraint — drops renditions this environment
+   * can't decode before selection runs. Injected (rather than imported) so the DOM-free behavior never reaches a DOM
+   * API directly; the engine defaults it to the `MediaSource.isTypeSupported`-backed `canPlayTrack`. Absent → no codec
    * filtering (the constraint passes everything through).
    */
   canPlayTrack?: CanPlayTrack;
   /**
-   * Codec families (RFC 6381 4CCs, e.g. `'avc1'` / `'hvc1'` / `'mp4a'`) the
-   * initial pick prefers on a mixed-codec source, read by the
-   * `preferCodecFamilies` scope. With no `SourceBuffer.changeType()`, the
-   * initial family is the one `stickToSelectedCodecs` holds for the source's
-   * lifetime, so this decides which family that is. Cross-cutting like
-   * `getCdnId` — one list serves video and audio (each type's rule matches
-   * only the families its tracks carry). Defaults to
-   * `DEFAULT_PREFERRED_CODECS` (AVC + AAC); pass `[]` to disable.
+   * Codec families (RFC 6381 4CCs, e.g. `'avc1'` / `'hvc1'` / `'mp4a'`) the initial pick prefers on a mixed-codec
+   * source, read by the `preferCodecFamilies` scope. With no `SourceBuffer.changeType()`, the initial family is the one
+   * `stickToSelectedCodecs` holds for the source's lifetime, so this decides which family that is. Cross-cutting like
+   * `getCdnId` — one list serves video and audio (each type's rule matches only the families its tracks carry).
+   * Defaults to `DEFAULT_PREFERRED_CODECS` (AVC + AAC); pass `[]` to disable.
    */
   preferredCodecs?: string[];
 }
@@ -221,12 +191,10 @@ export {
 // ============================================================================
 
 /**
- * Minimum candidate-track shape consumed by the helper and its rules: an `id`
- * (the pick), a `url` (the active-CDN scope derives the CDN from it), an
- * optional `bandwidth` (the ranker's throughput sort), and optional
- * `width`/`height` (the ranker's equal-bitrate tie-break — absent on audio, so
- * audio candidates area-compare equal). Every resolved/partially-resolved video
- * track carries them all; audio tracks omit the dimensions.
+ * Minimum candidate-track shape consumed by the helper and its rules: an `id` (the pick), a `url` (the active-CDN scope
+ * derives the CDN from it), an optional `bandwidth` (the ranker's throughput sort), and optional `width`/`height` (the
+ * ranker's equal-bitrate tie-break — absent on audio, so audio candidates area-compare equal). Every
+ * resolved/partially-resolved video track carries them all; audio tracks omit the dimensions.
  */
 type SwitchableTrack = {
   id: string;
@@ -242,13 +210,11 @@ type SwitchableTrack = {
 };
 
 /**
- * Map the rule chain's surviving candidates to the final selection id, or
- * `undefined` for a deliberate no-selection. Defaults to the chain head
- * (`selectChainHead`) — the always-pick contract video and audio rely on
- * (`applyRules` guarantees a non-empty result, so the head is always there). A
- * variant whose selection is legitimately optional (text: opt-in captions,
- * explicit off) supplies its own picker that may return `undefined`; the helper
- * writes that straight through to the slot, clearing it.
+ * Map the rule chain's surviving candidates to the final selection id, or `undefined` for a deliberate no-selection.
+ * Defaults to the chain head (`selectChainHead`) — the always-pick contract video and audio rely on (`applyRules`
+ * guarantees a non-empty result, so the head is always there). A variant whose selection is legitimately optional
+ * (text: opt-in captions, explicit off) supplies its own picker that may return `undefined`; the helper writes that
+ * straight through to the slot, clearing it.
  */
 export type ResolveSelection<T extends SwitchableTrack, State = unknown, Context = unknown, Config = unknown> = (
   candidates: readonly T[],
@@ -275,25 +241,20 @@ export type TrackSwitchingStateMap<S extends SelectionKey> = {
 } & { [P in S]: Signal<TrackSwitchingState[P]> };
 
 /**
- * The lifecycle map plus the *optional* `errors` slot reporters append to. Owned
- * by `collectErrors`; optional so a composition without it still type-checks and
- * emission no-ops. The behavior reads no constraint's state — see
+ * The lifecycle map plus the _optional_ `errors` slot reporters append to. Owned by `collectErrors`; optional so a
+ * composition without it still type-checks and emission no-ops. The behavior reads no constraint's state — see
  * `noSupportedTrackCode`.
  */
 type TrackSwitchingReporterStateMap<S extends SelectionKey> = TrackSwitchingStateMap<S> & ErrorEmitterState;
 
 /**
- * Config `setupTrackSwitching` itself reads — its own wiring: which selection
- * slot to write and clear (`selectionKey`), how to enumerate candidate tracks
- * (`getTracks`), the optional **hard-constraints pre-pass** (`constraints`,
- * applied before the chain to prune the unplayable), and the **rule chain** to
- * run (`rules`), and how to map the chain's survivors to the final pick
- * (`resolveSelection`, defaulting to the chain head). Rule-/constraint-specific
- * config is deliberately absent — each declares the fields it reads as *optional*
- * on its own config view (`UserSelectionConfig`, `BandwidthRankerConfig`), so the
- * behavior never enumerates them. The variant builds the concrete config as this
- * base plus whatever its chain consults; it flows through untouched as the `C`
- * type param on `setupTrackSwitching`.
+ * Config `setupTrackSwitching` itself reads — its own wiring: which selection slot to write and clear (`selectionKey`),
+ * how to enumerate candidate tracks (`getTracks`), the optional **hard-constraints pre-pass** (`constraints`, applied
+ * before the chain to prune the unplayable), and the **rule chain** to run (`rules`), and how to map the chain's
+ * survivors to the final pick (`resolveSelection`, defaulting to the chain head). Rule-/constraint-specific config is
+ * deliberately absent — each declares the fields it reads as _optional_ on its own config view (`UserSelectionConfig`,
+ * `BandwidthRankerConfig`), so the behavior never enumerates them. The variant builds the concrete config as this base
+ * plus whatever its chain consults; it flows through untouched as the `C` type param on `setupTrackSwitching`.
  */
 interface TrackSwitchingConfig<S extends SelectionKey, T extends SwitchableTrack> {
   selectionKey: S;
@@ -301,30 +262,25 @@ interface TrackSwitchingConfig<S extends SelectionKey, T extends SwitchableTrack
   constraints?: readonly SelectionRule<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingConfig<S, T>>[];
   rules: readonly SelectionRule<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingConfig<S, T>>[];
   /**
-   * Map the chain's surviving candidates to the final selection id. Optional —
-   * absent means the chain head (`selectChainHead`), the always-pick path video
-   * and audio use. A variant with optional selection (text) supplies one that
-   * may return `undefined`.
+   * Map the chain's surviving candidates to the final selection id. Optional — absent means the chain head
+   * (`selectChainHead`), the always-pick path video and audio use. A variant with optional selection (text) supplies
+   * one that may return `undefined`.
    */
   resolveSelection?: ResolveSelection<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingConfig<S, T>>;
   /**
-   * SVTA code to report when this type *has* tracks but the constraints pruned
-   * every one. Per-variant because the condition isn't universally an error:
-   * video and audio supply {@link SVTA_NO_SUPPORTED_VIDEO_TRACK} /
-   * {@link SVTA_NO_SUPPORTED_AUDIO_TRACK}, while text supplies none — an
-   * unavailable subtitle track is a legitimate outcome, not a playback failure.
-   * Absent → the selection still clears, nothing is reported.
+   * SVTA code to report when this type _has_ tracks but the constraints pruned every one. Per-variant because the
+   * condition isn't universally an error: video and audio supply {@link SVTA_NO_SUPPORTED_VIDEO_TRACK} /
+   * {@link SVTA_NO_SUPPORTED_AUDIO_TRACK}, while text supplies none — an unavailable subtitle track is a legitimate
+   * outcome, not a playback failure. Absent → the selection still clears, nothing is reported.
    */
   noSupportedTrackCode?: number;
 }
 
 /**
- * State the user-selection filter reads: the lifecycle map plus an *optional*
- * user-selection slot (keyed by `U`), holding a partial-track description to
- * match against the candidates (`Partial<T>` — `{ id }`, `{ language }`,
- * `{ height }`, …). The slot exists only when the composition provides it
- * (materialized by `shareSignals`); the filter reads it defensively and no-ops
- * when it's absent (no user override).
+ * State the user-selection filter reads: the lifecycle map plus an _optional_ user-selection slot (keyed by `U`),
+ * holding a partial-track description to match against the candidates (`Partial<T>` — `{ id }`, `{ language }`, `{
+ * height }`, …). The slot exists only when the composition provides it (materialized by `shareSignals`); the filter
+ * reads it defensively and no-ops when it's absent (no user override).
  */
 type UserSelectionStateMap<
   S extends SelectionKey,
@@ -335,9 +291,8 @@ type UserSelectionStateMap<
 };
 
 /**
- * Config the user-selection filter reads: `userSelectionKey` names the state
- * slot holding the user's selection. *Optional* on the rule's view — the base
- * config doesn't carry it, so an unwired key means "no user selection" and the
+ * Config the user-selection filter reads: `userSelectionKey` names the state slot holding the user's selection.
+ * _Optional_ on the rule's view — the base config doesn't carry it, so an unwired key means "no user selection" and the
  * filter passes through. The variants always supply it.
  */
 type UserSelectionConfig<
@@ -347,57 +302,52 @@ type UserSelectionConfig<
 > = TrackSwitchingConfig<S, T> & { userSelectionKey?: U };
 
 /**
- * State the bandwidth ranker reads: the lifecycle map plus an *optional*
- * `bandwidthState`. The signal exists only when the composition includes a
- * bandwidth sampler; the ranker reads it defensively and falls back to
- * `initialBandwidth` (with a debug note) when it's absent.
+ * State the bandwidth ranker reads: the lifecycle map plus an _optional_ `bandwidthState`. The signal exists only when
+ * the composition includes a bandwidth sampler; the ranker reads it defensively and falls back to `initialBandwidth`
+ * (with a debug note) when it's absent.
  */
 type BandwidthRankerStateMap<S extends SelectionKey> = TrackSwitchingStateMap<S> & {
   bandwidthState?: ReadonlySignal<BandwidthState | undefined>;
 };
 
 /**
- * Config the bandwidth ranker reads: the ABR tuning in `SwitchVideoTrackConfig`
- * (`quality` / `bandwidth` / `initialBandwidth`), all optional with defaults.
+ * Config the bandwidth ranker reads: the ABR tuning in `SwitchVideoTrackConfig` (`quality` / `bandwidth` /
+ * `initialBandwidth`), all optional with defaults.
  */
 type BandwidthRankerConfig<S extends SelectionKey, T extends SwitchableTrack> = TrackSwitchingConfig<S, T> &
   SwitchVideoTrackConfig;
 
 /**
- * State the player-resolution cap reads: TrackSwitchingStateMap plus the
- * *optional* player measurement, manifested by `trackPlayerResolution`.
+ * State the player-resolution cap reads: TrackSwitchingStateMap plus the _optional_ player measurement, manifested by
+ * `trackPlayerResolution`.
  */
 type PlayerResolutionCapStateMap<S extends SelectionKey> = TrackSwitchingStateMap<S> & {
   playerResolution?: ReadonlySignal<Resolution | undefined>;
 };
 
 /**
- * State the active-CDN scope reads: the lifecycle map plus an *optional*
- * `cdnPriority` — the manifest-ordered CDN list (most-preferred first). The
- * signal exists only when the composition includes `deriveCdnPriority` (which
- * materializes + owns it); the scope reads it defensively and passes through
- * when it's absent (no CDN preference).
+ * State the active-CDN scope reads: the lifecycle map plus an _optional_ `cdnPriority` — the manifest-ordered CDN list
+ * (most-preferred first). The signal exists only when the composition includes `deriveCdnPriority` (which materializes
+ * + owns it); the scope reads it defensively and passes through when it's absent (no CDN preference).
  */
 type CdnScopeStateMap<S extends SelectionKey> = TrackSwitchingStateMap<S> & {
   cdnPriority?: ReadonlySignal<string[] | undefined>;
 };
 
 /**
- * State the failed-CDN constraint reads: the lifecycle map plus an *optional*
- * `failedCdns` — the CDN ids currently in failover cooldown. The signal exists
- * only when the composition includes a failover monitor (or an external driver); the
- * constraint reads it defensively and excludes nothing when it's absent.
+ * State the failed-CDN constraint reads: the lifecycle map plus an _optional_ `failedCdns` — the CDN ids currently in
+ * failover cooldown. The signal exists only when the composition includes a failover monitor (or an external driver);
+ * the constraint reads it defensively and excludes nothing when it's absent.
  */
 type CdnConstraintStateMap<S extends SelectionKey> = TrackSwitchingStateMap<S> & {
   failedCdns?: ReadonlySignal<string[] | undefined>;
 };
 
 /**
- * Config the CDN rules read: the base config plus an *optional* `getCdnId`
- * override. Both `excludeFailedCdns` and `preferActiveCdn` derive a track's CDN
- * from its URL; the override must be the *same* one `deriveCdnPriority` and the
- * failover trip use, or the keys stop matching. Optional → defaults to the
- * origin-based `getCdnId`, so the base config (without it) stays assignable.
+ * Config the CDN rules read: the base config plus an _optional_ `getCdnId` override. Both `excludeFailedCdns` and
+ * `preferActiveCdn` derive a track's CDN from its URL; the override must be the _same_ one `deriveCdnPriority` and the
+ * failover trip use, or the keys stop matching. Optional → defaults to the origin-based `getCdnId`, so the base config
+ * (without it) stays assignable.
  */
 type CdnRuleConfig<S extends SelectionKey, T extends SwitchableTrack> = TrackSwitchingConfig<S, T> & {
   getCdnId?: GetCdnId;
@@ -414,10 +364,8 @@ type TextTrackCandidate = PartiallyResolvedTextTrack | TextTrack;
 // ----------------------------------------------------------------------------
 
 /**
- * User intent — a soft filter. Narrows to tracks matching the partial-track
- * selection in `user*TrackSelection`; an empty match falls through (the
- * composer skips it) to the unfiltered set — e.g. a stale id from a previous
- * source.
+ * User intent — a soft filter. Narrows to tracks matching the partial-track selection in `user*TrackSelection`; an
+ * empty match falls through (the composer skips it) to the unfiltered set — e.g. a stale id from a previous source.
  */
 function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
@@ -433,34 +381,27 @@ function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKe
 }
 
 /**
- * Player-resolution cap — a soft filter, video only. Narrows to the renditions
- * worth delivering at the player element's rendered size, so a small embed
- * doesn't pull segments nobody can perceive. The tighter sibling of
+ * Player-resolution cap — a soft filter, video only. Narrows to the renditions worth delivering at the player element's
+ * rendered size, so a small embed doesn't pull segments nobody can perceive. The tighter sibling of
  * `screenResolutionCap`: the element's box, not the screen behind it.
  *
- * The cap is the *smallest tier that still covers the player*, and everything at
- * or below it survives — not "everything at or below the player's area," which
- * under-serves a player falling between two tiers. Take an 800×450 player
- * against a 360p/720p/1080p ladder: only 360p is below it, so capping at the
- * player's area would hold an 800-px-wide box to a 640-px-wide picture. The
- * honest answer is the tier above, 720p, with 360p left in for the ranker.
- * `smallestCoveringPixelArea` picks that cap; `tracksUnderPixelArea` — the same
- * filter `screenResolutionCap` narrows with — applies it.
+ * The cap is the _smallest tier that still covers the player_, and everything at or below it survives — not "everything
+ * at or below the player's area," which under-serves a player falling between two tiers. Take an 800×450 player against
+ * a 360p/720p/1080p ladder: only 360p is below it, so capping at the player's area would hold an 800-px-wide box to a
+ * 640-px-wide picture. The honest answer is the tier above, 720p, with 360p left in for the ranker.
+ * `smallestCoveringPixelArea` picks that cap; `tracksUnderPixelArea` — the same filter `screenResolutionCap` narrows
+ * with — applies it.
  *
- * Renditions declaring no width or height compare as area `0` and are never capped
- * out — they can't be judged against the player, and dropping them could strand
- * a source whose renditions all omit it.
+ * Renditions declaring no width or height compare as area `0` and are never capped out — they can't be judged against
+ * the player, and dropping them could strand a source whose renditions all omit it.
  *
- * Runs *after* `preferActiveCdn`, so it narrows within the host already chosen.
- * Ahead of it, a cap that pruned every rendition of the preferred CDN would leave
- * the scope to fall to the next one with survivors — a size preference silently
- * moving playback to another host. Redundant streams normally mirror the same
- * ladder, which makes that a nonstandard-but-legal mismatch across CDNs rather
- * than an everyday case; the ordering costs nothing either way.
+ * Runs _after_ `preferActiveCdn`, so it narrows within the host already chosen. Ahead of it, a cap that pruned every
+ * rendition of the preferred CDN would leave the scope to fall to the next one with survivors — a size preference
+ * silently moving playback to another host. Redundant streams normally mirror the same ladder, which makes that a
+ * nonstandard-but-legal mismatch across CDNs rather than an everyday case; the ordering costs nothing either way.
  *
- * Reading `state.playerResolution` through its signal is what subscribes the
- * chain to resizes; `undefined` — no signal composed, or nothing to measure —
- * means "don't cap" rather than a cap of zero, so the chain proceeds unnarrowed.
+ * Reading `state.playerResolution` through its signal is what subscribes the chain to resizes; `undefined` — no signal
+ * composed, or nothing to measure — means "don't cap" rather than a cap of zero, so the chain proceeds unnarrowed.
  */
 function playerResolutionCap<S extends SelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
@@ -478,15 +419,13 @@ function playerResolutionCap<S extends SelectionKey, T extends SwitchableTrack>(
 }
 
 /**
- * Failed-CDN constraint — a *hard* filter (constraints pre-pass), shared by
- * video and audio. Removes tracks served from a CDN currently in failover
- * cooldown (`failedCdns`, written by the failover monitor). Removed tracks are never
- * attempted; the scope then narrows to the next surviving CDN in `cdnPriority`,
- * and snaps back to the primary once it leaves cooldown.
+ * Failed-CDN constraint — a _hard_ filter (constraints pre-pass), shared by video and audio. Removes tracks served from
+ * a CDN currently in failover cooldown (`failedCdns`, written by the failover monitor). Removed tracks are never
+ * attempted; the scope then narrows to the next surviving CDN in `cdnPriority`, and snaps back to the primary once it
+ * leaves cooldown.
  *
- * Passes everything through when there's no `failedCdns` signal/value. When it
- * prunes *every* track (all CDNs cooled down), the empty result is preserved
- * (per `applyConstraints`) — "nothing playable," which clears the selection (no
+ * Passes everything through when there's no `failedCdns` signal/value. When it prunes _every_ track (all CDNs cooled
+ * down), the empty result is preserved (per `applyConstraints`) — "nothing playable," which clears the selection (no
  * pick); a later CDN recovery refills the candidate set and re-picks.
  */
 function excludeFailedCdns<S extends SelectionKey, T extends SwitchableTrack>(
@@ -504,25 +443,21 @@ function excludeFailedCdns<S extends SelectionKey, T extends SwitchableTrack>(
 }
 
 /**
- * Active-CDN scope — a soft filter, shared by video and audio. Narrows to the
- * highest-priority CDN in `cdnPriority` (owned by `deriveCdnPriority`) that
- * still has tracks, so every track type stays on one CDN. A redundant-streams
- * source lists the same renditions on multiple hosts; this keeps the pick on one
- * host rather than letting the ranker drift across them.
+ * Active-CDN scope — a soft filter, shared by video and audio. Narrows to the highest-priority CDN in `cdnPriority`
+ * (owned by `deriveCdnPriority`) that still has tracks, so every track type stays on one CDN. A redundant-streams
+ * source lists the same renditions on multiple hosts; this keeps the pick on one host rather than letting the ranker
+ * drift across them.
  *
- * "Active" is derived, not stored: constraints run before the rule chain, so a
- * failed CDN's tracks are already pruned by the time this runs — "first CDN with
- * survivors" *is* the active CDN, and it falls through to the next on failover
- * (and snaps back to the primary when it recovers). Content steering reorders
- * `cdnPriority`; this rule just honors the order.
+ * "Active" is derived, not stored: constraints run before the rule chain, so a failed CDN's tracks are already pruned
+ * by the time this runs — "first CDN with survivors" _is_ the active CDN, and it falls through to the next on failover
+ * (and snaps back to the primary when it recovers). Content steering reorders `cdnPriority`; this rule just honors the
+ * order.
  *
- * Soft-filter semantics: passes through when there's no `cdnPriority` signal/value
- * (no preference) or when nothing matches (`applyRules` skips an empty result).
- * Non-redundant sources have one CDN, so the narrow is a no-op.
+ * Soft-filter semantics: passes through when there's no `cdnPriority` signal/value (no preference) or when nothing
+ * matches (`applyRules` skips an empty result). Non-redundant sources have one CDN, so the narrow is a no-op.
  *
- * The CDN-id derivation defaults to origin-based `getCdnId`, overridable via the
- * `getCdnId` config — it must match the one `deriveCdnPriority` used to build
- * `cdnPriority`, or no track's CDN would ever equal an entry.
+ * The CDN-id derivation defaults to origin-based `getCdnId`, overridable via the `getCdnId` config — it must match the
+ * one `deriveCdnPriority` used to build `cdnPriority`, or no track's CDN would ever equal an entry.
  */
 function preferActiveCdn<S extends SelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
@@ -544,49 +479,36 @@ function preferActiveCdn<S extends SelectionKey, T extends SwitchableTrack>(
 }
 
 /**
- * Codec-family sticky constraint — a *hard* filter for the constraints
- * pre-pass, shared by video and audio, and the reason the re-evaluating
- * variants can run ABR over a mixed-codec source at all: SPF implements no
- * `SourceBuffer.changeType()`, so once segments of the selected track's codec
- * families are what a buffer was created for, a pick outside them could
- * never play — constraint semantics ("can't play here"), not preference.
- * Removes the candidates whose codec-family set doesn't *equal* the selected
- * track's (set-equality so a muxed `hvc1,mp4a` rendition can't pass as a
- * match for `avc1,mp4a` on its audio half). Purely relational: the lock *is*
- * the current selection's families, no state of its own. Pruned pre-pass, a
- * cross-family user selection mid-stream never reaches the user filter,
- * which falls through unhonored instead of killing playback. Before any
- * selection exists (the initial pick) it removes nothing, which is what
- * leaves the initial family choice to the rule chain (user intent, then
+ * Codec-family sticky constraint — a _hard_ filter for the constraints pre-pass, shared by video and audio, and the
+ * reason the re-evaluating variants can run ABR over a mixed-codec source at all: SPF implements no
+ * `SourceBuffer.changeType()`, so once segments of the selected track's codec families are what a buffer was created
+ * for, a pick outside them could never play — constraint semantics ("can't play here"), not preference. Removes the
+ * candidates whose codec-family set doesn't _equal_ the selected track's (set-equality so a muxed `hvc1,mp4a` rendition
+ * can't pass as a match for `avc1,mp4a` on its audio half). Purely relational: the lock _is_ the current selection's
+ * families, no state of its own. Pruned pre-pass, a cross-family user selection mid-stream never reaches the user
+ * filter, which falls through unhonored instead of killing playback. Before any selection exists (the initial pick) it
+ * removes nothing, which is what leaves the initial family choice to the rule chain (user intent, then
  * `preferCodecFamilies`).
  *
- * The selected track's families come from the *presentation's* track list,
- * not the already-pruned candidates: a CDN entering cooldown may prune the
- * current track itself while same-family renditions survive on another host,
- * and the lock must carry over to them. Removes nothing when: no selection
- * yet, a selection the presentation no longer carries, or a selected track
- * without codecs (then no candidate's compatibility is decidable — same
- * inertness as `preferCodecFamilies` on a codec-less ladder).
+ * The selected track's families come from the _presentation's_ track list, not the already-pruned candidates: a CDN
+ * entering cooldown may prune the current track itself while same-family renditions survive on another host, and the
+ * lock must carry over to them. Removes nothing when: no selection yet, a selection the presentation no longer carries,
+ * or a selected track without codecs (then no candidate's compatibility is decidable — same inertness as
+ * `preferCodecFamilies` on a codec-less ladder).
  *
- * When the selected family genuinely vanishes from the playable set, the
- * pre-pass empties: the behavior reports the type's no-supported-track code
- * and clears the selection — an explicable stop instead of a cross-family
- * append surfacing as an opaque decode error. Clearing also releases the
- * lock (it keys on the live selection), so a following pick may land in the
- * surviving family on freshly-created buffer actors; whether the append
- * layer survives that rebuild is the changeType gap, out of this
- * constraint's hands. If `changeType` support ever lands, this constraint is
+ * When the selected family genuinely vanishes from the playable set, the pre-pass empties: the behavior reports the
+ * type's no-supported-track code and clears the selection — an explicable stop instead of a cross-family append
+ * surfacing as an opaque decode error. Clearing also releases the lock (it keys on the live selection), so a following
+ * pick may land in the surviving family on freshly-created buffer actors; whether the append layer survives that
+ * rebuild is the changeType gap, out of this constraint's hands. If `changeType` support ever lands, this constraint is
  * what relaxes.
  *
- * Reading the selection here — a slot the picking effect itself writes, from
- * inside the candidate-set computed — is safe only because the effect
- * scheduler revalidates an effect's sources after each run; see
- * `core/signals/effect.ts` (`revalidateSources`) for the lost-wakeup it
- * prevents.
+ * Reading the selection here — a slot the picking effect itself writes, from inside the candidate-set computed — is
+ * safe only because the effect scheduler revalidates an effect's sources after each run; see `core/signals/effect.ts`
+ * (`revalidateSources`) for the lost-wakeup it prevents.
  *
- * Composed only into the re-evaluating `switch*` variants: the pinned
- * `selectVideoTrack` (background compositions) evaluates once and never
- * re-picks, so it's immune by construction.
+ * Composed only into the re-evaluating `switch*` variants: the pinned `selectVideoTrack` (background compositions)
+ * evaluates once and never re-picks, so it's immune by construction.
  */
 export function stickToSelectedCodecs<S extends SelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
@@ -617,24 +539,18 @@ export function stickToSelectedCodecs<S extends SelectionKey, T extends Switchab
 }
 
 /**
- * Bandwidth ranking — the terminal sort, shared by video and audio. Orders by
- * the throughput estimate: tracks within the bandwidth threshold first
- * (fitting), highest bitrate first; then over-threshold tracks, least-over
- * first. The head is the best-quality track that fits, falling back to the
- * smallest over-throughput track when nothing fits.
+ * Bandwidth ranking — the terminal sort, shared by video and audio. Orders by the throughput estimate: tracks within
+ * the bandwidth threshold first (fitting), highest bitrate first; then over-threshold tracks, least-over first. The
+ * head is the best-quality track that fits, falling back to the smallest over-throughput track when nothing fits.
  *
- * Hysteresis without temporal state: the current track's effective bitrate is
- * boosted by `upgradeMargin` in the fitting sort, so a higher track only
- * outranks it once it clears `current.bitrate * upgradeMargin` (no flapping on
- * marginal bandwidth gains). Downgrades fall out for free — a current track
- * over the threshold isn't in the fitting set to be boosted, so the best fit (a
- * downgrade) wins immediately. Equal-bitrate tracks break by resolution (higher
- * `width × height` first), so an equal-bitrate ladder never picks a lower-
- * quality rendition by manifest order; audio tracks carry no dimensions, so
- * they area-compare equal and a stable sort keeps their candidate order (e.g.
- * same-bitrate language variants). Early-bail skips this rule when a prior one
- * narrowed to a single track, so the estimate is neither read nor subscribed
- * while that holds.
+ * Hysteresis without temporal state: the current track's effective bitrate is boosted by `upgradeMargin` in the fitting
+ * sort, so a higher track only outranks it once it clears `current.bitrate * upgradeMargin` (no flapping on marginal
+ * bandwidth gains). Downgrades fall out for free — a current track over the threshold isn't in the fitting set to be
+ * boosted, so the best fit (a downgrade) wins immediately. Equal-bitrate tracks break by resolution (higher `width ×
+ * height` first), so an equal-bitrate ladder never picks a lower- quality rendition by manifest order; audio tracks
+ * carry no dimensions, so they area-compare equal and a stable sort keeps their candidate order (e.g. same-bitrate
+ * language variants). Early-bail skips this rule when a prior one narrowed to a single track, so the estimate is
+ * neither read nor subscribed while that holds.
  */
 function rankByBandwidth<S extends SelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
@@ -672,25 +588,22 @@ function rankByBandwidth<S extends SelectionKey, T extends SwitchableTrack>(
 }
 
 /**
- * Default final pick: the chain head. `applyRules` never narrows to nothing and
- * early-bails to a single survivor, so video and audio always converge to a
- * track and the head is the pick.
+ * Default final pick: the chain head. `applyRules` never narrows to nothing and early-bails to a single survivor, so
+ * video and audio always converge to a track and the head is the pick.
  */
 function selectChainHead<T extends SwitchableTrack>(candidates: readonly T[]): string {
   return candidates[0]!.id;
 }
 
 /**
- * State the text terminal reads: the lifecycle map plus an *optional*
- * `userTextTrackSelection` — the standing user intent. `Partial<TextTrack>` is an
- * explicit pick (language-based), `'off'` is explicit no-captions, `undefined` is
- * auto (no preference). The slot exists only when the composition materializes it
- * (`shareSignals`); the terminal reads it defensively and treats absence as auto.
+ * State the text terminal reads: the lifecycle map plus an _optional_ `userTextTrackSelection` — the standing user
+ * intent. `Partial<TextTrack>` is an explicit pick (language-based), `'off'` is explicit no-captions, `undefined` is
+ * auto (no preference). The slot exists only when the composition materializes it (`shareSignals`); the terminal reads
+ * it defensively and treats absence as auto.
  *
- * Unlike `user*TrackSelection` for video/audio, this carries the `'off'` sentinel
- * and feeds the terminal pick (not the shared `filterByUserSelection`) — text is
- * the only type whose selection is legitimately optional, so the off/auto logic
- * lives in one text-specific place rather than widening the shared filter.
+ * Unlike `user*TrackSelection` for video/audio, this carries the `'off'` sentinel and feeds the terminal pick (not the
+ * shared `filterByUserSelection`) — text is the only type whose selection is legitimately optional, so the off/auto
+ * logic lives in one text-specific place rather than widening the shared filter.
  */
 type TextSelectionStateMap = TrackSwitchingStateMap<'selectedTextTrackId'> & {
   userTextTrackSelection?: ReadonlySignal<Partial<TextTrack> | 'off' | undefined>;
@@ -700,20 +613,18 @@ type TextSelectionStateMap = TrackSwitchingStateMap<'selectedTextTrackId'> & {
 type TextTerminalConfig = TrackSwitchingConfig<'selectedTextTrackId', TextTrackCandidate> & TextSelectionConfig;
 
 /**
- * Terminal pick for text — the `resolveSelection` the text variant supplies.
- * Resolves the standing `userTextTrackSelection` intent against the chain's
- * survivors (already CDN-failover-pruned and active-CDN-scoped):
+ * Terminal pick for text — the `resolveSelection` the text variant supplies. Resolves the standing
+ * `userTextTrackSelection` intent against the chain's survivors (already CDN-failover-pruned and active-CDN-scoped):
  *
- *   - `'off'` → no selection (clear the slot). Sticky through re-evaluation, so a
- *     live refresh or failover re-run can't re-assert a default.
- *   - explicit `Partial<TextTrack>` → narrow to the match (language-based). A
- *     stale pick whose match is gone (e.g. the language dropped on a source
- *     change) falls through to the default policy.
- *   - auto (`undefined`) → the opt-in default policy (`preferredSubtitleLanguage`
- *     → `DEFAULT=YES + AUTOSELECT=YES` → none), via `pickTextTrackFromTracks`.
+ * - `'off'` → no selection (clear the slot). Sticky through re-evaluation, so a live refresh or failover re-run can't
+ *   re-assert a default.
+ * - Explicit `Partial<TextTrack>` → narrow to the match (language-based). A stale pick whose match is gone (e.g. the
+ *   language dropped on a source change) falls through to the default policy.
+ * - Auto (`undefined`) → the opt-in default policy (`preferredSubtitleLanguage` → `DEFAULT=YES + AUTOSELECT=YES` → none),
+ *   via `pickTextTrackFromTracks`.
  *
- * Returning `undefined` is a real outcome (captions are opt-in), which is why the
- * text variant relies on `setupTrackSwitching`'s no-selection seam.
+ * Returning `undefined` is a real outcome (captions are opt-in), which is why the text variant relies on
+ * `setupTrackSwitching`'s no-selection seam.
  */
 function pickResolvedTextTrack<T extends TextTrackCandidate>(
   candidates: readonly T[],
@@ -871,13 +782,12 @@ export function setupTrackSwitching<
 // ============================================================================
 
 /**
- * Manage `selectedVideoTrackId`: pick a default on src load, dynamically
- * adjust based on bandwidth, clear on src unload. Honors
- * `userVideoTrackSelection` as a partial-track constraint on candidates;
- * short-circuits ABR when the constraint narrows to a single track.
+ * Manage `selectedVideoTrackId`: pick a default on src load, dynamically adjust based on bandwidth, clear on src
+ * unload. Honors `userVideoTrackSelection` as a partial-track constraint on candidates; short-circuits ABR when the
+ * constraint narrows to a single track.
  *
  * @example
- * const reactor = switchVideoTrack.setup({ state });
+ *   const reactor = switchVideoTrack.setup({ state });
  */
 export const switchVideoTrack = defineBehavior({
   stateKeys: ['presentation', 'selectedVideoTrackId'],
@@ -910,17 +820,15 @@ export const switchVideoTrack = defineBehavior({
 // ============================================================================
 
 /**
- * Manage `selectedAudioTrackId`: pick a default on src load, narrow by
- * `userAudioTrackSelection` filter, re-pick on filter change, clear on
- * src unload.
+ * Manage `selectedAudioTrackId`: pick a default on src load, narrow by `userAudioTrackSelection` filter, re-pick on
+ * filter change, clear on src unload.
  *
- * Mid-stream flush on language switch is handled by the segment-loader's
- * `planTasks` (see `playback/actors/dom/segment-loader.ts`) — not this
- * behavior. Same split as the video pipeline: slot owner writes; loader
- * orchestrates segment + flush plans.
+ * Mid-stream flush on language switch is handled by the segment-loader's `planTasks` (see
+ * `playback/actors/dom/segment-loader.ts`) — not this behavior. Same split as the video pipeline: slot owner writes;
+ * loader orchestrates segment + flush plans.
  *
  * @example
- * const reactor = switchAudioTrack.setup({ state });
+ *   const reactor = switchAudioTrack.setup({ state });
  */
 export const switchAudioTrack = defineBehavior({
   stateKeys: ['presentation', 'selectedAudioTrackId'],
@@ -962,10 +870,9 @@ export const switchAudioTrack = defineBehavior({
 // ============================================================================
 
 /**
- * Config for `switchTextTrack` — the opt-in default policy
- * (`preferredSubtitleLanguage` / `includeForcedTracks` / `enableDefaultTrack`,
- * via `TextSelectionConfig`) read by the terminal when the user has no standing
- * intent, plus the `getCdnId` override shared with the CDN constraint + scope.
+ * Config for `switchTextTrack` — the opt-in default policy (`preferredSubtitleLanguage` / `includeForcedTracks` /
+ * `enableDefaultTrack`, via `TextSelectionConfig`) read by the terminal when the user has no standing intent, plus the
+ * `getCdnId` override shared with the CDN constraint + scope.
  */
 export interface SwitchTextTrackConfig extends TextSelectionConfig {
   /** Override CDN-id derivation (shared by the failed-CDN constraint + active-CDN scope). */
@@ -973,21 +880,19 @@ export interface SwitchTextTrackConfig extends TextSelectionConfig {
 }
 
 /**
- * Manage `selectedTextTrackId` as the single-writer **output** of standing user
- * intent (`userTextTrackSelection`) resolved against the playable, CDN-scoped
- * text renditions: clear on src unload; re-resolve when a CDN fails or recovers.
+ * Manage `selectedTextTrackId` as the single-writer **output** of standing user intent (`userTextTrackSelection`)
+ * resolved against the playable, CDN-scoped text renditions: clear on src unload; re-resolve when a CDN fails or
+ * recovers.
  *
- * Unlike video/audio, the selection is *optional* — captions are opt-in and the
- * user can turn them off — so the chain skips the bandwidth ranker and the shared
- * user-selection filter, and supplies a text-specific terminal
- * (`pickResolvedTextTrack`) that may resolve to no-selection via
- * `setupTrackSwitching`'s `resolveSelection` seam. Constraints are failed-CDN only
- * (`excludeUnplayableTracks`/`canPlayTrack` is MSE-based — the wrong probe for
- * text, whose playability is SPF-parser support); the active-CDN scope co-locates
- * captions with the surviving CDN on failover.
+ * Unlike video/audio, the selection is _optional_ — captions are opt-in and the user can turn them off — so the chain
+ * skips the bandwidth ranker and the shared user-selection filter, and supplies a text-specific terminal
+ * (`pickResolvedTextTrack`) that may resolve to no-selection via `setupTrackSwitching`'s `resolveSelection` seam.
+ * Constraints are failed-CDN only (`excludeUnplayableTracks`/`canPlayTrack` is MSE-based — the wrong probe for text,
+ * whose playability is SPF-parser support); the active-CDN scope co-locates captions with the surviving CDN on
+ * failover.
  *
  * @example
- * const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'en' } });
+ *   const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'en' } });
  */
 export const switchTextTrack = defineBehavior({
   stateKeys: ['presentation', 'selectedTextTrackId'],

--- a/packages/spf/src/playback/engines/hls/engine-audio-only.ts
+++ b/packages/spf/src/playback/engines/hls/engine-audio-only.ts
@@ -58,9 +58,8 @@ import {
 /**
  * State shape for the audio-only HLS playback engine.
  *
- * Subset of `HlsVideoEngineState` covering only the slots written and read
- * by audio-side behaviors. Video and text-track slots are absent —
- * subtractive composition removes the behaviors that declare them.
+ * Subset of `HlsVideoEngineState` covering only the slots written and read by audio-side behaviors. Video and
+ * text-track slots are absent — subtractive composition removes the behaviors that declare them.
  */
 export interface HlsAudioEngineState {
   presentation?: MaybeResolvedPresentation;
@@ -70,58 +69,48 @@ export interface HlsAudioEngineState {
   // `establishStartMediaTime`. Remove with the composed reactor.
   mediaContainerData?: Record<string, MediaContainerData>;
   /**
-   * Consumer-driven constraint narrowing the audio candidate set. Sibling
-   * of `userVideoTrackSelection` in the default engine. Partial-track
-   * shape — `{ language: 'es' }`, `{ id: 'audio-en' }`, etc.
-   * `selectAudioTrack` reads this and re-picks when it changes.
-   * Multi-language-audio Tier 2 programmatic-write path.
+   * Consumer-driven constraint narrowing the audio candidate set. Sibling of `userVideoTrackSelection` in the default
+   * engine. Partial-track shape — `{ language: 'es' }`, `{ id: 'audio-en' }`, etc. `selectAudioTrack` reads this and
+   * re-picks when it changes. Multi-language-audio Tier 2 programmatic-write path.
    */
   userAudioTrackSelection?: Partial<AudioTrack>;
   /**
-   * The CDNs the source is served from, in manifest priority order (mirrors
-   * HLS content steering's `PATHWAY-PRIORITY`). Owned by `deriveCdnPriority`,
-   * read by `track-switching`'s `preferActiveCdn` scope. Only meaningful for
+   * The CDNs the source is served from, in manifest priority order (mirrors HLS content steering's `PATHWAY-PRIORITY`).
+   * Owned by `deriveCdnPriority`, read by `track-switching`'s `preferActiveCdn` scope. Only meaningful for
    * redundant-stream sources; a single-CDN source has one entry.
    */
   cdnPriority?: string[];
   /**
-   * CDN ids currently in failover cooldown — read by `track-switching`'s
-   * `excludeFailedCdns` constraint, which prunes their tracks so the active-CDN
-   * scope falls to the next CDN. Empty / absent means all CDNs are eligible.
+   * CDN ids currently in failover cooldown — read by `track-switching`'s `excludeFailedCdns` constraint, which prunes
+   * their tracks so the active-CDN scope falls to the next CDN. Empty / absent means all CDNs are eligible.
    */
   failedCdns?: string[];
   /**
-   * Conditions reported during playback, in order — appended by whichever
-   * behavior detects one, owned and cleared per source by `collectErrors`.
-   * Severity is decided above the engine. Audio-only makes an all-audio-pruned
-   * source unrecoverable: there's no video fallback to fall back to.
+   * Conditions reported during playback, in order — appended by whichever behavior detects one, owned and cleared per
+   * source by `collectErrors`. Severity is decided above the engine. Audio-only makes an all-audio-pruned source
+   * unrecoverable: there's no video fallback to fall back to.
    */
   errors?: SvtaError[];
   currentTime?: number;
   loadActivated?: boolean;
   /**
-   * One-shot command: start the current source at this position
-   * (presentation-timeline seconds). Written by consumers or by
-   * `setupAirPlay`'s session-end snapshot; consumed (cleared) by
-   * `applyStartPosition` once the element seeks. See
+   * One-shot command: start the current source at this position (presentation-timeline seconds). Written by consumers
+   * or by `setupAirPlay`'s session-end snapshot; consumed (cleared) by `applyStartPosition` once the element seeks. See
    * `behaviors/dom/apply-start-position.ts`.
    */
   startPosition?: number;
   /**
-   * Intent-level loading policy: initiate no new loading work while `true`.
-   * Written by `setupAirPlay` (the only behavior declaring the key) while a
-   * remote-playback session owns presentation; observed by `loadAudioSegments`
-   * (parks in `'dormant'`) and by `setupMediaSource` (a pending rebuild
-   * waits). See `SegmentLoadingState['loadingSuspended']`.
+   * Intent-level loading policy: initiate no new loading work while `true`. Written by `setupAirPlay` (the only
+   * behavior declaring the key) while a remote-playback session owns presentation; observed by `loadAudioSegments`
+   * (parks in `'dormant'`) and by `setupMediaSource` (a pending rebuild waits). See
+   * `SegmentLoadingState['loadingSuspended']`.
    */
   loadingSuspended?: boolean;
   /**
-   * Author intent for the AirPlay/remote-playback picker, written by the media
-   * adapter's `disableRemotePlayback` IDL property. `true` is an explicit
-   * opt-out: `setupAirPlay` reads it at attach and sets nothing up, leaving the
-   * element's remote playback disabled. Distinct from the underlying media
-   * element's own `disableRemotePlayback`, which stays programmatically managed
-   * (ManagedMediaSource / AirPlay).
+   * Author intent for the AirPlay/remote-playback picker, written by the media adapter's `disableRemotePlayback` IDL
+   * property. `true` is an explicit opt-out: `setupAirPlay` reads it at attach and sets nothing up, leaving the
+   * element's remote playback disabled. Distinct from the underlying media element's own `disableRemotePlayback`, which
+   * stays programmatically managed (ManagedMediaSource / AirPlay).
    */
   disableRemotePlayback?: boolean;
 }
@@ -129,8 +118,7 @@ export interface HlsAudioEngineState {
 /**
  * Context shape for the audio-only HLS playback engine.
  *
- * Subset of `HlsVideoEngineContext` covering only the platform objects and
- * actor refs managed by audio-side behaviors.
+ * Subset of `HlsVideoEngineContext` covering only the platform objects and actor refs managed by audio-side behaviors.
  */
 export interface HlsAudioEngineContext {
   mediaElement?: HTMLMediaElement | undefined;
@@ -147,33 +135,29 @@ export type HlsAudioEngineSignals = {
 /**
  * Configuration for the audio-only HLS playback engine.
  *
- * Subset of `HlsVideoEngineConfig` — video-quality, bandwidth-estimator,
- * and text-track config fields are omitted (no behavior consumes them).
+ * Subset of `HlsVideoEngineConfig` — video-quality, bandwidth-estimator, and text-track config fields are omitted (no
+ * behavior consumes them).
  */
 export interface HlsAudioEngineConfig extends ShareSignalsConfig<HlsAudioEngineState, HlsAudioEngineContext> {
   preferredAudioLanguage?: string;
   /**
-   * Codec capability probe read by `track-switching`'s `excludeUnplayableTracks`
-   * constraint. Defaults to the `MediaSource.isTypeSupported`-backed
-   * `canPlayTrack`; override to force-exclude a codec. Mirrors the default
-   * engine — without it, capability probing (and TS / raw-AAC detection) would
-   * be inert for audio-only playback.
+   * Codec capability probe read by `track-switching`'s `excludeUnplayableTracks` constraint. Defaults to the
+   * `MediaSource.isTypeSupported`-backed `canPlayTrack`; override to force-exclude a codec. Mirrors the default engine
+   * — without it, capability probing (and TS / raw-AAC detection) would be inert for audio-only playback.
    */
   canPlayTrack?: CanPlayTrack;
   /**
-   * Codec families the initial audio pick prefers on a mixed-codec source
-   * (`preferCodecFamilies` scope) — the family it lands in is then sticky for
-   * the source's lifetime (`stickToSelectedCodecs`; SPF implements no
-   * `SourceBuffer.changeType()`). Defaults to `DEFAULT_PREFERRED_CODECS`
-   * (AAC, plus video 4CCs inert here); pass `[]` to disable.
+   * Codec families the initial audio pick prefers on a mixed-codec source (`preferCodecFamilies` scope) — the family it
+   * lands in is then sticky for the source's lifetime (`stickToSelectedCodecs`; SPF implements no
+   * `SourceBuffer.changeType()`). Defaults to `DEFAULT_PREFERRED_CODECS` (AAC, plus video 4CCs inert here); pass `[]`
+   * to disable.
    */
   preferredCodecs?: string[];
   /**
-   * Conditions reported about each rendition as it resolves — the *causes* behind
-   * a later verdict, and the copy a verdict reuses when they agree. Defaults to
-   * {@link reportUnsupportedTrackConditions}, which reports non-fMP4 containers
-   * and encryption; supply your own to report a different set (a provider that
-   * never ships MPEG-TS can drop that check) or `() => []` to report nothing.
+   * Conditions reported about each rendition as it resolves — the _causes_ behind a later verdict, and the copy a
+   * verdict reuses when they agree. Defaults to {@link reportUnsupportedTrackConditions}, which reports non-fMP4
+   * containers and encryption; supply your own to report a different set (a provider that never ships MPEG-TS can drop
+   * that check) or `() => []` to report nothing.
    */
   reportUnsupportedTrackConditions?: ReportUnsupportedTrackConditions;
   resolveDuration?: PresentationDurationResolver;
@@ -183,9 +167,8 @@ export interface HlsAudioEngineConfig extends ShareSignalsConfig<HlsAudioEngineS
   /** Multi-CDN failover monitor tuning. Defaults: `DEFAULT_FAILOVER_MONITOR_CONFIG`. */
   failover?: Partial<FailoverMonitorConfig>;
   /**
-   * Derive a CDN grouping key from a track URL (used by `cdnPriority`, the
-   * failover trip, and the track-switching CDN rules — one function read by all).
-   * Defaults to the URL origin; override to key on e.g. Mux's `cdn=` param.
+   * Derive a CDN grouping key from a track URL (used by `cdnPriority`, the failover trip, and the track-switching CDN
+   * rules — one function read by all). Defaults to the URL origin; override to key on e.g. Mux's `cdn=` param.
    */
   getCdnId?: GetCdnId;
   /** Non-zero-PTS relocation (spike): the reduce seam (tier knob); defaults to per-track own. */
@@ -209,32 +192,28 @@ const shareSignals = makeShareSignals<HlsAudioEngineState, HlsAudioEngineContext
 /**
  * Create an audio-only HLS playback engine.
  *
- * Subtractive composition variant of `createHlsVideoEngine`: omits
- * video-side behaviors (`resolveVideoTrack`, `switchVideoTrack`,
- * `setupVideoBufferActors`, `loadVideoSegments`) and text-track behaviors
- * (`switchTextTrack`, `resolveTextTrack`, `syncTextTracks`,
- * `setupTextTrackActors`, `loadTextTrackSegments`). The remaining audio
- * pipeline composes unchanged.
+ * Subtractive composition variant of `createHlsVideoEngine`: omits video-side behaviors (`resolveVideoTrack`,
+ * `switchVideoTrack`, `setupVideoBufferActors`, `loadVideoSegments`) and text-track behaviors (`switchTextTrack`,
+ * `resolveTextTrack`, `syncTextTracks`, `setupTextTrackActors`, `loadTextTrackSegments`). The remaining audio pipeline
+ * composes unchanged.
  *
- * Handles both truly audio-only HLS sources (no video stream-inf) and
- * mixed-AV HLS sources where the audio rendition is selected and video /
- * subtitle renditions are ignored at composition time. The variant decision
- * is encoded by adapter choice; this engine does not branch on source
- * shape.
+ * Handles both truly audio-only HLS sources (no video stream-inf) and mixed-AV HLS sources where the audio rendition is
+ * selected and video / subtitle renditions are ignored at composition time. The variant decision is encoded by adapter
+ * choice; this engine does not branch on source shape.
  *
  * @example
- * ```ts
- * let signals: HlsAudioEngineSignals;
- * const engine = createHlsAudioEngine({
- *   preferredAudioLanguage: 'en',
- *   onSignalsReady: (refs) => {
- *     signals = refs;
- *   },
- * });
+ *   ```ts
+ *   let signals: HlsAudioEngineSignals;
+ *   const engine = createHlsAudioEngine({
+ *     preferredAudioLanguage: 'en',
+ *     onSignalsReady: (refs) => {
+ *       signals = refs;
+ *     },
+ *   });
  *
- * signals.context.mediaElement.set(audioEl);
- * signals.state.presentation.set({ url: 'https://example.com/stream.m3u8' });
- * ```
+ *   signals.context.mediaElement.set(audioEl);
+ *   signals.state.presentation.set({ url: 'https://example.com/stream.m3u8' });
+ *   ```;
  */
 export function createHlsAudioEngine(
   config: HlsAudioEngineConfig = {}

--- a/packages/spf/src/playback/engines/hls/engine-background-video.ts
+++ b/packages/spf/src/playback/engines/hls/engine-background-video.ts
@@ -43,44 +43,37 @@ import { excludeUnplayableTracks } from '../../primitives/selection-rules';
 /**
  * State shape for the background-video playback engine.
  *
- * Mostly narrower than `HlsVideoEngineState`: audio/text track slots are absent
- * because their selection/resolution behaviors are subtracted. `bandwidthState`
- * is present because `setupVideoBufferActors` declares it and `loadVideoSegments`
- * samples into it (wasted work in this variant — a Phase 3 alt-impl will skip
- * sampling).
+ * Mostly narrower than `HlsVideoEngineState`: audio/text track slots are absent because their selection/resolution
+ * behaviors are subtracted. `bandwidthState` is present because `setupVideoBufferActors` declares it and
+ * `loadVideoSegments` samples into it (wasted work in this variant — a Phase 3 alt-impl will skip sampling).
  *
- * `screenResolution` is the one slot this variant has and the HLS video engine
- * doesn't, because the screen-size cap is being built here first. It generalizes
- * — the cap is a selection rule both engines can compose — so expect the slot to
+ * `screenResolution` is the one slot this variant has and the HLS video engine doesn't, because the screen-size cap is
+ * being built here first. It generalizes — the cap is a selection rule both engines can compose — so expect the slot to
  * appear there too rather than staying variant-specific.
  */
 export interface BackgroundVideoEngineState {
   /**
-   * The presentation being played. A caller writes `{ url }`;
-   * `resolvePresentation` parses the manifest and populates the rest.
+   * The presentation being played. A caller writes `{ url }`; `resolvePresentation` parses the manifest and populates
+   * the rest.
    */
   presentation?: MaybeResolvedPresentation;
   preload?: 'auto' | 'metadata' | 'none';
   selectedVideoTrackId?: string;
   loadActivated?: boolean;
   /**
-   * The screen's pixel dimensions, or `undefined` where there is none to read.
-   * Written by `trackScreenResolution`, read by the `screenResolutionCap`
-   * selection rule — which treats `undefined` as "don't cap".
+   * The screen's pixel dimensions, or `undefined` where there is none to read. Written by `trackScreenResolution`, read
+   * by the `screenResolutionCap` selection rule — which treats `undefined` as "don't cap".
    */
   screenResolution?: ScreenResolution;
   /**
-   * Conditions reported while this source is loaded — the per-rendition causes
-   * `resolveVideoTrack` reports and the verdict `selectVideoTrack` reports when
-   * the constraints prune every rendition. Owned and cleared per source by
+   * Conditions reported while this source is loaded — the per-rendition causes `resolveVideoTrack` reports and the
+   * verdict `selectVideoTrack` reports when the constraints prune every rendition. Owned and cleared per source by
    * `collectErrors`; the adapter derives which are fatal.
    */
   errors?: SvtaError[];
 }
 
-/**
- * Context shape for the background-video engine.
- */
+/** Context shape for the background-video engine. */
 export interface BackgroundVideoEngineContext {
   mediaElement?: HTMLMediaElement | undefined;
   mediaSource?: MediaSource;
@@ -89,10 +82,8 @@ export interface BackgroundVideoEngineContext {
 }
 
 /**
- * The composition signal refs handed to `onSignalsReady` callers — the
- * canonical way to drive the engine externally (writes) or observe its
- * state (reads) without touching `composition.state` / `composition.context`
- * directly.
+ * The composition signal refs handed to `onSignalsReady` callers — the canonical way to drive the engine externally
+ * (writes) or observe its state (reads) without touching `composition.state` / `composition.context` directly.
  */
 export type BackgroundVideoEngineSignals = {
   state: StateSignals<BackgroundVideoEngineState>;
@@ -102,53 +93,40 @@ export type BackgroundVideoEngineSignals = {
 /**
  * Configuration for the background-video engine.
  *
- * Each option is consumed by the appropriate behavior — the engine itself
- * has no config beyond what its behaviors read. Compared to
- * `HlsVideoEngineConfig`, audio/text/ABR/bandwidth/quality knobs are
- * dropped: the variant subtracts the behaviors that read them.
+ * Each option is consumed by the appropriate behavior — the engine itself has no config beyond what its behaviors read.
+ * Compared to `HlsVideoEngineConfig`, audio/text/ABR/bandwidth/quality knobs are dropped: the variant subtracts the
+ * behaviors that read them.
  */
 export interface BackgroundVideoEngineConfig extends ShareSignalsConfig<
   BackgroundVideoEngineState,
   BackgroundVideoEngineContext
 > {
   /**
-   * Hard-constraint pre-pass handed to `selectVideoTrack`. Defaults to
-   * `[excludeUnplayableTracks, reportAbsentTrackType(2011)]` — prune the renditions
-   * this environment can't decode, then report 2011 if nothing is left (this engine
-   * composes only video, so a source with none playable can never play).
+   * Hard-constraint pre-pass handed to `selectVideoTrack`. Defaults to `[excludeUnplayableTracks,
+   * reportAbsentTrackType(2011)]` — prune the renditions this environment can't decode, then report 2011 if nothing is
+   * left (this engine composes only video, so a source with none playable can never play).
    */
   constraints?: SelectVideoTrackConfig['constraints'];
   /**
-   * Selection-rule chain handed to `selectVideoTrack`. Defaults to
-   * `[screenResolutionCap, preferHighestResolution]` — narrows to the renditions
-   * that fit the screen, takes the largest of those, and pins it for the session.
+   * Selection-rule chain handed to `selectVideoTrack`. Defaults to `[screenResolutionCap, preferHighestResolution]` —
+   * narrows to the renditions that fit the screen, takes the largest of those, and pins it for the session.
    *
-   * The cap sits ahead of the ranker because a scope that narrows first wins over
-   * one applied later; pass `[preferHighestResolution]` alone to opt out and always
-   * pin the largest rendition on offer.
+   * The cap sits ahead of the ranker because a scope that narrows first wins over one applied later; pass
+   * `[preferHighestResolution]` alone to opt out and always pin the largest rendition on offer.
    */
   rules?: readonly NonNullable<SelectVideoTrackConfig['rules']>[number][];
-  /**
-   * Manifest parser handed to `resolvePresentation`. Defaults to the HLS
-   * multivariant-playlist parser.
-   */
+  /** Manifest parser handed to `resolvePresentation`. Defaults to the HLS multivariant-playlist parser. */
   parsePresentation?: ParsePresentation;
-  /**
-   * Whether `state.screenResolution` is reported in device pixels. Read by
-   * `trackScreenResolution`; defaults to `true`.
-   */
+  /** Whether `state.screenResolution` is reported in device pixels. Read by `trackScreenResolution`; defaults to `true`. */
   useDevicePixelRatio?: boolean;
   /**
-   * Codec/container capability probe read by `selectVideoTrack`'s constraint
-   * pre-pass. Defaults to the DOM `canPlayTrack`; override to force-exclude a
-   * codec.
+   * Codec/container capability probe read by `selectVideoTrack`'s constraint pre-pass. Defaults to the DOM
+   * `canPlayTrack`; override to force-exclude a codec.
    */
   canPlayTrack?: CanPlayTrack;
   /**
-   * Per-rendition condition reporting, called by `resolveVideoTrack` once a
-   * media playlist parses. Defaults to
-   * {@link reportUnsupportedTrackConditions}, which reports non-fMP4 containers
-   * (1004) and encryption (4008).
+   * Per-rendition condition reporting, called by `resolveVideoTrack` once a media playlist parses. Defaults to
+   * {@link reportUnsupportedTrackConditions}, which reports non-fMP4 containers (1004) and encryption (4008).
    */
   reportUnsupportedTrackConditions?: ReportUnsupportedTrackConditions;
 }
@@ -162,39 +140,34 @@ const shareSignals = makeShareSignals<BackgroundVideoEngineState, BackgroundVide
 /**
  * Create a background-video playback engine.
  *
- * Subtractive composition over the HLS engine baseline:
- * audio-side, text-side, ABR-driven, preload-monitoring, and play/seek
- * load-trigger behaviors are removed. `selectVideoTrack` (with a
- * highest-resolution rule by default) replaces `switchVideoQuality`, pinning
- * a single rendition for the session. The initial state seeds
- * `loadActivated: true` so the composition behaves as if preload has
- * already been activated — appropriate for ambient / hero / GIF-replacement
+ * Subtractive composition over the HLS engine baseline: audio-side, text-side, ABR-driven, preload-monitoring, and
+ * play/seek load-trigger behaviors are removed. `selectVideoTrack` (with a highest-resolution rule by default) replaces
+ * `switchVideoQuality`, pinning a single rendition for the session. The initial state seeds `loadActivated: true` so
+ * the composition behaves as if preload has already been activated — appropriate for ambient / hero / GIF-replacement
  * surfaces that should start loading the moment a src is set.
  *
- * Error reporting is *not* subtracted: `collectErrors` owns the sequence,
- * `resolveVideoTrack` reports per-rendition causes, and `selectVideoTrack`
- * reports the video verdict when nothing survives its constraints. Without them
- * every unplayable source here is a silent stall — an unsupported container,
- * encryption this engine can't decrypt, and an undecodable codec all leave
- * `HTMLMediaElement.error` null on both Chromium and WebKit.
+ * Error reporting is _not_ subtracted: `collectErrors` owns the sequence, `resolveVideoTrack` reports per-rendition
+ * causes, and `selectVideoTrack` reports the video verdict when nothing survives its constraints. Without them every
+ * unplayable source here is a silent stall — an unsupported container, encryption this engine can't decrypt, and an
+ * undecodable codec all leave `HTMLMediaElement.error` null on both Chromium and WebKit.
  *
- * Native `loop` / `muted` / `autoplay` are adapter concerns and live on
- * `HlsBackgroundVideoMediaElement` rather than the engine.
+ * Native `loop` / `muted` / `autoplay` are adapter concerns and live on `HlsBackgroundVideoMediaElement` rather than
+ * the engine.
  *
  * @example
- * ```ts
- * let signals: BackgroundVideoEngineSignals;
- * const engine = createBackgroundVideoEngine({
- *   onSignalsReady: (refs) => {
- *     signals = refs;
- *   },
- * });
+ *   ```ts
+ *   let signals: BackgroundVideoEngineSignals;
+ *   const engine = createBackgroundVideoEngine({
+ *     onSignalsReady: (refs) => {
+ *       signals = refs;
+ *     },
+ *   });
  *
- * signals.context.mediaElement.set(videoEl);
- * signals.state.presentation.set({ url: 'https://example.com/stream.m3u8' });
+ *   signals.context.mediaElement.set(videoEl);
+ *   signals.state.presentation.set({ url: 'https://example.com/stream.m3u8' });
  *
- * await engine.destroy();
- * ```
+ *   await engine.destroy();
+ *   ```;
  */
 export function createBackgroundVideoEngine(
   config: BackgroundVideoEngineConfig = {}

--- a/packages/spf/src/playback/engines/hls/engine.ts
+++ b/packages/spf/src/playback/engines/hls/engine.ts
@@ -87,14 +87,13 @@ import type { TextTrackSegmentResolver } from '../../primitives/text-segment-loa
 /**
  * State shape for the HLS playback engine.
  *
- * This is the union of all state required by the behaviors composed into
- * the HLS engine. Each behavior declares its own state interface; this
- * type satisfies all of them.
+ * This is the union of all state required by the behaviors composed into the HLS engine. Each behavior declares its own
+ * state interface; this type satisfies all of them.
  */
 export interface HlsVideoEngineState {
   /**
-   * The presentation being played. A caller writes `{ url }`;
-   * `resolvePresentation` parses the manifest and populates the rest.
+   * The presentation being played. A caller writes `{ url }`; `resolvePresentation` parses the manifest and populates
+   * the rest.
    */
   presentation?: MaybeResolvedPresentation;
   preload?: 'auto' | 'metadata' | 'none';
@@ -107,80 +106,63 @@ export interface HlsVideoEngineState {
   mediaContainerData?: Record<string, MediaContainerData>;
   userVideoTrackSelection?: Partial<VideoTrack>;
   /**
-   * Consumer-driven constraint narrowing the audio candidate set. Sibling
-   * of `userVideoTrackSelection`. Partial-track shape — `{ language: 'es' }`,
-   * `{ id: 'audio-en' }`, etc. `selectAudioTrack` reads this and re-picks
-   * when it changes. Multi-language-audio Tier 2 programmatic-write path.
+   * Consumer-driven constraint narrowing the audio candidate set. Sibling of `userVideoTrackSelection`. Partial-track
+   * shape — `{ language: 'es' }`, `{ id: 'audio-en' }`, etc. `selectAudioTrack` reads this and re-picks when it
+   * changes. Multi-language-audio Tier 2 programmatic-write path.
    */
   userAudioTrackSelection?: Partial<AudioTrack>;
   /**
-   * Consumer-driven *intent* for text selection, resolved into
-   * `selectedTextTrackId` by `switchTextTrack`. A language-based partial
-   * (`{ language: 'es' }`) selects captions, `'off'` disables them, and absence
-   * means auto (the engine's `preferredSubtitleLanguage` / DEFAULT-track policy).
-   * Also the write path for the DOM caption UI (via `syncTextTracks`); unlike the
-   * resolved id it persists across source changes (sticky preference).
+   * Consumer-driven _intent_ for text selection, resolved into `selectedTextTrackId` by `switchTextTrack`. A
+   * language-based partial (`{ language: 'es' }`) selects captions, `'off'` disables them, and absence means auto (the
+   * engine's `preferredSubtitleLanguage` / DEFAULT-track policy). Also the write path for the DOM caption UI (via
+   * `syncTextTracks`); unlike the resolved id it persists across source changes (sticky preference).
    */
   userTextTrackSelection?: Partial<TextTrack> | 'off';
   /**
-   * The CDNs the source is served from (track-URL origins), in manifest
-   * priority order — most-preferred first (mirrors HLS content steering's
-   * `PATHWAY-PRIORITY`). Owned by `deriveCdnPriority`, read by
-   * `track-switching`'s `preferActiveCdn` scope, which narrows to the
-   * highest-priority CDN with surviving tracks so video / audio / text stay on
-   * one host. Only meaningful for redundant-stream sources; a single-CDN source
-   * has one entry.
+   * The CDNs the source is served from (track-URL origins), in manifest priority order — most-preferred first (mirrors
+   * HLS content steering's `PATHWAY-PRIORITY`). Owned by `deriveCdnPriority`, read by `track-switching`'s
+   * `preferActiveCdn` scope, which narrows to the highest-priority CDN with surviving tracks so video / audio / text
+   * stay on one host. Only meaningful for redundant-stream sources; a single-CDN source has one entry.
    */
   cdnPriority?: string[];
   /**
-   * CDN ids (origins) currently in failover cooldown — written by the CDN
-   * monitor when a host fails too often, read by `track-switching`'s
-   * `excludeFailedCdns` hard constraint, which prunes their tracks so the
-   * active-CDN scope falls to the next CDN in `cdnPriority`. Empty / absent
-   * means all CDNs are eligible.
+   * CDN ids (origins) currently in failover cooldown — written by the CDN monitor when a host fails too often, read by
+   * `track-switching`'s `excludeFailedCdns` hard constraint, which prunes their tracks so the active-CDN scope falls to
+   * the next CDN in `cdnPriority`. Empty / absent means all CDNs are eligible.
    */
   failedCdns?: string[];
   /**
-   * Conditions reported during playback, in the order encountered — appended by
-   * whichever behavior detects one (`emitError`), owned and cleared per source by
-   * `collectErrors`. Carries no severity: which of these is fatal is decided
-   * above the engine, at the adapter. See
-   * `internal/design/spf/features/errors.md`.
+   * Conditions reported during playback, in the order encountered — appended by whichever behavior detects one
+   * (`emitError`), owned and cleared per source by `collectErrors`. Carries no severity: which of these is fatal is
+   * decided above the engine, at the adapter. See `internal/design/spf/features/errors.md`.
    */
   errors?: SvtaError[];
   currentTime?: number;
   /**
-   * The player element's rendered pixel dimensions, or `undefined` where there
-   * is nothing to measure. Written by `trackPlayerResolution`, read by the
-   * `playerResolutionCap` selection rule — which treats `undefined` as
-   * "don't cap".
+   * The player element's rendered pixel dimensions, or `undefined` where there is nothing to measure. Written by
+   * `trackPlayerResolution`, read by the `playerResolutionCap` selection rule — which treats `undefined` as "don't
+   * cap".
    */
   playerResolution?: PlayerResolution;
   loadActivated?: boolean;
   /**
-   * One-shot command: start the current source at this position
-   * (presentation-timeline seconds). Written by consumers or by
-   * `setupAirPlay`'s session-end snapshot; consumed (cleared) by
-   * `applyStartPosition` once the element seeks. See
+   * One-shot command: start the current source at this position (presentation-timeline seconds). Written by consumers
+   * or by `setupAirPlay`'s session-end snapshot; consumed (cleared) by `applyStartPosition` once the element seeks. See
    * `behaviors/dom/apply-start-position.ts`.
    */
   startPosition?: number;
   /**
-   * Intent-level loading policy: initiate no new loading work while `true`.
-   * Written by `setupAirPlay` (the only behavior declaring the key) while a
-   * remote-playback session owns presentation; observed by the
-   * `loadXSegments` dispatchers (park in `'dormant'`) and by
-   * `setupMediaSource` (a pending rebuild waits). See
+   * Intent-level loading policy: initiate no new loading work while `true`. Written by `setupAirPlay` (the only
+   * behavior declaring the key) while a remote-playback session owns presentation; observed by the `loadXSegments`
+   * dispatchers (park in `'dormant'`) and by `setupMediaSource` (a pending rebuild waits). See
    * `SegmentLoadingState['loadingSuspended']`.
    */
   loadingSuspended?: boolean;
   /**
-   * Author intent for the AirPlay/remote-playback picker, written by the media
-   * adapter's `disableRemotePlayback` IDL property. `true` is an explicit
-   * opt-out: `setupAirPlay` reads it at attach and sets nothing up, leaving the
-   * element's remote playback disabled. Distinct from the underlying
-   * `<video>.disableRemotePlayback`, which stays programmatically managed
-   * (ManagedMediaSource / AirPlay).
+   * Author intent for the AirPlay/remote-playback picker, written by the media adapter's `disableRemotePlayback` IDL
+   * property. `true` is an explicit opt-out: `setupAirPlay` reads it at attach and sets nothing up, leaving the
+   * element's remote playback disabled. Distinct from the underlying `<video>.disableRemotePlayback`, which stays
+   * programmatically managed (ManagedMediaSource / AirPlay).
    */
   disableRemotePlayback?: boolean;
 }
@@ -202,10 +184,8 @@ export interface HlsVideoEngineContext {
 }
 
 /**
- * The composition signal refs handed to `onSignalsReady` callers — the
- * canonical way to drive the engine externally (writes) or observe its
- * state (reads) without touching `composition.state` / `composition.context`
- * directly.
+ * The composition signal refs handed to `onSignalsReady` callers — the canonical way to drive the engine externally
+ * (writes) or observe its state (reads) without touching `composition.state` / `composition.context` directly.
  */
 export type HlsVideoEngineSignals = {
   state: StateSignals<HlsVideoEngineState>;
@@ -215,41 +195,34 @@ export type HlsVideoEngineSignals = {
 /**
  * Configuration for the HLS playback engine.
  *
- * Each option is consumed by the appropriate behavior — the engine itself
- * has no config beyond what its behaviors read.
+ * Each option is consumed by the appropriate behavior — the engine itself has no config beyond what its behaviors read.
  */
 export interface HlsVideoEngineConfig extends ShareSignalsConfig<HlsVideoEngineState, HlsVideoEngineContext> {
   /**
-   * Bandwidth estimate in bps to use before enough samples have been
-   * collected. Default: `DEFAULT_INITIAL_BANDWIDTH` (5 Mbps).
+   * Bandwidth estimate in bps to use before enough samples have been collected. Default: `DEFAULT_INITIAL_BANDWIDTH` (5
+   * Mbps).
    */
   initialBandwidth?: number;
   /**
-   * Codec capability probe injected into `track-switching`'s
-   * `excludeUnplayableTracks` constraint — drops renditions the environment
-   * can't decode before selection. Defaults to the `MediaSource.isTypeSupported`
-   * -backed `canPlayTrack`; supply your own to override (e.g. force-exclude a
-   * codec).
+   * Codec capability probe injected into `track-switching`'s `excludeUnplayableTracks` constraint — drops renditions
+   * the environment can't decode before selection. Defaults to the `MediaSource.isTypeSupported` -backed
+   * `canPlayTrack`; supply your own to override (e.g. force-exclude a codec).
    */
   canPlayTrack?: CanPlayTrack;
   /**
-   * Codec families (RFC 6381 4CCs, e.g. `'avc1'` / `'hvc1'` / `'mp4a'`) the
-   * initial video/audio picks prefer on a mixed-codec source, read by the
-   * `preferCodecFamilies` selection scope. SPF implements no
-   * `SourceBuffer.changeType()`, so the initial pick's codec family is sticky
-   * for the source's lifetime (`stickToSelectedCodecs`); this decides which
-   * family that is. Soft — a source with no preferred-family rendition is
-   * unaffected. Defaults to `DEFAULT_PREFERRED_CODECS` (AVC + AAC, the
-   * broadest-decode pair); pass `[]` to disable and let ABR pick the initial
-   * family (it then still can't leave it mid-stream).
+   * Codec families (RFC 6381 4CCs, e.g. `'avc1'` / `'hvc1'` / `'mp4a'`) the initial video/audio picks prefer on a
+   * mixed-codec source, read by the `preferCodecFamilies` selection scope. SPF implements no
+   * `SourceBuffer.changeType()`, so the initial pick's codec family is sticky for the source's lifetime
+   * (`stickToSelectedCodecs`); this decides which family that is. Soft — a source with no preferred-family rendition is
+   * unaffected. Defaults to `DEFAULT_PREFERRED_CODECS` (AVC + AAC, the broadest-decode pair); pass `[]` to disable and
+   * let ABR pick the initial family (it then still can't leave it mid-stream).
    */
   preferredCodecs?: string[];
   /**
-   * Conditions reported about each rendition as it resolves — the *causes* behind
-   * a later verdict, and the copy a verdict reuses when they agree. Defaults to
-   * {@link reportUnsupportedTrackConditions}, which reports non-fMP4 containers
-   * and encryption; supply your own to report a different set (a provider that
-   * never ships MPEG-TS can drop that check) or `() => []` to report nothing.
+   * Conditions reported about each rendition as it resolves — the _causes_ behind a later verdict, and the copy a
+   * verdict reuses when they agree. Defaults to {@link reportUnsupportedTrackConditions}, which reports non-fMP4
+   * containers and encryption; supply your own to report a different set (a provider that never ships MPEG-TS can drop
+   * that check) or `() => []` to report nothing.
    */
   reportUnsupportedTrackConditions?: ReportUnsupportedTrackConditions;
   preferredAudioLanguage?: string;
@@ -257,121 +230,97 @@ export interface HlsVideoEngineConfig extends ShareSignalsConfig<HlsVideoEngineS
   includeForcedTracks?: boolean;
   enableDefaultTrack?: boolean;
   /**
-   * Resolver that turns a text-track segment fetch into VTT cues.
-   * Defaults to the DOM-bound `resolveVttSegment` resolver, which uses an
-   * offscreen `<track>` element to parse WebVTT.
+   * Resolver that turns a text-track segment fetch into VTT cues. Defaults to the DOM-bound `resolveVttSegment`
+   * resolver, which uses an offscreen `<track>` element to parse WebVTT.
    */
   resolveTextTrackSegment?: TextTrackSegmentResolver<VTTCue>;
   /**
-   * Resolver for `presentation.duration`. Defaults to picking the first
-   * resolved selected track's duration (video preferred, audio fallback) —
-   * appropriate for VoD and audio-only. Live engines should supply a
-   * resolver that returns `Number.POSITIVE_INFINITY` once the presentation
-   * is established as live; downstream `updateMediaSourceDuration` propagates
-   * that value to `mediaSource.duration` per the MSE spec.
+   * Resolver for `presentation.duration`. Defaults to picking the first resolved selected track's duration (video
+   * preferred, audio fallback) — appropriate for VoD and audio-only. Live engines should supply a resolver that returns
+   * `Number.POSITIVE_INFINITY` once the presentation is established as live; downstream `updateMediaSourceDuration`
+   * propagates that value to `mediaSource.duration` per the MSE spec.
    */
   resolveDuration?: PresentationDurationResolver;
   /**
-   * Manifest parser handed to `resolvePresentation`. Defaults to the HLS
-   * multivariant-playlist parser; supply your own for alternate format
-   * support without forking the engine.
+   * Manifest parser handed to `resolvePresentation`. Defaults to the HLS multivariant-playlist parser; supply your own
+   * for alternate format support without forking the engine.
    */
   parsePresentation?: ParsePresentation;
   /**
-   * Allocate SPF-owned text-track slots on the media element. Defaults to
-   * the standard `<track>`-element implementation in
-   * `media/dom/text/text-track-slots`.
+   * Allocate SPF-owned text-track slots on the media element. Defaults to the standard `<track>`-element implementation
+   * in `media/dom/text/text-track-slots`.
    */
   addSubtitlesTracksToMedia?: typeof addSubtitlesTracksToMedia;
   /**
-   * Return the SPF-owned subtitle/caption `TextTrack` currently in showing
-   * mode. Defaults to the standard selector-based implementation in
-   * `media/dom/text/text-track-slots`.
+   * Return the SPF-owned subtitle/caption `TextTrack` currently in showing mode. Defaults to the standard
+   * selector-based implementation in `media/dom/text/text-track-slots`.
    */
   getShowingSubtitlesTrackFromMedia?: typeof getShowingSubtitlesTrackFromMedia;
   /**
-   * Evict all SPF-owned text-track slots from the media element. Defaults to
-   * the standard selector-based implementation in
-   * `media/dom/text/text-track-slots`.
+   * Evict all SPF-owned text-track slots from the media element. Defaults to the standard selector-based implementation
+   * in `media/dom/text/text-track-slots`.
    */
   removeAllSubtitlesTracksFromMedia?: typeof removeAllSubtitlesTracksFromMedia;
   /**
-   * Forward-buffer tuning. `bufferDuration` controls how far ahead of the
-   * playhead segments are loaded (and where forward-flush kicks in).
-   * Defaults: see `DEFAULT_FORWARD_BUFFER_CONFIG` (30 seconds). Threaded to
-   * segment-loader actors (v/a + text) at construction time and to
-   * `loadXSegments` dispatchers for the load-message range.
+   * Forward-buffer tuning. `bufferDuration` controls how far ahead of the playhead segments are loaded (and where
+   * forward-flush kicks in). Defaults: see `DEFAULT_FORWARD_BUFFER_CONFIG` (30 seconds). Threaded to segment-loader
+   * actors (v/a + text) at construction time and to `loadXSegments` dispatchers for the load-message range.
    */
   forwardBuffer?: Partial<ForwardBufferConfig>;
   /**
-   * Back-buffer tuning. `keepSegments` controls how many segments stay
-   * behind the playhead before eviction. Defaults: see
-   * `DEFAULT_BACK_BUFFER_CONFIG` (2 segments). Threaded to the v/a
-   * segment-loader actor only (text tracks don't use back-buffer eviction).
+   * Back-buffer tuning. `keepSegments` controls how many segments stay behind the playhead before eviction. Defaults:
+   * see `DEFAULT_BACK_BUFFER_CONFIG` (2 segments). Threaded to the v/a segment-loader actor only (text tracks don't use
+   * back-buffer eviction).
    */
   backBuffer?: Partial<BackBufferConfig>;
   /**
-   * Bandwidth-estimator tuning. Overrides any field of `BandwidthConfig`
-   * (`fastHalfLife`, `slowHalfLife`, `minTotalBytes`, `minBytes`,
-   * `minDuration`). `bandwidth.minTotalBytes` supersedes the flat
-   * `minTotalBytes` field above. Defaults: see `DEFAULT_BANDWIDTH_CONFIG`.
+   * Bandwidth-estimator tuning. Overrides any field of `BandwidthConfig` (`fastHalfLife`, `slowHalfLife`,
+   * `minTotalBytes`, `minBytes`, `minDuration`). `bandwidth.minTotalBytes` supersedes the flat `minTotalBytes` field
+   * above. Defaults: see `DEFAULT_BANDWIDTH_CONFIG`.
    */
   bandwidth?: Partial<BandwidthConfig>;
   /**
-   * Quality-selection tuning. `safetyMargin` is the bandwidth-headroom
-   * multiplier used by `selectQuality`; `upgradeMargin` is the hysteresis
-   * ratio gating ABR upgrades. Defaults: `DEFAULT_QUALITY_CONFIG` (0.85 / 1.15).
+   * Quality-selection tuning. `safetyMargin` is the bandwidth-headroom multiplier used by `selectQuality`;
+   * `upgradeMargin` is the hysteresis ratio gating ABR upgrades. Defaults: `DEFAULT_QUALITY_CONFIG` (0.85 / 1.15).
    */
   quality?: Partial<QualityConfig>;
   /**
-   * Whether video renditions are capped to the player element's rendered size.
-   * Read by `trackPlayerResolution`; `false` measures nothing, which leaves the
-   * `playerResolutionCap` rule inert. Defaults to `true`.
+   * Whether video renditions are capped to the player element's rendered size. Read by `trackPlayerResolution`; `false`
+   * measures nothing, which leaves the `playerResolutionCap` rule inert. Defaults to `true`.
    */
   capRenditionToPlayerSize?: boolean;
-  /**
-   * Whether `state.playerResolution` is reported in device pixels. Read by
-   * `trackPlayerResolution`; defaults to `true`.
-   */
+  /** Whether `state.playerResolution` is reported in device pixels. Read by `trackPlayerResolution`; defaults to `true`. */
   useDevicePixelRatio?: boolean;
   /**
-   * Multi-CDN failover monitor tuning. `cooldownMs` is how long a CDN stays
-   * excluded after a failed fetch trips it. Defaults:
-   * `DEFAULT_FAILOVER_MONITOR_CONFIG` (300s). Only meaningful for redundant-stream
-   * sources.
+   * Multi-CDN failover monitor tuning. `cooldownMs` is how long a CDN stays excluded after a failed fetch trips it.
+   * Defaults: `DEFAULT_FAILOVER_MONITOR_CONFIG` (300s). Only meaningful for redundant-stream sources.
    */
   failover?: Partial<FailoverMonitorConfig>;
   /**
-   * How to derive a CDN grouping key from a track URL — used to build
-   * `cdnPriority`, to record the failover trip in `failedCdns`, and by the
-   * track-switching CDN scope + failover constraint. One function, read by all of
-   * them, so the keys stay comparable. Defaults to the URL origin; override to
-   * key on something else (e.g. Mux's `cdn=` query param).
+   * How to derive a CDN grouping key from a track URL — used to build `cdnPriority`, to record the failover trip in
+   * `failedCdns`, and by the track-switching CDN scope + failover constraint. One function, read by all of them, so the
+   * keys stay comparable. Defaults to the URL origin; override to key on something else (e.g. Mux's `cdn=` query
+   * param).
    */
   getCdnId?: GetCdnId;
   /**
-   * Non-zero-PTS relocation (spike): the reduce seam consumed by the
-   * `establishStartMediaTime` reactor. Defaults to per-track own origin (Tier 1);
-   * a Tier-2 variant returns the shared `min` across selected A/V. Relocation is
-   * composed into the standard engine below — see the marked block — so this only
-   * needs setting to swap the tier policy. See
-   * `internal/design/spf/presentation-timeline-model.md`.
+   * Non-zero-PTS relocation (spike): the reduce seam consumed by the `establishStartMediaTime` reactor. Defaults to
+   * per-track own origin (Tier 1); a Tier-2 variant returns the shared `min` across selected A/V. Relocation is
+   * composed into the standard engine below — see the marked block — so this only needs setting to swap the tier
+   * policy. See `internal/design/spf/presentation-timeline-model.md`.
    */
   deriveStartMediaTime?: DeriveStartMediaTime;
   /**
-   * Proximity window (seconds) for the `recoverEndStall` behavior — how close the
-   * playhead must be to the reachable buffered end for a `waiting` to be treated as the
-   * end-of-stream freeze and nudged to `ended`. Defaults to `0.2`. See
-   * `behaviors/dom/recover-end-stall`.
+   * Proximity window (seconds) for the `recoverEndStall` behavior — how close the playhead must be to the reachable
+   * buffered end for a `waiting` to be treated as the end-of-stream freeze and nudged to `ended`. Defaults to `0.2`.
+   * See `behaviors/dom/recover-end-stall`.
    */
   endStallNudgeWindow?: number;
   /**
-   * Live media-playlist re-run policy for the resolve* loaders' `RecurringRunner`:
-   * returns a promise that resolves when the playlist should reload, or `null` to
-   * stop. Defaults to `mediaPlaylistReloadDelay` (target-duration cadence, half on
-   * an unchanged window, stop on `#EXT-X-ENDLIST`) composed with a cancellable
-   * `sleep`. Inert for VoD (a complete playlist stops it after the first resolve).
-   * Override to tune live reload timing.
+   * Live media-playlist re-run policy for the resolve* loaders' `RecurringRunner`: returns a promise that resolves when
+   * the playlist should reload, or `null` to stop. Defaults to `mediaPlaylistReloadDelay` (target-duration cadence,
+   * half on an unchanged window, stop on `#EXT-X-ENDLIST`) composed with a cancellable `sleep`. Inert for VoD (a
+   * complete playlist stops it after the first resolve). Override to tune live reload timing.
    */
   reschedule?: Reschedule<ResolvedTrack>;
 }
@@ -381,12 +330,10 @@ export interface HlsVideoEngineConfig extends ShareSignalsConfig<HlsVideoEngineS
 // ============================================================================
 
 /**
- * Generic `shareSignals` instantiated against the HLS engine's full state
- * and context — captures composition signal refs into the consumer's
- * `onSignalsReady` callback at setup time, and materializes input slots that no
- * composed behavior produces: `user*TrackSelection` (track-switching only reads
- * them). `failedCdns` is owned by `setupFailoverMonitor`, so it's already
- * materialized and reachable on the `onSignalsReady` refs without being listed
+ * Generic `shareSignals` instantiated against the HLS engine's full state and context — captures composition signal
+ * refs into the consumer's `onSignalsReady` callback at setup time, and materializes input slots that no composed
+ * behavior produces: `user*TrackSelection` (track-switching only reads them). `failedCdns` is owned by
+ * `setupFailoverMonitor`, so it's already materialized and reachable on the `onSignalsReady` refs without being listed
  * here.
  */
 const shareSignals = makeShareSignals<HlsVideoEngineState, HlsVideoEngineContext>([
@@ -399,28 +346,27 @@ const shareSignals = makeShareSignals<HlsVideoEngineState, HlsVideoEngineContext
 /**
  * Create an HLS playback engine.
  *
- * Composes SPF behaviors into a reactive pipeline for HLS playback over MSE:
- * manifest resolution, track selection, ABR, segment loading, and
- * end-of-stream coordination.
+ * Composes SPF behaviors into a reactive pipeline for HLS playback over MSE: manifest resolution, track selection, ABR,
+ * segment loading, and end-of-stream coordination.
  *
  * @example
- * ```ts
- * let signals: HlsVideoEngineSignals;
- * const engine = createHlsVideoEngine({
- *   initialBandwidth: 2_000_000,
- *   preferredAudioLanguage: 'en',
- *   onSignalsReady: (refs) => {
- *     signals = refs;
- *   },
- * });
+ *   ```ts
+ *   let signals: HlsVideoEngineSignals;
+ *   const engine = createHlsVideoEngine({
+ *     initialBandwidth: 2_000_000,
+ *     preferredAudioLanguage: 'en',
+ *     onSignalsReady: (refs) => {
+ *       signals = refs;
+ *     },
+ *   });
  *
- * signals.context.mediaElement.set(videoEl);
- * signals.state.presentation.set({ url: 'https://example.com/stream.m3u8' });
+ *   signals.context.mediaElement.set(videoEl);
+ *   signals.state.presentation.set({ url: 'https://example.com/stream.m3u8' });
  *
- * videoEl.play();
+ *   videoEl.play();
  *
- * await engine.destroy();
- * ```
+ *   await engine.destroy();
+ *   ```;
  */
 export function createHlsVideoEngine(
   config: HlsVideoEngineConfig = {}

--- a/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
+++ b/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
@@ -1,11 +1,10 @@
 /**
- * createBackgroundVideoEngine tests.
+ * CreateBackgroundVideoEngine tests.
  *
- * The variant subtracts audio, text, ABR, and preload-monitoring behaviors
- * from the HLS video engine, then seeds `loadActivated: true` so the
- * composition behaves as if preload has already been activated. These tests
- * confirm the seed, the absence of subtracted state slots, and the selection
- * rule chain — its screen-size cap and its configurability.
+ * The variant subtracts audio, text, ABR, and preload-monitoring behaviors from the HLS video engine, then seeds
+ * `loadActivated: true` so the composition behaves as if preload has already been activated. These tests confirm the
+ * seed, the absence of subtracted state slots, and the selection rule chain — its screen-size cap and its
+ * configurability.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 

--- a/packages/spf/src/playback/primitives/derive-start-media-time.ts
+++ b/packages/spf/src/playback/primitives/derive-start-media-time.ts
@@ -1,10 +1,9 @@
 /**
- * The `startMediaTime` coordination seam — shared by the `establishStartMediaTime`
- * reactor (which owns the lifecycle and holds one of these as config) and the DOM-free
- * relocation pipelines that fill its state (`relocation-pipelines`). It lives here rather
- * than with the behavior because the pipelines are a lower layer and can't import from
- * `behaviors/`; a playback-domain contract (it names selected track ids), so not `media/`.
- * See `internal/design/spf/presentation-timeline-model.md`.
+ * The `startMediaTime` coordination seam — shared by the `establishStartMediaTime` reactor (which owns the lifecycle
+ * and holds one of these as config) and the DOM-free relocation pipelines that fill its state (`relocation-pipelines`).
+ * It lives here rather than with the behavior because the pipelines are a lower layer and can't import from
+ * `behaviors/`; a playback-domain contract (it names selected track ids), so not `media/`. See
+ * `internal/design/spf/presentation-timeline-model.md`.
  */
 import type { MediaContainerData } from '../../media/types';
 
@@ -15,9 +14,9 @@ export interface DeriveStartMediaTimeContext {
 }
 
 /**
- * Reduce the discovered {@link MediaContainerData} (keyed by track type) into each type's
- * `startMediaTime` origin; `undefined` means "not ready yet". Pure and injected — the single
- * coordination seam the reactor and the loader stamp share.
+ * Reduce the discovered {@link MediaContainerData} (keyed by track type) into each type's `startMediaTime` origin;
+ * `undefined` means "not ready yet". Pure and injected — the single coordination seam the reactor and the loader stamp
+ * share.
  */
 export type DeriveStartMediaTime = (
   containerData: Record<string, MediaContainerData>,

--- a/packages/spf/src/playback/primitives/error-messages.ts
+++ b/packages/spf/src/playback/primitives/error-messages.ts
@@ -1,53 +1,44 @@
 /**
  * Developer-facing copy for what this engine reports.
  *
- * Everything here reaches a **console**, never a viewer. Viewer-facing copy for
- * a fatal condition is the presentation layer's to compose: the engine reports a
- * code, and a consumer maps that code to localized text it owns.
+ * Everything here reaches a **console**, never a viewer. Viewer-facing copy for a fatal condition is the presentation
+ * layer's to compose: the engine reports a code, and a consumer maps that code to localized text it owns.
  *
- * Plain string constants, one export each. Nothing is parameterized — a message
- * that names the engine has to be built at the call site from state the engine
- * carries around solely to say it, which is a lot of plumbing for a console
- * prefix. Separate exports rather than one object so a composition that logs
- * neither notice doesn't carry their bytes.
+ * Plain string constants, one export each. Nothing is parameterized — a message that names the engine has to be built
+ * at the call site from state the engine carries around solely to say it, which is a lot of plumbing for a console
+ * prefix. Separate exports rather than one object so a composition that logs neither notice doesn't carry their bytes.
  */
 
 /**
  * Logged when a fatal `SVTA_UNSUPPORTED_PLAYBACK_FEATURE` is surfaced.
  *
- * The developer's half of that event; the viewer gets the localized copy the
- * code maps to. One sentence is enough because the specifics — which container,
- * which rendition, whether it was DRM — stay structured on the reported
+ * The developer's half of that event; the viewer gets the localized copy the code maps to. One sentence is enough
+ * because the specifics — which container, which rendition, whether it was DRM — stay structured on the reported
  * conditions logged beside it.
  */
 export const UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE =
   "Can't play this source: it requires an unsupported playback feature.";
 
 /**
- * Logged for **any** fatal condition, by a composition whose failures don't all
- * reduce to a missing feature.
+ * Logged for **any** fatal condition, by a composition whose failures don't all reduce to a missing feature.
  *
- * The background variant is the case: it treats a per-rendition cause as fatal on
- * its own, so what reaches its surface can be an unsupported container, DRM it
- * can't decrypt, or a source carrying no video at all. Naming one feature would be
- * wrong for the last of those, so all three are named broadly. Deferring the *why*
- * to the conditions instead would promise prose they don't carry — an `SvtaError`
- * is a code and its context, and nothing on this path sets `message`.
+ * The background variant is the case: it treats a per-rendition cause as fatal on its own, so what reaches its surface
+ * can be an unsupported container, DRM it can't decrypt, or a source carrying no video at all. Naming one feature would
+ * be wrong for the last of those, so all three are named broadly. Deferring the _why_ to the conditions instead would
+ * promise prose they don't carry — an `SvtaError` is a code and its context, and nothing on this path sets `message`.
  */
 export const UNPLAYABLE_SOURCE_MESSAGE =
   "Can't play this source — unsupported container, encryption, or no usable video track.";
 
 /**
- * LL-HLS delivery, played as standard live. The parser ignores partial segments
- * and the loader fetches whole ones, so latency lands wherever `HOLD-BACK` puts
- * it — the stream plays, just not at the latency it was published for.
+ * LL-HLS delivery, played as standard live. The parser ignores partial segments and the loader fetches whole ones, so
+ * latency lands wherever `HOLD-BACK` puts it — the stream plays, just not at the latency it was published for.
  */
 export const LOW_LATENCY_UNSUPPORTED_MESSAGE =
   'Low-Latency HLS is unsupported; playing as standard live at higher latency.';
 
 /**
- * `#EXT-X-PLAYLIST-TYPE:EVENT` — a growing window, which is how DVR is
- * delivered. It plays, but the seekable-range and live-edge handling for it is
- * newer and less exercised than sliding-window live.
+ * `#EXT-X-PLAYLIST-TYPE:EVENT` — a growing window, which is how DVR is delivered. It plays, but the seekable-range and
+ * live-edge handling for it is newer and less exercised than sliding-window live.
  */
 export const DVR_EXPERIMENTAL_MESSAGE = 'DVR support for EVENT playlists is experimental.';

--- a/packages/spf/src/playback/primitives/failover-fetch.ts
+++ b/packages/spf/src/playback/primitives/failover-fetch.ts
@@ -7,13 +7,12 @@ import type { FetchOptions, Resource } from '../../network/fetch';
 type SelectedTrackKey = 'selectedVideoTrackId' | 'selectedAudioTrackId' | 'selectedTextTrackId';
 
 /**
- * State a failover-decorated fetch reads: the presentation, the per-type
- * selected-track slot, and the failover monitor's `failedCdns`.
+ * State a failover-decorated fetch reads: the presentation, the per-type selected-track slot, and the failover
+ * monitor's `failedCdns`.
  *
- * `failedCdns` is *optional* — the failover monitor owns that slot, so a
- * behavior's narrow state is assignable here without the behavior declaring it
- * (and the intersection shares keys, so it isn't a weak type). When no monitor
- * is composed the slot is absent and tracking no-ops.
+ * `failedCdns` is _optional_ — the failover monitor owns that slot, so a behavior's narrow state is assignable here
+ * without the behavior declaring it (and the intersection shares keys, so it isn't a weak type). When no monitor is
+ * composed the slot is absent and tracking no-ops.
  */
 type FailoverState<K extends SelectedTrackKey> = {
   presentation: ReadonlySignal<MaybeResolvedPresentation | undefined>;
@@ -24,22 +23,17 @@ type FailoverState<K extends SelectedTrackKey> = {
 type FailoverableFetch = (addressable: Resource, options?: FetchOptions) => Promise<unknown>;
 
 /**
- * Decorate a fetch so a failed request trips the **selected track's** CDN into
- * `failedCdns`. The decorated fetch's type is preserved, so this wraps both
- * `resolve-track`'s playlist `FetchText` and the segment loaders' `FetchBytes`.
+ * Decorate a fetch so a failed request trips the **selected track's** CDN into `failedCdns`. The decorated fetch's type
+ * is preserved, so this wraps both `resolve-track`'s playlist `FetchText` and the segment loaders' `FetchBytes`.
  *
- * The CDN id comes from the selected track's media-playlist URL, never the
- * failed addressable: a segment URL resolves relative to its playlist and, per
- * RFC 3986, drops the playlist's query string (`…/r.m3u8?cdn=fastly` → `…/0.ts`),
- * so a query-keyed `getCdnId` (e.g. Mux's `cdn=`) keyed on it would derive an id
- * that never matches the ones `deriveCdnPriority` / track-switching build from
- * `track.url`. The in-flight fetch belongs to the selected track — a source or
- * track switch aborts it, and aborts don't trip — so the selected track is the
- * right CDN to fail over. For `resolve-track` the resolving track *is* the
- * selected track, so this is identical to keying on its addressable.
+ * The CDN id comes from the selected track's media-playlist URL, never the failed addressable: a segment URL resolves
+ * relative to its playlist and, per RFC 3986, drops the playlist's query string (`…/r.m3u8?cdn=fastly` → `…/0.ts`), so
+ * a query-keyed `getCdnId` (e.g. Mux's `cdn=`) keyed on it would derive an id that never matches the ones
+ * `deriveCdnPriority` / track-switching build from `track.url`. The in-flight fetch belongs to the selected track — a
+ * source or track switch aborts it, and aborts don't trip — so the selected track is the right CDN to fail over. For
+ * `resolve-track` the resolving track _is_ the selected track, so this is identical to keying on its addressable.
  *
- * No-op when no failover monitor is composed (it owns the signal) or the
- * selected track can't be located.
+ * No-op when no failover monitor is composed (it owns the signal) or the selected track can't be located.
  */
 export function failoverFetch<K extends SelectedTrackKey, Fetch extends FailoverableFetch>(
   baseFetch: Fetch,

--- a/packages/spf/src/playback/primitives/gate-first-parse.ts
+++ b/packages/spf/src/playback/primitives/gate-first-parse.ts
@@ -1,12 +1,9 @@
 /**
- * The first-parse placement gate — the coordination seam between track
- * resolution (`resolve-track`, which awaits it between fetching a media
- * playlist and parsing it) and the establishment unit that supplies the
- * policy (`establishStartMediaTime` exports `gateFirstParseOnAnchor`). It
- * lives here rather than with either behavior so the two coordinate through
- * an injected contract, never by importing each other; a playback-domain
- * contract (it names selected track ids), so not `media/`.
- * See `internal/design/spf/live-presentation-timeline-model.md`.
+ * The first-parse placement gate — the coordination seam between track resolution (`resolve-track`, which awaits it
+ * between fetching a media playlist and parsing it) and the establishment unit that supplies the policy
+ * (`establishStartMediaTime` exports `gateFirstParseOnAnchor`). It lives here rather than with either behavior so the
+ * two coordinate through an injected contract, never by importing each other; a playback-domain contract (it names
+ * selected track ids), so not `media/`. See `internal/design/spf/live-presentation-timeline-model.md`.
  */
 import type { MaybeResolvedPresentation } from '../../media/types';
 
@@ -17,10 +14,9 @@ export interface GateFirstParseContext {
 }
 
 /**
- * Whether `trackId`'s **first** parse may place its segments now. Pure over
- * the current presentation + selection — callers re-evaluate it reactively
- * (e.g. via `when`) until it opens. Returning `false` holds the parse, not
- * the fetch: playlist bytes may arrive concurrently; only placement waits.
+ * Whether `trackId`'s **first** parse may place its segments now. Pure over the current presentation + selection —
+ * callers re-evaluate it reactively (e.g. via `when`) until it opens. Returning `false` holds the parse, not the fetch:
+ * playlist bytes may arrive concurrently; only placement waits.
  */
 export type GateFirstParse = (
   presentation: MaybeResolvedPresentation | undefined,

--- a/packages/spf/src/playback/primitives/head-peek.ts
+++ b/packages/spf/src/playback/primitives/head-peek.ts
@@ -1,9 +1,8 @@
 /**
- * Eager head-of-stream peek. Pulls chunks from an async byte stream only until
- * `tryParse` signals it has read what it needs (or the stream ends), then returns
- * a stream that re-emits the pulled head followed by the untouched tail — so
- * reading a head-of-stream mp4 box (`mdhd` / `tfdt`) doesn't break streaming of
- * the append. Once the caller has what it wants, the rest streams as normal.
+ * Eager head-of-stream peek. Pulls chunks from an async byte stream only until `tryParse` signals it has read what it
+ * needs (or the stream ends), then returns a stream that re-emits the pulled head followed by the untouched tail — so
+ * reading a head-of-stream mp4 box (`mdhd` / `tfdt`) doesn't break streaming of the append. Once the caller has what it
+ * wants, the rest streams as normal.
  */
 
 function concat(chunks: Uint8Array[]): Uint8Array {
@@ -29,11 +28,9 @@ async function* reassemble(head: Uint8Array[], tail: AsyncIterator<Uint8Array>):
 }
 
 /**
- * Pull chunks until `tryParse(accumulatedHead)` returns `true` — it found and read
- * its box — or the stream ends, then return a stream re-emitting the pulled head
- * followed by the untouched tail. `tryParse` is called with the growing head after
- * each chunk; it performs the side effect (publishing the parsed value) and returns
- * whether it's done.
+ * Pull chunks until `tryParse(accumulatedHead)` returns `true` — it found and read its box — or the stream ends, then
+ * return a stream re-emitting the pulled head followed by the untouched tail. `tryParse` is called with the growing
+ * head after each chunk; it performs the side effect (publishing the parsed value) and returns whether it's done.
  */
 export async function peekHead(
   data: AsyncIterable<Uint8Array>,

--- a/packages/spf/src/playback/primitives/live-window.ts
+++ b/packages/spf/src/playback/primitives/live-window.ts
@@ -1,19 +1,15 @@
 /**
- * Resolve the live window from engine state — the single call site the
- * seek-to-live-edge and live-seekable-range behaviors share, so their window
- * derivation can't drift apart.
+ * Resolve the live window from engine state — the single call site the seek-to-live-edge and live-seekable-range
+ * behaviors share, so their window derivation can't drift apart.
  *
- * The window is the **intersection over the selected A/V tracks'** windows
- * (`max` of starts, `min` of ends): publication skew between the two playlists
- * shrinks the window to what both can actually serve, and the `max` also clamps
- * the legitimate *negative* early `startTime` of a non-reference track whose
- * window precedes the join point (presentation-0) — see
- * `internal/design/spf/live-presentation-timeline-model.md` (Phase 2 window
- * math). With one selected type (video-only / audio-only) its window stands
- * alone.
+ * The window is the **intersection over the selected A/V tracks'** windows (`max` of starts, `min` of ends):
+ * publication skew between the two playlists shrinks the window to what both can actually serve, and the `max` also
+ * clamps the legitimate _negative_ early `startTime` of a non-reference track whose window precedes the join point
+ * (presentation-0) — see `internal/design/spf/live-presentation-timeline-model.md` (Phase 2 window math). With one
+ * selected type (video-only / audio-only) its window stands alone.
  *
- * Reads signals lazily — call it inside a reactive context (an effect) so the
- * read tracks `presentation` + the selected-track ids.
+ * Reads signals lazily — call it inside a reactive context (an effect) so the read tracks `presentation` + the
+ * selected-track ids.
  */
 import type { ReadonlySignal } from '../../core/signals/primitives';
 import { type LiveWindow, liveWindowFor } from '../../media/live-window';
@@ -27,22 +23,20 @@ export interface LiveWindowState {
 }
 
 /**
- * The id of the timeline-bearing track: the selected video track when present,
- * else the selected audio track. The single pick both the window derivation and
- * the live-latency resolution (`seek-to-live-edge`) share, so they can't drift.
+ * The id of the timeline-bearing track: the selected video track when present, else the selected audio track. The
+ * single pick both the window derivation and the live-latency resolution (`seek-to-live-edge`) share, so they can't
+ * drift.
  */
 export function liveTrackId(state: LiveWindowState): string | undefined {
   return state.selectedVideoTrackId?.get() ?? state.selectedAudioTrackId?.get();
 }
 
 /**
- * One type's window: the selected track's when it's resolved, else any resolved
- * track of the type. The fallback keeps the window from blinking to `null`
- * mid ABR / user switch — all renditions of a type are time-aligned and share
- * the anchor, so a deselected track's window may trail live by up to one reload
- * during the switch gap (acceptable; the selected track's fresh window resumes
- * the moment it resolves). A null blink would flip `seekToLiveEdge` out of
- * `live` and stall the seekable-range writer.
+ * One type's window: the selected track's when it's resolved, else any resolved track of the type. The fallback keeps
+ * the window from blinking to `null` mid ABR / user switch — all renditions of a type are time-aligned and share the
+ * anchor, so a deselected track's window may trail live by up to one reload during the switch gap (acceptable; the
+ * selected track's fresh window resumes the moment it resolves). A null blink would flip `seekToLiveEdge` out of `live`
+ * and stall the seekable-range writer.
  */
 function liveWindowForType(
   presentation: MaybeResolvedPresentation | undefined,
@@ -83,10 +77,9 @@ export function liveWindowFromState(state: LiveWindowState): LiveWindow | null {
 }
 
 /**
- * Resolve the target live latency (seconds the playhead should trail the live
- * edge) for the timeline-bearing track. Format-specific — supplied by the engine
- * (HLS: `HOLD-BACK`; DASH would use `suggestedPresentationDelay`) — so the live
- * edge stays format-neutral.
+ * Resolve the target live latency (seconds the playhead should trail the live edge) for the timeline-bearing track.
+ * Format-specific — supplied by the engine (HLS: `HOLD-BACK`; DASH would use `suggestedPresentationDelay`) — so the
+ * live edge stays format-neutral.
  */
 export type ResolveLiveLatency = (
   presentation: MaybeResolvedPresentation | undefined,
@@ -100,11 +93,10 @@ export interface LiveEdge extends LiveWindow {
 }
 
 /**
- * Resolve the live edge — the window bounds plus the target playhead position —
- * from a behavior's setup arguments. Bundles the window geometry and the
- * format-specific latency policy (`config.resolveLiveLatency`) so the consuming
- * behavior never has to compose them; it just forwards its `{ state, config }`.
- * `null` when there is no live edge (VOD / ended / unresolved).
+ * Resolve the live edge — the window bounds plus the target playhead position — from a behavior's setup arguments.
+ * Bundles the window geometry and the format-specific latency policy (`config.resolveLiveLatency`) so the consuming
+ * behavior never has to compose them; it just forwards its `{ state, config }`. `null` when there is no live edge (VOD
+ * / ended / unresolved).
  *
  * Reads signals lazily — call it inside a reactive context (an effect).
  */

--- a/packages/spf/src/playback/primitives/relocation-pipelines.ts
+++ b/packages/spf/src/playback/primitives/relocation-pipelines.ts
@@ -1,29 +1,24 @@
 /**
- * Non-zero-PTS relocation pipelines — the config-supplied, loader-facing half of the
- * `establishStartMediaTime` behavior (`../behaviors/establish-start-media-time`). The
- * reactor there owns the lifecycle and the `derive` coordination seam; this file supplies
- * the `messagePipelines` the segment/text loaders run to *fill and act on* that behavior's
- * state. It's the relocation analog of `track-switching`'s config-supplied constraint/rule
- * chain — a pluggable strategy handed to the machinery via config, not applied inline —
- * supplied to the loaders rather than applied by the behavior, so the two coordinate
- * through the shared `mediaContainerData` / `startMediaTime` slots alone, never by import.
+ * Non-zero-PTS relocation pipelines — the config-supplied, loader-facing half of the `establishStartMediaTime` behavior
+ * (`../behaviors/establish-start-media-time`). The reactor there owns the lifecycle and the `derive` coordination seam;
+ * this file supplies the `messagePipelines` the segment/text loaders run to _fill and act on_ that behavior's state.
+ * It's the relocation analog of `track-switching`'s config-supplied constraint/rule chain — a pluggable strategy handed
+ * to the machinery via config, not applied inline — supplied to the loaders rather than applied by the behavior, so the
+ * two coordinate through the shared `mediaContainerData` / `startMediaTime` slots alone, never by import.
  *
- * DOM-free: it composes the loader vocabularies (`segment-load-pipeline`,
- * `text-segment-load-pipeline`) through their structural sink seams and shifts cues via
- * the structural `Cue` type, so it names no `SourceBuffer`, `TextTracksActor`, or
- * `VTTCue`. The A/V pipeline is a plain `messagePipelines` array:
- *   - `discover` — init `track_id` + `mdhd` timescale for the buffered media track, then
- *     that same track's `tfdt` baseMediaDecodeTime, matched by `track_id` so a muxed
- *     segment reads the media track's origin, not the first `traf` — writes
- *     `state.mediaContainerData`.
- *   - `stamp` — reads that track's derived origin back and relocates via
- *     `timestampOffset = −startMediaTime`.
- * Steps read composition `state` from their call-time `deps` (no closures, no context).
+ * DOM-free: it composes the loader vocabularies (`segment-load-pipeline`, `text-segment-load-pipeline`) through their
+ * structural sink seams and shifts cues via the structural `Cue` type, so it names no `SourceBuffer`,
+ * `TextTracksActor`, or `VTTCue`. The A/V pipeline is a plain `messagePipelines` array:
  *
- * The text half (`relocatingTextPipelines`) is the same idea for the text-segment loader:
- * a `resolveWithMetadata → relocateCues → dispatchCues` pipeline that shifts cues onto the
- * same 0-based timeline, reading the primary A/V track's `startMediaTime` (the reactor's
- * consumed value) via `deps`.
+ * - `discover` — init `track_id` + `mdhd` timescale for the buffered media track, then that same track's `tfdt`
+ *   baseMediaDecodeTime, matched by `track_id` so a muxed segment reads the media track's origin, not the first `traf`
+ *   — writes `state.mediaContainerData`.
+ * - `stamp` — reads that track's derived origin back and relocates via `timestampOffset = −startMediaTime`. Steps read
+ *   composition `state` from their call-time `deps` (no closures, no context).
+ *
+ * The text half (`relocatingTextPipelines`) is the same idea for the text-segment loader: a `resolveWithMetadata →
+ * relocateCues → dispatchCues` pipeline that shifts cues onto the same 0-based timeline, reading the primary A/V
+ * track's `startMediaTime` (the reactor's consumed value) via `deps`.
  */
 import type { StateSignals } from '../../core/composition/create-composition';
 import { effect } from '../../core/signals/effect';
@@ -68,10 +63,9 @@ function writeContainer(slot: ContainerSlot, trackType: string, patch: Partial<M
 }
 
 /**
- * Resolve once `read()` returns a number. Shared by the A/V stamp (waits for the
- * `derive`d origin — immediate for per-type, the shared-`min` barrier for coordinated)
- * and the text step (waits for the primary A/V origin). No bound: for fMP4 the origin
- * always establishes.
+ * Resolve once `read()` returns a number. Shared by the A/V stamp (waits for the `derive`d origin — immediate for
+ * per-type, the shared-`min` barrier for coordinated) and the text step (waits for the primary A/V origin). No bound:
+ * for fMP4 the origin always establishes.
  */
 function awaitDefined(read: () => number | undefined): Promise<number> {
   return new Promise((resolve) => {
@@ -89,21 +83,19 @@ function awaitDefined(read: () => number | undefined): Promise<number> {
 }
 
 /**
- * Relocation pipelines for one track type — a plain config `messagePipelines`.
- * Keyed by **track type** (`'video'` / `'audio'`), so ABR rungs of a type share the
- * origin (discover skips once the type's value is present). The steps read/write
- * `state.mediaContainerData[trackType]` via their call-time `deps`; the stamp applies
- * the same `derive` seam the reactor uses (pass the composition's resolved
- * `deriveStartMediaTime` so the buffer offset and the model's `startMediaTime` agree).
+ * Relocation pipelines for one track type — a plain config `messagePipelines`. Keyed by **track type** (`'video'` /
+ * `'audio'`), so ABR rungs of a type share the origin (discover skips once the type's value is present). The steps
+ * read/write `state.mediaContainerData[trackType]` via their call-time `deps`; the stamp applies the same `derive` seam
+ * the reactor uses (pass the composition's resolved `deriveStartMediaTime` so the buffer offset and the model's
+ * `startMediaTime` agree).
  */
 export function relocationPipelinesFor(trackType: 'video' | 'audio', derive: DeriveStartMediaTime): MessagePipelines {
   const handlerType: MediaHandlerType = trackType === 'video' ? 'vide' : 'soun';
 
   /**
-   * Init step: head-peek the buffered media track's `track_id` + `mdhd` timescale into
-   * `mediaContainerData[trackType]`. Matching by handler (`vide`/`soun`) skips a muxed
-   * `clcp` caption track, and the `track_id` lets `readSegmentOrigin` read *this*
-   * track's `tfdt` rather than the first `traf` in the segment.
+   * Init step: head-peek the buffered media track's `track_id` + `mdhd` timescale into `mediaContainerData[trackType]`.
+   * Matching by handler (`vide`/`soun`) skips a muxed `clcp` caption track, and the `track_id` lets `readSegmentOrigin`
+   * read _this_ track's `tfdt` rather than the first `traf` in the segment.
    */
   const readInitTrackInfo: LoadStep = async (frame, _signal, deps) => {
     const { op } = frame;
@@ -125,12 +117,10 @@ export function relocationPipelinesFor(trackType: 'video' | 'audio', derive: Der
   };
 
   /**
-   * Media-segment step: head-peek the `tfdt` baseMediaDecodeTime of the media track's
-   * `traf` (matched by the `track_id` discovered from the init), recording the
-   * segment's 0-based `startTime` with it — the origin is `bmdt/ts − segmentStartTime`,
-   * so the first *loaded* segment need not be the 0th. Without a discovered `track_id`
-   * (non-fMP4 / mock init) there's no media track to relocate, so the step no-ops and
-   * the append stays native.
+   * Media-segment step: head-peek the `tfdt` baseMediaDecodeTime of the media track's `traf` (matched by the `track_id`
+   * discovered from the init), recording the segment's 0-based `startTime` with it — the origin is `bmdt/ts −
+   * segmentStartTime`, so the first _loaded_ segment need not be the 0th. Without a discovered `track_id` (non-fMP4 /
+   * mock init) there's no media track to relocate, so the step no-ops and the append stays native.
    */
   const readSegmentOrigin: LoadStep = async (frame, _signal, deps) => {
     const { op } = frame;
@@ -159,15 +149,13 @@ export function relocationPipelinesFor(trackType: 'video' | 'audio', derive: Der
   };
 
   /**
-   * Stamp step — tier-agnostic apply. Relocate by the `derive`d `startMediaTime` for
-   * this type (`offset = −startMediaTime`). Applies the **same** `derive` the reactor
-   * uses, over the shared `mediaContainerData` slot — so the buffer offset matches the
-   * model's stamped `startMediaTime`, and it's robust to `established` + late tracks
-   * (the slot persists; the model value may not be re-stamped after the reactor goes
-   * sticky). Awaited: per-type resolves at once (own origin discovered earlier in this
-   * pipeline); shared-`min` waits until every selected A/V origin is in — the barrier,
-   * filled by the other type's discover step. A derived `0` (0-PTS / below threshold)
-   * leaves the append native — setting `timestampOffset` at all can ripple.
+   * Stamp step — tier-agnostic apply. Relocate by the `derive`d `startMediaTime` for this type (`offset =
+   * −startMediaTime`). Applies the **same** `derive` the reactor uses, over the shared `mediaContainerData` slot — so
+   * the buffer offset matches the model's stamped `startMediaTime`, and it's robust to `established` + late tracks (the
+   * slot persists; the model value may not be re-stamped after the reactor goes sticky). Awaited: per-type resolves at
+   * once (own origin discovered earlier in this pipeline); shared-`min` waits until every selected A/V origin is in —
+   * the barrier, filled by the other type's discover step. A derived `0` (0-PTS / below threshold) leaves the append
+   * native — setting `timestampOffset` at all can ripple.
    */
   const stampStartMediaTime: LoadStep = async (frame, signal, deps) => {
     if (frame.op.type !== 'append-segment') return;
@@ -212,12 +200,10 @@ export function relocationPipelinesFor(trackType: 'video' | 'audio', derive: Der
 // ============================================================================
 
 /**
- * Resolve step for the relocation text pipeline. Reuses the injected host resolver
- * (the loader's folded `resolveSegment`, via `textStepWiring`) for cues and fetches
- * the `X-TIMESTAMP-MAP` header in parallel, stashing it on `frame.metadata` for
- * `relocateCuesStep`. Replaces the
- * base `resolveCuesStep` (which fetches cues only) — text's native `<track>` parser
- * discards the header, so the map needs its own raw-bytes fetch.
+ * Resolve step for the relocation text pipeline. Reuses the injected host resolver (the loader's folded
+ * `resolveSegment`, via `textStepWiring`) for cues and fetches the `X-TIMESTAMP-MAP` header in parallel, stashing it on
+ * `frame.metadata` for `relocateCuesStep`. Replaces the base `resolveCuesStep` (which fetches cues only) — text's
+ * native `<track>` parser discards the header, so the map needs its own raw-bytes fetch.
  */
 const resolveWithMetadataStep = async <C extends Cue>(
   frame: TextFrame<C>,
@@ -236,14 +222,12 @@ const resolveWithMetadataStep = async <C extends Cue>(
 };
 
 /**
- * Relocate step — shifts each cue onto the 0-based presentation timeline:
- * `cueFinal = cueNative − startMediaTime`, where `startMediaTime` is the primary
- * A/V track's origin (selected **video**, else **audio** — the single-anchor rule,
- * and defensive like the reactor's optional selection) and `cueNative` folds in the
- * `X-TIMESTAMP-MAP` correction (`mpegts/90000 − local`) for map-bearing VTT (Apple)
- * or is the absolute cue time (no map, e.g. Mux). Text can resolve before A/V
- * establishes, so the origin is awaited; fMP4 always establishes it (0-PTS → 0),
- * and a text-only source (no A/V selected) simply gets offset 0.
+ * Relocate step — shifts each cue onto the 0-based presentation timeline: `cueFinal = cueNative − startMediaTime`,
+ * where `startMediaTime` is the primary A/V track's origin (selected **video**, else **audio** — the single-anchor
+ * rule, and defensive like the reactor's optional selection) and `cueNative` folds in the `X-TIMESTAMP-MAP` correction
+ * (`mpegts/90000 − local`) for map-bearing VTT (Apple) or is the absolute cue time (no map, e.g. Mux). Text can resolve
+ * before A/V establishes, so the origin is awaited; fMP4 always establishes it (0-PTS → 0), and a text-only source (no
+ * A/V selected) simply gets offset 0.
  */
 const relocateCuesStep = async <C extends Cue>(
   frame: TextFrame<C>,
@@ -291,9 +275,8 @@ const relocateCuesStep = async <C extends Cue>(
 };
 
 /**
- * Relocation text pipeline — the text analog of `relocationPipelinesFor(type)`.
- * `resolveWithMetadata` (cues + `X-TIMESTAMP-MAP`) → `relocateCues` (shift by the
- * primary A/V origin) → `dispatchCues`.
+ * Relocation text pipeline — the text analog of `relocationPipelinesFor(type)`. `resolveWithMetadata` (cues +
+ * `X-TIMESTAMP-MAP`) → `relocateCues` (shift by the primary A/V origin) → `dispatchCues`.
  */
 export const relocatingTextPipelines = <C extends Cue>(): TextLoadStep<C>[] => [
   resolveWithMetadataStep,

--- a/packages/spf/src/playback/primitives/report-track-conditions.ts
+++ b/packages/spf/src/playback/primitives/report-track-conditions.ts
@@ -1,21 +1,16 @@
 /**
- * The seam `resolve-track` uses to report conditions discovered in a freshly
- * parsed media playlist.
+ * The seam `resolve-track` uses to report conditions discovered in a freshly parsed media playlist.
  *
- * Injected rather than baked in so `resolve-track` stays free of format and
- * policy knowledge: it parses and commits, and whatever the composition wants
- * noticed about the result is this function's business. Which conditions matter,
- * and which codes they carry, therefore vary per composition — a provider that
- * never ships MPEG-TS can drop that check, and future playlist-derived notices
- * (LL-HLS or DVR support that's partial rather than absent) attach here without
+ * Injected rather than baked in so `resolve-track` stays free of format and policy knowledge: it parses and commits,
+ * and whatever the composition wants noticed about the result is this function's business. Which conditions matter, and
+ * which codes they carry, therefore vary per composition — a provider that never ships MPEG-TS can drop that check, and
+ * future playlist-derived notices (LL-HLS or DVR support that's partial rather than absent) attach here without
  * touching the resolver.
  *
- * Reported **per rendition, as it resolves**, which is why these are causes and
- * not verdicts: one rendition being unplayable doesn't make the source
- * unplayable. The verdict is `track-switching`'s, which reports
- * `SVTA_NO_SUPPORTED_{VIDEO,AUDIO}_TRACK` when a type's candidates actually
- * empty. Keeping the two apart is what lets a mixed source — some renditions
- * encrypted or MPEG-TS, others playable — log its causes and still play.
+ * Reported **per rendition, as it resolves**, which is why these are causes and not verdicts: one rendition being
+ * unplayable doesn't make the source unplayable. The verdict is `track-switching`'s, which reports
+ * `SVTA_NO_SUPPORTED_{VIDEO,AUDIO}_TRACK` when a type's candidates actually empty. Keeping the two apart is what lets a
+ * mixed source — some renditions encrypted or MPEG-TS, others playable — log its causes and still play.
  */
 import {
   SVTA_UNSUPPORTED_AUDIO_FORMAT,
@@ -26,10 +21,7 @@ import {
 import { NON_FMP4_CONTAINER_MIMES } from '../../media/hls/parse-media-playlist';
 import { getMediaPlaylistMetadata, type ResolvedTrack, type TrackType } from '../../media/types';
 
-/**
- * Conditions worth reporting about a just-resolved track. Return an empty array
- * (or omit the seam) to report nothing.
- */
+/** Conditions worth reporting about a just-resolved track. Return an empty array (or omit the seam) to report nothing. */
 export type ReportUnsupportedTrackConditions = (track: ResolvedTrack) => readonly SvtaError[];
 
 /** Unsupported-format code per type; text has none — absent captions aren't a failure. */
@@ -39,38 +31,31 @@ const UNSUPPORTED_FORMAT_CODE: Partial<Record<TrackType, number>> = {
 };
 
 /**
- * The types a reported cause can legitimately describe: the ones whose candidates
- * `canPlayTrack` actually prunes, via `track-switching`'s `excludeUnplayableTracks`
- * pre-pass.
+ * The types a reported cause can legitimately describe: the ones whose candidates `canPlayTrack` actually prunes, via
+ * `track-switching`'s `excludeUnplayableTracks` pre-pass.
  *
- * Text is outside it by design — its switching chain runs failed-CDN constraints
- * alone, because an MSE codec probe is the wrong question for a WebVTT rendition
- * (see `track-switching.ts`). So nothing prunes a text rendition, no verdict can
- * follow from one, and a cause reported against it would be an orphan: the
- * adapter's unsupported-feature substitution scans the sequence as a whole, so a
- * lone encrypted subtitle would otherwise recode an unrelated verdict — an
- * all-CDN cooldown among them — as "this engine can't play the source".
+ * Text is outside it by design — its switching chain runs failed-CDN constraints alone, because an MSE codec probe is
+ * the wrong question for a WebVTT rendition (see `track-switching.ts`). So nothing prunes a text rendition, no verdict
+ * can follow from one, and a cause reported against it would be an orphan: the adapter's unsupported-feature
+ * substitution scans the sequence as a whole, so a lone encrypted subtitle would otherwise recode an unrelated verdict
+ * — an all-CDN cooldown among them — as "this engine can't play the source".
  */
 const CAPABILITY_PRUNED_TYPES: ReadonlySet<TrackType> = new Set<TrackType>(['video', 'audio']);
 
 /**
- * The default: report what makes a rendition unplayable *to this engine* — a
- * container MSE can't accept, or encryption with no decryption pipeline. Both
- * mirror what `canPlayTrack` prunes on, so a reported cause always has a
+ * The default: report what makes a rendition unplayable _to this engine_ — a container MSE can't accept, or encryption
+ * with no decryption pipeline. Both mirror what `canPlayTrack` prunes on, so a reported cause always has a
  * corresponding exclusion.
  *
- * A condition carries its code and its context, not copy. `data.mimeType` is
- * what preserves the specificity — the format codes cover every non-fMP4
- * container, so "which one" lives there for a consumer that wants to say, rather
- * than being flattened into an English sentence here.
+ * A condition carries its code and its context, not copy. `data.mimeType` is what preserves the specificity — the
+ * format codes cover every non-fMP4 container, so "which one" lives there for a consumer that wants to say, rather than
+ * being flattened into an English sentence here.
  *
- * Both carry `trackType`, redundantly for the format codes (1004/1005 are
- * already per type) but not for 4008, which isn't per type — SVTA has one
- * content-protection code for both. Nothing branches on the tag: it's diagnostic
- * context, reaching a developer through the logged sequence and `error.data`,
- * which is why it goes on every condition rather than only where the code can't
- * carry it. `trackId` alongside it is what distinguishes two renditions of the
- * same type.
+ * Both carry `trackType`, redundantly for the format codes (1004/1005 are already per type) but not for 4008, which
+ * isn't per type — SVTA has one content-protection code for both. Nothing branches on the tag: it's diagnostic context,
+ * reaching a developer through the logged sequence and `error.data`, which is why it goes on every condition rather
+ * than only where the code can't carry it. `trackId` alongside it is what distinguishes two renditions of the same
+ * type.
  */
 export function reportUnsupportedTrackConditions(track: ResolvedTrack): readonly SvtaError[] {
   if (!CAPABILITY_PRUNED_TYPES.has(track.type)) return [];

--- a/packages/spf/src/playback/primitives/segment-load-pipeline.ts
+++ b/packages/spf/src/playback/primitives/segment-load-pipeline.ts
@@ -1,15 +1,12 @@
 /**
- * The v/a segment **load pipeline** — the step vocabulary and base steps a segment
- * loader runs, extracted from the loader actor so the "what" (the composable steps)
- * is separable from the "how" (the actor's scheduling). A pipeline is a per-op list
- * of {@link LoadStep}s the loader drains in order; the default is `fetch → dispatch`,
- * and a composition can insert its own steps between them (e.g. non-zero-PTS
- * relocation) without the loader knowing.
+ * The v/a segment **load pipeline** — the step vocabulary and base steps a segment loader runs, extracted from the
+ * loader actor so the "what" (the composable steps) is separable from the "how" (the actor's scheduling). A pipeline is
+ * a per-op list of {@link LoadStep}s the loader drains in order; the default is `fetch → dispatch`, and a composition
+ * can insert its own steps between them (e.g. non-zero-PTS relocation) without the loader knowing.
  *
- * The base steps reach their SourceBuffer sink through the structural {@link AppendSink}
- * seam rather than the concrete actor type — the loader folds the real actor into
- * `config` at construction, and it satisfies the seam by structure — so this module
- * carries no dependency on the actor implementation, and no dependency on the DOM.
+ * The base steps reach their SourceBuffer sink through the structural {@link AppendSink} seam rather than the concrete
+ * actor type — the loader folds the real actor into `config` at construction, and it satisfies the seam by structure —
+ * so this module carries no dependency on the actor implementation, and no dependency on the DOM.
  */
 import type { AnySlotMap } from '../../core/composition/create-composition';
 import { effect } from '../../core/signals/effect';
@@ -27,9 +24,9 @@ import type {
 // ============================================================================
 
 /**
- * The structural view of a SourceBuffer sink the base steps use — just the ops
- * {@link dispatchStep} needs (`send` + a `snapshot` to await idle). The concrete
- * `SourceBufferActor` satisfies it by structure, so the pipeline names no actor.
+ * The structural view of a SourceBuffer sink the base steps use — just the ops {@link dispatchStep} needs (`send` + a
+ * `snapshot` to await idle). The concrete `SourceBufferActor` satisfies it by structure, so the pipeline names no
+ * actor.
  */
 export interface AppendSink {
   send(message: IndividualSourceBufferMessage): void;
@@ -41,16 +38,13 @@ export interface AppendSink {
 // ============================================================================
 
 /**
- * A LoadTask is the intent to perform one unit of SegmentLoader work.
- * Unlike SourceBufferMessage, fetch-based tasks carry a URL rather than
- * pre-fetched data — the runner fetches and appends them in sequence.
+ * A LoadTask is the intent to perform one unit of SegmentLoader work. Unlike SourceBufferMessage, fetch-based tasks
+ * carry a URL rather than pre-fetched data — the runner fetches and appends them in sequence.
  *
- * Derived from SourceBufferMessage types by removing `data` and adding
- * a fetch URL via AddressableObject.
+ * Derived from SourceBufferMessage types by removing `data` and adding a fetch URL via AddressableObject.
  *
- * @todo Rename — "LoadTask" risks confusion with the `Task` class used for
- * SourceBufferActor scheduling. These are closer to operation descriptors or
- * messages than tasks in that sense.
+ * @todo Rename — "LoadTask" risks confusion with the `Task` class used for SourceBufferActor scheduling. These are
+ *   closer to operation descriptors or messages than tasks in that sense.
  */
 export type LoadTask =
   | (Omit<AppendInitMessage, 'data'> & AddressableObject)
@@ -58,12 +52,10 @@ export type LoadTask =
   | RemoveMessage;
 
 /**
- * A {@link LoadTask} mid-reassembly into its append message. `LoadTask` is a
- * message with `data` omitted and a URL added; the pipeline reverses that —
- * `fetchStep` produces `data`, `dispatchStep` reassembles the message. `data` is
- * the omitted payload (kept as the fetched stream — the loader never produces the
- * `ArrayBuffer` arm of `SegmentData` — widened back at dispatch). `meta` overrides
- * `op.meta` for `append-segment` (e.g. a stamped `timestampOffset`); an
+ * A {@link LoadTask} mid-reassembly into its append message. `LoadTask` is a message with `data` omitted and a URL
+ * added; the pipeline reverses that — `fetchStep` produces `data`, `dispatchStep` reassembles the message. `data` is
+ * the omitted payload (kept as the fetched stream — the loader never produces the `ArrayBuffer` arm of `SegmentData` —
+ * widened back at dispatch). `meta` overrides `op.meta` for `append-segment` (e.g. a stamped `timestampOffset`); an
  * `append-init` dispatches `op.meta` directly.
  */
 export interface Frame {
@@ -73,22 +65,19 @@ export interface Frame {
 }
 
 /**
- * One stage of a message pipeline. Mutates the {@link Frame} in place and may be
- * async; the runner checks `signal.aborted` before each step and passes the
- * actor's {@link StepDeps} on every call, so a stateless step (e.g.
- * {@link fetchStep}) is a plain value, and a step that needs composition signals
- * (relocation's discover/stamp) reads them from `deps` at call time.
+ * One stage of a message pipeline. Mutates the {@link Frame} in place and may be async; the runner checks
+ * `signal.aborted` before each step and passes the actor's {@link StepDeps} on every call, so a stateless step (e.g.
+ * {@link fetchStep}) is a plain value, and a step that needs composition signals (relocation's discover/stamp) reads
+ * them from `deps` at call time.
  */
 export type LoadStep = (frame: Frame, signal: AbortSignal, deps: StepDeps) => void | Promise<void>;
 
 /**
- * The uniform passthrough handed to every {@link LoadStep} on every call — the
- * composition triple, nothing more. `state`/`context` are the full composition signal
- * maps; `config` is the threaded config with the loader's own wiring folded in (see
- * {@link stepWiring} + `createSegmentLoaderActor`). All three are typed loose: the
- * loader is a conduit and never reads them; a step asserts the slots it knows are
- * present (composition steps read `state`; base steps read the folded wiring off
- * `config`).
+ * The uniform passthrough handed to every {@link LoadStep} on every call — the composition triple, nothing more.
+ * `state`/`context` are the full composition signal maps; `config` is the threaded config with the loader's own wiring
+ * folded in (see {@link stepWiring} + `createSegmentLoaderActor`). All three are typed loose: the loader is a conduit
+ * and never reads them; a step asserts the slots it knows are present (composition steps read `state`; base steps read
+ * the folded wiring off `config`).
  */
 export interface StepDeps {
   state: AnySlotMap;
@@ -97,24 +86,21 @@ export interface StepDeps {
 }
 
 /**
- * Base-step view of the loader's own wiring. `createSegmentLoaderActor` folds its
- * `sourceBufferActor` + `fetch` into the threaded `config` so base steps read them
- * from the uniform passthrough — present whether the loader runs inside a composition
- * or standalone. `config` is loose (`object`), so assert the shape here (one cast, like
- * relocation's `containerSlot`).
+ * Base-step view of the loader's own wiring. `createSegmentLoaderActor` folds its `sourceBufferActor` + `fetch` into
+ * the threaded `config` so base steps read them from the uniform passthrough — present whether the loader runs inside a
+ * composition or standalone. `config` is loose (`object`), so assert the shape here (one cast, like relocation's
+ * `containerSlot`).
  */
 function stepWiring(deps: StepDeps): { sourceBufferActor: AppendSink; fetch: FetchBytes } {
   return deps.config as { sourceBufferActor: AppendSink; fetch: FetchBytes };
 }
 
 /**
- * Builds the ordered step list for each message type. Called **once per actor**
- * — its role is per-actor instantiation, so stateful steps (relocation's origin
- * discoverer) get fresh state per source reset; deps arrive at step-call time,
- * not here. The default ({@link DEFAULT_MESSAGE_PIPELINES}) is `fetch → dispatch`;
- * a non-zero-PTS composition returns a map that inserts its own discover/stamp
- * steps between them (see `establishStartMediaTime`), so the loader stays oblivious
- * to relocation and the Tier 0 pipeline carries no relocation vocabulary at all.
+ * Builds the ordered step list for each message type. Called **once per actor** — its role is per-actor instantiation,
+ * so stateful steps (relocation's origin discoverer) get fresh state per source reset; deps arrive at step-call time,
+ * not here. The default ({@link DEFAULT_MESSAGE_PIPELINES}) is `fetch → dispatch`; a non-zero-PTS composition returns a
+ * map that inserts its own discover/stamp steps between them (see `establishStartMediaTime`), so the loader stays
+ * oblivious to relocation and the Tier 0 pipeline carries no relocation vocabulary at all.
  */
 export type MessagePipelines = () => Record<LoadTask['type'], LoadStep[]>;
 
@@ -128,12 +114,11 @@ export type FetchBytes = (
 ) => Promise<AsyncIterable<Uint8Array>>;
 
 /**
- * Resolves when the SourceBufferActor snapshot reaches 'idle'.
- * Rejects if the signal is aborted or the actor is destroyed.
+ * Resolves when the SourceBufferActor snapshot reaches 'idle'. Rejects if the signal is aborted or the actor is
+ * destroyed.
  *
- * Used to sequence SourceBufferActor operations without awaiting send()
- * directly — send() is fire-and-forget; callers observe completion via
- * state transition.
+ * Used to sequence SourceBufferActor operations without awaiting send() directly — send() is fire-and-forget; callers
+ * observe completion via state transition.
  */
 function waitForIdle(snapshot: AppendSink['snapshot'], signal: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -173,7 +158,10 @@ function waitForIdle(snapshot: AppendSink['snapshot'], signal: AbortSignal): Pro
   });
 }
 
-/** Build the SourceBuffer message a completed frame dispatches. `fetchStep` always precedes `dispatchStep` in append pipelines, so `data` is set by now. */
+/**
+ * Build the SourceBuffer message a completed frame dispatches. `fetchStep` always precedes `dispatchStep` in append
+ * pipelines, so `data` is set by now.
+ */
 function toMessage({ op, data, meta }: Frame): IndividualSourceBufferMessage {
   switch (op.type) {
     case 'remove':
@@ -186,10 +174,9 @@ function toMessage({ op, data, meta }: Frame): IndividualSourceBufferMessage {
 }
 
 /**
- * Fetch this op's bytes into the frame. Init segments need the full body
- * (`minChunkSize: Infinity`) before appending; media segments stream so chunks
- * append as they arrive. Awaiting headers eagerly also starts the HTTP
- * connection (and records the fetch in observers like tests).
+ * Fetch this op's bytes into the frame. Init segments need the full body (`minChunkSize: Infinity`) before appending;
+ * media segments stream so chunks append as they arrive. Awaiting headers eagerly also starts the HTTP connection (and
+ * records the fetch in observers like tests).
  */
 export const fetchStep: LoadStep = async (frame, signal, deps) => {
   const { op } = frame;

--- a/packages/spf/src/playback/primitives/selection-rules.ts
+++ b/packages/spf/src/playback/primitives/selection-rules.ts
@@ -1,28 +1,23 @@
 /**
- * The selection-rule substrate: the shape of a rule, and the two composers that
- * turn a list of them into a pick.
+ * The selection-rule substrate: the shape of a rule, and the two composers that turn a list of them into a pick.
  *
- * Lives here rather than beside `switchVideoTrack` so both track-selection
- * behaviors can share rules. The simple `selectVideoTrack` variant exists
- * specifically to tree-shake the ABR path out, so importing a composer from
- * `behaviors/track-switching.ts` would drag the bandwidth estimator and quality
- * selection back in with it. Nothing here reaches past pure generics over a
- * candidate list and small media-layer helpers, so either side can reach
- * them freely.
+ * Lives here rather than beside `switchVideoTrack` so both track-selection behaviors can share rules. The simple
+ * `selectVideoTrack` variant exists specifically to tree-shake the ABR path out, so importing a composer from
+ * `behaviors/track-switching.ts` would drag the bandwidth estimator and quality selection back in with it. Nothing here
+ * reaches past pure generics over a candidate list and small media-layer helpers, so either side can reach them
+ * freely.
  *
- * See `internal/design/spf/track-switching-model.md` for the model these
- * implement: a hard constraints pre-pass, then an ordered chain of soft
- * narrowing rules and rankers, with the pick as the first survivor.
+ * See `internal/design/spf/track-switching-model.md` for the model these implement: a hard constraints pre-pass, then
+ * an ordered chain of soft narrowing rules and rankers, with the pick as the first survivor.
  */
 
 import type { CanPlayTrack } from '../../media/types';
 import { getCodecFamilies, getCodecFamily } from '../../media/utils/tracks';
 
 /**
- * Deps handed to each rule and to `applyRules`, mirroring a behavior's setup
- * deps so a rule reads from the same surfaces a behavior does. `context` is
- * optional — it's threaded through but absent on direct setup calls (and
- * unread by today's rules), so the whole deps object can pass straight through.
+ * Deps handed to each rule and to `applyRules`, mirroring a behavior's setup deps so a rule reads from the same
+ * surfaces a behavior does. `context` is optional — it's threaded through but absent on direct setup calls (and unread
+ * by today's rules), so the whole deps object can pass straight through.
  */
 export interface SelectionRuleDeps<State = unknown, Context = unknown, Config = unknown> {
   state: State;
@@ -31,12 +26,10 @@ export interface SelectionRuleDeps<State = unknown, Context = unknown, Config = 
 }
 
 /**
- * A selection rule narrows or reorders the candidate list. It reads the state,
- * context, and config it needs at apply time (tightly-coupled reads), so a
- * rule's `.get()`s subscribe the running effect to exactly what it consulted.
- * Returning an empty list means "no match" — the composer skips it, so a soft
- * filter never narrows the set to nothing. A ranker returns the list with its
- * pick at the head.
+ * A selection rule narrows or reorders the candidate list. It reads the state, context, and config it needs at apply
+ * time (tightly-coupled reads), so a rule's `.get()`s subscribe the running effect to exactly what it consulted.
+ * Returning an empty list means "no match" — the composer skips it, so a soft filter never narrows the set to nothing.
+ * A ranker returns the list with its pick at the head.
  */
 export type SelectionRule<T, State = unknown, Context = unknown, Config = unknown> = (
   tracks: readonly T[],
@@ -44,12 +37,10 @@ export type SelectionRule<T, State = unknown, Context = unknown, Config = unknow
 ) => readonly T[];
 
 /**
- * Apply rules to a candidate list in order; the pick is the first survivor.
- * Two responsibilities the rules don't carry: a rule that returns nothing is
- * skipped (fall-through — a preference never empties the set), and once one
- * survivor remains the chain stops (early-bail — later rules, including the
- * bandwidth ranker, never run, so the effect doesn't subscribe to their
- * signals while the choice is fixed).
+ * Apply rules to a candidate list in order; the pick is the first survivor. Two responsibilities the rules don't carry:
+ * a rule that returns nothing is skipped (fall-through — a preference never empties the set), and once one survivor
+ * remains the chain stops (early-bail — later rules, including the bandwidth ranker, never run, so the effect doesn't
+ * subscribe to their signals while the choice is fixed).
  *
  * @param rules - Rules to apply, most authoritative first
  * @param tracks - Candidate tracks
@@ -77,15 +68,12 @@ export function applyRules<T, State, Context, Config>(
 }
 
 /**
- * Apply hard constraints to a candidate list — the pre-pass that runs before the
- * rule chain. A constraint shares a rule's signature but its exclusion is
- * *hard*: it removes the unplayable (a codec the environment can't decode, a CDN
- * in failover cooldown) and a removed track is never attempted. Unlike
- * `applyRules`, this never skips an empty result and never early-bails — every
- * constraint always applies, and an empty survivor set is a real outcome
- * ("nothing playable here"), not a fall-through. Because each constraint only
- * removes, the order they run in can't change which tracks survive — though one
- * that also *reports* reads the list at its own position, so placement matters.
+ * Apply hard constraints to a candidate list — the pre-pass that runs before the rule chain. A constraint shares a
+ * rule's signature but its exclusion is _hard_: it removes the unplayable (a codec the environment can't decode, a CDN
+ * in failover cooldown) and a removed track is never attempted. Unlike `applyRules`, this never skips an empty result
+ * and never early-bails — every constraint always applies, and an empty survivor set is a real outcome ("nothing
+ * playable here"), not a fall-through. Because each constraint only removes, the order they run in can't change which
+ * tracks survive — though one that also _reports_ reads the list at its own position, so placement matters.
  *
  * @param constraints - Constraints to apply, in order
  * @param tracks - Candidate tracks
@@ -107,11 +95,10 @@ export function applyConstraints<T, State, Context, Config>(
 /**
  * Whether two candidate sets hold the same tracks, by id.
  *
- * The `equals` both selection behaviors give their candidate-set `computed`. A
- * live playlist refresh swaps in a new presentation object carrying the same
- * variants, and a constraint's own inputs can churn without changing which
- * tracks survive; in both cases the set is unchanged and the reaction must not
- * re-fire. Compares by id rather than array identity for exactly that.
+ * The `equals` both selection behaviors give their candidate-set `computed`. A live playlist refresh swaps in a new
+ * presentation object carrying the same variants, and a constraint's own inputs can churn without changing which tracks
+ * survive; in both cases the set is unchanged and the reaction must not re-fire. Compares by id rather than array
+ * identity for exactly that.
  */
 export function sameCandidateSet<T extends { id: string }>(a: readonly T[], b: readonly T[]): boolean {
   return a.length === b.length && a.every((track) => b.some((other) => other.id === track.id));
@@ -120,36 +107,30 @@ export function sameCandidateSet<T extends { id: string }>(a: readonly T[], b: r
 /**
  * What {@link excludeUnplayableTracks} reads off the config it is handed.
  *
- * Read through a cast rather than constraining the rule's `Config` generic, the
- * same way `screenResolutionCap` reads `screenResolution` off its state: a rule
- * composes into chains whose config types have nothing else in common, and
- * constraining the generic would make every one of those a weak-type mismatch.
- * Each engine defaults `canPlayTrack` to the DOM-bound probe; unwired means "no
- * capability filtering" and the constraint passes everything through.
+ * Read through a cast rather than constraining the rule's `Config` generic, the same way `screenResolutionCap` reads
+ * `screenResolution` off its state: a rule composes into chains whose config types have nothing else in common, and
+ * constraining the generic would make every one of those a weak-type mismatch. Each engine defaults `canPlayTrack` to
+ * the DOM-bound probe; unwired means "no capability filtering" and the constraint passes everything through.
  */
 export interface CapabilityConstraintConfig {
   canPlayTrack?: CanPlayTrack;
 }
 
 /**
- * Capability constraint — a *hard* filter for the {@link applyConstraints}
- * pre-pass. Removes renditions this environment can't decode, probed via the
- * injected `canPlayTrack` (codec → `MediaSource.isTypeSupported`, plus the
- * container and encryption assertions that probe can't make). Constraining here
- * — before selection — means an unplayable variant is pruned upstream and never
- * picked, instead of surviving into the pipeline to fail late at
- * `createSourceBuffer`. That late throw stays as a defensive structural
- * guarantee; with this constraint it should rarely fire.
+ * Capability constraint — a _hard_ filter for the {@link applyConstraints} pre-pass. Removes renditions this
+ * environment can't decode, probed via the injected `canPlayTrack` (codec → `MediaSource.isTypeSupported`, plus the
+ * container and encryption assertions that probe can't make). Constraining here — before selection — means an
+ * unplayable variant is pruned upstream and never picked, instead of surviving into the pipeline to fail late at
+ * `createSourceBuffer`. That late throw stays as a defensive structural guarantee; with this constraint it should
+ * rarely fire.
  *
- * Lives here rather than beside `switchVideoTrack` for the reason this module
- * exists: both the re-evaluating variant and the pinned `selectVideoTrack` apply
- * it, and reaching it through `behaviors/track-switching.ts` would drag the ABR
+ * Lives here rather than beside `switchVideoTrack` for the reason this module exists: both the re-evaluating variant
+ * and the pinned `selectVideoTrack` apply it, and reaching it through `behaviors/track-switching.ts` would drag the ABR
  * path into a composition that deliberately omits it.
  *
- * Passes everything through when there's no probe (a composition that didn't
- * wire one, or DOM-free tests). When it prunes *every* track, the empty result is
- * preserved (per `applyConstraints`) — "nothing playable" — which each consuming
- * behavior answers by clearing its selection; reporting the verdict is separate.
+ * Passes everything through when there's no probe (a composition that didn't wire one, or DOM-free tests). When it
+ * prunes _every_ track, the empty result is preserved (per `applyConstraints`) — "nothing playable" — which each
+ * consuming behavior answers by clearing its selection; reporting the verdict is separate.
  */
 export function excludeUnplayableTracks<T, State, Context, Config>(
   tracks: readonly T[],
@@ -163,47 +144,38 @@ export function excludeUnplayableTracks<T, State, Context, Config>(
 }
 
 /**
- * What {@link preferCodecFamilies} reads off the config it is handed — a cast
- * view, for the same reason as {@link CapabilityConstraintConfig}.
+ * What {@link preferCodecFamilies} reads off the config it is handed — a cast view, for the same reason as
+ * {@link CapabilityConstraintConfig}.
  */
 export interface CodecPreferenceConfig {
   preferredCodecs?: string[];
 }
 
 /**
- * The codec families {@link preferCodecFamilies} narrows to when the config
- * carries no `preferredCodecs`: AVC (both its 4CCs) and AAC. The default is
- * deliberate rather than neutral — SPF implements no
- * `SourceBuffer.changeType()`, so on a mixed-codec source the *initial*
- * family choice is the one ABR lives inside for the whole source (see
- * `stickToSelectedCodecs` in `behaviors/track-switching.ts`), and AVC/AAC is
- * the family pair with the broadest decode support. The cost, equally
- * deliberate: on a ladder whose higher rungs are HEVC-only (a common 4K
- * shape), the default caps quality at the top AVC rung — configure
- * `preferredCodecs` (or pass `[]`) to trade the other way.
+ * The codec families {@link preferCodecFamilies} narrows to when the config carries no `preferredCodecs`: AVC (both its
+ * 4CCs) and AAC. The default is deliberate rather than neutral — SPF implements no `SourceBuffer.changeType()`, so on a
+ * mixed-codec source the _initial_ family choice is the one ABR lives inside for the whole source (see
+ * `stickToSelectedCodecs` in `behaviors/track-switching.ts`), and AVC/AAC is the family pair with the broadest decode
+ * support. The cost, equally deliberate: on a ladder whose higher rungs are HEVC-only (a common 4K shape), the default
+ * caps quality at the top AVC rung — configure `preferredCodecs` (or pass `[]`) to trade the other way.
  */
 export const DEFAULT_PREFERRED_CODECS: readonly string[] = ['avc1', 'avc3', 'mp4a'];
 
 /**
- * Codec-family preference — a *soft* filter (scope) for a selection-rule
- * chain; the `hevc-variant-selection` concern from
- * `internal/design/spf/track-switching-model.md`. Narrows to the tracks whose
- * codec families are all in `preferredCodecs` (family-compared, so entries
- * may be 4CCs or full codec strings). Soft-filter semantics: a source with no
- * preferred-family rendition (an HEVC-only ladder under the AVC default) is
- * left unnarrowed, and a track without codecs never matches — on a ladder
- * with no codecs anywhere (DOM-free tests) the rule is inert.
+ * Codec-family preference — a _soft_ filter (scope) for a selection-rule chain; the `hevc-variant-selection` concern
+ * from `internal/design/spf/track-switching-model.md`. Narrows to the tracks whose codec families are all in
+ * `preferredCodecs` (family-compared, so entries may be 4CCs or full codec strings). Soft-filter semantics: a source
+ * with no preferred-family rendition (an HEVC-only ladder under the AVC default) is left unnarrowed, and a track
+ * without codecs never matches — on a ladder with no codecs anywhere (DOM-free tests) the rule is inert.
  *
- * `preferredCodecs` defaults to {@link DEFAULT_PREFERRED_CODECS}; explicitly
- * pass `[]` to disable the preference while keeping the rule composed.
+ * `preferredCodecs` defaults to {@link DEFAULT_PREFERRED_CODECS}; explicitly pass `[]` to disable the preference while
+ * keeping the rule composed.
  *
- * "All families" rather than "any" so a muxed rendition is judged as the unit
- * it is: `hvc1,mp4a` must not count as preferred just because its audio half
- * matches.
+ * "All families" rather than "any" so a muxed rendition is judged as the unit it is: `hvc1,mp4a` must not count as
+ * preferred just because its audio half matches.
  *
- * Lives here rather than beside `switchVideoTrack` for the module's usual
- * reason: the pinned `selectVideoTrack` variant can compose it without
- * dragging the ABR path in.
+ * Lives here rather than beside `switchVideoTrack` for the module's usual reason: the pinned `selectVideoTrack` variant
+ * can compose it without dragging the ABR path in.
  */
 export function preferCodecFamilies<T, State, Context, Config>(
   tracks: readonly T[],

--- a/packages/spf/src/playback/primitives/source-buffer-messages.ts
+++ b/packages/spf/src/playback/primitives/source-buffer-messages.ts
@@ -1,10 +1,9 @@
 /**
- * SourceBuffer sink message protocol — the operations a source-buffer sink accepts
- * (`append-init` / `append-segment` / `remove`). Plain, transport-neutral data: the
- * load pipeline (`segment-load-pipeline`) produces them and the SourceBuffer actor
- * consumes them, so they live at the primitives layer both depend on rather than in
- * either. DOM-free — the segment bytes are the generic {@link SegmentData}, and only the
- * actor that hands them to a real `SourceBuffer` is DOM-bound.
+ * SourceBuffer sink message protocol — the operations a source-buffer sink accepts (`append-init` / `append-segment` /
+ * `remove`). Plain, transport-neutral data: the load pipeline (`segment-load-pipeline`) produces them and the
+ * SourceBuffer actor consumes them, so they live at the primitives layer both depend on rather than in either. DOM-free
+ * — the segment bytes are the generic {@link SegmentData}, and only the actor that hands them to a real `SourceBuffer`
+ * is DOM-bound.
  */
 import type { Segment, SegmentData, Track } from '../../media/types';
 
@@ -13,10 +12,9 @@ export type AppendSegmentMeta = Pick<Segment, 'id' | 'startTime' | 'duration'> &
   /** Declared track bandwidth in bps (from playlist BANDWIDTH attribute). */
   trackBandwidth?: number;
   /**
-   * Non-zero-PTS relocation: when present, applied as `SourceBuffer.timestampOffset`
-   * before this append so native PTS is relocated onto a 0-based presentation
-   * timeline. A relocating composition stamps it (constant per source) onto each
-   * media segment's meta; the apply is idempotent-guarded. Absent = no relocation.
+   * Non-zero-PTS relocation: when present, applied as `SourceBuffer.timestampOffset` before this append so native PTS
+   * is relocated onto a 0-based presentation timeline. A relocating composition stamps it (constant per source) onto
+   * each media segment's meta; the apply is idempotent-guarded. Absent = no relocation.
    */
   timestampOffset?: number;
 };
@@ -25,11 +23,9 @@ export type AppendInitMessage = {
   type: 'append-init';
   data: SegmentData;
   /**
-   * `language` is captured alongside `trackId` so downstream loaders can
-   * compare the buffered track's language to the newly-selected track's
-   * language and decide whether ahead-buffer flush is warranted on track
-   * switch (see `segment-loader`'s `planTasks`). Undefined for video and
-   * for audio without explicit `LANGUAGE` attribute.
+   * `language` is captured alongside `trackId` so downstream loaders can compare the buffered track's language to the
+   * newly-selected track's language and decide whether ahead-buffer flush is warranted on track switch (see
+   * `segment-loader`'s `planTasks`). Undefined for video and for audio without explicit `LANGUAGE` attribute.
    */
   meta: { trackId: Track['id']; language?: string };
 };

--- a/packages/spf/src/playback/primitives/tests/relocation-pipelines.test.ts
+++ b/packages/spf/src/playback/primitives/tests/relocation-pipelines.test.ts
@@ -33,8 +33,10 @@ function makeDeps(): {
   return { deps: { state: { mediaContainerData: slot }, context: {}, config: {} }, slot };
 }
 
-/** The discover steps at their pipeline positions: `[fetch, discover, dispatch]`. The
- * derive is irrelevant here (only the stamp step consumes it), so a no-op suffices. */
+/**
+ * The discover steps at their pipeline positions: `[fetch, discover, dispatch]`. The derive is irrelevant here (only
+ * the stamp step consumes it), so a no-op suffices.
+ */
 function discoverSteps(trackType: 'video' | 'audio') {
   const pipelines = relocationPipelinesFor(trackType, () => ({}))();
 

--- a/packages/spf/src/playback/primitives/tests/selection-rules.test.ts
+++ b/packages/spf/src/playback/primitives/tests/selection-rules.test.ts
@@ -1,10 +1,9 @@
 /**
  * The rule-chain composers, tested pure — no signals, no behavior, no engine.
  *
- * The two differ in exactly three ways, and each is asserted here: a rule that
- * matches nothing falls through while a constraint's empty result stands, a rule
- * chain bails at one survivor while every constraint always runs, and constraint
- * order can't change the outcome while rule order can.
+ * The two differ in exactly three ways, and each is asserted here: a rule that matches nothing falls through while a
+ * constraint's empty result stands, a rule chain bails at one survivor while every constraint always runs, and
+ * constraint order can't change the outcome while rule order can.
  */
 import { describe, expect, it } from 'vite-plus/test';
 

--- a/packages/spf/src/playback/primitives/text-segment-load-pipeline.ts
+++ b/packages/spf/src/playback/primitives/text-segment-load-pipeline.ts
@@ -1,16 +1,13 @@
 /**
- * The text-track **load pipeline** — the step vocabulary and base steps a text-segment
- * loader runs, the text mirror of `segment-load-pipeline`. Extracted from the loader
- * actor so the "what" (the composable steps) is separable from the "how" (scheduling).
- * A pipeline is a flat, ordered list of {@link TextLoadStep}s (text has a single op
- * type, so no per-type `Record`); the default is `resolveCues → dispatchCues`, and a
- * composition can insert its own steps (e.g. non-zero-PTS cue rebase) without the
- * loader knowing.
+ * The text-track **load pipeline** — the step vocabulary and base steps a text-segment loader runs, the text mirror of
+ * `segment-load-pipeline`. Extracted from the loader actor so the "what" (the composable steps) is separable from the
+ * "how" (scheduling). A pipeline is a flat, ordered list of {@link TextLoadStep}s (text has a single op type, so no
+ * per-type `Record`); the default is `resolveCues → dispatchCues`, and a composition can insert its own steps (e.g.
+ * non-zero-PTS cue rebase) without the loader knowing.
  *
- * The dispatch step reaches its cue sink through the structural {@link CueSink} seam
- * rather than the concrete `TextTracksActor` type — the loader folds the real actor
- * into `config`, and it satisfies the seam by structure — so this module names no
- * actor and stays DOM-free (generic over the cue type `C`).
+ * The dispatch step reaches its cue sink through the structural {@link CueSink} seam rather than the concrete
+ * `TextTracksActor` type — the loader folds the real actor into `config`, and it satisfies the seam by structure — so
+ * this module names no actor and stays DOM-free (generic over the cue type `C`).
  */
 import type { AnySlotMap } from '../../core/composition/create-composition';
 import type { Cue, Segment } from '../../media/types';
@@ -21,9 +18,8 @@ import type { AddCuesMessage } from './text-track-messages';
 // ============================================================================
 
 /**
- * The structural view of a cue sink the base steps use — just the `send`
- * {@link dispatchCuesStep} needs. The concrete `TextTracksActor` satisfies it by
- * structure, so the pipeline names no actor.
+ * The structural view of a cue sink the base steps use — just the `send` {@link dispatchCuesStep} needs. The concrete
+ * `TextTracksActor` satisfies it by structure, so the pipeline names no actor.
  */
 export interface CueSink<C extends Cue = Cue> {
   send(message: AddCuesMessage<C>): void;
@@ -36,12 +32,10 @@ export interface CueSink<C extends Cue = Cue> {
 /**
  * Resolves a text-track segment URL into the array of cues it contains.
  *
- * "Resolve" because the fn covers both network fetch and parse into the
- * domain model. Host-agnostic — the concrete resolver (e.g. the
- * browser's native VTT resolver) is supplied at engine-assembly time,
- * so this stays DOM-free. A pure `url → cues` primitive (the text
- * analog of the v/a loader's `fetchBytes`); composition-awareness lives in
- * the injected {@link TextLoadStep}s, not here.
+ * "Resolve" because the fn covers both network fetch and parse into the domain model. Host-agnostic — the concrete
+ * resolver (e.g. the browser's native VTT resolver) is supplied at engine-assembly time, so this stays DOM-free. A pure
+ * `url → cues` primitive (the text analog of the v/a loader's `fetchBytes`); composition-awareness lives in the
+ * injected {@link TextLoadStep}s, not here.
  */
 export type TextTrackSegmentResolver<C extends Cue = Cue> = (url: string) => Promise<C[]>;
 
@@ -52,12 +46,10 @@ export interface TextLoadTask {
 }
 
 /**
- * A text load in mid-pipeline — the text analog of the v/a loader's `Frame`.
- * `resolveCuesStep` fills `cues`; `dispatchCuesStep` sends them. `metadata` is
- * opaque header metadata a resolve step may attach for a later step to read
- * (e.g. relocation stashes the `X-TIMESTAMP-MAP` correlation here for its rebase
- * step). Typed `unknown` so the generic loader stays host-agnostic — the step
- * that reads it knows its concrete shape (mirrors `StepDeps.state`).
+ * A text load in mid-pipeline — the text analog of the v/a loader's `Frame`. `resolveCuesStep` fills `cues`;
+ * `dispatchCuesStep` sends them. `metadata` is opaque header metadata a resolve step may attach for a later step to
+ * read (e.g. relocation stashes the `X-TIMESTAMP-MAP` correlation here for its rebase step). Typed `unknown` so the
+ * generic loader stays host-agnostic — the step that reads it knows its concrete shape (mirrors `StepDeps.state`).
  */
 export interface TextFrame<C extends Cue = Cue> {
   readonly op: TextLoadTask;
@@ -66,12 +58,10 @@ export interface TextFrame<C extends Cue = Cue> {
 }
 
 /**
- * One stage of a text message pipeline — the text analog of the v/a loader's
- * `LoadStep`. Mutates the {@link TextFrame} in place and may be async; the runner
- * checks `signal.aborted` before each step and passes the actor's
- * {@link TextStepDeps} on every call, so a stateless step (`resolveCuesStep`) is a
- * plain value and a step that needs composition signals (relocation's cue rebase)
- * reads them from `deps` at call time.
+ * One stage of a text message pipeline — the text analog of the v/a loader's `LoadStep`. Mutates the {@link TextFrame}
+ * in place and may be async; the runner checks `signal.aborted` before each step and passes the actor's
+ * {@link TextStepDeps} on every call, so a stateless step (`resolveCuesStep`) is a plain value and a step that needs
+ * composition signals (relocation's cue rebase) reads them from `deps` at call time.
  */
 export type TextLoadStep<C extends Cue = Cue> = (
   frame: TextFrame<C>,
@@ -80,11 +70,10 @@ export type TextLoadStep<C extends Cue = Cue> = (
 ) => void | Promise<void>;
 
 /**
- * The uniform passthrough handed to each {@link TextLoadStep} — the composition triple,
- * the text analog of `StepDeps`. `state`/`context` are the composition signal maps;
- * `config` is the threaded config with the loader's wiring folded in (see
- * {@link textStepWiring} + `createTextTrackSegmentLoaderActor`). Typed loose: composition
- * steps read `state`; base steps read the folded wiring off `config`.
+ * The uniform passthrough handed to each {@link TextLoadStep} — the composition triple, the text analog of `StepDeps`.
+ * `state`/`context` are the composition signal maps; `config` is the threaded config with the loader's wiring folded in
+ * (see {@link textStepWiring} + `createTextTrackSegmentLoaderActor`). Typed loose: composition steps read `state`; base
+ * steps read the folded wiring off `config`.
  */
 export interface TextStepDeps {
   state: AnySlotMap;
@@ -93,11 +82,10 @@ export interface TextStepDeps {
 }
 
 /**
- * Base-step view of the loader's wiring, folded into `config` by
- * `createTextTrackSegmentLoaderActor` so base steps read it from the uniform passthrough
- * — present in both composition and standalone use. `config` is loose (`object`), so
- * assert the shape here (mirrors the v/a loader's `stepWiring`). The sink is the
- * structural {@link CueSink}, not the concrete actor.
+ * Base-step view of the loader's wiring, folded into `config` by `createTextTrackSegmentLoaderActor` so base steps read
+ * it from the uniform passthrough — present in both composition and standalone use. `config` is loose (`object`), so
+ * assert the shape here (mirrors the v/a loader's `stepWiring`). The sink is the structural {@link CueSink}, not the
+ * concrete actor.
  */
 export function textStepWiring<C extends Cue>(
   deps: TextStepDeps
@@ -106,12 +94,10 @@ export function textStepWiring<C extends Cue>(
 }
 
 /**
- * Builds the ordered step list, called **once per actor** (mirrors the v/a loader's
- * `MessagePipelines`, but text has a single op type so it's a flat array, not a
- * `Record`). The default ({@link DEFAULT_TEXT_MESSAGE_PIPELINES}) is
- * `resolveCues → dispatchCues`; a non-zero-PTS composition returns a list that
- * inserts a cue-rebase step (see `relocatingTextPipelines`), so the loader stays
- * oblivious to relocation.
+ * Builds the ordered step list, called **once per actor** (mirrors the v/a loader's `MessagePipelines`, but text has a
+ * single op type so it's a flat array, not a `Record`). The default ({@link DEFAULT_TEXT_MESSAGE_PIPELINES}) is
+ * `resolveCues → dispatchCues`; a non-zero-PTS composition returns a list that inserts a cue-rebase step (see
+ * `relocatingTextPipelines`), so the loader stays oblivious to relocation.
  */
 export type TextMessagePipelines<C extends Cue = Cue> = () => TextLoadStep<C>[];
 

--- a/packages/spf/src/playback/primitives/text-track-messages.ts
+++ b/packages/spf/src/playback/primitives/text-track-messages.ts
@@ -1,8 +1,7 @@
 /**
- * Cue-sink message protocol — the `add-cues` operation a text-track sink accepts.
- * Plain, transport-neutral data: the text load pipeline (`text-segment-load-pipeline`)
- * produces it and the TextTracksActor consumes it, so it lives at the primitives layer
- * both depend on. The text mirror of `source-buffer-messages`.
+ * Cue-sink message protocol — the `add-cues` operation a text-track sink accepts. Plain, transport-neutral data: the
+ * text load pipeline (`text-segment-load-pipeline`) produces it and the TextTracksActor consumes it, so it lives at the
+ * primitives layer both depend on. The text mirror of `source-buffer-messages`.
  */
 import type { Cue, Segment } from '../../media/types';
 

--- a/packages/spf/src/playback/primitives/track-types.ts
+++ b/packages/spf/src/playback/primitives/track-types.ts
@@ -1,22 +1,16 @@
 /**
  * **Per-type config bundles for per-type behavior variants.**
  *
- * Each `*_TYPE_CONFIG` constant names the per-type slot keys that
- * per-type-variant setup-shape helpers consume. Variants reference the
- * shared constant at their `defineBehavior` setup body rather than
- * constructing the config inline, so the per-type identity (which state
- * slot, which context slot, which discriminant) lives in one place per
+ * Each `*_TYPE_CONFIG` constant names the per-type slot keys that per-type-variant setup-shape helpers consume.
+ * Variants reference the shared constant at their `defineBehavior` setup body rather than constructing the config
+ * inline, so the per-type identity (which state slot, which context slot, which discriminant) lives in one place per
  * type.
  *
- * Variants spread their composition-time `config` over the defaults so
- * engines can layer composition-supplied additions on top (e.g. a
- * custom fetch closure, a non-default segment resolver). Defaults
- * first, engine config second.
+ * Variants spread their composition-time `config` over the defaults so engines can layer composition-supplied additions
+ * on top (e.g. a custom fetch closure, a non-default segment resolver). Defaults first, engine config second.
  *
- * Helpers continue to consume their slice via the existing typed-key
- * generics (`<K extends SelectedTrackKey>` etc.); the extra fields on
- * the config object (carrying facets other helpers care about) are fine
- * under structural typing.
+ * Helpers continue to consume their slice via the existing typed-key generics (`<K extends SelectedTrackKey>` etc.);
+ * the extra fields on the config object (carrying facets other helpers care about) are fine under structural typing.
  */
 
 /**
@@ -44,11 +38,9 @@ export const AUDIO_TYPE_CONFIG = {
 } as const;
 
 /**
- * Type-identity bundle for text-track-typed behaviors. Text tracks have
- * no `SourceBufferActor` (MSE doesn't apply), so this bundle omits
- * `actorKey`. The `loaderKey` points at the text-track-segment-loader
- * actor (a `MessageActor` with continue-vs-preempt semantics, parallel
- * to v/a's `SegmentLoaderActor`).
+ * Type-identity bundle for text-track-typed behaviors. Text tracks have no `SourceBufferActor` (MSE doesn't apply), so
+ * this bundle omits `actorKey`. The `loaderKey` points at the text-track-segment-loader actor (a `MessageActor` with
+ * continue-vs-preempt semantics, parallel to v/a's `SegmentLoaderActor`).
  *
  * @see loadTextTrackSegments, setupTextTrackActors
  */

--- a/packages/store/src/core/selector.ts
+++ b/packages/store/src/core/selector.ts
@@ -15,15 +15,14 @@ const stateContext: StateContext<unknown> = {
 /**
  * Create a type-safe selector for a slice's state.
  *
- * The selector returns the slice's state, or `undefined` if the slice
- * is not configured in the store.
+ * The selector returns the slice's state, or `undefined` if the slice is not configured in the store.
  *
  * @example
- * ```ts
- * const selectPlayback = createSelector(playbackSlice);
- * selectPlayback(store.state); // { paused, play, pause, ... } | undefined
- * selectPlayback.displayName;  // 'playback' (from slice name)
- * ```
+ *   ```ts
+ *   const selectPlayback = createSelector(playbackSlice);
+ *   selectPlayback(store.state); // { paused, play, pause, ... } | undefined
+ *   selectPlayback.displayName; // 'playback' (from slice name)
+ *   ```;
  *
  * @param slice - The slice to create a selector for.
  */

--- a/packages/store/src/core/slice.ts
+++ b/packages/store/src/core/slice.ts
@@ -34,11 +34,10 @@ export interface StateContext<Target> {
    * Cancellation signals for async operations.
    *
    * - `signals.base` — Aborts on detach or reattach. Use for cleanup.
-   * - `signals.supersede(key)` — Returns a signal that aborts when the same key
-   *   is superseded or when base aborts. Use for operations that should cancel
-   *   previous in-flight work (e.g., seek superseding seek).
-   * - `signals.clear()` — Aborts all keyed signals. Use when starting fresh
-   *   (e.g., loading a new source cancels pending seeks).
+   * - `signals.supersede(key)` — Returns a signal that aborts when the same key is superseded or when base aborts. Use
+   *   for operations that should cancel previous in-flight work (e.g., seek superseding seek).
+   * - `signals.clear()` — Aborts all keyed signals. Use when starting fresh (e.g., loading a new source cancels pending
+   *   seeks).
    */
   signals: AbortControllerRegistry;
   /** Read slice state before derived values. Safe inside action closures, not during `state()` init. */

--- a/packages/store/src/html/controllers/snapshot-controller.ts
+++ b/packages/store/src/html/controllers/snapshot-controller.ts
@@ -10,13 +10,13 @@ export type SnapshotControllerHost = ReactiveControllerHost & HTMLElement;
 /**
  * Subscribe to a `State<T>` container with optional selector.
  *
- * Without selector: returns full state, re-renders on any state change.
- * With selector: returns selected slice, re-renders only when the slice changes (shallowEqual).
+ * Without selector: returns full state, re-renders on any state change. With selector: returns selected slice,
+ * re-renders only when the slice changes (shallowEqual).
  *
  * @example
- * ```ts
- * #state = new SnapshotController(this, sliderState, (s) => s.value);
- * ```
+ *   ```ts
+ *   #state = new SnapshotController(this, sliderState, (s) => s.value);
+ *   ```;
  */
 export class SnapshotController<T extends object, R = T> implements ReactiveController {
   readonly #host: ReactiveControllerHost;
@@ -27,16 +27,16 @@ export class SnapshotController<T extends object, R = T> implements ReactiveCont
   #unsubscribe = noop;
 
   /**
-   * @label Without Selector
    * @param host - The host element that owns this controller.
    * @param state - The State container to subscribe to.
+   * @label Without Selector
    */
   constructor(host: ReactiveControllerHost, state: State<T>);
   /**
-   * @label With Selector
    * @param host - The host element that owns this controller.
    * @param state - The State container to subscribe to.
    * @param selector - Derives a value from the state.
+   * @label With Selector
    */
   constructor(host: ReactiveControllerHost, state: State<T>, selector: Selector<T, R>);
   constructor(host: ReactiveControllerHost, state: State<T>, selector?: Selector<T, R>) {

--- a/packages/store/src/html/controllers/store-controller.ts
+++ b/packages/store/src/html/controllers/store-controller.ts
@@ -11,33 +11,33 @@ export type StoreControllerHost = ReactiveControllerHost & HTMLElement;
 /**
  * Access store state and actions.
  *
- * Without selector: Returns the store, does NOT subscribe to changes.
- * With selector: Returns selected state, triggers update when selected state changes (shallowEqual).
+ * Without selector: Returns the store, does NOT subscribe to changes. With selector: Returns selected state, triggers
+ * update when selected state changes (shallowEqual).
  *
  * @example
- * ```ts
- * // Store access (no subscription) - access actions
- * class Controls extends LitElement {
+ *   ```ts
+ *   // Store access (no subscription) - access actions
+ *   class Controls extends LitElement {
  *   #store = new StoreController(this, storeSource);
  *
  *   handleClick() {
- *     this.#store.value.setVolume(0.5);
+ *   this.#store.value.setVolume(0.5);
  *   }
- * }
+ *   }
  *
- * // Selector-based subscription - re-renders when playback changes
- * class PlayButton extends LitElement {
+ *   // Selector-based subscription - re-renders when playback changes
+ *   class PlayButton extends LitElement {
  *   #playback = new StoreController(this, storeSource, selectPlayback);
  *
  *   render() {
- *     const playback = this.#playback.value;
- *     if (!playback) return nothing;
- *     return html`<button @click=${playback.toggle}>
- *       ${playback.paused ? 'Play' : 'Pause'}
- *     </button>`;
+ *   const playback = this.#playback.value;
+ *   if (!playback) return nothing;
+ *   return html`<button @click=${playback.toggle}>
+ *   ${playback.paused ? 'Play' : 'Pause'}
+ *   </button>`;
  *   }
- * }
- * ```
+ *   }
+ *   ```
  */
 export class StoreController<Store extends AnyStore, Result = Store> implements ReactiveController {
   readonly #host: StoreControllerHost;
@@ -47,16 +47,16 @@ export class StoreController<Store extends AnyStore, Result = Store> implements 
   #snapshot: SnapshotController<object, Result> | null = null;
 
   /**
-   * @label Without Selector
    * @param host - The host element that owns this controller.
    * @param source - Store instance or context to resolve the store from.
+   * @label Without Selector
    */
   constructor(host: StoreControllerHost, source: StoreSource<Store>);
   /**
-   * @label With Selector
    * @param host - The host element that owns this controller.
    * @param source - Store instance or context to resolve the store from.
    * @param selector - Derives a value from the store state.
+   * @label With Selector
    */
   constructor(
     host: StoreControllerHost,

--- a/packages/store/src/html/controllers/subscription-controller.ts
+++ b/packages/store/src/html/controllers/subscription-controller.ts
@@ -15,26 +15,26 @@ export interface SubscriptionControllerConfig<Store extends AnyStore, Value> {
 /**
  * Resolves a store from context or direct source and manages subscription lifecycle.
  *
- * Combines store resolution (direct or context) with subscription management.
- * Use as a building block for controllers that need store access with subscriptions.
+ * Combines store resolution (direct or context) with subscription management. Use as a building block for controllers
+ * that need store access with subscriptions.
  *
  * @example
- * ```ts
- * class MyController<Store extends AnyStore> {
- *   #ctrl: SubscriptionController<Store, Tasks>;
+ *   ```ts
+ *   class MyController<Store extends AnyStore> {
+ *     #ctrl: SubscriptionController<Store, Tasks>;
  *
- *   constructor(host: Host, source: StoreSource<Store>) {
- *     this.#ctrl = new SubscriptionController(host, source, {
- *       subscribe: (store, onChange) => store.queue.subscribe(onChange),
- *       getValue: (store) => store.queue.tasks,
- *     });
- *   }
+ *     constructor(host: Host, source: StoreSource<Store>) {
+ *       this.#ctrl = new SubscriptionController(host, source, {
+ *         subscribe: (store, onChange) => store.queue.subscribe(onChange),
+ *         getValue: (store) => store.queue.tasks,
+ *       });
+ *     }
  *
- *   get value() {
- *     return this.#ctrl.value;
+ *     get value() {
+ *       return this.#ctrl.value;
+ *     }
  *   }
- * }
- * ```
+ *   ```;
  */
 export class SubscriptionController<Store extends AnyStore, Value> implements ReactiveController {
   readonly #host: SubscriptionControllerHost;

--- a/packages/store/src/html/store-accessor.ts
+++ b/packages/store/src/html/store-accessor.ts
@@ -13,20 +13,22 @@ export type StoreAccessorHost = ReactiveControllerHost & HTMLElement;
 /**
  * Resolves a store from either a direct instance or context.
  *
- * When given a direct store, provides immediate access.
- * When given a context, sets up a ContextConsumer to receive the store.
+ * When given a direct store, provides immediate access. When given a context, sets up a ContextConsumer to receive the
+ * store.
  *
- * @example Direct store
- * ```ts
- * const accessor = new StoreAccessor(host, store, (s) => console.log('available', s));
- * accessor.value; // Store (immediately available)
- * ```
+ * @example
+ *   Direct store
+ *   ```ts
+ *   const accessor = new StoreAccessor(host, store, (s) => console.log('available', s));
+ *   accessor.value; // Store (immediately available)
+ *   ```
  *
- * @example Context source
- * ```ts
- * const accessor = new StoreAccessor(host, context, (s) => console.log('available', s));
- * accessor.value; // null until context provides store
- * ```
+ * @example
+ *   Context source
+ *   ```ts
+ *   const accessor = new StoreAccessor(host, context, (s) => console.log('available', s));
+ *   accessor.value; // null until context provides store
+ *   ```
  */
 export class StoreAccessor<Store extends AnyStore> implements ReactiveController {
   readonly #onAvailable: (store: Store) => void;

--- a/packages/store/src/html/tests/test-utils.ts
+++ b/packages/store/src/html/tests/test-utils.ts
@@ -9,10 +9,7 @@ import { createStore as createCoreStore } from '../../core/store';
 /** Concrete base class for mixin tests (ReactiveElement is abstract). */
 export class TestBaseElement extends ReactiveElement {}
 
-/**
- * Test host element that extends ReactiveElement.
- * Tracks update calls for assertions.
- */
+/** Test host element that extends ReactiveElement. Tracks update calls for assertions. */
 export class TestHostElement extends ReactiveElement {
   updateCount = 0;
 

--- a/packages/store/src/react/hooks/use-snapshot.ts
+++ b/packages/store/src/react/hooks/use-snapshot.ts
@@ -16,9 +16,9 @@ export function useSnapshot<T extends object>(state: State<T>): T;
 /**
  * Select a value from state. Re-renders when the selected value changes.
  *
- * @label With Selector
  * @param selector - Derives a value from state.
  * @param isEqual - Custom equality function. Defaults to `shallowEqual`.
+ * @label With Selector
  */
 export function useSnapshot<T extends object, R>(state: State<T>, selector: Selector<T, R>, isEqual?: Comparator<R>): R;
 

--- a/packages/store/src/react/hooks/use-store.ts
+++ b/packages/store/src/react/hooks/use-store.ts
@@ -8,22 +8,22 @@ const noopSubscribe = () => noop;
 /**
  * Access store state and actions.
  *
- * Without selector: Returns the store, does NOT subscribe to changes.
- * With selector: Returns selected state, re-renders when selected state changes (shallowEqual).
+ * Without selector: Returns the store, does NOT subscribe to changes. With selector: Returns selected state, re-renders
+ * when selected state changes (shallowEqual).
  *
  * @example
- * ```tsx
- * // Store access (no subscription) - access actions, subscribe without re-render
- * function Controls() {
- *   const { setVolume } = useStore(store);
- * }
+ *   ```tsx
+ *   // Store access (no subscription) - access actions, subscribe without re-render
+ *   function Controls() {
+ *     const { setVolume } = useStore(store);
+ *   }
  *
- * // Selector-based subscription - re-renders when paused changes
- * function PlayButton() {
- *   const paused = useStore(store, (s) => s.paused);
- *   return <button>{paused ? 'Play' : 'Pause'}</button>;
- * }
- * ```
+ *   // Selector-based subscription - re-renders when paused changes
+ *   function PlayButton() {
+ *     const paused = useStore(store, (s) => s.paused);
+ *     return <button>{paused ? 'Play' : 'Pause'}</button>;
+ *   }
+ *   ```;
  */
 /** @label Without Selector */
 export function useStore<S extends AnyStore>(store: S): S;
@@ -31,9 +31,9 @@ export function useStore<S extends AnyStore>(store: S): S;
 /**
  * Select a value from the store. Re-renders when the selected value changes (shallowEqual).
  *
- * @label With Selector
  * @param selector - Derives a value from the store state.
  * @param isEqual - Custom equality function. Defaults to `shallowEqual`.
+ * @label With Selector
  */
 export function useStore<S extends AnyStore, R>(
   store: S,

--- a/packages/utils/src/array/uniq-by.ts
+++ b/packages/utils/src/array/uniq-by.ts
@@ -1,13 +1,17 @@
 /**
- * Returns array with duplicates removed, keeping the LAST occurrence.
- * Useful for feature merging where extensions should override base features.
+ * Returns array with duplicates removed, keeping the LAST occurrence. Useful for feature merging where extensions
+ * should override base features.
  *
  * @example
- * ```ts
- * const features = [{ id: 'a', v: 1 }, { id: 'b', v: 2 }, { id: 'a', v: 3 }];
- * uniqBy(features, s => s.id);
- * // => [{ id: 'b', v: 2 }, { id: 'a', v: 3 }]
- * ```
+ *   ```ts
+ *   const features = [
+ *     { id: 'a', v: 1 },
+ *     { id: 'b', v: 2 },
+ *     { id: 'a', v: 3 },
+ *   ];
+ *   uniqBy(features, (s) => s.id);
+ *   // => [{ id: 'b', v: 2 }, { id: 'a', v: 3 }]
+ *   ```;
  */
 export function uniqBy<T, K>(arr: T[], mapper: (item: T) => K): T[] {
   const seen = new Map<K, number>();

--- a/packages/utils/src/dom/animation-frame.ts
+++ b/packages/utils/src/dom/animation-frame.ts
@@ -2,10 +2,10 @@
  * Request an animation frame with cleanup.
  *
  * @example
- * ```ts
- * const cancel = animationFrame((time) => console.log('Frame at', time));
- * cancel(); // Cancel if needed
- * ```
+ *   ```ts
+ *   const cancel = animationFrame((time) => console.log('Frame at', time));
+ *   cancel(); // Cancel if needed
+ *   ```;
  */
 export function animationFrame(callback: FrameRequestCallback): () => void {
   const id = requestAnimationFrame(callback);

--- a/packages/utils/src/dom/attributes.ts
+++ b/packages/utils/src/dom/attributes.ts
@@ -23,9 +23,7 @@ export function restoreAttributes(element: Element, snapshot: AttributeSnapshot)
   }
 }
 
-/**
- * Convert a NamedNodeMap to a plain object.
- */
+/** Convert a NamedNodeMap to a plain object. */
 export function namedNodeMapToObject(namedNodeMap: NamedNodeMap) {
   const obj: Record<string, string> = {};
 
@@ -36,9 +34,7 @@ export function namedNodeMapToObject(namedNodeMap: NamedNodeMap) {
   return obj;
 }
 
-/**
- * Helper function to serialize attributes into a string.
- */
+/** Helper function to serialize attributes into a string. */
 export function serializeAttributes(attrs: Record<string, string>) {
   let html = '';
 

--- a/packages/utils/src/dom/device-pixel-ratio.ts
+++ b/packages/utils/src/dom/device-pixel-ratio.ts
@@ -9,20 +9,17 @@ export function getDevicePixelRatio(): number {
 /**
  * Call `onChange` with the new ratio whenever `devicePixelRatio` changes.
  *
- * `devicePixelRatio` fires no change event, so the ratio is watched through a
- * `(resolution: …dppx)` media query. Each query only answers about the ratio it
- * was built for, so it reports a single change and the handler builds the next.
- * `once: true` is what keeps that from accumulating listeners: the fired one is
- * gone before the replacement is armed. Same shape as MDN's snippet for this,
- * whose earlier non-re-arming version fired exactly once and stopped.
+ * `devicePixelRatio` fires no change event, so the ratio is watched through a `(resolution: …dppx)` media query. Each
+ * query only answers about the ratio it was built for, so it reports a single change and the handler builds the next.
+ * `once: true` is what keeps that from accumulating listeners: the fired one is gone before the replacement is armed.
+ * Same shape as MDN's snippet for this, whose earlier non-re-arming version fired exactly once and stopped.
  *
- * Worth watching separately from an element's size: browser zoom, or dragging
- * the window to a display with a different ratio, changes the ratio without
- * resizing the element.
+ * Worth watching separately from an element's size: browser zoom, or dragging the window to a display with a different
+ * ratio, changes the ratio without resizing the element.
  *
  * @param onChange - Called with the new `devicePixelRatio` after each change
- * @param signal - Optional, for a caller that tears every subscription down
- * through one signal rather than a handle each; aborting it stops the watching
+ * @param signal - Optional, for a caller that tears every subscription down through one signal rather than a handle
+ *   each; aborting it stops the watching
  * @returns Cleanup that detaches the armed query
  */
 export function watchDevicePixelRatio(onChange: (devicePixelRatio: number) => void, signal?: AbortSignal): () => void {

--- a/packages/utils/src/dom/event.ts
+++ b/packages/utils/src/dom/event.ts
@@ -18,9 +18,9 @@ export interface OnEventOptions extends AddEventListenerOptions {
  * Wait for an event to occur on a target.
  *
  * @example
- * ```ts
- * const event = await onEvent(video, 'seeked');
- * ```
+ *   ```ts
+ *   const event = await onEvent(video, 'seeked');
+ *   ```;
  */
 export function onEvent<K extends keyof HTMLMediaElementEventMap>(
   target: HTMLMediaElement,

--- a/packages/utils/src/dom/idle-callback.ts
+++ b/packages/utils/src/dom/idle-callback.ts
@@ -4,10 +4,10 @@ import { supportsIdleCallback } from './supports';
  * Request an idle callback with cleanup. Falls back to setTimeout for Safari.
  *
  * @example
- * ```ts
- * const cancel = idleCallback(doWork, { timeout: 1000 });
- * cancel(); // Cancel if needed
- * ```
+ *   ```ts
+ *   const cancel = idleCallback(doWork, { timeout: 1000 });
+ *   cancel(); // Cancel if needed
+ *   ```;
  */
 export function idleCallback(callback: IdleRequestCallback, options?: IdleRequestOptions): () => void {
   if (supportsIdleCallback()) {

--- a/packages/utils/src/dom/interactive.ts
+++ b/packages/utils/src/dom/interactive.ts
@@ -48,9 +48,8 @@ export function isInteractiveTarget(event: Event): boolean {
 const ACTIVATION_KEYS = new Set([' ', 'Enter']);
 
 /**
- * Selector for elements that use Space/Enter as a native activation key.
- * Narrower than `INTERACTIVE_SELECTOR` — excludes editable elements like
- * `input`, `textarea`, `select` where Space/Enter is text input, not activation.
+ * Selector for elements that use Space/Enter as a native activation key. Narrower than `INTERACTIVE_SELECTOR` —
+ * excludes editable elements like `input`, `textarea`, `select` where Space/Enter is text input, not activation.
  */
 const ACTIVATABLE_SELECTOR = 'button,a[href],[role="slider"],[role="button"]';
 

--- a/packages/utils/src/dom/listen.ts
+++ b/packages/utils/src/dom/listen.ts
@@ -2,10 +2,10 @@
  * Add an event listener and return a cleanup function to remove it.
  *
  * @example
- * ```ts
- * const cleanup = listen(video, 'play', () => console.log('playing'));
- * cleanup(); // Remove listener
- * ```
+ *   ```ts
+ *   const cleanup = listen(video, 'play', () => console.log('playing'));
+ *   cleanup(); // Remove listener
+ *   ```;
  */
 export function listen<K extends keyof HTMLMediaElementEventMap>(
   target: HTMLMediaElement,

--- a/packages/utils/src/dom/locale/merge-locale-overlays.ts
+++ b/packages/utils/src/dom/locale/merge-locale-overlays.ts
@@ -1,6 +1,6 @@
 /**
- * Loads overlay layers for each resolved locale key, least-specific first, then merges
- * most-specific-last (same semantics as the core i18n registry).
+ * Loads overlay layers for each resolved locale key, least-specific first, then merges most-specific-last (same
+ * semantics as the core i18n registry).
  */
 export async function mergeLocaleOverlays<Overlay extends object>(
   locale: string,

--- a/packages/utils/src/dom/locale/resolve-lang-attr.ts
+++ b/packages/utils/src/dom/locale/resolve-lang-attr.ts
@@ -1,8 +1,8 @@
 import { isUndefined } from '../../predicate';
 
 /**
- * Normalizes a raw `lang` string (e.g. from {@link findNearestLang}): empty or whitespace-only →
- * `undefined`, otherwise the trimmed value.
+ * Normalizes a raw `lang` string (e.g. from {@link findNearestLang}): empty or whitespace-only → `undefined`, otherwise
+ * the trimmed value.
  */
 export function resolveLangAttr<Locale extends string = string>(raw: string | undefined): Locale | undefined {
   if (isUndefined(raw) || raw.trim() === '') {

--- a/packages/utils/src/dom/locale/subscribe-ambient-lang.ts
+++ b/packages/utils/src/dom/locale/subscribe-ambient-lang.ts
@@ -42,8 +42,8 @@ function stop(): void {
 }
 
 /**
- * Subscribes to DOM updates that can change inherited `lang`: any `lang` attribute edit,
- * or subtree structural changes under `<html>` (which can move nodes between labeled ancestors).
+ * Subscribes to DOM updates that can change inherited `lang`: any `lang` attribute edit, or subtree structural changes
+ * under `<html>` (which can move nodes between labeled ancestors).
  */
 export function subscribeAmbientLang(onStoreChange: () => void): () => void {
   if (typeof document === 'undefined') {

--- a/packages/utils/src/dom/observe-elements.ts
+++ b/packages/utils/src/dom/observe-elements.ts
@@ -28,8 +28,8 @@ export interface ObserveElementsOptions {
 }
 
 /**
- * Observe a dynamically resolved element set. When the optional root mutates,
- * the set is resolved again before `onChange` is called.
+ * Observe a dynamically resolved element set. When the optional root mutates, the set is resolved again before
+ * `onChange` is called.
  */
 export function observeElements({ getElements, onChange, root, mutations }: ObserveElementsOptions): () => void {
   let stopObservingResize = noop;
@@ -64,8 +64,8 @@ function toElementSize(entry: ResizeObserverEntry): ElementSize {
 }
 
 /**
- * Call `onResize` with `element`'s content box whenever it changes, starting with
- * the observer's initial delivery. Returns a cleanup function.
+ * Call `onResize` with `element`'s content box whenever it changes, starting with the observer's initial delivery.
+ * Returns a cleanup function.
  */
 export function observeElementSize(element: Element, onResize: (size: ElementSize) => void): () => void {
   return observeResize(element, (entries) => {
@@ -81,8 +81,8 @@ export interface RenderedSize extends ElementSize {
 }
 
 /**
- * Call `onResize` with `element`'s content box and the current `devicePixelRatio`
- * whenever either changes. Returns a cleanup function to stop both watchers.
+ * Call `onResize` with `element`'s content box and the current `devicePixelRatio` whenever either changes. Returns a
+ * cleanup function to stop both watchers.
  */
 export function observeRenderedSize(element: Element, onResize: (size: RenderedSize) => void): () => void {
   let size: ElementSize | undefined;

--- a/packages/utils/src/dom/script.ts
+++ b/packages/utils/src/dom/script.ts
@@ -9,9 +9,8 @@ export function hasScript(src: string): boolean {
 }
 
 /**
- * Load a script once. Concurrent and repeat calls for the same `src` share a
- * single promise; failed loads are evicted (and the tag removed) so they can
- * be retried.
+ * Load a script once. Concurrent and repeat calls for the same `src` share a single promise; failed loads are evicted
+ * (and the tag removed) so they can be retried.
  */
 export function loadScript(src: string): Promise<void> {
   let promise = cache.get(src);

--- a/packages/utils/src/dom/slotted.ts
+++ b/packages/utils/src/dom/slotted.ts
@@ -3,20 +3,16 @@ import type { Falsy } from '../types';
 /**
  * Finds the first element in a slot's assigned elements that matches a predicate.
  *
+ * @example
+ *   ```ts
+ *   // Find a video element in the default slot
+ *   const video = getSlottedElement(this.shadowRoot, '', (el) => el instanceof HTMLVideoElement);
+ *   ```;
+ *
  * @param shadowRoot - The shadow root containing the slot
  * @param slotName - The slot name to search (empty string for default slot)
  * @param predicate - Function that returns the element if it matches, or falsy if not
  * @returns The first matching element, or null if not found
- *
- * @example
- * ```ts
- * // Find a video element in the default slot
- * const video = getSlottedElement(
- *   this.shadowRoot,
- *   '',
- *   el => el instanceof HTMLVideoElement,
- * );
- * ```
  */
 export function getSlottedElement<T extends Element>(
   shadowRoot: ShadowRoot,
@@ -36,9 +32,7 @@ export function getSlottedElement<T extends Element>(
   return null;
 }
 
-/**
- * Queries a slot element by name in a shadow root.
- */
+/** Queries a slot element by name in a shadow root. */
 export function querySlot(shadowRoot: ShadowRoot, name: string): HTMLSlotElement | null {
   return shadowRoot.querySelector<HTMLSlotElement>(name ? `slot[name="${name}"]` : 'slot:not([name])');
 }

--- a/packages/utils/src/dom/tests/device-pixel-ratio.test.ts
+++ b/packages/utils/src/dom/tests/device-pixel-ratio.test.ts
@@ -3,10 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { getDevicePixelRatio, watchDevicePixelRatio } from '../device-pixel-ratio';
 
 /**
- * A `MediaQueryList` stand-in — `listen` only needs an `EventTarget`, and a real
- * one lets the test drive `change` through `dispatchEvent`. The ratio itself
- * can't be changed from a test, so `matchMedia` is stubbed to record which query
- * each arming built.
+ * A `MediaQueryList` stand-in — `listen` only needs an `EventTarget`, and a real one lets the test drive `change`
+ * through `dispatchEvent`. The ratio itself can't be changed from a test, so `matchMedia` is stubbed to record which
+ * query each arming built.
  */
 class FakeMediaQueryList extends EventTarget {
   constructor(readonly media: string) {

--- a/packages/utils/src/dom/tests/text-track.test.ts
+++ b/packages/utils/src/dom/tests/text-track.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vite-plus/test';
 import { findTrackElement, isCaptionOrSubtitleTrack } from '../text-track';
 
 /**
- * jsdom does not create unique TextTrack objects per <track> element,
- * so we mock the `.track` property to simulate real browser behavior.
+ * Jsdom does not create unique TextTrack objects per <track> element, so we mock the `.track` property to simulate real
+ * browser behavior.
  */
 function mockTrackProperty(el: HTMLTrackElement): TextTrack {
   const track = {} as TextTrack;

--- a/packages/utils/src/dom/tests/time-ranges.test.ts
+++ b/packages/utils/src/dom/tests/time-ranges.test.ts
@@ -30,9 +30,7 @@ describe('serializeTimeRanges', () => {
   });
 });
 
-/**
- * Helper to create a mock TimeRanges object.
- */
+/** Helper to create a mock TimeRanges object. */
 function createTimeRanges(ranges: Array<[number, number]>): TimeRanges {
   return {
     length: ranges.length,

--- a/packages/utils/src/dom/webkit.ts
+++ b/packages/utils/src/dom/webkit.ts
@@ -3,7 +3,7 @@ export type WebKitPresentationMode = 'inline' | 'fullscreen' | 'picture-in-pictu
 
 /** Extended HTMLVideoElement with WebKit vendor APIs. */
 export interface WebKitVideoElement extends HTMLVideoElement {
-  /**  Whether the current playback target is wireless (WebKit) */
+  /** Whether the current playback target is wireless (WebKit) */
   webkitCurrentPlaybackTargetIsWireless?: boolean;
   /** Current WebKit presentation mode (iOS Safari). */
   webkitPresentationMode?: WebKitPresentationMode;

--- a/packages/utils/src/events/abort.ts
+++ b/packages/utils/src/events/abort.ts
@@ -1,7 +1,6 @@
 /**
- * Compose multiple abort signals into one that aborts when **any** input fires.
- * Uses native `AbortSignal.any` when available, otherwise falls back to a
- * manual `AbortController` composition for Chromium ≤115 and similar runtimes.
+ * Compose multiple abort signals into one that aborts when **any** input fires. Uses native `AbortSignal.any` when
+ * available, otherwise falls back to a manual `AbortController` composition for Chromium ≤115 and similar runtimes.
  */
 export function anyAbortSignal(signals: AbortSignal[]): AbortSignal {
   if ('any' in AbortSignal) {
@@ -25,8 +24,8 @@ export function anyAbortSignal(signals: AbortSignal[]): AbortSignal {
 }
 
 /**
- * Race a promise against an abort signal. Rejects immediately if the signal
- * is already aborted or becomes aborted before the promise settles.
+ * Race a promise against an abort signal. Rejects immediately if the signal is already aborted or becomes aborted
+ * before the promise settles.
  */
 export function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
   if (signal.aborted) {

--- a/packages/utils/src/function/compose-callbacks.ts
+++ b/packages/utils/src/function/compose-callbacks.ts
@@ -1,14 +1,14 @@
 import { isNil } from '../predicate';
 
 /**
- * Composes multiple callbacks into one. All callbacks receive same args, no return value.
- * Returns undefined if no callbacks provided.
+ * Composes multiple callbacks into one. All callbacks receive same args, no return value. Returns undefined if no
+ * callbacks provided.
  *
  * @example
- * ```ts
- * const onSetup = composeCallbacks(base.onSetup, extension.onSetup);
- * onSetup?.(ctx); // Calls both if defined
- * ```
+ *   ```ts
+ *   const onSetup = composeCallbacks(base.onSetup, extension.onSetup);
+ *   onSetup?.(ctx); // Calls both if defined
+ *   ```;
  */
 export function composeCallbacks<T extends (...args: any[]) => void>(...fns: (T | undefined | null)[]): T | undefined {
   const defined = fns.filter((fn): fn is T => !isNil(fn));

--- a/packages/utils/src/function/public-promise.ts
+++ b/packages/utils/src/function/public-promise.ts
@@ -6,16 +6,15 @@ export interface PublicPromise<T> extends Promise<T> {
 /**
  * A promise that can be settled from outside its executor.
  *
- * Useful as a barrier that one piece of code waits on and another settles — for
- * example an in-flight load that callers await until whichever event finishes it
- * resolves.
+ * Useful as a barrier that one piece of code waits on and another settles — for example an in-flight load that callers
+ * await until whichever event finishes it resolves.
  *
  * @example
- * ```ts
- * const ready = createPublicPromise<void>();
- * element.addEventListener('load', () => ready.resolve(), { once: true });
- * await ready;
- * ```
+ *   ```ts
+ *   const ready = createPublicPromise<void>();
+ *   element.addEventListener('load', () => ready.resolve(), { once: true });
+ *   await ready;
+ *   ```;
  */
 export function createPublicPromise<T>(): PublicPromise<T> {
   let resolve!: (value: T) => void;

--- a/packages/utils/src/function/throttle.ts
+++ b/packages/utils/src/function/throttle.ts
@@ -7,10 +7,9 @@ export interface Throttled<Args extends unknown[]> {
 
 export interface ThrottleOptions {
   /**
-   * When `true`, the first call invokes `fn` immediately (leading edge) and
-   * starts the cooldown window. Calls during cooldown are coalesced and fire
-   * on the trailing edge. If no calls arrive during the window the next call
-   * is treated as a fresh leading invocation.
+   * When `true`, the first call invokes `fn` immediately (leading edge) and starts the cooldown window. Calls during
+   * cooldown are coalesced and fire on the trailing edge. If no calls arrive during the window the next call is treated
+   * as a fresh leading invocation.
    */
   leading?: boolean;
 }
@@ -18,12 +17,10 @@ export interface ThrottleOptions {
 /**
  * Throttle: limits `fn` to at most once per `ms` window.
  *
- * - Default (no options): trailing-edge only — the first call schedules a
- *   timer; subsequent calls within the window update the arguments. The
- *   function fires once per window with the latest arguments.
- * - `{ leading: true }`: leading + trailing — the first call invokes
- *   immediately and opens a cooldown window. Subsequent calls within the
- *   window are coalesced to a single trailing-edge invocation.
+ * - Default (no options): trailing-edge only — the first call schedules a timer; subsequent calls within the window
+ *   update the arguments. The function fires once per window with the latest arguments.
+ * - `{ leading: true }`: leading + trailing — the first call invokes immediately and opens a cooldown window. Subsequent
+ *   calls within the window are coalesced to a single trailing-edge invocation.
  */
 export function throttle<Args extends unknown[]>(
   fn: (...args: Args) => void,

--- a/packages/utils/src/function/try-call.ts
+++ b/packages/utils/src/function/try-call.ts
@@ -1,13 +1,13 @@
 /**
  * Run a function that is expected to throw when the thing it targets is gone, ignoring the failure.
  *
- * Prefer `tryCatch` when the error should be handled or the result is needed; this is for fire-and-forget
- * calls into an API that can be torn down underneath the caller, such as an embed inside an iframe.
+ * Prefer `tryCatch` when the error should be handled or the result is needed; this is for fire-and-forget calls into an
+ * API that can be torn down underneath the caller, such as an embed inside an iframe.
  *
  * @example
- * ```ts
- * tryCall(() => player.destroy()); // Never throws
- * ```
+ *   ```ts
+ *   tryCall(() => player.destroy()); // Never throws
+ *   ```;
  */
 export function tryCall(fn: () => void): void {
   try {

--- a/packages/utils/src/function/try-catch.ts
+++ b/packages/utils/src/function/try-catch.ts
@@ -2,10 +2,10 @@
  * Wrap a function to catch and handle errors instead of throwing.
  *
  * @example
- * ```ts
- * const safeFn = tryCatch(riskyFn, (e) => logger.error(e));
- * safeFn?.(); // Never throws
- * ```
+ *   ```ts
+ *   const safeFn = tryCatch(riskyFn, (e) => logger.error(e));
+ *   safeFn?.(); // Never throws
+ *   ```;
  */
 export function tryCatch<T extends (...args: any[]) => unknown>(
   fn: T | undefined,

--- a/packages/utils/src/object/deep-equal.ts
+++ b/packages/utils/src/object/deep-equal.ts
@@ -1,16 +1,15 @@
 import { isPlainObject, isUndefined } from '../predicate';
 
 /**
- * Deep structural equality for plain objects, arrays, and primitives. Keys
- * explicitly set to `undefined` are treated as absent (matching JSON
- * semantics), leaf values are compared with `Object.is`, and non-plain
- * objects (class instances, Maps, Sets, etc.) are only equal by reference.
+ * Deep structural equality for plain objects, arrays, and primitives. Keys explicitly set to `undefined` are treated as
+ * absent (matching JSON semantics), leaf values are compared with `Object.is`, and non-plain objects (class instances,
+ * Maps, Sets, etc.) are only equal by reference.
  *
  * @example
- * ```ts
- * deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] }); // true
- * deepEqual({ a: 1, b: undefined }, { a: 1 }); // true
- * ```
+ *   ```ts
+ *   deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] }); // true
+ *   deepEqual({ a: 1, b: undefined }, { a: 1 }); // true
+ *   ```;
  */
 export function deepEqual(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) return true;

--- a/packages/utils/src/object/defaults.ts
+++ b/packages/utils/src/object/defaults.ts
@@ -6,18 +6,16 @@ type PartialWithUndefined<T> = { [K in keyof T]?: T[K] | undefined };
 /**
  * Creates a new object with default values filled in for undefined properties.
  *
- * Only keys owned by `defaultValues` are read from `object`; any other key on
- * `object` is ignored. Callers pass live DOM elements as `object`, and
- * enumerating those would touch hundreds of inherited accessors such as
- * `offsetWidth` and `innerHTML`, forcing style recalculation and layout on
- * every call.
+ * Only keys owned by `defaultValues` are read from `object`; any other key on `object` is ignored. Callers pass live
+ * DOM elements as `object`, and enumerating those would touch hundreds of inherited accessors such as `offsetWidth` and
+ * `innerHTML`, forcing style recalculation and layout on every call.
  *
  * @example
- * ```ts
- * const props = { label: undefined, disabled: true };
- * const defaultProps = { label: '', disabled: false };
- * defaults(props, defaultProps); // { label: '', disabled: true }
- * ```
+ *   ```ts
+ *   const props = { label: undefined, disabled: true };
+ *   const defaultProps = { label: '', disabled: false };
+ *   defaults(props, defaultProps); // { label: '', disabled: true }
+ *   ```;
  */
 export function defaults<T extends object>(object: PartialWithUndefined<T>, defaultValues: T): T {
   const result = { ...defaultValues };

--- a/packages/utils/src/object/flatten.ts
+++ b/packages/utils/src/object/flatten.ts
@@ -1,15 +1,15 @@
 /**
  * Flattens nested object values into dot-separated keys.
  *
+ * @example
+ *   ```ts
+ *   flatten({ buttons: { play: 'Play' } });
+ *   // { 'buttons.play': 'Play' }
+ *   ```;
+ *
  * @param object - The object to flatten.
  * @param options - Options controlling the flattened key path.
  * @returns A new object containing the flattened values.
- *
- * @example
- * ```ts
- * flatten({ buttons: { play: 'Play' } });
- * // { 'buttons.play': 'Play' }
- * ```
  */
 export interface FlattenOptions {
   prefix?: string;

--- a/packages/utils/src/object/omit.ts
+++ b/packages/utils/src/object/omit.ts
@@ -2,8 +2,8 @@
  * Creates a new object without the specified keys.
  *
  * @example
- * const obj = { a: 1, b: 2, c: 3 };
- * omit(obj, ['b']); // { a: 1, c: 3 }
+ *   const obj = { a: 1, b: 2, c: 3 };
+ *   omit(obj, ['b']); // { a: 1, c: 3 }
  */
 export function omit<T extends Record<string, unknown>, K extends keyof T>(obj: T, keys: readonly K[]): Omit<T, K> {
   const result = {} as Record<string, unknown>;

--- a/packages/utils/src/object/pick.ts
+++ b/packages/utils/src/object/pick.ts
@@ -2,8 +2,8 @@
  * Creates a new object with only the specified keys.
  *
  * @example
- * const obj = { a: 1, b: 2, c: 3 };
- * pick(obj, ['a', 'c']); // { a: 1, c: 3 }
+ *   const obj = { a: 1, b: 2, c: 3 };
+ *   pick(obj, ['a', 'c']); // { a: 1, c: 3 }
  */
 export function pick<T extends Record<string, unknown>, K extends keyof T>(obj: T, keys: readonly K[]): Pick<T, K> {
   const result = {} as Pick<T, K>;

--- a/packages/utils/src/predicate/predicate.ts
+++ b/packages/utils/src/predicate/predicate.ts
@@ -30,9 +30,7 @@ export function isPromise(value: unknown): value is Promise<any> {
   return value instanceof Promise;
 }
 
-/**
- * Check if a value is an object, excluding null.
- */
+/** Check if a value is an object, excluding null. */
 export function isObject(value: unknown): value is object {
   return value !== null && typeof value === 'object';
 }
@@ -40,8 +38,8 @@ export function isObject(value: unknown): value is object {
 /**
  * Check if a value is an object carrying a callable method for every given name.
  *
- * Recognizes a foreign object by the shape a caller needs from it, without
- * importing the library that defines it or testing against its class.
+ * Recognizes a foreign object by the shape a caller needs from it, without importing the library that defines it or
+ * testing against its class.
  */
 export function hasMethods<K extends string>(
   value: unknown,
@@ -52,9 +50,7 @@ export function hasMethods<K extends string>(
   return methods.every((method) => isFunction((value as Record<string, unknown>)[method]));
 }
 
-/**
- * Check if a value is a plain object (not a class instance like Date, Map, etc).
- */
+/** Check if a value is a plain object (not a class instance like Date, Map, etc). */
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (!isObject(value)) return false;
 
@@ -63,9 +59,7 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
   return proto === null || proto === Object.prototype;
 }
 
-/**
- * Check if a value is an AbortError.
- */
+/** Check if a value is an AbortError. */
 export function isAbortError(value: unknown): value is Error {
   return value instanceof Error && value.name === 'AbortError';
 }

--- a/packages/utils/src/string/generate-id.ts
+++ b/packages/utils/src/string/generate-id.ts
@@ -1,10 +1,10 @@
 /**
  * Generate a unique-ish string ID via timestamp + random.
  *
- * @returns String in `timestamp-random` format (e.g. `"1738423156789-542891"`).
- *
  * @example
- * const id = generateId(); // "1738423156789-542891"
+ *   const id = generateId(); // "1738423156789-542891"
+ *
+ * @returns String in `timestamp-random` format (e.g. `"1738423156789-542891"`).
  */
 export function generateId(): string {
   return `${Date.now()}-${Math.floor(Math.random() * 1000000)}`;

--- a/packages/utils/src/style/cn.ts
+++ b/packages/utils/src/style/cn.ts
@@ -11,16 +11,16 @@ export function resolveClassName<State>(className: ClassName<State>, state: Stat
 }
 
 /**
- * A (very basic) utility to merge class names and make them a little easier to read.
- * Aims to replicate the API of popular libraries like `clsx` and `classnames` but with a much simpler implementation.
- * This is not intended to be a full replacement for those libraries, but it should be sufficient for our use case.
- * It also allows us to avoid adding an additional dependency to our packages.
+ * A (very basic) utility to merge class names and make them a little easier to read. Aims to replicate the API of
+ * popular libraries like `clsx` and `classnames` but with a much simpler implementation. This is not intended to be a
+ * full replacement for those libraries, but it should be sufficient for our use case. It also allows us to avoid adding
+ * an additional dependency to our packages.
  *
  * @example
- * ```ts
- * cn('foo', { bar: true, baz: false }, 'qux');
- * // => 'foo bar qux'
- * ```
+ *   ```ts
+ *   cn('foo', { bar: true, baz: false }, 'qux');
+ *   // => 'foo bar qux'
+ *   ```;
  */
 export function cn(...classes: ClassValue[]): string {
   const result: string[] = [];

--- a/packages/utils/src/time/format.ts
+++ b/packages/utils/src/time/format.ts
@@ -82,16 +82,16 @@ function isValidTime(value: number): boolean {
 /**
  * Format seconds to digital display string.
  *
+ * @example
+ *   formatTime(90); // "1:30"
+ *   formatTime(3661); // "1:01:01"
+ *   formatTime(35, 3600); // "0:00:35" (guided by 1-hour duration)
+ *   formatTime(35, 600); // "00:35" (guided by 10-minute duration)
+ *
  * @param seconds - Time in seconds (can be negative)
  * @param guide - Guide time (typically duration) to determine display format
  * @param options - Digital formatting options
  * @returns Formatted string like "1:30" or "1:05:30"
- *
- * @example
- * formatTime(90) // "1:30"
- * formatTime(3661) // "1:01:01"
- * formatTime(35, 3600) // "0:00:35" (guided by 1-hour duration)
- * formatTime(35, 600) // "00:35" (guided by 10-minute duration)
  */
 export function formatTime(seconds: number, guide?: number, options?: Pick<TimeFormatOptions, 'locale'>): string {
   if (!isValidTime(seconds)) {
@@ -128,12 +128,12 @@ export function formatTime(seconds: number, guide?: number, options?: Pick<TimeF
 /**
  * Convert seconds to ISO 8601 duration for datetime attribute.
  *
+ * @example
+ *   secondsToIsoDuration(90); // "PT1M30S"
+ *   secondsToIsoDuration(3661); // "PT1H1M1S"
+ *
  * @param seconds - Time in seconds
  * @returns ISO 8601 duration string like "PT1M30S"
- *
- * @example
- * secondsToIsoDuration(90) // "PT1M30S"
- * secondsToIsoDuration(3661) // "PT1H1M1S"
  */
 export function secondsToIsoDuration(seconds: number): string {
   if (!isValidTime(seconds)) {
@@ -160,8 +160,8 @@ export function secondsToIsoDuration(seconds: number): string {
 /**
  * Human-readable duration using `Intl.NumberFormat` and `Intl.ListFormat`.
  *
- * Negative `seconds` denote remaining time: the absolute value is formatted, then wrapped in a
- * localized phrase via {@link TimeFormatOptions.formatRemaining}; otherwise `{duration} remaining`.
+ * Negative `seconds` denote remaining time: the absolute value is formatted, then wrapped in a localized phrase via
+ * {@link TimeFormatOptions.formatRemaining}; otherwise `{duration} remaining`.
  */
 export function formatTimeAsPhrase(seconds: number, options?: TimeFormatOptions): string {
   if (!isValidTime(seconds)) {

--- a/packages/utils/src/time/sleep.ts
+++ b/packages/utils/src/time/sleep.ts
@@ -1,7 +1,6 @@
 /**
- * Resolve after `ms` milliseconds. Pass a `signal` to make it cancellable: the
- * timer is cleared and the promise rejects with the signal's reason as soon as
- * the signal aborts (including if it's already aborted).
+ * Resolve after `ms` milliseconds. Pass a `signal` to make it cancellable: the timer is cleared and the promise rejects
+ * with the signal's reason as soon as the signal aborts (including if it's already aborted).
  */
 export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise<void>((resolve, reject) => {

--- a/packages/vjsc/src/plugins/component-meta.ts
+++ b/packages/vjsc/src/plugins/component-meta.ts
@@ -26,14 +26,14 @@ interface ExportedMeta {
 }
 
 /**
- * Extract static component metadata and remove its export from runtime code.
- * Use before source capture when registry tooling needs a component's `meta` export.
+ * Extract static component metadata and remove its export from runtime code. Use before source capture when registry
+ * tooling needs a component's `meta` export.
  *
  * @example
- * ```diff
- * - export const meta = { name: 'play-button' };
+ *   ```diff
+ *   - export const meta = { name: 'play-button' };
  *   export function PlayButton() {}
- * ```
+ *   ```;
  *
  * @param exportName - Metadata export to extract. Defaults to `meta`.
  */

--- a/packages/vjsc/src/plugins/component-modules.ts
+++ b/packages/vjsc/src/plugins/component-modules.ts
@@ -16,14 +16,15 @@ export interface ComponentModulesPluginOptions {
 }
 
 /**
- * Carry a component transform query through relative imports and retain type-only modules.
- * Use before component transforms when one source tree is built for multiple targets.
+ * Carry a component transform query through relative imports and retain type-only modules. Use before component
+ * transforms when one source tree is built for multiple targets.
  *
- * @example An import from `entry.tsx?target=react` inherits its transform query:
- * ```diff
- * - icon.tsx
- * + icon.tsx?target=react
- * ```
+ * @example
+ *   An import from `entry.tsx?target=react` inherits its transform query:
+ *   ```diff
+ *   - icon.tsx
+ *   + icon.tsx?target=react
+ *   ```
  *
  * @param options - Controls which query-bearing modules participate.
  */

--- a/packages/vjsc/src/plugins/component-schema.ts
+++ b/packages/vjsc/src/plugins/component-schema.ts
@@ -12,16 +12,16 @@ export interface ComponentSchemaPluginOptions extends Omit<CreateSchemaModuleOpt
 }
 
 /**
- * Generate a build entry that exports schemas for matching components.
- * Use in package builds that publish a typed component schema.
+ * Generate a build entry that exports schemas for matching components. Use in package builds that publish a typed
+ * component schema.
  *
  * @example
- * ```ts
- * componentSchemaPlugin({
- *   source: '@videojs/core/vjsc',
- *   include: ['./src/components/*-component.ts'],
- * });
- * ```
+ *   ```ts
+ *   componentSchemaPlugin({
+ *     source: '@videojs/core/vjsc',
+ *     include: ['./src/components/*-component.ts'],
+ *   });
+ *   ```;
  *
  * @param config - Component discovery and output settings.
  */

--- a/packages/vjsc/src/plugins/component-source.ts
+++ b/packages/vjsc/src/plugins/component-source.ts
@@ -5,8 +5,8 @@ import { mergeComponentModuleMeta } from './component-meta';
 const SCRIPT_ID = /\.[cm]?[jt]sx?(?:\?|$)/;
 
 /**
- * Capture final transformed component source in module metadata.
- * Used internally by graph emitters such as `shadcnPlugin`.
+ * Capture final transformed component source in module metadata. Used internally by graph emitters such as
+ * `shadcnPlugin`.
  */
 export function componentSourcePlugin(): Plugin {
   return {

--- a/packages/vjsc/src/plugins/vjsc.ts
+++ b/packages/vjsc/src/plugins/vjsc.ts
@@ -29,8 +29,8 @@ export interface VjscPluginOptions {
 }
 
 /**
- * Create the ordered compiler passes for query-selected component modules.
- * Use this as the default VJSC integration for Rolldown-compatible builds.
+ * Create the ordered compiler passes for query-selected component modules. Use this as the default VJSC integration for
+ * Rolldown-compatible builds.
  *
  * @param options - Resolves targets and styles once for each module identity.
  */

--- a/packages/vjsc/src/styles/css-ast.ts
+++ b/packages/vjsc/src/styles/css-ast.ts
@@ -4,8 +4,10 @@ export function cloneCssAst<T>(value: T): T {
   return structuredClone(value);
 }
 
-/** Lightning CSS serializes optional AST fields as `null`, but its returned-AST
- * deserializer accepts them only when omitted. */
+/**
+ * Lightning CSS serializes optional AST fields as `null`, but its returned-AST deserializer accepts them only when
+ * omitted.
+ */
 export function withoutNullValues<T>(value: T): T {
   if (Array.isArray(value)) return value.map(withoutNullValues) as T;
 

--- a/packages/vjsc/src/styles/selectors.ts
+++ b/packages/vjsc/src/styles/selectors.ts
@@ -35,8 +35,10 @@ export function replaceRuleClasses(rule: Rule, replacements: ReadonlyMap<string,
   return clone;
 }
 
-/** Render Tailwind group descendants in the component-oriented form a person
- * would normally author, while retaining Tailwind's zero-specificity owner. */
+/**
+ * Render Tailwind group descendants in the component-oriented form a person would normally author, while retaining
+ * Tailwind's zero-specificity owner.
+ */
 export function foldGroupDescendantSelectors(selectors: SelectorList): SelectorList {
   return selectors.map((selector) => {
     const relationships = selector.flatMap((component) => {

--- a/site/integrations/llms-markdown.ts
+++ b/site/integrations/llms-markdown.ts
@@ -335,10 +335,9 @@ function renderSidebarToMarkdown(
 }
 
 /**
- * Inline sidebar filter for the integration context where `@/` path aliases
- * aren't available (can't import `filterSidebar` from `src/utils/docs/sidebar`).
- * Filters out `devOnly` items and sections restricted to other frameworks,
- * then removes empty sections.
+ * Inline sidebar filter for the integration context where `@/` path aliases aren't available (can't import
+ * `filterSidebar` from `src/utils/docs/sidebar`). Filters out `devOnly` items and sections restricted to other
+ * frameworks, then removes empty sections.
  */
 function filterSidebarForLlms(items: Sidebar, framework: SupportedFramework): Sidebar {
   return items

--- a/site/scripts/api-docs-builder/src/core-handler.ts
+++ b/site/scripts/api-docs-builder/src/core-handler.ts
@@ -7,10 +7,8 @@ import type { CoreExtraction, ExtractedProp } from './types.js';
 /**
  * Extract Props, State, and defaultProps from a core component file.
  *
- * Looks for patterns like:
- * - interface PlayButtonProps { ... }
- * - interface PlayButtonState { ... }
- * - class PlayButtonCore { static defaultProps = { ... } }
+ * Looks for patterns like: - interface PlayButtonProps { ... } - interface PlayButtonState { ... } - class
+ * PlayButtonCore { static defaultProps = { ... } }
  */
 export function extractCore(filePath: string, program: ts.Program, componentName: string): CoreExtraction | null {
   const ast = tae.parseFromProgram(filePath, program);
@@ -116,9 +114,7 @@ export function extractDefaultProps(
   return defaultProps;
 }
 
-/**
- * Get a string representation of a property value.
- */
+/** Get a string representation of a property value. */
 export function getPropertyValue(node: ts.Expression, sourceFile: ts.SourceFile): string | undefined {
   if (ts.isStringLiteral(node)) {
     return `'${node.text}'`;

--- a/site/scripts/api-docs-builder/src/css-vars-handler.ts
+++ b/site/scripts/api-docs-builder/src/css-vars-handler.ts
@@ -8,6 +8,7 @@ import { unwrapObjectLiteral } from './utils.js';
  * Extract CSS custom properties from a component's vars.ts file.
  *
  * Looks for patterns like:
+ *
  * ```ts
  * export const SliderCSSVars = {
  *   /** Fill level percentage (0–100). *\/

--- a/site/scripts/api-docs-builder/src/data-attrs-handler.ts
+++ b/site/scripts/api-docs-builder/src/data-attrs-handler.ts
@@ -51,6 +51,7 @@ function inferStateTypes(satisfiesType: ts.TypeNode, program: ts.Program): Map<s
  * Extract data attributes from a component's data.ts file.
  *
  * Looks for patterns like:
+ *
  * ```ts
  * export const PlayButtonDataAttrs = {
  *   /** Present when the media is paused. *\/
@@ -136,9 +137,7 @@ export function extractDataAttrs(
   return { attrs };
 }
 
-/**
- * Parse JSDoc comment, extracting description and optional `@type` tag.
- */
+/** Parse JSDoc comment, extracting description and optional `@type` tag. */
 export function parseJsDoc(
   node: ts.PropertyAssignment,
   sourceFile: ts.SourceFile
@@ -159,9 +158,7 @@ export function parseJsDoc(
   return { description, type };
 }
 
-/**
- * Extract JSDoc comment from a property assignment.
- */
+/** Extract JSDoc comment from a property assignment. */
 export function getJsDocComment(node: ts.PropertyAssignment, sourceFile: ts.SourceFile): string {
   // Get leading comment ranges
   const fullText = sourceFile.getFullText();

--- a/site/scripts/api-docs-builder/src/feature-handler.ts
+++ b/site/scripts/api-docs-builder/src/feature-handler.ts
@@ -1,32 +1,29 @@
 /**
  * Feature reference extraction.
  *
- * Discovers features from packages/core/src/dom/store/features/ and extracts
- * state/action definitions from their state interfaces in media/state.ts.
+ * Discovers features from packages/core/src/dom/store/features/ and extracts state/action definitions from their state
+ * interfaces in media/state.ts.
  *
- * Uses the TypeScript checker API (not TAE) for interface extraction because
- * state interfaces use method signatures (play(): void) which TAE doesn't
- * handle — it only handles property-with-function-type syntax.
+ * Uses the TypeScript checker API (not TAE) for interface extraction because state interfaces use method signatures
+ * (play(): void) which TAE doesn't handle — it only handles property-with-function-type syntax.
  *
  * Convention:
- *   - Feature files: *.ts in the features directory (excluding index, presets, feature.parts)
- *   - Feature exports: const matching *Feature (singular, not *Features)
- *   - State type: explicit return type annotation on the state() arrow function
- *   - Silent features: state() returns an empty object
- *   - State interfaces: exported from packages/media/src/core/state.ts
  *
- * Most features annotate state() with an interface from media/state.ts, which is
- * also the shape the store publishes. A feature that resolves several inputs
- * instead keeps them in private, symbol-keyed source state and publishes the
- * resolved value through `derived`, so its annotation names an interface that
- * lives in the feature's own file and describes internals.
+ * - Feature files: *.ts in the features directory (excluding index, presets, feature.parts)
+ * - Feature exports: const matching *Feature (singular, not *Features)
+ * - State type: explicit return type annotation on the state() arrow function
+ * - Silent features: state() returns an empty object
+ * - State interfaces: exported from packages/media/src/core/state.ts
  *
- * When the annotated name isn't in media/state.ts, the published shape is
- * derived from the feature itself: every non-symbol property of the source
- * state (inherited members included, with their JSDoc) plus every `derived`
- * key. Symbol-keyed members are private by construction, so nothing needs to
- * mark them — TypeScript names them `__@SYMBOL@id`, which is how they're
- * recognized. No annotation, and nothing for a feature author to remember.
+ * Most features annotate state() with an interface from media/state.ts, which is also the shape the store publishes. A
+ * feature that resolves several inputs instead keeps them in private, symbol-keyed source state and publishes the
+ * resolved value through `derived`, so its annotation names an interface that lives in the feature's own file and
+ * describes internals.
+ *
+ * When the annotated name isn't in media/state.ts, the published shape is derived from the feature itself: every
+ * non-symbol property of the source state (inherited members included, with their JSDoc) plus every `derived` key.
+ * Symbol-keyed members are private by construction, so nothing needs to mark them — TypeScript names them
+ * `__@SYMBOL@id`, which is how they're recognized. No annotation, and nothing for a feature author to remember.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -60,8 +57,8 @@ interface DerivedKeySource {
 }
 
 /**
- * One `config` entry, resolved to the private source-state keys it drives.
- * `actionKey` types the input; `stateKey` supplies its initial value.
+ * One `config` entry, resolved to the private source-state keys it drives. `actionKey` types the input; `stateKey`
+ * supplies its initial value.
  */
 interface FeatureConfigSource {
   name: string;
@@ -189,11 +186,10 @@ function parseDerivedKeys(node: ts.Expression): DerivedKeySource[] {
 /**
  * Read the `config` map: `{ title: { action: SET_USER_TITLE, state: USER_TITLE } }`.
  *
- * Each value names a source-state member either as an identifier bound to a
- * private symbol or as a string naming the member outright, which is how an
- * input that forwards to the feature's own public setter is written. An entry
- * naming anything else is dropped — and warned about, because a silently
- * missing input reads to a docs reader as "this feature has no such setting".
+ * Each value names a source-state member either as an identifier bound to a private symbol or as a string naming the
+ * member outright, which is how an input that forwards to the feature's own public setter is written. An entry naming
+ * anything else is dropped — and warned about, because a silently missing input reads to a docs reader as "this feature
+ * has no such setting".
  */
 function parseConfigEntries(node: ts.Expression, featureName: string): FeatureConfigSource[] {
   const literal = unwrapObjectLiteral(node);
@@ -253,9 +249,8 @@ function parseConfigEntries(node: ts.Expression, featureName: string): FeatureCo
 /**
  * Read the attribute name out of a config entry's `html` block.
  *
- * The name is text in markup rather than a reference to a state or action key,
- * so only a literal counts: an identifier here would be a constant this pass
- * cannot resolve, and guessing at it would put a wrong attribute in the docs.
+ * The name is text in markup rather than a reference to a state or action key, so only a literal counts: an identifier
+ * here would be a constant this pass cannot resolve, and guessing at it would put a wrong attribute in the docs.
  */
 function htmlAttributeName(node: ts.Expression): string | undefined {
   const literal = unwrapObjectLiteral(node);
@@ -274,11 +269,9 @@ function htmlAttributeName(node: ts.Expression): string | undefined {
 }
 
 /**
- * Read the source-state member a config entry points at. An identifier names a
- * symbol constant, so the member is keyed by that symbol; a string names the
- * member itself. Both collapse to the written text, and the lookups that
- * consume it try each shape, since a symbol constant's name and a member name
- * never collide.
+ * Read the source-state member a config entry points at. An identifier names a symbol constant, so the member is keyed
+ * by that symbol; a string names the member itself. Both collapse to the written text, and the lookups that consume it
+ * try each shape, since a symbol constant's name and a member name never collide.
  */
 function configKeyReference(node: ts.Expression): string | undefined {
   if (ts.isIdentifier(node)) return node.text;
@@ -289,15 +282,13 @@ function configKeyReference(node: ts.Expression): string | undefined {
 }
 
 /**
- * Map each key in the state() object literal to the value it starts at, under
- * the same name a config entry uses to reach it: the identifier inside a
- * computed key, or a published member's own name.
+ * Map each key in the state() object literal to the value it starts at, under the same name a config entry uses to
+ * reach it: the identifier inside a computed key, or a published member's own name.
  *
- * A named constant is resolved to its literal so the docs show the value rather
- * than a private identifier; anything else falls back to the written text. A key
- * that starts at `undefined` is left out, because an unset input is what an
- * absent default already says — and every other reference omits it rather than
- * printing "undefined" in the default column.
+ * A named constant is resolved to its literal so the docs show the value rather than a private identifier; anything
+ * else falls back to the written text. A key that starts at `undefined` is left out, because an unset input is what an
+ * absent default already says — and every other reference omits it rather than printing "undefined" in the default
+ * column.
  */
 function parseStateInitialValues(node: ts.Expression, sourceFile: ts.SourceFile): Map<string, string> {
   const values = new Map<string, string>();
@@ -468,14 +459,12 @@ function extractInterfaceMembers(
 // ─── Derived Publication ──────────────────────────────────────────
 
 /**
- * Derive the published shape from the feature itself, for features whose
- * state() annotation names a private interface rather than a media/state.ts one.
+ * Derive the published shape from the feature itself, for features whose state() annotation names a private interface
+ * rather than a media/state.ts one.
  *
- * Every non-symbol property of the source-state type is public — inherited
- * members included, which is how a `MediaMetadataState`-style base contributes
- * its members and their JSDoc. Symbol-keyed members are private by
- * construction. `derived` keys are published on top, typed from what their
- * function returns.
+ * Every non-symbol property of the source-state type is public — inherited members included, which is how a
+ * `MediaMetadataState`-style base contributes its members and their JSDoc. Symbol-keyed members are private by
+ * construction. `derived` keys are published on top, typed from what their function returns.
  */
 function extractPublishedShape(
   sourceStateDecl: ts.InterfaceDeclaration,
@@ -551,9 +540,8 @@ function derivedValueType(
 /**
  * Type each config input from the action it forwards to.
  *
- * An input whose action can't be found is still emitted — the prop exists
- * either way — with its type left unresolved, and warned about so an unresolved
- * type isn't mistaken for a deliberate one.
+ * An input whose action can't be found is still emitted — the prop exists either way — with its type left unresolved,
+ * and warned about so an unresolved type isn't mistaken for a deliberate one.
  */
 function extractFeatureConfig(
   entries: readonly FeatureConfigSource[],
@@ -606,9 +594,8 @@ function configInputType(
 }
 
 /**
- * Type an action named outright rather than through a symbol. It may be
- * inherited from the published interface the source state extends, so it is
- * matched against the resolved type instead of this declaration's own members.
+ * Type an action named outright rather than through a symbol. It may be inherited from the published interface the
+ * source state extends, so it is matched against the resolved type instead of this declaration's own members.
  */
 function namedActionInputType(
   actionKey: string,
@@ -706,9 +693,8 @@ export function generateFeatureReferences(monorepoRoot: string): FeatureResult[]
 }
 
 /**
- * A feature file joins the program only when the checker has to read it: to
- * type a config input's private action, or to derive a published shape the
- * state file doesn't hold.
+ * A feature file joins the program only when the checker has to read it: to type a config input's private action, or to
+ * derive a published shape the state file doesn't hold.
  */
 function needsOwnSourceFile(source: FeatureSource): boolean {
   return source.config.length > 0 || source.derivedKeys.length > 0;
@@ -721,9 +707,8 @@ interface PublishedShape {
 }
 
 /**
- * Prefer the media/state.ts interface the annotation names. When it isn't there,
- * the annotation describes private source state, so derive the published shape
- * from the feature itself.
+ * Prefer the media/state.ts interface the annotation names. When it isn't there, the annotation describes private
+ * source state, so derive the published shape from the feature itself.
  */
 function resolvePublishedShape(
   source: FeatureSource,

--- a/site/scripts/api-docs-builder/src/formatter.ts
+++ b/site/scripts/api-docs-builder/src/formatter.ts
@@ -6,9 +6,9 @@ import type { PropDef } from './types.js';
 /**
  * Detect if a type string is a single function type (vs a top-level union).
  *
- * Tracks bracket depth to find the matching `)` for the opening `(` of the parameter list,
- * then checks if `=>` follows. Returns `false` for top-level unions that happen to contain
- * a function member (e.g., `((state: object) => string) | undefined`).
+ * Tracks bracket depth to find the matching `)` for the opening `(` of the parameter list, then checks if `=>` follows.
+ * Returns `false` for top-level unions that happen to contain a function member (e.g., `((state: object) => string) |
+ * undefined`).
  */
 function isFunctionType(type: string): boolean {
   if (!type.startsWith('(')) return false;
@@ -96,9 +96,7 @@ export function abbreviateType(name: string, type: string): string | undefined {
   return undefined;
 }
 
-/**
- * Format a list of properties into API reference format.
- */
+/** Format a list of properties into API reference format. */
 export function formatProperties(props: tae.PropertyNode[], allExports?: tae.ExportNode[]): Record<string, PropDef> {
   const result: Record<string, PropDef> = {};
 
@@ -133,8 +131,8 @@ export function formatProperties(props: tae.PropertyNode[], allExports?: tae.Exp
 /**
  * Format a type into a human-readable string, expanding type aliases when possible.
  *
- * Resolves `ExternalTypeNode` references against `allExports` so that type aliases
- * like `TimeType` are expanded to their underlying union (`'current' | 'duration' | 'remaining'`).
+ * Resolves `ExternalTypeNode` references against `allExports` so that type aliases like `TimeType` are expanded to
+ * their underlying union (`'current' | 'duration' | 'remaining'`).
  */
 export function formatDetailedType(
   type: tae.AnyType,
@@ -176,9 +174,7 @@ export function formatDetailedType(
   return formatType(type, removeUndefined);
 }
 
-/**
- * Format a type into a human-readable string.
- */
+/** Format a type into a human-readable string. */
 export function formatType(type: tae.AnyType, removeUndefined: boolean): string {
   if (type instanceof tae.ExternalTypeNode) {
     if (/^ReactElement(<.*>)?/.test(type.typeName.name || '')) {
@@ -323,9 +319,7 @@ function createNameWithTypeArguments(typeName: tae.TypeName): string {
   return typeName.name;
 }
 
-/**
- * Order members so null, undefined, and any come last.
- */
+/** Order members so null, undefined, and any come last. */
 function orderMembers(members: readonly tae.AnyType[]): readonly tae.AnyType[] {
   let ordered = pushToEnd(members, 'any');
 

--- a/site/scripts/api-docs-builder/src/media-element-handler.ts
+++ b/site/scripts/api-docs-builder/src/media-element-handler.ts
@@ -1,24 +1,25 @@
 /**
  * Media element reference extraction.
  *
- * Discovers media elements from packages/html/src/define/media/*.ts and extracts
- * host properties, shared attributes/events, and CSS vars.
+ * Discovers media elements from packages/html/src/define/media/*.ts and extracts host properties, shared
+ * attributes/events, and CSS vars.
  *
  * Convention:
- *   - Define files: packages/html/src/define/media/*.ts with inline class + static tagName
- *   - Media element classes: packages/html/src/media/{name}/media.ts
- *     composed as MediaAttachMixin(CustomMediaElement('video'|'audio', Host))
- *   - React media components: packages/react/src/media/{name}/media.tsx
- *   - Host classes: packages/media/src/dom/{name}/media.ts extending
- *     HTMLVideoElementHost or HTMLAudioElementHost with getter/setter pairs
- *   - Shared data: packages/media/src/dom/custom-media-element/custom-media-element.ts
- *     exports CustomMediaElement factory (with static properties), VideoCSSVars,
- *     AudioCSSVars
+ *
+ * - Define files: packages/html/src/define/media/*.ts with inline class + static tagName
+ * - Media element classes: packages/html/src/media/{name}/media.ts composed as
+ *   MediaAttachMixin(CustomMediaElement('video'|'audio', Host))
+ * - React media components: packages/react/src/media/{name}/media.tsx
+ * - Host classes: packages/media/src/dom/{name}/media.ts extending HTMLVideoElementHost or HTMLAudioElementHost with
+ *   getter/setter pairs
+ * - Shared data: packages/media/src/dom/custom-media-element/custom-media-element.ts exports CustomMediaElement factory
+ *   (with static properties), VideoCSSVars, AudioCSSVars
  *
  * Exclusions (elements discovered but intentionally skipped):
- *   - container.ts: re-exports a class, doesn't declare one inline → no static tagName found
- *   - background-video.ts: uses MediaAttachMixin(HTMLElement) without CustomMediaElement →
- *     parseCustomMediaElementCall returns null. Its API reference is manually maintained in MDX.
+ *
+ * - Container.ts: re-exports a class, doesn't declare one inline → no static tagName found
+ * - Background-video.ts: uses MediaAttachMixin(HTMLElement) without CustomMediaElement → parseCustomMediaElementCall
+ *   returns null. Its API reference is manually maintained in MDX.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -74,15 +75,12 @@ interface StaticMediaProperty {
 // ─── Module Resolution ───────────────────────────────────────────────
 
 /**
- * Resolve an import specifier to an absolute file path using TypeScript's
- * module resolution. Handles both relative paths and workspace package
- * imports (e.g., @videojs/media/dom/hls) via the project's tsconfig.
+ * Resolve an import specifier to an absolute file path using TypeScript's module resolution. Handles both relative
+ * paths and workspace package imports (e.g., @videojs/media/dom/hls) via the project's tsconfig.
  *
- * Workspace imports go through `package.json#exports` and resolve to the
- * built `dist/dev/*.d.ts` files, where the TypeScript compiler has collapsed
- * mixin chains into opaque `_base` aliases. To preserve the original mixin
- * structure for extraction, we remap the resolved dist `.d.ts` path back to
- * the corresponding source `.ts` file.
+ * Workspace imports go through `package.json#exports` and resolve to the built `dist/dev/*.d.ts` files, where the
+ * TypeScript compiler has collapsed mixin chains into opaque `_base` aliases. To preserve the original mixin structure
+ * for extraction, we remap the resolved dist `.d.ts` path back to the corresponding source `.ts` file.
  */
 function resolveModuleToFile(
   fromFile: string,
@@ -156,9 +154,9 @@ function discoverMediaElements(monorepoRoot: string, compilerOptions: ts.Compile
 }
 
 /**
- * Parse a define/media file to extract class name, tagName, and import chain.
- * Returns null if the file doesn't declare an inline class with static tagName
- * (container.ts) or if the class doesn't use CustomMediaElement (background-video.ts).
+ * Parse a define/media file to extract class name, tagName, and import chain. Returns null if the file doesn't declare
+ * an inline class with static tagName (container.ts) or if the class doesn't use CustomMediaElement
+ * (background-video.ts).
  */
 function parseDefineFile(
   sourceFile: ts.SourceFile,
@@ -276,8 +274,8 @@ function stripElementSuffix(name: string): string {
 }
 
 /**
- * Parse the media element class to find the CustomMediaElement(tag, Host) call.
- * Returns null for elements that don't use CustomMediaElement (e.g., BackgroundVideo).
+ * Parse the media element class to find the CustomMediaElement(tag, Host) call. Returns null for elements that don't
+ * use CustomMediaElement (e.g., BackgroundVideo).
  */
 function parseCustomMediaElementCall(
   sourceFile: ts.SourceFile,
@@ -359,11 +357,9 @@ function parseCustomMediaElementCall(
 // ─── Host Property Extraction ───────────────────────────────────────
 
 /**
- * Extract getter/setter pairs from a host class and its ancestors,
- * mirroring what CustomMediaElement does at runtime when it walks
- * the MediaHost prototype chain. Defaults are collected from the
- * `*DefaultProps` exports in every file the walk visits — base files first,
- * then mixins innermost-to-outermost, then the leaf class file — so the
+ * Extract getter/setter pairs from a host class and its ancestors, mirroring what CustomMediaElement does at runtime
+ * when it walks the MediaHost prototype chain. Defaults are collected from the `*DefaultProps` exports in every file
+ * the walk visits — base files first, then mixins innermost-to-outermost, then the leaf class file — so the
  * most-derived default wins, matching property override semantics.
  */
 function extractHostProperties(
@@ -395,10 +391,9 @@ function extractHostProperties(
 }
 
 /**
- * Recursively extract getter/setter pairs from a class and its parent chain.
- * Handles both `extends Identifier` and `extends MixinA(MixinB(Base))`. Child
- * properties override parent properties (checked via the `seen` set). Stops
- * at host base classes (HTMLMediaElementHost, HTMLVideoElementHost, etc.).
+ * Recursively extract getter/setter pairs from a class and its parent chain. Handles both `extends Identifier` and
+ * `extends MixinA(MixinB(Base))`. Child properties override parent properties (checked via the `seen` set). Stops at
+ * host base classes (HTMLMediaElementHost, HTMLVideoElementHost, etc.).
  */
 function extractClassProperties(
   filePath: string,
@@ -474,9 +469,8 @@ function resolveLocalInitializer(sourceFile: ts.SourceFile, name: string): ts.Ex
 }
 
 /**
- * Process an `extends` expression — either an `Identifier` (regular class
- * inheritance) or a `CallExpression` (mixin chain like `OuterMixin(InnerMixin(Base))`).
- * Mixins are applied innermost-first so that outer mixin overrides win.
+ * Process an `extends` expression — either an `Identifier` (regular class inheritance) or a `CallExpression` (mixin
+ * chain like `OuterMixin(InnerMixin(Base))`). Mixins are applied innermost-first so that outer mixin overrides win.
  */
 function processExtendsExpression(
   extendsExpr: ts.Expression,
@@ -531,9 +525,8 @@ function processExtendsExpression(
 }
 
 /**
- * Unwind a mixin call chain like `OuterMixin(InnerMixin(Base))` into a list
- * of mixin names (outermost first) and the innermost expression (the base).
- * Parens and `as` casts are stripped between layers.
+ * Unwind a mixin call chain like `OuterMixin(InnerMixin(Base))` into a list of mixin names (outermost first) and the
+ * innermost expression (the base). Parens and `as` casts are stripped between layers.
  */
 function unwindMixinChain(callExpr: ts.CallExpression): {
   mixins: Array<{ name: string }>;
@@ -559,14 +552,13 @@ function unwindMixinChain(callExpr: ts.CallExpression): {
 }
 
 /**
- * Walk a mixin function and merge the inner class's getters/setters into
- * `properties`. Supports the three mixin shapes used in this codebase:
- *   A: `function MixinName(arg) { class Inner extends arg { ... } }`
- *   B: `const MixinName: Mixin<...> = (arg) => { class Inner extends arg { ... } }`
- *   C: `const MixinName = <Base extends ...>(arg) => { class Inner extends arg { ... } }`
+ * Walk a mixin function and merge the inner class's getters/setters into `properties`. Supports the three mixin shapes
+ * used in this codebase: A: `function MixinName(arg) { class Inner extends arg { ... } }` B: `const MixinName:
+ * Mixin<...> = (arg) => { class Inner extends arg { ... } }` C: `const MixinName = <Base extends ...>(arg) => { class
+ * Inner extends arg { ... } }`
  *
- * The inner class always extends a function parameter; we don't recurse on
- * that — the outer chain walk already handles the base.
+ * The inner class always extends a function parameter; we don't recurse on that — the outer chain walk already handles
+ * the base.
  */
 function processMixin(
   mixinName: string,
@@ -593,9 +585,8 @@ function processMixin(
 }
 
 /**
- * Resolve a mixin name to the file containing its declaration and the inner
- * class returned by the mixin. Follows re-exports through barrel files
- * (`export { Foo } from './bar'`). Returns `undefined` if not found.
+ * Resolve a mixin name to the file containing its declaration and the inner class returned by the mixin. Follows
+ * re-exports through barrel files (`export { Foo } from './bar'`). Returns `undefined` if not found.
  */
 function resolveMixinDeclaration(
   mixinName: string,
@@ -688,9 +679,8 @@ function resolveMixinDeclaration(
 }
 
 /**
- * Look for a `export { Foo } from './bar'` (or `export { Foo as Bar } from './bar'`)
- * matching the given name. Returns the source module specifier and the actual
- * exported identifier in the target module.
+ * Look for a `export { Foo } from './bar'` (or `export { Foo as Bar } from './bar'`) matching the given name. Returns
+ * the source module specifier and the actual exported identifier in the target module.
  */
 function findReExportSource(
   sourceFile: ts.SourceFile,
@@ -721,10 +711,7 @@ function findReExportSource(
   return result;
 }
 
-/**
- * Find the inner class declared inside a mixin function whose `extends`
- * targets one of the function's parameters.
- */
+/** Find the inner class declared inside a mixin function whose `extends` targets one of the function's parameters. */
 function findMixinInnerClass(sourceFile: ts.SourceFile, mixinName: string): ts.ClassDeclaration | undefined {
   let result: ts.ClassDeclaration | undefined;
 
@@ -794,9 +781,8 @@ function getParameterNames(params: ts.NodeArray<ts.ParameterDeclaration>): Set<s
 }
 
 /**
- * Collect getter/setter pairs from a single class node and merge them into
- * `properties`. Description fallback: if a child override has no JSDoc,
- * the closest ancestor's description is preserved.
+ * Collect getter/setter pairs from a single class node and merge them into `properties`. Description fallback: if a
+ * child override has no JSDoc, the closest ancestor's description is preserved.
  */
 function applyClassMembers(
   classNode: ts.ClassDeclaration,
@@ -851,9 +837,8 @@ function applyClassMembers(
 }
 
 /**
- * Resolve host property types via the type checker, keyed by property name.
- * Walking own class members only sees explicit annotations, so this reads the
- * class's full instance type — which the checker resolves through the mixin
+ * Resolve host property types via the type checker, keyed by property name. Walking own class members only sees
+ * explicit annotations, so this reads the class's full instance type — which the checker resolves through the mixin
  * chain — to recover types for unannotated getters (e.g. `get src()` → string).
  */
 function resolveInferredTypes(
@@ -894,15 +879,13 @@ function resolveInferredTypes(
 /**
  * Collect the options a media accepts under `source.engine`, keyed by engine name.
  *
- * Walks the host's `source` property type to `engine`, then lists each engine's
- * own members with their declared type and JSDoc. Driven by the type rather than
- * by file or name convention: the config interfaces sit in different files per
- * provider (`source.ts` for most, `media.ts` for Vimeo) and one extends a
- * third-party type (`@vimeo/player`), which the checker resolves the same way.
+ * Walks the host's `source` property type to `engine`, then lists each engine's own members with their declared type
+ * and JSDoc. Driven by the type rather than by file or name convention: the config interfaces sit in different files
+ * per provider (`source.ts` for most, `media.ts` for Vimeo) and one extends a third-party type (`@vimeo/player`), which
+ * the checker resolves the same way.
  *
- * Every member is emitted, described or not: an option in the API surface is one
- * a reader can set, and a name with its type still says what exists and what
- * shape it takes. JSDoc is the only source of prose, so a missing or wrong
+ * Every member is emitted, described or not: an option in the API surface is one a reader can set, and a name with its
+ * type still says what exists and what shape it takes. JSDoc is the only source of prose, so a missing or wrong
  * description is fixed on the interface member, never in the docs page.
  */
 function extractEngineOptions(
@@ -1012,9 +995,8 @@ function findImportPath(sourceFile: ts.SourceFile, name: string): string | undef
 const fileDefaultsCache = new Map<string, Map<string, string>>();
 
 /**
- * Collect default values from every `*DefaultProps` object literal exported
- * by a file, in declaration order. Spread entries are resolved through
- * imports (e.g. `{ ...hlsMediaDefaultProps, castSrc: '' }`).
+ * Collect default values from every `*DefaultProps` object literal exported by a file, in declaration order. Spread
+ * entries are resolved through imports (e.g. `{ ...hlsMediaDefaultProps, castSrc: '' }`).
  */
 function collectFileDefaults(filePath: string, compilerOptions: ts.CompilerOptions): Map<string, string> {
   const cached = fileDefaultsCache.get(filePath);
@@ -1052,9 +1034,8 @@ function collectFileDefaults(filePath: string, compilerOptions: ts.CompilerOptio
 }
 
 /**
- * Flatten an object literal into name → serialized value, resolving spreads
- * of identifiers declared in the same file or imported from another file.
- * Entries are processed in source order, so later entries override spreads.
+ * Flatten an object literal into name → serialized value, resolving spreads of identifiers declared in the same file or
+ * imported from another file. Entries are processed in source order, so later entries override spreads.
  */
 function resolveObjectLiteralEntries(
   objectLiteral: ts.ObjectLiteralExpression,
@@ -1102,13 +1083,12 @@ function resolveObjectLiteralEntries(
 }
 
 /**
- * Resolve an identifier to a `const name = { ... }` object literal declared in
- * the same file or reachable by following the imports that provide it.
+ * Resolve an identifier to a `const name = { ... }` object literal declared in the same file or reachable by following
+ * the imports that provide it.
  *
- * The chain is walked rather than hopped once: a React media file imports its
- * defaults from a package barrel, `mapDistToSource` rewrites that barrel to the
- * sibling `media.ts`, and a host module that keeps its props in a separate
- * `props.ts` only re-imports the const from there.
+ * The chain is walked rather than hopped once: a React media file imports its defaults from a package barrel,
+ * `mapDistToSource` rewrites that barrel to the sibling `media.ts`, and a host module that keeps its props in a
+ * separate `props.ts` only re-imports the const from there.
  */
 function resolveConstObjectLiteral(
   name: string,
@@ -1164,12 +1144,10 @@ function findConstObjectLiteral(sourceFile: ts.SourceFile, name: string): ts.Obj
 const LITERAL_IDENTIFIERS = new Set(['NaN', 'Infinity']);
 
 /**
- * Serialize a default value expression for display in the docs:
- *   - Literals (strings, numbers, booleans, null, undefined, NaN) verbatim
- *   - Empty object literals as `{}`, non-empty abbreviated as `{…}`
- *   - Short array literals verbatim, long ones abbreviated as `[…]`
- *   - `Obj.MEMBER` resolved to the member's literal in a `... as const` object
- *   - Anything else is omitted (returns undefined)
+ * Serialize a default value expression for display in the docs: - Literals (strings, numbers, booleans, null,
+ * undefined, NaN) verbatim - Empty object literals as `{}`, non-empty abbreviated as `{…}` - Short array literals
+ * verbatim, long ones abbreviated as `[…]` - `Obj.MEMBER` resolved to the member's literal in a `... as const` object -
+ * Anything else is omitted (returns undefined)
  */
 function serializeDefaultValue(
   expr: ts.Expression,
@@ -1225,9 +1203,8 @@ function serializeDefaultValue(
 // ─── Shared Data Extraction ──────────────────────────────────────────
 
 /**
- * Extract property-to-attribute mappings from the `static properties` object
- * inside the CustomMediaElement factory. The property name is needed to
- * classify standard attributes separately from Video.js-specific ones.
+ * Extract property-to-attribute mappings from the `static properties` object inside the CustomMediaElement factory. The
+ * property name is needed to classify standard attributes separately from Video.js-specific ones.
  */
 function extractStaticProperties(filePath: string): StaticMediaProperty[] {
   const content = fs.readFileSync(filePath, 'utf-8');
@@ -1284,11 +1261,10 @@ function extractStaticProperties(filePath: string): StaticMediaProperty[] {
  * Extract the public React surface from the matching media component.
  *
  * Convention:
- *   - `forwardRef<HTML*Element, *Props>` declares the public ref target.
- *   - extending `VideoHTMLAttributes` / `AudioHTMLAttributes` opts into the
- *     native React DOM props.
- *   - the defaults object passed to `useSyncProps` is the runtime source of
- *     truth for Video.js-specific props.
+ *
+ * - `forwardRef<HTML*Element, *Props>` declares the public ref target.
+ * - Extending `VideoHTMLAttributes` / `AudioHTMLAttributes` opts into the native React DOM props.
+ * - The defaults object passed to `useSyncProps` is the runtime source of truth for Video.js-specific props.
  */
 function extractReactReference(
   monorepoRoot: string,
@@ -1449,10 +1425,9 @@ const EXCLUDED_METHOD_NAMES = new Set([
 ]);
 
 /**
- * Collect public instance method names declared directly on a named class.
- * Excludes the constructor, lifecycle methods (attach/detach/destroy),
- * private/protected `_`/`#` names, and accessors (getters/setters are
- * properties, not methods). Returns [] if the file or class isn't found.
+ * Collect public instance method names declared directly on a named class. Excludes the constructor, lifecycle methods
+ * (attach/detach/destroy), private/protected `_`/`#` names, and accessors (getters/setters are properties, not
+ * methods). Returns [] if the file or class isn't found.
  */
 function extractPublicMethodNames(filePath: string, className: string): string[] {
   if (!fs.existsSync(filePath)) return [];
@@ -1503,11 +1478,11 @@ function mergeMethodNames(a: readonly string[], b: readonly string[]): string[] 
 // ─── Event Extraction ────────────────────────────────────────────────
 
 /**
- * Extract event names from a composite event interface (e.g. VideoEvents, AudioEvents)
- * by walking its `extends` chain and collecting property keys from each parent interface.
+ * Extract event names from a composite event interface (e.g. VideoEvents, AudioEvents) by walking its `extends` chain
+ * and collecting property keys from each parent interface.
  *
- * Convention: capability event interfaces (MediaPlaybackEvents, etc.) are flat
- * `eventName: EventLike` maps, and VideoEvents/AudioEvents compose them via `extends`.
+ * Convention: capability event interfaces (MediaPlaybackEvents, etc.) are flat `eventName: EventLike` maps, and
+ * VideoEvents/AudioEvents compose them via `extends`.
  */
 function extractEventsFromTypes(filePath: string, interfaceName: string): string[] {
   const content = fs.readFileSync(filePath, 'utf-8');
@@ -1569,12 +1544,11 @@ function extractEventsFromTypes(filePath: string, interfaceName: string): string
 }
 
 /**
- * Scan a host class (and its mixin/parent chain) for `this.dispatchEvent(new Event('name'))`
- * style calls and `@fires` JSDoc tags, collecting dispatched event names into `events`
- * and tag descriptions into `fires` (which also acts as an event source — dispatch
- * sites in helper files the walk never visits can be declared via `@fires` alone).
- * Forwarding patterns like `new (event.constructor as ...)(event.type, event)` are
- * naturally skipped because their first argument is not a `StringLiteral`.
+ * Scan a host class (and its mixin/parent chain) for `this.dispatchEvent(new Event('name'))` style calls and `@fires`
+ * JSDoc tags, collecting dispatched event names into `events` and tag descriptions into `fires` (which also acts as an
+ * event source — dispatch sites in helper files the walk never visits can be declared via `@fires` alone). Forwarding
+ * patterns like `new (event.constructor as ...)(event.type, event)` are naturally skipped because their first argument
+ * is not a `StringLiteral`.
  */
 function extractDispatchedEvents(
   filePath: string,
@@ -1685,9 +1659,8 @@ function walkExtendsForDispatchEvents(
 }
 
 /**
- * Collect `@fires name - description` JSDoc tags from a file. The tag may sit
- * on the dispatching class, a mixin function, or the const holding a mixin
- * arrow function.
+ * Collect `@fires name - description` JSDoc tags from a file. The tag may sit on the dispatching class, a mixin
+ * function, or the const holding a mixin arrow function.
  */
 function scanForFiresTags(sourceFile: ts.SourceFile, fires: Map<string, string>): void {
   function visit(node: ts.Node): void {
@@ -1808,9 +1781,8 @@ function dedupeStrings(values: readonly string[]): string[] {
 }
 
 /**
- * Build the set of property names declared on `HTMLMediaElement`,
- * `HTMLVideoElement`, and `HTMLAudioElement` (per `lib.dom.d.ts`). Used to
- * tag host properties that override a native member.
+ * Build the set of property names declared on `HTMLMediaElement`, `HTMLVideoElement`, and `HTMLAudioElement` (per
+ * `lib.dom.d.ts`). Used to tag host properties that override a native member.
  */
 function collectNativeMemberNames(program: ts.Program, anchorFile: ts.SourceFile): Set<string> {
   const checker = program.getTypeChecker();

--- a/site/scripts/api-docs-builder/src/output.ts
+++ b/site/scripts/api-docs-builder/src/output.ts
@@ -108,10 +108,7 @@ export function validateReferenceGroup<T>(group: ReferenceGroup<T>): ReferenceGr
   };
 }
 
-/**
- * Write a validated group and remove JSON files that are no longer generated.
- * Non-JSON files are left untouched.
- */
+/** Write a validated group and remove JSON files that are no longer generated. Non-JSON files are left untouched. */
 export function writeReferenceGroup(group: ValidatedReferenceGroup): { written: number; removed: string[] } {
   const parentPath = path.dirname(group.outputPath);
 

--- a/site/scripts/api-docs-builder/src/parts-handler.ts
+++ b/site/scripts/api-docs-builder/src/parts-handler.ts
@@ -15,14 +15,12 @@ export interface PartExport {
 /**
  * Extract part definitions from a React `index.parts.ts` file.
  *
- * Discovery algorithm:
- * 1. Parses named exports from `index.parts.ts` (filters out type-only exports)
- * 2. Each value export becomes a part: `export { Group } from './time-group'` -> part "Group"
- * 3. Source path is preserved for HTML element matching in the main builder
+ * Discovery algorithm: 1. Parses named exports from `index.parts.ts` (filters out type-only exports) 2. Each value
+ * export becomes a part: `export { Group } from './time-group'` -> part "Group" 3. Source path is preserved for HTML
+ * element matching in the main builder
  *
- * If a part isn't appearing in the output:
- * - Ensure it's exported as a value export (not `type`-only) in `index.parts.ts`
- * - Ensure the source path follows `'./{component}-{part}'` naming
+ * If a part isn't appearing in the output: - Ensure it's exported as a value export (not `type`-only) in
+ * `index.parts.ts` - Ensure the source path follows `'./{component}-{part}'` naming
  */
 export function extractParts(filePath: string, program: ts.Program): PartExport[] {
   const sourceFile = program.getSourceFile(filePath);
@@ -66,8 +64,8 @@ export function extractParts(filePath: string, program: ts.Program): PartExport[
 /**
  * Extract the JSDoc description from a React component export.
  *
- * Parses the file with `typescript-api-extractor`, finds the export matching
- * `partName`, and returns its description (stripping `@example` blocks).
+ * Parses the file with `typescript-api-extractor`, finds the export matching `partName`, and returns its description
+ * (stripping `@example` blocks).
  */
 export function extractPartDescription(filePath: string, program: ts.Program, partName: string): string | undefined {
   const ast = tae.parseFromProgram(filePath, program);
@@ -82,10 +80,9 @@ export function extractPartDescription(filePath: string, program: ts.Program, pa
 /**
  * Extract custom React-specific props from a sub-part's Props interface.
  *
- * Walks syntactic own members of `{localName}Props`, then also includes
- * members from any extended interface declared within the project (i.e., not
- * from `node_modules`). This picks up props from project types like
- * `TooltipGroupProps` while excluding inherited React DOM attributes.
+ * Walks syntactic own members of `{localName}Props`, then also includes members from any extended interface declared
+ * within the project (i.e., not from `node_modules`). This picks up props from project types like `TooltipGroupProps`
+ * while excluding inherited React DOM attributes.
  */
 export function extractSubPartProps(filePath: string, program: ts.Program, localName: string): Record<string, PropDef> {
   const sourceFile = program.getSourceFile(filePath);

--- a/site/scripts/api-docs-builder/src/pipeline.ts
+++ b/site/scripts/api-docs-builder/src/pipeline.ts
@@ -1,8 +1,8 @@
 /**
  * Component reference discovery, extraction, and building.
  *
- * Kept separate from the CLI so E2E tests can run the component pipeline
- * against a fixture monorepo by passing a custom root path.
+ * Kept separate from the CLI so E2E tests can run the component pipeline against a fixture monorepo by passing a custom
+ * root path.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/site/scripts/api-docs-builder/src/preset-handler.ts
+++ b/site/scripts/api-docs-builder/src/preset-handler.ts
@@ -1,23 +1,27 @@
 /**
  * Preset reference extraction.
  *
- * Discovers presets from package.json exports in packages/{html,react}/ and
- * extracts feature bundles, skins, and media elements.
+ * Discovers presets from package.json exports in packages/{html,react}/ and extracts feature bundles, skins, and media
+ * elements.
  *
  * Discovery:
- *   - Reads package.json exports to find preset names and their source paths
- *   - Barrel file (./X export) → feature bundle name + file-level description
- *   - Source directory (./X/* export) → skins + media elements via directory scan
+ *
+ * - Reads package.json exports to find preset names and their source paths
+ * - Barrel file (./X export) → feature bundle name + file-level description
+ * - Source directory (./X/* export) → skins + media elements via directory scan
  *
  * Classification (positive detection only):
- *   - HTML: classes with `static readonly tagName`
- *     - *Skin*Element → skin
- *     - *Player* → skip
- *     - remaining → media element
- *   - React: exported functions/classes/consts
- *     - *Skin → skin
- *     - remaining → media element
- *   - .tailwind in filename → excluded (both frameworks)
+ *
+ * - HTML: classes with `static readonly tagName`
+ *
+ *   - _Skin_Element → skin
+ *   - _Player_ → skip
+ *   - Remaining → media element
+ * - React: exported functions/classes/consts
+ *
+ *   - *Skin → skin
+ *   - Remaining → media element
+ * - .tailwind in filename → excluded (both frameworks)
  *
  * Feature resolution: packages/core/src/dom/store/features/presets.ts
  */
@@ -51,9 +55,8 @@ export interface PresetResult {
 // ─── Package.json Discovery ─────────────────────────────────────────
 
 /**
- * Resolve a dist output path back to its source path.
- * Handles both real packages (dist/dev/... → src/...) and test fixtures
- * (src/... → src/..., already source paths).
+ * Resolve a dist output path back to its source path. Handles both real packages (dist/dev/... → src/...) and test
+ * fixtures (src/... → src/..., already source paths).
  */
 function distToSrc(distPath: string): string {
   // Real packages: dist/(dev|default)/foo/bar.js → src/foo/bar.ts
@@ -66,8 +69,8 @@ function distToSrc(distPath: string): string {
 }
 
 /**
- * Extract the source file path from a package.json export value.
- * Handles both conditional exports ({ types, default }) and string exports.
+ * Extract the source file path from a package.json export value. Handles both conditional exports ({ types, default })
+ * and string exports.
  */
 function resolveExportPath(exportValue: unknown): string | undefined {
   if (typeof exportValue === 'string') return exportValue;
@@ -84,8 +87,8 @@ function resolveExportPath(exportValue: unknown): string | undefined {
 }
 
 /**
- * Discover presets from package.json exports for a single package.
- * Returns a map of preset name → { barrelPath, scanDir }.
+ * Discover presets from package.json exports for a single package. Returns a map of preset name → { barrelPath, scanDir
+ * }.
  */
 function discoverPresetsFromPackage(packageDir: string): Map<string, { barrelPath: string; scanDir: string }> {
   const pkgJsonPath = path.join(packageDir, 'package.json');
@@ -132,9 +135,7 @@ function discoverPresetsFromPackage(packageDir: string): Map<string, { barrelPat
   return result;
 }
 
-/**
- * Discover all presets from both HTML and React packages.
- */
+/** Discover all presets from both HTML and React packages. */
 function discoverPresets(monorepoRoot: string): PresetInfo[] {
   const htmlPkgDir = path.join(monorepoRoot, 'packages/html');
   const reactPkgDir = path.join(monorepoRoot, 'packages/react');
@@ -289,9 +290,8 @@ function extractValueExports(filePath: string): string[] {
 // ─── Barrel Parsing (feature bundle only) ───────────────────────────
 
 /**
- * Parse named value export names from a barrel file.
- * Only reads `export { X } from '...'` syntax — skips `export *` since
- * skins are discovered via directory scanning.
+ * Parse named value export names from a barrel file. Only reads `export { X } from '...'` syntax — skips `export *`
+ * since skins are discovered via directory scanning.
  */
 function parseBarrelExportNames(filePath: string): string[] {
   if (!fs.existsSync(filePath)) return [];
@@ -320,8 +320,8 @@ function findFeatureBundleExport(filePath: string): string | undefined {
 }
 
 /**
- * Find the media element from a React barrel's named exports.
- * The media element is a named re-export that isn't a feature bundle or skin.
+ * Find the media element from a React barrel's named exports. The media element is a named re-export that isn't a
+ * feature bundle or skin.
  */
 function findReactMediaElement(filePath: string): string | undefined {
   const names = parseBarrelExportNames(filePath);
@@ -342,8 +342,8 @@ function findReactMediaElement(filePath: string): string | undefined {
 // ─── Feature Bundle Resolution ──────────────────────────────────────
 
 /**
- * Feature names whose kebab-cased form doesn't match the docs page slug.
- * Example: `textTrack` → `feature-text-tracks.mdx`.
+ * Feature names whose kebab-cased form doesn't match the docs page slug. Example: `textTrack` →
+ * `feature-text-tracks.mdx`.
  */
 const FEATURE_SLUG_OVERRIDES: Record<string, string> = {
   textTrack: 'text-tracks',

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -1,41 +1,27 @@
 /**
- * ┌─────────────────────────────────────────────────────────────────────────────┐
- * │                    API DOCS BUILDER — END-TO-END SPEC                      │
- * │                                                                            │
- * │  This file IS the specification for the API docs builder pipeline.         │
- * │  It exercises every pattern the builder must handle, using a mock          │
- * │  monorepo under fixtures/monorepo/. If you're an agent trying to          │
- * │  understand how the builder works: read this file. The fixtures are        │
- * │  the inputs, the expected JSON objects are the outputs.                    │
- * │                                                                            │
- * │  The builder is a black box: given TypeScript source files following       │
- * │  specific conventions, it produces JSON reference objects. These tests     │
- * │  verify the contract between input conventions and output shape.           │
+ * ┌─────────────────────────────────────────────────────────────────────────────┐ │ API DOCS BUILDER — END-TO-END SPEC
+ * │ │ │ │ This file IS the specification for the API docs builder pipeline. │ │ It exercises every pattern the builder
+ * must handle, using a mock │ │ monorepo under fixtures/monorepo/. If you're an agent trying to │ │ understand how the
+ * builder works: read this file. The fixtures are │ │ the inputs, the expected JSON objects are the outputs. │ │ │ │
+ * The builder is a black box: given TypeScript source files following │ │ specific conventions, it produces JSON
+ * reference objects. These tests │ │ verify the contract between input conventions and output shape. │
  * └─────────────────────────────────────────────────────────────────────────────┘
  *
  * FIXTURE LAYOUT (under fixtures/monorepo/):
  *
- * Components (packages/core/src/core/ui/):
- *   toggle-button/  — Single-part component. Exercises: props, state, data-attrs,
- *                     CSS vars, defaultProps, HTML element, type abbreviation,
- *                     @ignore skipping, ref auto-skip, function-typed props.
- *   gauge/          — Multi-part component. Exercises: primary part detection via
- *                     Core instantiation, sub-parts with/without HTML elements,
- *                     React-only parts (no platforms.html), sub-part data-attr
- *                     inheritance (stateAttrMap heuristic), non-boolean type
- *                     inference (number, string literal union via type alias),
- *                     extra @parts-tagged data-attrs files attaching to the
- *                     listed parts (label-data.ts).
- *   slider/         — Base multi-part component. Exercises: base component whose
- *                     parts are re-exported by domain variants.
- *   volume-slider/  — Domain variant. Exercises: re-exported parts from slider,
- *                     origin-based element + data-attr resolution, re-exported
- *                     parts are never primary, always multi-part (no fallback).
+ * Components (packages/core/src/core/ui/): toggle-button/ — Single-part component. Exercises: props, state, data-attrs,
+ * CSS vars, defaultProps, HTML element, type abbreviation, @ignore skipping, ref auto-skip, function-typed props.
+ * gauge/ — Multi-part component. Exercises: primary part detection via Core instantiation, sub-parts with/without HTML
+ * elements, React-only parts (no platforms.html), sub-part data-attr inheritance (stateAttrMap heuristic), non-boolean
+ * type inference (number, string literal union via type alias), extra @parts-tagged data-attrs files attaching to the
+ * listed parts (label-data.ts). slider/ — Base multi-part component. Exercises: base component whose parts are
+ * re-exported by domain variants. volume-slider/ — Domain variant. Exercises: re-exported parts from slider,
+ * origin-based element + data-attr resolution, re-exported parts are never primary, always multi-part (no fallback).
  *
- * Utils (already existing fixtures for hooks, controllers, selectors, etc.):
- *   Exercises: hook discovery, controller discovery, @public context,
- *   create* factory, mixin display name stripping, selector discovery,
- *   @label overloads, slug collision (react vs html create-player),
+ * Utils (already existing fixtures for hooks, controllers, selectors, etc.): Exercises: hook discovery, controller
+ * discovery, @public context, create* factory, mixin display name stripping, selector discovery,
+ *
+ * @label overloads, slug collision (react vs html create-player),
  *   framework assignment.
  *   ui/rate-options/ — Hook re-exported through a directory index
  *   (entry index → ./ui/rate-options → ./use-rate-options), with a
@@ -55,13 +41,13 @@
  *                  naming the published interface when state() annotates
  *                  private source state, and `config` inputs typed from the
  *                  symbol-keyed private actions they forward to.
- *   presets.ts   — Feature bundles. Exercises: plural *Features naming
+ *   presets.ts   — Feature bundles. Exercises: plural _Features naming
  *                  (filtered out of feature discovery), array resolution
  *                  for preset feature lists.
  *   feature.parts.ts — Short aliases (playbackFeature as playback, etc.).
  *                  Exercises: namespace re-export filtering (export * as features).
  *   index.ts     — Re-export barrel. Exercises: feature discovery filtering
- *                  (singular *Feature only, not *Features or namespaces).
+ *                  (singular _Feature only, not *Features or namespaces).
  *
  * Presets:
  *   HTML (packages/html/src/presets/):
@@ -69,13 +55,13 @@
  *                  (SkinElement inheritance), tailwind skin exclusion.
  *     audio.ts   — Exercises: single skin, subset of features.
  *   React (packages/react/src/presets/):
- *     video/     — Exercises: feature bundle, React skins (*Skin naming),
+ *     video/     — Exercises: feature bundle, React skins (_Skin naming),
  *                  media element export, tailwind skin exclusion.
  *     audio/     — Exercises: single skin, different media element.
  *
  * Media elements (packages/html/src/define/media/ + packages/media/src/dom/):
  *   simple-video  — Simple media element. Exercises: discovery via static
- *                   tagName in define/media/*.ts, minimal host (src rw,
+ *                   tagName in define/media/_.ts, minimal host (src rw,
  *                   engine readonly), shared attributes/events/CSS vars
  *                   from custom-media-element.
  *   complex-video — Complex media element. Exercises: host with JSDoc

--- a/site/scripts/api-docs-builder/src/types.ts
+++ b/site/scripts/api-docs-builder/src/types.ts
@@ -1,6 +1,6 @@
 /**
- * Re-export types from the shared schema.
- * The shared schema in src/types/component-reference.ts is the single source of truth.
+ * Re-export types from the shared schema. The shared schema in src/types/component-reference.ts is the single source of
+ * truth.
  */
 export type {
   ComponentReference,
@@ -36,9 +36,7 @@ export { PresetReferenceSchema } from '../../../src/types/preset-reference.js';
 export type { UtilReference } from '../../../src/types/util-reference.js';
 export { UtilReferenceSchema } from '../../../src/types/util-reference.js';
 
-/**
- * Discovered part within a multi-part component.
- */
+/** Discovered part within a multi-part component. */
 export interface PartSource {
   /** PascalCase name (e.g., "Value", "Group", "Separator"). */
   name: string;
@@ -58,9 +56,7 @@ export interface PartSource {
   dataAttrsComponentName?: string;
 }
 
-/**
- * Source file locations for a component across packages.
- */
+/** Source file locations for a component across packages. */
 export interface ComponentSource {
   /** PascalCase component name (e.g., PlayButton) */
   name: string;
@@ -86,9 +82,7 @@ export interface ExtraDataAttrsSource {
   parts: string[];
 }
 
-/**
- * Extracted property from TypeScript analysis.
- */
+/** Extracted property from TypeScript analysis. */
 export interface ExtractedProp {
   name: string;
   type: string;
@@ -98,9 +92,7 @@ export interface ExtractedProp {
   required?: boolean;
 }
 
-/**
- * Extraction result from core package.
- */
+/** Extraction result from core package. */
 export interface CoreExtraction {
   description?: string;
   props: ExtractedProp[];
@@ -108,9 +100,7 @@ export interface CoreExtraction {
   defaultProps: Record<string, string>;
 }
 
-/**
- * Extraction result from data attributes file.
- */
+/** Extraction result from data attributes file. */
 export interface DataAttrsExtraction {
   attrs: Array<{ name: string; description: string; type?: string }>;
 }

--- a/site/scripts/api-docs-builder/src/util-handler.ts
+++ b/site/scripts/api-docs-builder/src/util-handler.ts
@@ -1,36 +1,32 @@
 /**
  * Util reference handler — TAE-based auto-discovery.
  *
- * Generates JSON reference files for hooks, controllers, mixins, factories,
- * contexts, selectors, and utilities by scanning package entry points.
+ * Generates JSON reference files for hooks, controllers, mixins, factories, contexts, selectors, and utilities by
+ * scanning package entry points.
  *
- * Exports are included by naming convention or `@public` JSDoc tag:
- *   select* (capital 3rd), use* (capital 3rd), *Controller (class),
- *   create* (function), or any export tagged @public.
+ * Exports are included by naming convention or `@public` JSDoc tag: select* (capital 3rd), use* (capital 3rd),
+ * _Controller (class), create_ (function), or any export tagged @public.
  *
  * Extraction routing is determined by export node type:
- *   - Class / *Controller non-function → controller extraction (raw TS AST)
- *   - Non-function → context extraction (type only)
- *   - Function → function extraction (TAE call signatures)
+ *
+ * - Class / *Controller non-function → controller extraction (raw TS AST)
+ * - Non-function → context extraction (type only)
+ * - Function → function extraction (TAE call signatures)
  *
  * 4 Discovery Strategies (run per entry point, in order):
  *
- *   Strategy 1 — TAE on local modules (primary path)
- *     Parses each resolved local module with typescript-api-extractor.
+ * Strategy 1 — TAE on local modules (primary path) Parses each resolved local module with typescript-api-extractor.
  *
- *   Strategy 2 — TAE on index file (class re-exports)
- *     Parses the entry index file itself to find controllers that are
- *     re-exported but whose source module is separate.
+ * Strategy 2 — TAE on index file (class re-exports) Parses the entry index file itself to find controllers that are
+ * re-exported but whose source module is separate.
  *
- *   Strategy 3 — Raw TS AST fallback (failed modules)
- *     When TAE fails on a module (e.g., UniqueESSymbol in HTML bundle),
- *     falls back to walking the raw TypeScript AST for exports.
+ * Strategy 3 — Raw TS AST fallback (failed modules) When TAE fails on a module (e.g., UniqueESSymbol in HTML bundle),
+ * falls back to walking the raw TypeScript AST for exports.
  *
- *   Strategy 4 — Raw TS AST for missed classes
- *     Scans local modules for exported classes that TAE parsed but missed.
+ * Strategy 4 — Raw TS AST for missed classes Scans local modules for exported classes that TAE parsed but missed.
  *
- * All overloads are preserved. When a function or constructor has multiple
- * overload signatures, each becomes a separate entry in the overloads array.
+ * All overloads are preserved. When a function or constructor has multiple overload signatures, each becomes a separate
+ * entry in the overloads array.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/site/scripts/api-docs-builder/src/utils.ts
+++ b/site/scripts/api-docs-builder/src/utils.ts
@@ -85,8 +85,8 @@ export function kebabToPascal(str: string): string {
 /**
  * Derive the kebab-case part segment from an `index.parts.ts` source path.
  *
- * Strips the leading `'./{componentKebab}-'` prefix to get the part segment.
- * Example: `partKebabFromSource('./time-value', 'time')` -> `'value'`
+ * Strips the leading `'./{componentKebab}-'` prefix to get the part segment. Example:
+ * `partKebabFromSource('./time-value', 'time')` -> `'value'`
  */
 export function partKebabFromSource(source: string, componentKebab: string): string {
   const basename = source.split('/').at(-1) ?? source;

--- a/site/scripts/build-cdn-manifest.ts
+++ b/site/scripts/build-cdn-manifest.ts
@@ -1,17 +1,15 @@
 /**
  * Build the CDN media manifest for the installation guide.
  *
- * Scans the built `@videojs/html` CDN media bundles and records which media
- * subpaths actually ship a CDN build. The installation page uses this to hide
- * the CDN install option for a renderer that has no CDN bundle.
+ * Scans the built `@videojs/html` CDN media bundles and records which media subpaths actually ship a CDN build. The
+ * installation page uses this to hide the CDN install option for a renderer that has no CDN bundle.
  *
- * Produces `site/src/content/cdn-media.json` as an array of `{ id }` entries
- * (one per media subpath), consumed via the `cdnMedia` content collection.
+ * Produces `site/src/content/cdn-media.json` as an array of `{ id }` entries (one per media subpath), consumed via the
+ * `cdnMedia` content collection.
  *
- * Source of truth: the built output of `@videojs/html`'s `build:cdn` task
- * (configured in `packages/html/vite.config.ts`). Reading the build
- * output — rather than a hand-maintained list — means a renderer that fails to
- * ship a CDN bundle correctly shows as no-CDN.
+ * Source of truth: the built output of `@videojs/html`'s `build:cdn` task (configured in
+ * `packages/html/vite.config.ts`). Reading the build output — rather than a hand-maintained list — means a renderer
+ * that fails to ship a CDN bundle correctly shows as no-CDN.
  *
  * Prerequisites: `@videojs/html`'s `build:cdn` (wired as a Vite+ task dependency).
  */
@@ -39,9 +37,8 @@ const ManifestSchema = z.array(z.object({ id: z.string() }));
 /**
  * Media subpaths that ship a production bundle, walking the flavor directories.
  *
- * An element with more than one engine ships its flavors in a directory named
- * for the element, so the id keeps the slash and stays equal to the npm media
- * subpath the installation page resolves against.
+ * An element with more than one engine ships its flavors in a directory named for the element, so the id keeps the
+ * slash and stays equal to the npm media subpath the installation page resolves against.
  */
 function collectSubpaths(dir: string, prefix = ''): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {

--- a/site/scripts/ejected-skins/react.ts
+++ b/site/scripts/ejected-skins/react.ts
@@ -2,6 +2,7 @@
  * Build ejected skin snippets for copy-paste usage.
  *
  * Produces `site/src/content/ejected-skins.json` with:
+ *
  * - HTML skins: rendered HTML templates with <media-icon> elements and resolved classes
  * - React skins: TSX (with types) and JSX (types stripped) with public icon imports
  * - CSS variants include a `css` field with all @imports resolved
@@ -386,8 +387,8 @@ function tsxToJsx(source: string): string {
 // After all transforms, collected code is inserted after the final import.
 
 /**
- * Remove `cn` import and replace all `cn(...)` calls with template literals.
- * `cn(a, b)` → `` `${a} ${b}` ``, with string literal args inlined directly.
+ * Remove `cn` import and replace all `cn(...)` calls with template literals. `cn(a, b)` → `` `${a} ${b}` ``, with
+ * string literal args inlined directly.
  */
 function inlineCn(source: string): string {
   if (!source.match(/import\s+\{[^}]*\bcn\b[^}]*\}\s+from\s+['"]@videojs\/utils\/style['"]/)) {
@@ -491,10 +492,7 @@ function splitTopLevelCommas(str: string): string[] {
   return result;
 }
 
-/**
- * Rewrite package-private or local React icon imports to public package
- * re-exports for ejected skins.
- */
+/** Rewrite package-private or local React icon imports to public package re-exports for ejected skins. */
 function rewriteReactIconImports(source: string): string {
   return source
     .replace(/from\s+['"]@videojs\/icons\/react(?:\/default)?['"]/g, "from '@videojs/react/icons'")
@@ -506,8 +504,8 @@ function rewriteReactIconImports(source: string): string {
 }
 
 /**
- * Replace `@videojs/skins/*` imports (private package) with inline const
- * declarations containing the resolved token values.
+ * Replace `@videojs/skins/*` imports (private package) with inline const declarations containing the resolved token
+ * values.
  */
 async function inlineSkinTokens(source: string, postImport: string[]): Promise<string> {
   const regex = /import\s+\{([^}]*)\}\s+from\s+['"](@videojs\/skins\/[^'"]+)['"]\s*;?\n?/;
@@ -531,8 +529,8 @@ async function inlineSkinTokens(source: string, postImport: string[]): Promise<s
 }
 
 /**
- * Consolidate `@/` path alias imports into `@videojs/react`.
- * All UI components and hooks are re-exported from the main package entry.
+ * Consolidate `@/` path alias imports into `@videojs/react`. All UI components and hooks are re-exported from the main
+ * package entry.
  */
 function rewritePathAliases(source: string): string {
   const aliasRegex = /import\s+(type\s+)?\{([^}]+)\}\s+from\s+['"]@\/[^'"]+['"];?\n?/g;
@@ -579,10 +577,9 @@ function rewritePathAliases(source: string): string {
 }
 
 /**
- * Rewrite imports from private/internal packages:
- * - `@videojs/core/dom` → merge into `@videojs/react` (re-exported publicly)
- * - `@videojs/utils/predicate` → inline function definitions
- * - `isRenderProp` from `@videojs/react` → inline (not a public export)
+ * Rewrite imports from private/internal packages: - `@videojs/core/dom` → merge into `@videojs/react` (re-exported
+ * publicly) - `@videojs/utils/predicate` → inline function definitions - `isRenderProp` from `@videojs/react` → inline
+ * (not a public export)
  */
 function inlinePrivatePackages(source: string): { source: string; utilities: string[] } {
   const utilities: string[] = [];
@@ -689,9 +686,8 @@ function findLastImportEnd(source: string): number {
 // ---------------------------------------------------------------------------
 
 /**
- * The members a `Base*SkinProps` alias adds on top of `BaseSkinProps`, without
- * their JSDoc: the comments describe the skin component, not the player the
- * ejected file exports.
+ * The members a `Base*SkinProps` alias adds on top of `BaseSkinProps`, without their JSDoc: the comments describe the
+ * skin component, not the player the ejected file exports.
  */
 function getAddedMembers(statement: ts.Statement, sourceFile: ts.SourceFile): string[] {
   if (!ts.isTypeAliasDeclaration(statement) || !ts.isIntersectionTypeNode(statement.type)) return [];
@@ -703,9 +699,8 @@ function getAddedMembers(statement: ts.Statement, sourceFile: ts.SourceFile): st
 }
 
 /**
- * Replace the `BaseSkinProps` type chain with a clean interface. Removes the
- * intermediate type aliases and produces a flat exported interface, carrying
- * over whatever members those aliases added.
+ * Replace the `BaseSkinProps` type chain with a clean interface. Removes the intermediate type aliases and produces a
+ * flat exported interface, carrying over whatever members those aliases added.
  */
 export function resolvePropsInterface(source: string): string {
   const sourceFile = createSourceFile('props.tsx', source);
@@ -818,9 +813,8 @@ function sectionHeader(title: string): string {
 }
 
 /**
- * Reorganize the React skin output into well-defined sections.
- * Classifies each top-level declaration and reassembles with section headers.
- * Extra declarations (utilities, icon components) are appended to their sections.
+ * Reorganize the React skin output into well-defined sections. Classifies each top-level declaration and reassembles
+ * with section headers. Extra declarations (utilities, icon components) are appended to their sections.
  */
 function reorganizeReactOutput(source: string, extraUtilities: string[], extraIconComponents: string[]): string {
   const sourceFile = createSourceFile('output.tsx', source);
@@ -888,9 +882,8 @@ function reorganizeReactOutput(source: string, extraUtilities: string[], extraIc
 }
 
 /**
- * Flatten `ERROR_CLASSNAMES` into the inlined `ErrorDialog` component so the
- * ejected output has plain className strings instead of the classNames-prop
- * indirection.
+ * Flatten `ERROR_CLASSNAMES` into the inlined `ErrorDialog` component so the ejected output has plain className strings
+ * instead of the classNames-prop indirection.
  *
  * @temporary Remove once the ErrorDialog component no longer uses the
  *   `classNames` prop pattern. Tracked in https://github.com/videojs/v10/pull/1077.
@@ -944,9 +937,8 @@ function flattenErrorClasses(source: string): string {
 }
 
 /**
- * Move the destructured props from the skin function body into the function
- * argument so the signature reads e.g.:
- *   `function VideoSkin({ children, className, style, ...rest }: VideoSkinProps)`
+ * Move the destructured props from the skin function body into the function argument so the signature reads e.g.:
+ * `function VideoSkin({ children, className, style, ...rest }: VideoSkinProps)`
  */
 function destructureSkinProps(source: string): string {
   return source.replace(
@@ -956,15 +948,13 @@ function destructureSkinProps(source: string): string {
 }
 
 /**
- * Flatten the skin into a Player component. Produces two files:
- *   - `player.ts`: owns the `createPlayer({ features })` call and exports `Player`.
- *   - `VideoPlayer.tsx` / `AudioPlayer.tsx`: imports `Player` from `./player` and
- *     owns the React component. Splitting these avoids React Fast Refresh bailing
- *     out (a file must export only components for Fast Refresh to apply edits).
+ * Flatten the skin into a Player component. Produces two files: - `player.ts`: owns the `createPlayer({ features })`
+ * call and exports `Player`. - `VideoPlayer.tsx` / `AudioPlayer.tsx`: imports `Player` from `./player` and owns the
+ * React component. Splitting these avoids React Fast Refresh bailing out (a file must export only components for Fast
+ * Refresh to apply edits).
  *
- * Also: merges SkinProps into PlayerProps (adding `src`), inlines the skin body
- * into VideoPlayer/AudioPlayer wrapped in `Player`, and removes the
- * separate Skin export.
+ * Also: merges SkinProps into PlayerProps (adding `src`), inlines the skin body into VideoPlayer/AudioPlayer wrapped in
+ * `Player`, and removes the separate Skin export.
  */
 function flattenSkinIntoPlayer(
   source: string,
@@ -1053,10 +1043,7 @@ function flattenSkinIntoPlayer(
   return { player, component: source };
 }
 
-/**
- * Process a React skin: rewrite icon imports, resolve imports,
- * and produce both TSX and JSX versions.
- */
+/** Process a React skin: rewrite icon imports, resolve imports, and produce both TSX and JSX versions. */
 export async function processReactSkin(
   skin: ReactSkinDef
 ): Promise<{ tsx: Record<string, string>; jsx: Record<string, string> }> {

--- a/site/src/actions/auth.ts
+++ b/site/src/actions/auth.ts
@@ -8,9 +8,8 @@ export const auth = {
   /**
    * Initiates the OAuth 2.0 login flow
    *
-   * Generates a CSRF-protected state parameter and returns the authorization URL
-   * for the client to redirect to. The state is stored in a short-lived cookie
-   * and verified in the callback endpoint.
+   * Generates a CSRF-protected state parameter and returns the authorization URL for the client to redirect to. The
+   * state is stored in a short-lived cookie and verified in the callback endpoint.
    *
    * @returns {authorizationUrl} - The OAuth authorization URL to redirect to
    */

--- a/site/src/actions/mux.ts
+++ b/site/src/actions/mux.ts
@@ -6,8 +6,7 @@ import { MUX_API_URL, MUX_TOKEN_ID, MUX_TOKEN_SECRET } from 'astro:env/server';
 /**
  * Creates an authenticated Mux API client
  *
- * Uses the access token from the user's session (provided by middleware)
- * to authenticate requests to the Mux API.
+ * Uses the access token from the user's session (provided by middleware) to authenticate requests to the Mux API.
  *
  * @param token - OAuth access token from user session
  * @throws {Error} If token is missing or invalid
@@ -62,8 +61,7 @@ export const mux = {
   /**
    * List video assets with pagination
    *
-   * Fetches a paginated list of video assets from Mux.
-   * Requires an authenticated session with valid access token.
+   * Fetches a paginated list of video assets from Mux. Requires an authenticated session with valid access token.
    *
    * @param limit - Number of assets per page (default: 25)
    * @param page - Page number to fetch (default: 1)
@@ -96,8 +94,8 @@ export const mux = {
   /**
    * Retrieve a single video asset by ID
    *
-   * Fetches detailed information about a specific video asset.
-   * Requires an authenticated session with valid access token.
+   * Fetches detailed information about a specific video asset. Requires an authenticated session with valid access
+   * token.
    *
    * @param id - The unique Mux asset ID
    * @returns Video asset object with full details
@@ -122,10 +120,7 @@ export const mux = {
     },
   }),
 
-  /**
-   * Create a direct upload URL for client-side uploads.
-   * Returns the signed upload URL and upload ID for tracking.
-   */
+  /** Create a direct upload URL for client-side uploads. Returns the signed upload URL and upload ID for tracking. */
   createDirectUpload: defineAction({
     input: z.object({
       corsOrigin: z.string().optional(),
@@ -160,8 +155,8 @@ export const mux = {
   }),
 
   /**
-   * Poll upload status to get asset_id once processing begins.
-   * Status: 'waiting' | 'asset_created' | 'errored' | 'cancelled' | 'timed_out'
+   * Poll upload status to get asset_id once processing begins. Status: 'waiting' | 'asset_created' | 'errored' |
+   * 'cancelled' | 'timed_out'
    */
   getUploadStatus: defineAction({
     input: z.object({
@@ -186,10 +181,7 @@ export const mux = {
     },
   }),
 
-  /**
-   * Poll asset status to get playback_id once ready.
-   * Status: 'preparing' | 'ready' | 'errored'
-   */
+  /** Poll asset status to get playback_id once ready. Status: 'preparing' | 'ready' | 'errored' */
   getAssetStatus: defineAction({
     input: z.object({
       assetId: z.string(),

--- a/site/src/components/Code/ClientCode.tsx
+++ b/site/src/components/Code/ClientCode.tsx
@@ -23,14 +23,12 @@ function ClientCodeInner({ code, lang }: ClientCodeProps) {
 }
 
 /**
- * Uses `use()` + Suspense instead of top-level `await` because top-level
- * `await` causes Safari hydration errors when multiple `client:idle` islands
- * on the same Astro page share the module.
+ * Uses `use()` + Suspense instead of top-level `await` because top-level `await` causes Safari hydration errors when
+ * multiple `client:idle` islands on the same Astro page share the module.
  * https://github.com/withastro/astro/issues/10055
  *
- * The unhighlighted fallback is a safety net for the brief client hydration
- * gap — Astro's SSR awaits the full React stream, so the server-rendered
- * output already contains highlighted code.
+ * The unhighlighted fallback is a safety net for the brief client hydration gap — Astro's SSR awaits the full React
+ * stream, so the server-rendered output already contains highlighted code.
  */
 export default function ClientCode({ code, lang }: ClientCodeProps) {
   return (

--- a/site/src/components/Tabs.tsx
+++ b/site/src/components/Tabs.tsx
@@ -1,17 +1,14 @@
 /**
- * Accessible tabs component implementing the WAI-ARIA Tabs pattern.
- * Reference: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+ * Accessible tabs component implementing the WAI-ARIA Tabs pattern. Reference:
+ * https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
  *
- * Built without context, using some unusual patterns,
- * to work around some restrictions with Astro islands:
- * namely, that separate islands can't share context, and that,
- * depending on rendering context, Astro may render the component tree
+ * Built without context, using some unusual patterns, to work around some restrictions with Astro islands: namely, that
+ * separate islands can't share context, and that, depending on rendering context, Astro may render the component tree
  * bottom-up or top-down
  *
- * IMPORTANT: Use `client:idle` instead of `client:visible` when hydrating
- * these components. TabsPanel elements start with `hidden` attribute,
- * which prevents them from triggering Intersection Observer visibility,
- * causing `client:visible` to never hydrate non-initial panels.
+ * IMPORTANT: Use `client:idle` instead of `client:visible` when hydrating these components. TabsPanel elements start
+ * with `hidden` attribute, which prevents them from triggering Intersection Observer visibility, causing
+ * `client:visible` to never hydrate non-initial panels.
  */
 
 import clsx from 'clsx';
@@ -38,17 +35,15 @@ export function TabsRoot({ children, maxWidth = true, className, id: propId, var
   const isHydrated = useIsHydrated();
 
   /**
-   * When this component initializes,
-   * it generates an ID for itself, and then
-   * uses that ID to
-   * - set [role="tab"] ID
-   * - set [role="tab"][aria-controls]
-   * - set [role="tabpanel"] ID
-   * - set [role="tabpanel"][aria-labelledby]
+   * When this component initializes, it generates an ID for itself, and then uses that ID to
    *
-   * This allows tabs and tabpanels to be associated
-   * without relying on context or parent-child relationships,
-   * as well as complying with WAI-ARIA authoring practices.
+   * - Set [role="tab"] ID
+   * - Set [role="tab"][aria-controls]
+   * - Set [role="tabpanel"] ID
+   * - Set [role="tabpanel"][aria-labelledby]
+   *
+   * This allows tabs and tabpanels to be associated without relying on context or parent-child relationships, as well
+   * as complying with WAI-ARIA authoring practices.
    */
   useEffect(() => {
     // I know this isHydrated check looks weird,

--- a/site/src/components/docs/PreferenceSync.tsx
+++ b/site/src/components/docs/PreferenceSync.tsx
@@ -7,13 +7,11 @@ import { getFrameworkPreferenceClient, setFrameworkPreferenceClient } from '@/ut
 /**
  * PreferenceSync keeps the framework nanostore in sync with cookies.
  *
- * On mount: Reads cookies → initializes store
- * On store change: Writes to cookies
+ * On mount: Reads cookies → initializes store On store change: Writes to cookies
  *
  * Style preferences are handled via localStorage by StyleInit and PreferenceUpdater.
  *
- * This component should be loaded with client:idle in the base layout
- * to ensure preferences are available immediately.
+ * This component should be loaded with client:idle in the base layout to ensure preferences are available immediately.
  */
 export function PreferenceSync() {
   const framework = useStore(currentFramework);

--- a/site/src/components/docs/PreferenceUpdater.tsx
+++ b/site/src/components/docs/PreferenceUpdater.tsx
@@ -9,10 +9,9 @@ interface PreferenceUpdaterProps {
 }
 
 /**
- * PreferenceUpdater component updates the preference nanostore based on URL params and localStorage.
- * This component is loaded with client:idle directive on docs pages, making it non-blocking.
- * It updates the framework store from URL params and style store from localStorage.
- * PreferenceSync handles persisting framework to cookies.
+ * PreferenceUpdater component updates the preference nanostore based on URL params and localStorage. This component is
+ * loaded with client:idle directive on docs pages, making it non-blocking. It updates the framework store from URL
+ * params and style store from localStorage. PreferenceSync handles persisting framework to cookies.
  */
 export function PreferenceUpdater({ currentFramework }: PreferenceUpdaterProps) {
   useEffect(() => {

--- a/site/src/components/docs/TableOfContents/utils.ts
+++ b/site/src/components/docs/TableOfContents/utils.ts
@@ -11,9 +11,7 @@ export interface RailGeometry {
   gap: number;
 }
 
-/**
- * Keep the full heading map visible by reducing gaps first, then stripe height.
- */
+/** Keep the full heading map visible by reducing gaps first, then stripe height. */
 export function calculateRailGeometry(headingCount: number, availableHeight: number): RailGeometry {
   const stripeHeight = 2;
   const gap = 4;
@@ -40,9 +38,7 @@ export function calculateRailGeometry(headingCount: number, availableHeight: num
   };
 }
 
-/**
- * Find the first scrollable ancestor of an element
- */
+/** Find the first scrollable ancestor of an element */
 export function getScrollParent(element: HTMLElement): HTMLElement {
   let current: HTMLElement | null = element;
 
@@ -63,9 +59,7 @@ export function getScrollParent(element: HTMLElement): HTMLElement {
   return document.body;
 }
 
-/**
- * Check if an element is outside the visible bounds of its scroll container
- */
+/** Check if an element is outside the visible bounds of its scroll container */
 export function isElementOffscreen(element: HTMLElement, container: HTMLElement): boolean {
   const containerRect = container.getBoundingClientRect();
   const elementRect = element.getBoundingClientRect();
@@ -76,9 +70,7 @@ export function isElementOffscreen(element: HTMLElement, container: HTMLElement)
   return isAboveView || isBelowView;
 }
 
-/**
- * Include headings for docs TOC, including API-reference subsection H4s only.
- */
+/** Include headings for docs TOC, including API-reference subsection H4s only. */
 export function filterHeadingsForToc(headings: MarkdownHeading[]): MarkdownHeading[] {
   const apiReferenceSubsectionTitles = new Set(API_REFERENCE_SUBSECTION_TITLES);
   const isTocHeadingDepth = (depth: number): boolean => depth === 2 || depth === 3;
@@ -101,9 +93,7 @@ export function filterHeadingsForToc(headings: MarkdownHeading[]): MarkdownHeadi
   });
 }
 
-/**
- * Navigate to a heading by scrolling it into view and updating the URL
- */
+/** Navigate to a heading by scrolling it into view and updating the URL */
 export function navigateToHeading(slug: string): void {
   const element = document.getElementById(slug);
 
@@ -118,9 +108,7 @@ interface UseAutoScrollOptions {
   containerRef: RefObject<HTMLElement | null>;
 }
 
-/**
- * Auto-scrolls the active link into view when it becomes active and is offscreen
- */
+/** Auto-scrolls the active link into view when it becomes active and is offscreen */
 export function useAutoScroll({ activeId, containerRef }: UseAutoScrollOptions) {
   useEffect(() => {
     if (!activeId || !containerRef.current) return;
@@ -142,9 +130,7 @@ export function useAutoScroll({ activeId, containerRef }: UseAutoScrollOptions) 
   }, [activeId, containerRef]);
 }
 
-/**
- * Tracks which heading is currently active based on scroll position
- */
+/** Tracks which heading is currently active based on scroll position */
 export function useActiveHeading(headings: MarkdownHeading[]): string {
   const [activeId, setActiveId] = useState<string>('');
 

--- a/site/src/components/installation/MuxUploaderPanel.tsx
+++ b/site/src/components/installation/MuxUploaderPanel.tsx
@@ -20,13 +20,9 @@ import UploaderOverlay from './UploaderOverlay';
 /**
  * Mux video uploader with auth-gated flow.
  *
- * Flow:
- * 1. User drops/selects file → endpoint() called
- * 2. Try to create upload URL (requires auth)
- * 3. If 401: show login overlay, wait for auth, retry
- * 4. Upload begins with returned URL
- * 5. On success: poll for playback ID
- * 6. When ready: update renderer to 'hls', store playback ID in nanostore
+ * Flow: 1. User drops/selects file → endpoint() called 2. Try to create upload URL (requires auth) 3. If 401: show
+ * login overlay, wait for auth, retry 4. Upload begins with returned URL 5. On success: poll for playback ID 6. When
+ * ready: update renderer to 'hls', store playback ID in nanostore
  */
 export default function MuxUploaderPanel() {
   // Local state for upload flow (not shared across islands)
@@ -42,8 +38,7 @@ export default function MuxUploaderPanel() {
   const uploaderRef = useRef<HTMLElement>(null);
 
   /**
-   * Endpoint function called by MuxUploader when file is selected.
-   * Returns a Promise that resolves with the upload URL.
+   * Endpoint function called by MuxUploader when file is selected. Returns a Promise that resolves with the upload URL.
    * The upload waits for this Promise before starting.
    */
   const getEndpoint = useCallback(async (): Promise<string> => {
@@ -73,10 +68,7 @@ export default function MuxUploaderPanel() {
     return result.data.uploadUrl;
   }, []);
 
-  /**
-   * Handles OAuth login via popup.
-   * On success: fetches upload URL and resolves the pending Promise.
-   */
+  /** Handles OAuth login via popup. On success: fetches upload URL and resolves the pending Promise. */
   const handleLogin = useCallback(async () => {
     const result = await actions.auth.initiateLogin();
 
@@ -112,10 +104,7 @@ export default function MuxUploaderPanel() {
     });
   }, []);
 
-  /**
-   * Polls Mux API for playback ID after upload completes.
-   * Updates renderer to 'mux' and stores playback ID on success.
-   */
+  /** Polls Mux API for playback ID after upload completes. Updates renderer to 'mux' and stores playback ID on success. */
   const handleUploadSuccess = useCallback(async () => {
     if (!uploadId) return;
 

--- a/site/src/components/installation/UploaderOverlay.tsx
+++ b/site/src/components/installation/UploaderOverlay.tsx
@@ -30,10 +30,11 @@ function OverlayWrapper({ children, className }: { children: React.ReactNode; cl
 
 /**
  * Renders state-based overlays on top of MuxUploader.
- * - needs_login: Login prompt
- * - preparing: Spinner while polling for playback ID
- * - ready: Success message with playback ID
- * - polling_error: Error during post-upload processing (MuxUploader handles upload errors natively)
+ *
+ * - Needs_login: Login prompt
+ * - Preparing: Spinner while polling for playback ID
+ * - Ready: Success message with playback ID
+ * - Polling_error: Error during post-upload processing (MuxUploader handles upload errors natively)
  */
 export default function UploaderOverlay({ state, error, playbackId, onLogin, onRetry }: UploaderOverlayProps) {
   // No overlay needed for idle or uploading (MuxUploader handles its own UI)

--- a/site/src/components/typography/styles.ts
+++ b/site/src/components/typography/styles.ts
@@ -1,9 +1,8 @@
 /**
  * Shared Tailwind class strings for typography elements.
  *
- * Used by both the Astro typography components and `renderInlineMarkdown`
- * so styling stays in sync across server-rendered MDX and programmatic
- * HTML generation.
+ * Used by both the Astro typography components and `renderInlineMarkdown` so styling stays in sync across
+ * server-rendered MDX and programmatic HTML generation.
  */
 export const shared = {
   a: 'underline intent:decoration-gold',

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -12,8 +12,8 @@ import { defaultGitService } from './utils/gitService';
 import { globWithParser } from './utils/globWithParser';
 
 /**
- * Extract date from filename in format: YYYY-MM-DD-slug.mdx
- * Throws an error if the filename doesn't match the expected pattern
+ * Extract date from filename in format: YYYY-MM-DD-slug.mdx Throws an error if the filename doesn't match the expected
+ * pattern
  */
 export function extractDateFromFilename(id: string): Date {
   const match = id.match(/^(\d{4})-(\d{2})-(\d{2})-/);

--- a/site/src/middleware/index.ts
+++ b/site/src/middleware/index.ts
@@ -32,17 +32,12 @@ function isGated(actionName: string | undefined) {
 /**
  * Middleware to validate and refresh user sessions on every request
  *
- * Flow:
- * 1. Checks for session cookie and decrypts it
- * 2. Verifies access token validity using JWKS
- * 3. If expired, refreshes the token automatically
- * 4. Validates ID token and extracts user information
- * 5. Populates context.locals with user data and access token
+ * Flow: 1. Checks for session cookie and decrypts it 2. Verifies access token validity using JWKS 3. If expired,
+ * refreshes the token automatically 4. Validates ID token and extracts user information 5. Populates context.locals
+ * with user data and access token
  *
- * Security notes:
- * - Access tokens are verified against the OAuth server's JWKS
- * - Expired or invalid sessions are automatically cleared
- * - Access tokens SHOULD only be available server-side (context.locals)
+ * Security notes: - Access tokens are verified against the OAuth server's JWKS - Expired or invalid sessions are
+ * automatically cleared - Access tokens SHOULD only be available server-side (context.locals)
  */
 export const onRequest = defineMiddleware(async (context, next) => {
   // Middleware runs during build AND runtime. We only care about running this at runtime.

--- a/site/src/pages/api/auth/callback.ts
+++ b/site/src/pages/api/auth/callback.ts
@@ -9,11 +9,8 @@ export const prerender = false;
 /**
  * OAuth 2.0 callback endpoint - handles the redirect from the authorization server
  *
- * Flow:
- * 1. Validates the state parameter to prevent CSRF attacks
- * 2. Exchanges the authorization code for access & refresh tokens
- * 3. Encrypts and stores tokens in a secure HTTP-only cookie
- * 4. Redirects to success or error page
+ * Flow: 1. Validates the state parameter to prevent CSRF attacks 2. Exchanges the authorization code for access &
+ * refresh tokens 3. Encrypts and stores tokens in a secure HTTP-only cookie 4. Redirects to success or error page
  */
 export const GET: APIRoute = async ({ request, cookies, redirect }) => {
   const url = new URL(request.url);

--- a/site/src/stores/preferences.ts
+++ b/site/src/stores/preferences.ts
@@ -3,10 +3,9 @@ import { atom } from 'nanostores';
 import type { AnySupportedStyle, SupportedFramework } from '@/types/docs';
 
 /**
- * Nanostore atoms for current framework and style preferences.
- * Framework preference is kept in sync with cookies by PreferenceSync.
- * Style preference is read from localStorage and synced to DOM data-style.
- * All React components should read from these stores for reactive updates.
+ * Nanostore atoms for current framework and style preferences. Framework preference is kept in sync with cookies by
+ * PreferenceSync. Style preference is read from localStorage and synced to DOM data-style. All React components should
+ * read from these stores for reactive updates.
  */
 export const currentFramework = atom<SupportedFramework | null>(null);
 export const currentStyle = atom<AnySupportedStyle | null>(null);

--- a/site/src/stores/tabs.ts
+++ b/site/src/stores/tabs.ts
@@ -1,7 +1,4 @@
 import { map } from 'nanostores';
 
-/**
- * Store for managing tabs state across Astro islands.
- * Maps tabs ID to currently active tab value.
- */
+/** Store for managing tabs state across Astro islands. Maps tabs ID to currently active tab value. */
 export const $tabs = map<Record<string, string>>({});

--- a/site/src/types/component-reference.ts
+++ b/site/src/types/component-reference.ts
@@ -1,8 +1,8 @@
 /**
  * Zod schemas for API reference JSON files.
  *
- * This is the single source of truth for the shape of generated API reference data.
- * Both the builder (scripts/api-docs-builder) and Astro components import from here.
+ * This is the single source of truth for the shape of generated API reference data. Both the builder
+ * (scripts/api-docs-builder) and Astro components import from here.
  */
 import { z } from 'astro/zod';
 

--- a/site/src/types/docs.ts
+++ b/site/src/types/docs.ts
@@ -77,9 +77,7 @@ export type SidebarItem = Guide | Section | SidebarLink;
 
 export type Sidebar = Array<SidebarItem>;
 
-/**
- * Type guard to check if an item is a Section (vs a Guide or SidebarLink)
- */
+/** Type guard to check if an item is a Section (vs a Guide or SidebarLink) */
 export function isSection(item: SidebarItem): item is Section {
   return 'contents' in item;
 }

--- a/site/src/types/feature-reference.ts
+++ b/site/src/types/feature-reference.ts
@@ -1,12 +1,10 @@
 /**
  * Zod schemas for feature API reference JSON files.
  *
- * FeatureStateDef and FeatureActionDef reuse StateDefSchema (identical shape)
- * from component-reference.ts, following the same pattern as util-reference.ts.
- * FeatureConfigDef reuses PropDefSchema for the same reason: a config input is
- * rendered as a provider prop. Its HTML attribute name is derived from the key,
- * unless the feature declares one, which it does when the derived name would
- * collide with a global attribute.
+ * FeatureStateDef and FeatureActionDef reuse StateDefSchema (identical shape) from component-reference.ts, following
+ * the same pattern as util-reference.ts. FeatureConfigDef reuses PropDefSchema for the same reason: a config input is
+ * rendered as a provider prop. Its HTML attribute name is derived from the key, unless the feature declares one, which
+ * it does when the derived name would collide with a global attribute.
  */
 import { z } from 'astro/zod';
 

--- a/site/src/types/preset-reference.ts
+++ b/site/src/types/preset-reference.ts
@@ -1,6 +1,4 @@
-/**
- * Zod schemas for preset API reference JSON files.
- */
+/** Zod schemas for preset API reference JSON files. */
 import { z } from 'astro/zod';
 
 export const PresetSkinDefSchema = z.object({

--- a/site/src/types/util-reference.ts
+++ b/site/src/types/util-reference.ts
@@ -1,8 +1,8 @@
 /**
  * Zod schemas for util API reference JSON files (hooks, controllers, mixins, etc.).
  *
- * ParamDef reuses PropDefSchema (identical shape) from component-reference.ts.
- * ReturnFieldDef reuses StateDefSchema (identical shape).
+ * ParamDef reuses PropDefSchema (identical shape) from component-reference.ts. ReturnFieldDef reuses StateDefSchema
+ * (identical shape).
  */
 import { z } from 'astro/zod';
 

--- a/site/src/utils/api-reference-overrides.ts
+++ b/site/src/utils/api-reference-overrides.ts
@@ -1,13 +1,11 @@
 import { kebabCase } from 'es-toolkit/string';
 
 /**
- * Reference entries whose PascalCase name doesn't match a simple
- * kebab-to-pascal conversion. Keyed by generated-reference file slug (a
- * component's kebab directory name or a media element's tag name) →
- * PascalCase name.
+ * Reference entries whose PascalCase name doesn't match a simple kebab-to-pascal conversion. Keyed by
+ * generated-reference file slug (a component's kebab directory name or a media element's tag name) → PascalCase name.
  *
- * Consumed by the api-docs-builder for component generation, and inverted
- * below so reference pages can resolve a file slug from the public name.
+ * Consumed by the api-docs-builder for component generation, and inverted below so reference pages can resolve a file
+ * slug from the public name.
  */
 export const NAME_OVERRIDES: Record<string, string> = {
   'pip-button': 'PiPButton',

--- a/site/src/utils/auth.ts
+++ b/site/src/utils/auth.ts
@@ -36,6 +36,7 @@ export const SESSION_COOKIE_NAME = 'session';
 
 /**
  * Refresh an expired access token using a refresh token
+ *
  * @throws {Error} If token refresh fails
  */
 export async function refreshToken(refreshToken: string): Promise<OAuthResponse> {
@@ -63,6 +64,7 @@ export async function refreshToken(refreshToken: string): Promise<OAuthResponse>
 
 /**
  * Exchange an authorization code for access tokens
+ *
  * @throws {Error} If token exchange fails
  */
 export async function exchangeAuthorizationCode(code: string): Promise<OAuthResponse> {
@@ -88,9 +90,7 @@ export async function exchangeAuthorizationCode(code: string): Promise<OAuthResp
   return response.json();
 }
 
-/**
- *  JSON Web Key Set for verifying JWT tokens - lazily initialized
- */
+/** JSON Web Key Set for verifying JWT tokens - lazily initialized */
 let _jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
 
 export function getJWKS() {
@@ -105,9 +105,7 @@ export function getJWKS() {
 // Session Encryption
 // =============================================================================
 
-/**
- * Decrypt and unseal session data from an encrypted cookie value
- */
+/** Decrypt and unseal session data from an encrypted cookie value */
 export async function unseal<T>(cookieValue: string): Promise<T> {
   if (!SESSION_COOKIE_PASSWORD) throw new Error('SESSION_COOKIE_PASSWORD required');
 
@@ -116,9 +114,7 @@ export async function unseal<T>(cookieValue: string): Promise<T> {
   });
 }
 
-/**
- * Encrypt and seal session data for secure cookie storage
- */
+/** Encrypt and seal session data for secure cookie storage */
 export async function seal<T>(data: T): Promise<string> {
   if (!SESSION_COOKIE_PASSWORD) throw new Error('SESSION_COOKIE_PASSWORD required');
 

--- a/site/src/utils/docs/preferences.ts
+++ b/site/src/utils/docs/preferences.ts
@@ -13,9 +13,7 @@ export const STYLE_STORAGE_KEY_PREFIX = 'vjs_docs_style_';
 const COOKIE_MAX_AGE = 31536000; // 1 year in seconds
 const COOKIE_OPTIONS = `max-age=${COOKIE_MAX_AGE}; path=/; samesite=lax`;
 
-/**
- * Server-side API: Works with Astro.cookies
- */
+/** Server-side API: Works with Astro.cookies */
 
 interface NoPreference {
   framework: null;
@@ -33,9 +31,7 @@ export function getPreferencesServer(cookies: AstroCookies): Preference {
   return { framework } as Preference;
 }
 
-/**
- * Client-side API: Works with document.cookie and localStorage
- */
+/** Client-side API: Works with document.cookie and localStorage */
 
 export function getFrameworkPreferenceClient(): SupportedFramework | null {
   if (typeof document === 'undefined') return null;
@@ -64,9 +60,7 @@ export function setFrameworkPreferenceClient(framework: SupportedFramework): voi
   document.cookie = `${FRAMEWORK_COOKIE}=${framework}; ${COOKIE_OPTIONS}`;
 }
 
-/**
- * Get style preference from localStorage for a specific framework
- */
+/** Get style preference from localStorage for a specific framework */
 export function getStylePreferenceClient<F extends SupportedFramework>(framework: F): SupportedStyle<F> | null {
   if (typeof localStorage === 'undefined') return null;
 
@@ -80,9 +74,7 @@ export function getStylePreferenceClient<F extends SupportedFramework>(framework
   return null;
 }
 
-/**
- * Set style preference in localStorage for a specific framework
- */
+/** Set style preference in localStorage for a specific framework */
 export function setStylePreferenceClient<F extends SupportedFramework>(framework: F, style: SupportedStyle<F>): void {
   if (typeof localStorage === 'undefined') return;
 
@@ -95,9 +87,7 @@ export function setStylePreferenceClient<F extends SupportedFramework>(framework
   localStorage.setItem(storageKey, style);
 }
 
-/**
- * Update the DOM data-style attribute to match the current style
- */
+/** Update the DOM data-style attribute to match the current style */
 export function updateStyleAttribute(style: AnySupportedStyle): void {
   if (typeof document === 'undefined') return;
 

--- a/site/src/utils/docs/renderInlineMarkdown.ts
+++ b/site/src/utils/docs/renderInlineMarkdown.ts
@@ -99,8 +99,8 @@ const marked = new Marked({ renderer });
 /**
  * Unwrap a single `<p>` wrapper so simple descriptions sit inline.
  *
- * If the output is a lone `<p class="…">…</p>` with no other block-level
- * elements, strip the wrapper and return only the inner content.
+ * If the output is a lone `<p class="…">…</p>` with no other block-level elements, strip the wrapper and return only
+ * the inner content.
  */
 function unwrapSingleParagraph(html: string): string {
   const trimmed = html.trim();

--- a/site/src/utils/docs/routing.ts
+++ b/site/src/utils/docs/routing.ts
@@ -4,16 +4,12 @@ import { DEFAULT_FRAMEWORK, isValidFramework } from '@/types/docs';
 
 import { findFirstGuide, findGuideBySlug, getValidFrameworksForGuide } from './sidebar';
 
-/**
- * Build a docs URL from framework and guide slug components.
- */
+/** Build a docs URL from framework and guide slug components. */
 export function buildDocsUrl(framework: SupportedFramework, guideSlug: string): string {
   return `/docs/framework/${framework}/${guideSlug}`;
 }
 
-/**
- * Input for resolveIndexRedirect
- */
+/** Input for resolveIndexRedirect */
 export interface IndexRedirectInput {
   preferences: {
     framework: string | null;
@@ -23,9 +19,7 @@ export interface IndexRedirectInput {
   };
 }
 
-/**
- * Output from resolveIndexRedirect
- */
+/** Output from resolveIndexRedirect */
 export interface IndexRedirectResult {
   url: string;
   selectedFramework: SupportedFramework;
@@ -34,12 +28,10 @@ export interface IndexRedirectResult {
 }
 
 /**
- * Resolve redirect for index pages (/docs, /docs/framework/X).
- * Nothing is pinned - we must select framework AND slug.
+ * Resolve redirect for index pages (/docs, /docs/framework/X). Nothing is pinned - we must select framework AND slug.
  *
- * Logic:
- * 1. If params.framework → validate → find first guide
- * 2. If no param → get from preferences or defaults → find first guide
+ * Logic: 1. If params.framework → validate → find first guide 2. If no param → get from preferences or defaults → find
+ * first guide
  *
  * @param input - The input containing preferences and params
  * @param sidebar - Optional sidebar to search (defaults to main sidebar config)
@@ -85,18 +77,14 @@ export function resolveIndexRedirect(
   };
 }
 
-/**
- * Input for resolveFrameworkChange
- */
+/** Input for resolveFrameworkChange */
 export interface FrameworkChangeInput {
   currentFramework: SupportedFramework;
   currentSlug: string;
   newFramework: SupportedFramework;
 }
 
-/**
- * Output from resolveFrameworkChange
- */
+/** Output from resolveFrameworkChange */
 export interface FrameworkChangeResult {
   url: string;
   shouldReplace: boolean;
@@ -107,13 +95,10 @@ export interface FrameworkChangeResult {
 }
 
 /**
- * Resolve URL when user changes framework selector.
- * newFramework is PINNED (must keep), slug MAY change if not visible.
+ * Resolve URL when user changes framework selector. newFramework is PINNED (must keep), slug MAY change if not visible.
  *
- * Logic:
- * 1. framework = newFramework (PINNED)
- * 2. If currentSlug visible in newFramework → slug = currentSlug, shouldReplace = true
- *    Else → slug = first guide in newFramework, shouldReplace = false
+ * Logic: 1. framework = newFramework (PINNED) 2. If currentSlug visible in newFramework → slug = currentSlug,
+ * shouldReplace = true Else → slug = first guide in newFramework, shouldReplace = false
  *
  * @param input - The input containing current state and new framework
  * @param sidebar - Optional sidebar to search (defaults to main sidebar config)
@@ -165,17 +150,13 @@ export function resolveFrameworkChange(
   };
 }
 
-/**
- * Input for resolveDocsLinkUrl
- */
+/** Input for resolveDocsLinkUrl */
 export interface DocsLinkInput {
   targetSlug: string;
   contextFramework: SupportedFramework;
 }
 
-/**
- * Output from resolveDocsLinkUrl
- */
+/** Output from resolveDocsLinkUrl */
 export interface DocsLinkResult {
   url: string;
   selectedFramework: SupportedFramework;
@@ -185,14 +166,12 @@ export interface DocsLinkResult {
 }
 
 /**
- * Resolve the best URL for a guide slug link given current context.
- * targetSlug is PINNED (must keep), framework MAY change.
+ * Resolve the best URL for a guide slug link given current context. targetSlug is PINNED (must keep), framework MAY
+ * change.
  *
- * Logic (2-level priority cascade):
- * 1. slug = targetSlug (PINNED)
- * 2. Try to find best framework that supports targetSlug:
- *    - Priority 1: If targetSlug visible in contextFramework → use it (best UX)
- *    - Priority 2: Use guide's first valid framework
+ * Logic (2-level priority cascade): 1. slug = targetSlug (PINNED) 2. Try to find best framework that supports
+ * targetSlug: - Priority 1: If targetSlug visible in contextFramework → use it (best UX) - Priority 2: Use guide's
+ * first valid framework
  *
  * @param input - The input containing target slug and context
  * @param sidebar - Optional sidebar to search (defaults to main sidebar config)

--- a/site/src/utils/docs/sidebar.ts
+++ b/site/src/utils/docs/sidebar.ts
@@ -4,13 +4,13 @@ import { FRAMEWORK_STYLES, isLink, isSection } from '@/types/docs';
 import { sidebar } from '../../docs.config';
 
 /**
- * Check if an item (Guide or Section) should be shown based on framework.
- * If no frameworks are specified, the item is visible to all frameworks.
+ * Check if an item (Guide or Section) should be shown based on framework. If no frameworks are specified, the item is
+ * visible to all frameworks.
  *
  * @param item - The guide or section to check
  * @param framework - The currently selected framework
  * @param isDev - Whether in development mode (defaults to import.meta.env.DEV)
- * @returns true if the item should be visible
+ * @returns True if the item should be visible
  */
 export function isItemVisible(
   item: SidebarItem,
@@ -26,10 +26,8 @@ export function isItemVisible(
 }
 
 /**
- * Filter sidebar items based on selected framework.
- * Recursively filters sections and guides to only include
- * those that are visible for the given framework.
- * Removes empty sections after filtering.
+ * Filter sidebar items based on selected framework. Recursively filters sections and guides to only include those that
+ * are visible for the given framework. Removes empty sections after filtering.
  *
  * @param framework - The framework to filter for
  * @param sidebarToFilter - Optional sidebar to filter (defaults to main sidebar config)
@@ -68,11 +66,10 @@ export function filterSidebar(
 }
 
 /**
- * Find the first guide in the sidebar that matches the framework.
- * Recursively searches through sections and guides in order,
- * returning the slug of the first visible guide found.
- * A test validates that this function always returns a guide for any valid framework,
- * since the sidebar always includes at least one guide that has no framework restrictions.
+ * Find the first guide in the sidebar that matches the framework. Recursively searches through sections and guides in
+ * order, returning the slug of the first visible guide found. A test validates that this function always returns a
+ * guide for any valid framework, since the sidebar always includes at least one guide that has no framework
+ * restrictions.
  *
  * @param framework - The framework to match
  * @param sidebarToSearch - Optional sidebar to search (defaults to main sidebar config)
@@ -108,10 +105,9 @@ export function findFirstGuide(
 }
 
 /**
- * Get all guide slugs from a sidebar (recursively).
- * This function extracts ALL slugs from the provided sidebar structure,
- * including those in nested sections. It does not perform any filtering.
- * Typically used with an already-filtered sidebar to get allowed slugs.
+ * Get all guide slugs from a sidebar (recursively). This function extracts ALL slugs from the provided sidebar
+ * structure, including those in nested sections. It does not perform any filtering. Typically used with an
+ * already-filtered sidebar to get allowed slugs.
  *
  * @param sidebarToExtract - Optional sidebar to extract from (defaults to main sidebar config)
  * @returns An array of all guide slugs found in the sidebar
@@ -156,10 +152,9 @@ export function findGuideBySlug(slug: string, sidebarToSearch: Sidebar = sidebar
 }
 
 /**
- * Get the ancestor section labels for a guide by its slug.
- * Returns an array of sidebarLabel strings for all ancestor sections,
- * in order from outermost to innermost. If the guide has no ancestors
- * (i.e., it's at the top level) or if the guide is not found, returns an empty array.
+ * Get the ancestor section labels for a guide by its slug. Returns an array of sidebarLabel strings for all ancestor
+ * sections, in order from outermost to innermost. If the guide has no ancestors (i.e., it's at the top level) or if the
+ * guide is not found, returns an empty array.
  *
  * @param slug - The slug of the guide to find
  * @param sidebarToSearch - Optional sidebar to search (defaults to main sidebar config)
@@ -186,9 +181,9 @@ export function getSectionsForGuide(slug: string, sidebarToSearch: Sidebar = sid
 }
 
 /**
- * Get all valid frameworks for a guide, accounting for ancestor section restrictions.
- * Walks the sidebar tree to find the guide and intersects `frameworks` from every
- * ancestor section along the path, then applies the guide's own restriction on top.
+ * Get all valid frameworks for a guide, accounting for ancestor section restrictions. Walks the sidebar tree to find
+ * the guide and intersects `frameworks` from every ancestor section along the path, then applies the guide's own
+ * restriction on top.
  */
 export function getValidFrameworksForGuide(guide: Guide, sidebarToSearch: Sidebar = sidebar): SupportedFramework[] {
   const allFrameworks = Object.keys(FRAMEWORK_STYLES) as SupportedFramework[];
@@ -212,8 +207,8 @@ export function getValidFrameworksForGuide(guide: Guide, sidebarToSearch: Sideba
 }
 
 /**
- * Get the previous and next guides for a given guide slug.
- * Returns the adjacent guides in the filtered sidebar for the given framework.
+ * Get the previous and next guides for a given guide slug. Returns the adjacent guides in the filtered sidebar for the
+ * given framework.
  *
  * @param currentSlug - The slug of the current guide
  * @param framework - The framework to filter for

--- a/site/src/utils/docs/title.ts
+++ b/site/src/utils/docs/title.ts
@@ -3,8 +3,8 @@ import type { CollectionEntry } from 'astro:content';
 import type { SupportedFramework } from '@/types/docs';
 
 /**
- * Get the title for a document, using framework-specific title if available,
- * otherwise falling back to the default title.
+ * Get the title for a document, using framework-specific title if available, otherwise falling back to the default
+ * title.
  *
  * @param doc - The document from the docs collection
  * @param framework - The framework context (react or html)
@@ -18,8 +18,8 @@ const CAMEL_OR_PASCAL_CASE = /[a-z][A-Z]/;
 const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)+$/;
 
 /**
- * Detect whether a title is a code identifier that should preserve its casing
- * instead of being uppercased. Matches PascalCase, camelCase, and kebab-case.
+ * Detect whether a title is a code identifier that should preserve its casing instead of being uppercased. Matches
+ * PascalCase, camelCase, and kebab-case.
  */
 export function isCodeIdentifier(str: string): boolean {
   return CAMEL_OR_PASCAL_CASE.test(str) || KEBAB_CASE.test(str);

--- a/site/src/utils/featureReferenceModel.js
+++ b/site/src/utils/featureReferenceModel.js
@@ -1,17 +1,21 @@
 /**
  * Centralized feature API reference subsection definitions.
  *
- * Mirrors componentReferenceModel.js for feature APIs. Produces heading/id data
- * consumed by both FeatureReference.astro and satteriConditionalHeadings.
+ * Mirrors componentReferenceModel.js for feature APIs. Produces heading/id data consumed by both FeatureReference.astro
+ * and satteriConditionalHeadings.
  *
  * Structure:
- *   ## API Reference (H2)
- *   ### Configuration (H3) — if feature declares provider inputs
- *   ### State (H3) — if feature has state properties
- *   ### Actions (H3) — if feature has action methods
  *
- * Configuration leads, mirroring props-before-state in componentReferenceModel:
- * inputs first, then what the store publishes back.
+ * ## API Reference (H2)
+ *
+ * ### Configuration (H3) — if feature declares provider inputs
+ *
+ * ### State (H3) — if feature has state properties
+ *
+ * ### Actions (H3) — if feature has action methods
+ *
+ * Configuration leads, mirroring props-before-state in componentReferenceModel: inputs first, then what the store
+ * publishes back.
  */
 
 function hasEntries(value) {

--- a/site/src/utils/gitService.ts
+++ b/site/src/utils/gitService.ts
@@ -1,15 +1,11 @@
 import { simpleGit } from 'simple-git';
 
-/**
- * Git service interface for dependency injection (testability).
- */
+/** Git service interface for dependency injection (testability). */
 export interface GitService {
   getLastModifiedDate: (filePath: string) => Promise<Date | null>;
 }
 
-/**
- * Create a git service instance using simple-git.
- */
+/** Create a git service instance using simple-git. */
 export function createGitService(): GitService {
   const git = simpleGit();
 
@@ -28,7 +24,5 @@ export function createGitService(): GitService {
   };
 }
 
-/**
- * Default git service instance for production use.
- */
+/** Default git service instance for production use. */
 export const defaultGitService = createGitService();

--- a/site/src/utils/globWithParser.ts
+++ b/site/src/utils/globWithParser.ts
@@ -2,8 +2,8 @@ import type { ParseDataOptions } from 'astro/loaders';
 import { glob } from 'astro/loaders';
 
 /**
- * Parser function that runs before Astro's schema validation.
- * Receives the entry and the original filename (before generateId transforms it).
+ * Parser function that runs before Astro's schema validation. Receives the entry and the original filename (before
+ * generateId transforms it).
  */
 type Parser = <TData extends Record<string, unknown>>(
   options: ParseDataOptions<TData>,
@@ -15,33 +15,32 @@ type GlobWithParserOptions = Parameters<typeof glob>[0] & {
 };
 
 /**
- * Wraps Astro's glob loader to provide a parser function that has access to both
- * the transformed entry and the original filename.
+ * Wraps Astro's glob loader to provide a parser function that has access to both the transformed entry and the original
+ * filename.
  *
- * This is useful when using generateId to transform entry IDs (e.g., for clean URLs)
- * but still needing the original filename to extract metadata (e.g., dates from filenames).
+ * This is useful when using generateId to transform entry IDs (e.g., for clean URLs) but still needing the original
+ * filename to extract metadata (e.g., dates from filenames).
  *
  * @example
- * ```ts
- * loader: globWithParser({
- *   base: './src/content/blog',
- *   pattern: '**\/*.mdx',
- *   generateId: ({ entry }) => entry.replace(/^\d{4}-\d{2}-\d{2}-/, ''),
- *   parser: async (entry, originalEntry) => {
- *     // entry.id = "my-post", originalEntry = "2024-01-01-my-post.mdx"
- *     const date = extractDateFromFilename(originalEntry);
- *     entry.data.pubDate = date;
- *     return entry;
- *   }
- * })
- * ```
+ *   ```ts
+ *   loader: globWithParser({
+ *     base: './src/content/blog',
+ *     pattern: '**\/*.mdx',
+ *     generateId: ({ entry }) => entry.replace(/^\d{4}-\d{2}-\d{2}-/, ''),
+ *     parser: async (entry, originalEntry) => {
+ *       // entry.id = "my-post", originalEntry = "2024-01-01-my-post.mdx"
+ *       const date = extractDateFromFilename(originalEntry);
+ *       entry.data.pubDate = date;
+ *       return entry;
+ *     },
+ *   });
+ *   ```;
  */
 export function globWithParser({ parser, generateId, ...globOptions }: GlobWithParserOptions) {
   /**
-   * Store mapping of transformed IDs to original entry filenames.
-   * Created per-invocation to avoid memory leaks across builds.
-   * This is needed because generateId transforms the entry name (e.g., removes date prefix),
-   * but we need access to the original filename in the parser (e.g., to extract date from filename).
+   * Store mapping of transformed IDs to original entry filenames. Created per-invocation to avoid memory leaks across
+   * builds. This is needed because generateId transforms the entry name (e.g., removes date prefix), but we need access
+   * to the original filename in the parser (e.g., to extract date from filename).
    */
   const entryMap = new Map<string, string>();
 

--- a/site/src/utils/installation/types.ts
+++ b/site/src/utils/installation/types.ts
@@ -1,9 +1,8 @@
 /**
  * Every media renderer the installation flow can offer.
  *
- * Listed alphabetically; the order a picker shows comes from each preset's
- * `renderers`, not from here. Exported so callers can walk the full set — see
- * `renderersWithoutCdn` in `./cdn-code`.
+ * Listed alphabetically; the order a picker shows comes from each preset's `renderers`, not from here. Exported so
+ * callers can walk the full set — see `renderersWithoutCdn` in `./cdn-code`.
  */
 export const RENDERERS = [
   'background-video',
@@ -41,9 +40,8 @@ export interface InstallationPreset {
 /**
  * Installation presets in the order shown by the site and CLI.
  *
- * Renderer order is also guidance: index 0 is the default when URL detection
- * has no match. Live presets include only media that exposes Video.js live-edge
- * state; DASH playback does not currently provide that capability.
+ * Renderer order is also guidance: index 0 is the default when URL detection has no match. Live presets include only
+ * media that exposes Video.js live-edge state; DASH playback does not currently provide that capability.
  */
 export const INSTALLATION_PRESETS = {
   'default-video': {

--- a/site/src/utils/jsonLd/schemas.ts
+++ b/site/src/utils/jsonLd/schemas.ts
@@ -1,16 +1,13 @@
 /**
  * JSON-LD Schema Helpers
  *
- * Centralized functions for generating Schema.org JSON-LD structured data.
- * Uses schema-dts for type safety.
+ * Centralized functions for generating Schema.org JSON-LD structured data. Uses schema-dts for type safety.
  */
 
 import type { CollectionEntry } from 'astro:content';
 import type { BlogPosting, CollectionPage, Person, ProfilePage, TechArticle, WithContext } from 'schema-dts';
 
-/**
- * Create a TechArticle schema for documentation pages.
- */
+/** Create a TechArticle schema for documentation pages. */
 export function createTechArticleSchema(params: {
   title: string;
   description: string;
@@ -50,9 +47,7 @@ export function createTechArticleSchema(params: {
   };
 }
 
-/**
- * Create a BlogPosting schema for individual blog posts.
- */
+/** Create a BlogPosting schema for individual blog posts. */
 export function createBlogPostingSchema(params: {
   title: string;
   description: string;
@@ -108,9 +103,7 @@ export function createBlogPostingSchema(params: {
   };
 }
 
-/**
- * Create a CollectionPage schema for the blog index page.
- */
+/** Create a CollectionPage schema for the blog index page. */
 export function createBlogCollectionSchema(params: {
   url: string;
   posts: CollectionEntry<'blog'>[];
@@ -140,9 +133,7 @@ export function createBlogCollectionSchema(params: {
   };
 }
 
-/**
- * Create a CollectionPage schema for the blog author index page.
- */
+/** Create a CollectionPage schema for the blog author index page. */
 export function createAuthorCollectionSchema(params: {
   url: string;
   authors: CollectionEntry<'authors'>[];
@@ -188,9 +179,7 @@ export function createAuthorCollectionSchema(params: {
   };
 }
 
-/**
- * Create a ProfilePage schema for individual author pages.
- */
+/** Create a ProfilePage schema for individual author pages. */
 export function createProfilePageSchema(params: {
   url: string;
   author: CollectionEntry<'authors'>;

--- a/site/src/utils/mediaReferenceModel.js
+++ b/site/src/utils/mediaReferenceModel.js
@@ -1,12 +1,8 @@
-/**
- * Centralized media API subsection definitions shared by the renderer and the
- * generated table of contents.
- */
+/** Centralized media API subsection definitions shared by the renderer and the generated table of contents. */
 
 /**
- * Options under `source.engine`, shared by both platforms: the structured source
- * has the same shape in HTML and React, so the section is defined once and
- * placed after the properties or props it extends.
+ * Options under `source.engine`, shared by both platforms: the structured source has the same shape in HTML and React,
+ * so the section is defined once and placed after the properties or props it extends.
  */
 const ENGINE_OPTIONS_SUBSECTION = Object.freeze({
   key: 'engineOptions',
@@ -89,9 +85,8 @@ function createSections(definitions, source, ref) {
 }
 
 /**
- * One entry per engine under `source.engine`, in the order the generator emitted
- * them. Ids are lowercased so `hlsJs` and `nativeHls` anchor predictably; titles
- * are the exact path a reader types.
+ * One entry per engine under `source.engine`, in the order the generator emitted them. Ids are lowercased so `hlsJs`
+ * and `nativeHls` anchor predictably; titles are the exact path a reader types.
  */
 function createEngines(ref) {
   return Object.keys(ref.engineOptions ?? {}).map((key) => ({

--- a/site/src/utils/mux/auth-flow.ts
+++ b/site/src/utils/mux/auth-flow.ts
@@ -1,10 +1,8 @@
 /**
  * OAuth popup and endpoint coordination utilities for Mux uploader.
  *
- * Handles:
- * - Opening OAuth popup with proper dimensions
- * - Listening for auth-complete message from popup
- * - Coordinating the endpoint flow that pauses for auth when needed
+ * Handles: - Opening OAuth popup with proper dimensions - Listening for auth-complete message from popup - Coordinating
+ * the endpoint flow that pauses for auth when needed
  */
 
 export interface AuthPopupOptions {
@@ -98,13 +96,10 @@ export interface EndpointCoordinator {
 /**
  * Creates a coordinator that handles the auth-gated endpoint flow.
  *
- * Flow:
- * 1. Call createUpload()
- * 2. If 401: pause, initiate login, wait for popup auth-complete, retry
- * 3. Return the upload URL
+ * Flow: 1. Call createUpload() 2. If 401: pause, initiate login, wait for popup auth-complete, retry 3. Return the
+ * upload URL
  *
- * The Promise resolver pattern allows getEndpoint() to pause mid-execution
- * and resume when auth completes.
+ * The Promise resolver pattern allows getEndpoint() to pause mid-execution and resume when auth completes.
  */
 export function createEndpointCoordinator(options: EndpointCoordinatorOptions): EndpointCoordinator {
   const { createUpload, initiateLogin, openAuthPopup, onStateChange } = options;

--- a/site/src/utils/mux/polling.ts
+++ b/site/src/utils/mux/polling.ts
@@ -2,6 +2,7 @@
  * Mux upload polling utilities.
  *
  * Handles the 2-phase polling flow after upload completes:
+ *
  * 1. Poll upload status until asset_id is available
  * 2. Poll asset status until playback_id is ready
  */
@@ -35,8 +36,7 @@ export type PollResult = { status: 'ready'; playbackId: string } | { status: 'er
 /**
  * Polls Mux API for playback ID after upload completes.
  *
- * Phase 1: Poll getUploadStatus until assetId is available
- * Phase 2: Poll getAssetStatus until playbackId is ready
+ * Phase 1: Poll getUploadStatus until assetId is available Phase 2: Poll getAssetStatus until playbackId is ready
  */
 export async function pollForPlaybackId(options: PollOptions): Promise<PollResult> {
   const { uploadId, getUploadStatus, getAssetStatus, interval = 2000, signal } = options;

--- a/site/src/utils/satteriAstroData.ts
+++ b/site/src/utils/satteriAstroData.ts
@@ -1,15 +1,14 @@
 import type { MdastPluginInstance } from 'satteri';
 
 /**
- * Sätteri doesn't export its visitor-context class, so derive it from a visitor
- * signature. Every visitor receives the same context object.
+ * Sätteri doesn't export its visitor-context class, so derive it from a visitor signature. Every visitor receives the
+ * same context object.
  */
 export type MdastVisitorContext = Parameters<NonNullable<MdastPluginInstance['heading']>>[1];
 
 /**
- * Shape of the document data bag `@astrojs/markdown-satteri` (and the MDX
- * integration's Sätteri path) seed before running plugins. Whatever a plugin
- * leaves on `astro.frontmatter` is surfaced to templates as
+ * Shape of the document data bag `@astrojs/markdown-satteri` (and the MDX integration's Sätteri path) seed before
+ * running plugins. Whatever a plugin leaves on `astro.frontmatter` is surfaced to templates as
  * `render().remarkPluginFrontmatter`.
  */
 interface AstroData {

--- a/site/src/utils/satteriCodeFrame.ts
+++ b/site/src/utils/satteriCodeFrame.ts
@@ -6,17 +6,15 @@ import type { MdastVisitorContext } from './satteriAstroData';
 const TITLE_RE = /title=(?:"([^"]+)"|'([^']+)'|([^\s"']+))/;
 
 /**
- * Wraps each standalone fenced code block in a `<CodeFrame>` component so it
- * renders with a filename/language header and a copy button.
+ * Wraps each standalone fenced code block in a `<CodeFrame>` component so it renders with a filename/language header
+ * and a copy button.
  *
- * This runs at the MDAST stage rather than as a `pre`/`code` component override
- * because Shiki rewrites each `<pre>` into raw HTML before any HAST plugin or
- * component override runs — wrapping the node here keeps a real component frame
+ * This runs at the MDAST stage rather than as a `pre`/`code` component override because Shiki rewrites each `<pre>`
+ * into raw HTML before any HAST plugin or component override runs — wrapping the node here keeps a real component frame
  * around the still-highlighted code.
  *
- * Code blocks already inside an authored `<TabsPanel>` are left untouched: the
- * tab group is their frame. The title comes from the fence meta
- * (e.g. ```ts title="App.ts"```).
+ * Code blocks already inside an authored `<TabsPanel>` are left untouched: the tab group is their frame. The title
+ * comes from the fence meta (e.g. `ts title="App.ts"`).
  */
 export function satteriCodeFrame() {
   return defineMdastPlugin({

--- a/site/src/utils/satteriConditionalHeadings.ts
+++ b/site/src/utils/satteriConditionalHeadings.ts
@@ -9,7 +9,6 @@ import { defineMdastPlugin } from 'satteri';
 
 // Astro evaluates this module while Vite+ is still loading the task graph, so
 // the built workspace package is not available yet.
-import { isString } from '../../../packages/utils/src/predicate/index.ts';
 import { resolveReferenceSlug } from './api-reference-overrides';
 import { buildComponentReferenceTocHeadings, createComponentReferenceModel } from './componentReferenceModel';
 import { buildFeatureReferenceTocHeadings, createFeatureReferenceModel } from './featureReferenceModel';
@@ -35,20 +34,16 @@ interface ConditionalHeading {
 /**
  * Builds the conditional-heading list used for the docs table of contents.
  *
- * - Tracks which `<FrameworkCase>` / `<StyleCase>` a heading lives in (walking
- *   ancestors) and attaches that context.
- * - Reads `<ComponentReference>` / `<FeatureReference>` / `<UtilReference>` /
- *   `<MediaReference>` props, loads the generated JSON, and injects heading
- *   entries so API-reference sections appear in the TOC.
+ * - Tracks which `<FrameworkCase>` / `<StyleCase>` a heading lives in (walking ancestors) and attaches that context.
+ * - Reads `<ComponentReference>` / `<FeatureReference>` / `<UtilReference>` / `<MediaReference>` props, loads the
+ *   generated JSON, and injects heading entries so API-reference sections appear in the TOC.
  *
- * Markdown headings are slugged with a plain GithubSlugger in document order so
- * the slugs match the element ids the markdown-satteri `heading-ids` plugin
- * generates (otherwise TOC anchors would not resolve). API-reference headings
+ * Markdown headings are slugged with a plain GithubSlugger in document order so the slugs match the element ids the
+ * markdown-satteri `heading-ids` plugin generates (otherwise TOC anchors would not resolve). API-reference headings
  * keep their model-generated slugs, which match the ids their components render.
  *
- * A factory resets the per-document slugger and heading list. Sätteri has no
- * end hook, so we publish the (mutated-in-place) array reference onto the
- * frontmatter once and keep pushing to it.
+ * A factory resets the per-document slugger and heading list. Sätteri has no end hook, so we publish the
+ * (mutated-in-place) array reference onto the frontmatter once and keep pushing to it.
  */
 export function satteriConditionalHeadings(): MdastPluginInput {
   return () => {

--- a/site/src/utils/satteriReadingTime.ts
+++ b/site/src/utils/satteriReadingTime.ts
@@ -5,13 +5,12 @@ import { defineMdastPlugin } from 'satteri';
 import { getAstroFrontmatter, type MdastVisitorContext } from './satteriAstroData';
 
 /**
- * Calculates reading time and injects it into the Astro frontmatter bag for
- * templates (read via `remarkPluginFrontmatter`).
+ * Calculates reading time and injects it into the Astro frontmatter bag for templates (read via
+ * `remarkPluginFrontmatter`).
  *
- * Returned as a factory so the text accumulator resets per document. Sätteri
- * has no end-of-document hook, so text is accumulated across literal nodes and
- * the reading time is recomputed as it grows; the final visit leaves the
- * correct value on the frontmatter.
+ * Returned as a factory so the text accumulator resets per document. Sätteri has no end-of-document hook, so text is
+ * accumulated across literal nodes and the reading time is recomputed as it grows; the final visit leaves the correct
+ * value on the frontmatter.
  */
 export function satteriReadingTime(): MdastPluginInput {
   return () => {

--- a/site/src/utils/shikiStripPreStyle.ts
+++ b/site/src/utils/shikiStripPreStyle.ts
@@ -1,15 +1,14 @@
 import type { ShikiTransformer } from 'shiki';
 
 /**
- * Strip the inline `style` Astro's Shiki highlighter writes onto the `<pre>`
- * (the theme `background-color`/`color` and a trailing `overflow-x: auto`).
+ * Strip the inline `style` Astro's Shiki highlighter writes onto the `<pre>` (the theme `background-color`/`color` and
+ * a trailing `overflow-x: auto`).
  *
- * Shiki should only highlight the text; the code container's background and
- * scrolling are owned by `CodeFrame` and the `.astro-code` rules. Token colors
- * live on the inner spans, while `.astro-code` supplies the plaintext color.
+ * Shiki should only highlight the text; the code container's background and scrolling are owned by `CodeFrame` and the
+ * `.astro-code` rules. Token colors live on the inner spans, while `.astro-code` supplies the plaintext color.
  *
- * Astro adds its built-in `pre` transformer before user transformers, so this
- * one runs last and sees the fully-assembled style to remove.
+ * Astro adds its built-in `pre` transformer before user transformers, so this one runs last and sees the
+ * fully-assembled style to remove.
  */
 export const shikiStripPreStyle: ShikiTransformer = {
   name: 'strip-pre-inline-style',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     arrowParens: 'always',
     bracketSpacing: true,
     ignorePatterns: ignoredPaths,
+    jsdoc: true,
     printWidth: 120,
     semi: true,
     singleQuote: true,


### PR DESCRIPTION
## Summary

Enable Oxfmt JSDoc formatting so documentation comments are normalized consistently by the existing Vite+ formatting workflow.

## Changes

- Enable the shared `fmt.jsdoc` option
- Apply the initial JSDoc normalization across the workspace
- Keep future JSDoc updates covered by `vp check --fix` and staged formatting

## Testing

- `pnpm lint:fix` (0 errors; existing warning-level lint findings remain)
- `pnpm exec vp fmt --check`
- `pnpm check:workspace`
- `pnpm build:packages`
- `git diff --check`

`pnpm typecheck` was also run after building packages, but the repository currently reports unrelated DOM/custom-element typing failures such as `TestHostElement` not satisfying `Node` and element constructors missing `HTMLElement` members.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and JSDoc-only normalization with no behavioral code changes.
> 
> **Overview**
> Turns on **Oxfmt JSDoc formatting** (`fmt.jsdoc`) and applies a repo-wide pass so block comments and JSDoc stay consistent with `vp check --fix` / staged formatting.
> 
> The diff is almost entirely **comment reflow and JSDoc layout** in e2e fixtures and specs, sandbox sources, build plugins/scripts, and `packages/core`, `element`, and `html`—long prose is rewrapped, `@example` blocks are re-indented, and a few doc conventions shift (e.g. emphasis `*…*` → `_…_`, `hls.js` → `Hls.js`). **No executable logic changes** appear in the touched files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e641638a163ffdd442368715786fda6b5daca65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->