### PR TITLE
fix(packages): harden volume popover interactions

### DIFF
--- a/packages/core/src/core/ui/volume-popover/data.ts
+++ b/packages/core/src/core/ui/volume-popover/data.ts
@@ -1,19 +1,17 @@
+import { PopoverDataAttrs } from '../popover/data';
 import type { StateAttrMap } from '../types';
 import type { VolumePopoverState } from './core';
 
-export const VolumePopoverDataAttrs = {
-  /** Present when the popover is open. */
-  open: 'data-open',
-  /** Indicates the rendered side after collision handling. */
-  side: 'data-side',
-  /** Indicates how the popup is aligned relative to its side. */
-  align: 'data-align',
-  /** Present during the open transition. */
-  transitionStarting: 'data-starting-style',
-  /** Present during the close transition. */
-  transitionEnding: 'data-ending-style',
+/** Volume-specific state applied by VolumePopover adapters. */
+export const VolumePopoverStateDataAttrs = {
   /** Indicates volume control availability (`available`, `unavailable`, or `unsupported`). */
   availability: 'data-availability',
   /** Present when volume level controls are unavailable. */
   hidden: 'data-hidden',
+} as const satisfies StateAttrMap<Pick<VolumePopoverState, 'availability' | 'hidden'>>;
+
+/** All public VolumePopover data attributes exposed to component transforms. */
+export const VolumePopoverDataAttrs = {
+  ...PopoverDataAttrs,
+  ...VolumePopoverStateDataAttrs,
 } as const satisfies StateAttrMap<VolumePopoverState>;

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -129,6 +129,10 @@ export class PopoverElement extends UIElement {
     return this.#currentTrigger;
   }
 
+  protected get triggerInteractionsEnabled(): boolean {
+    return true;
+  }
+
   protected override willUpdate(changed: PropertyValues): void {
     super.willUpdate(changed);
     this.#core.setProps(this);
@@ -154,8 +158,9 @@ export class PopoverElement extends UIElement {
 
     // Discover trigger via commandfor linkage.
     const triggerEl = this.#position.findTrigger();
+    const triggerInteractionsEnabled = this.triggerInteractionsEnabled;
 
-    this.#syncTrigger(triggerEl);
+    this.#syncTrigger(triggerEl, triggerInteractionsEnabled);
 
     // Derive state from core + input.
     const input = this.#popover.input.current;
@@ -177,7 +182,11 @@ export class PopoverElement extends UIElement {
 
     // Apply trigger ARIA to the discovered trigger.
     if (this.#currentTrigger) {
-      applyElementProps(this.#currentTrigger, this.#core.getTriggerAttrs(state, this.id));
+      if (triggerInteractionsEnabled) {
+        applyElementProps(this.#currentTrigger, this.#core.getTriggerAttrs(state, this.id));
+      } else {
+        this.#clearTriggerAttrs(this.#currentTrigger);
+      }
     }
 
     // Skip positioning when closed — no rects to measure.
@@ -198,31 +207,40 @@ export class PopoverElement extends UIElement {
 
   // --- Trigger management ---
 
-  #syncTrigger(triggerEl: HTMLElement | null): void {
-    if (triggerEl === this.#currentTrigger) return;
-
-    this.#position.cleanup();
-    this.#cleanupTrigger();
-    this.#currentTrigger = triggerEl;
-    this.#popover?.setTriggerElement(triggerEl);
-
-    if (triggerEl && this.#popover) {
-      this.#triggerAbort = new AbortController();
-      applyElementProps(triggerEl, this.#popover.triggerProps, { signal: this.#triggerAbort.signal });
+  #syncTrigger(triggerEl: HTMLElement | null, interactionsEnabled: boolean): void {
+    if (triggerEl !== this.#currentTrigger) {
+      this.#position.cleanup();
+      this.#cleanupTrigger();
+      this.#currentTrigger = triggerEl;
     }
-  }
 
-  #cleanupTrigger(): void {
-    if (this.#currentTrigger) {
-      applyElementProps(this.#currentTrigger, {
-        'aria-expanded': undefined,
-        'aria-haspopup': undefined,
-        'aria-controls': undefined,
-      });
-    }
+    const shouldAttach = interactionsEnabled && triggerEl !== null;
+    if (shouldAttach === (this.#triggerAbort !== null)) return;
 
     this.#triggerAbort?.abort();
     this.#triggerAbort = null;
+    this.#popover?.setTriggerElement(shouldAttach ? triggerEl : null);
+
+    if (!shouldAttach || !this.#popover) return;
+
+    this.#triggerAbort = new AbortController();
+    applyElementProps(triggerEl, this.#popover.triggerProps, { signal: this.#triggerAbort.signal });
+  }
+
+  #cleanupTrigger(): void {
+    if (this.#currentTrigger) this.#clearTriggerAttrs(this.#currentTrigger);
+
+    this.#triggerAbort?.abort();
+    this.#triggerAbort = null;
+    this.#popover?.setTriggerElement(null);
     this.#currentTrigger = null;
+  }
+
+  #clearTriggerAttrs(trigger: HTMLElement): void {
+    applyElementProps(trigger, {
+      'aria-expanded': undefined,
+      'aria-haspopup': undefined,
+      'aria-controls': undefined,
+    });
   }
 }

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -125,12 +125,9 @@ export class PopoverElement extends UIElement {
     this.#popover?.close(reason);
   }
 
-  protected get triggerElement(): HTMLElement | null {
-    return this.#currentTrigger;
-  }
-
-  protected get triggerInteractionsEnabled(): boolean {
-    return true;
+  protected disconnectTrigger(): void {
+    this.#position.cleanup();
+    this.#cleanupTrigger();
   }
 
   protected override willUpdate(changed: PropertyValues): void {
@@ -158,9 +155,8 @@ export class PopoverElement extends UIElement {
 
     // Discover trigger via commandfor linkage.
     const triggerEl = this.#position.findTrigger();
-    const triggerInteractionsEnabled = this.triggerInteractionsEnabled;
 
-    this.#syncTrigger(triggerEl, triggerInteractionsEnabled);
+    this.#syncTrigger(triggerEl);
 
     // Derive state from core + input.
     const input = this.#popover.input.current;
@@ -182,11 +178,7 @@ export class PopoverElement extends UIElement {
 
     // Apply trigger ARIA to the discovered trigger.
     if (this.#currentTrigger) {
-      if (triggerInteractionsEnabled) {
-        applyElementProps(this.#currentTrigger, this.#core.getTriggerAttrs(state, this.id));
-      } else {
-        this.#clearTriggerAttrs(this.#currentTrigger);
-      }
+      applyElementProps(this.#currentTrigger, this.#core.getTriggerAttrs(state, this.id));
     }
 
     // Skip positioning when closed — no rects to measure.
@@ -207,24 +199,18 @@ export class PopoverElement extends UIElement {
 
   // --- Trigger management ---
 
-  #syncTrigger(triggerEl: HTMLElement | null, interactionsEnabled: boolean): void {
-    if (triggerEl !== this.#currentTrigger) {
-      this.#position.cleanup();
-      this.#cleanupTrigger();
-      this.#currentTrigger = triggerEl;
+  #syncTrigger(triggerEl: HTMLElement | null): void {
+    if (triggerEl === this.#currentTrigger) return;
+
+    this.#position.cleanup();
+    this.#cleanupTrigger();
+    this.#currentTrigger = triggerEl;
+    this.#popover?.setTriggerElement(triggerEl);
+
+    if (triggerEl && this.#popover) {
+      this.#triggerAbort = new AbortController();
+      applyElementProps(triggerEl, this.#popover.triggerProps, { signal: this.#triggerAbort.signal });
     }
-
-    const shouldAttach = interactionsEnabled && triggerEl !== null;
-    if (shouldAttach === (this.#triggerAbort !== null)) return;
-
-    this.#triggerAbort?.abort();
-    this.#triggerAbort = null;
-    this.#popover?.setTriggerElement(shouldAttach ? triggerEl : null);
-
-    if (!shouldAttach || !this.#popover) return;
-
-    this.#triggerAbort = new AbortController();
-    applyElementProps(triggerEl, this.#popover.triggerProps, { signal: this.#triggerAbort.signal });
   }
 
   #cleanupTrigger(): void {

--- a/packages/html/src/ui/volume-popover/tests/volume-popover-element.test.ts
+++ b/packages/html/src/ui/volume-popover/tests/volume-popover-element.test.ts
@@ -45,7 +45,17 @@ function createPopover(): VolumePopoverElement {
   return document.createElement(tag) as VolumePopoverElement;
 }
 
+function createPlayerProvider(): TestPlayerProviderElement {
+  // SAFETY: The tag is registered to TestPlayerProviderElement above.
+  return document.createElement('test-volume-popover-player') as TestPlayerProviderElement;
+}
+
+function makeDOMRect(x: number, y: number, width: number, height: number): DOMRect {
+  return new DOMRect(x, y, width, height);
+}
+
 afterEach(() => {
+  vi.restoreAllMocks();
   document.body.innerHTML = '';
 });
 
@@ -59,7 +69,7 @@ describe('VolumePopoverElement', () => {
     ['unavailable', true],
     ['unsupported', true],
   ] as const)('reflects %s volume controls with hidden=%s', async (volumeAvailability, hidden) => {
-    const provider = document.createElement('test-volume-popover-player') as TestPlayerProviderElement;
+    const provider = createPlayerProvider();
 
     provider.store = createVolumeStore(volumeAvailability);
     const trigger = document.createElement('button');
@@ -76,5 +86,52 @@ describe('VolumePopoverElement', () => {
     expect(trigger.hasAttribute('aria-expanded')).toBe(!hidden);
     expect(trigger.hasAttribute('aria-haspopup')).toBe(!hidden);
     expect(trigger.hasAttribute('aria-controls')).toBe(!hidden);
+  });
+
+  it('does not attach popover interactions when volume controls are unavailable', async () => {
+    const provider = createPlayerProvider();
+
+    provider.store = createVolumeStore('unsupported');
+    const trigger = document.createElement('button');
+    const popover = createPopover();
+    const onOpenChange = vi.fn();
+
+    popover.addEventListener('open-change', onOpenChange);
+    document.body.append(provider);
+    provider.append(trigger, popover);
+    await popover.updateComplete;
+
+    trigger.click();
+    await popover.updateComplete;
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(popover.hasAttribute('data-open')).toBe(false);
+    expect(trigger.hasAttribute('aria-expanded')).toBe(false);
+    expect(trigger.hasAttribute('aria-haspopup')).toBe(false);
+    expect(trigger.hasAttribute('aria-controls')).toBe(false);
+  });
+
+  it('preserves the collision-adjusted side', async () => {
+    const provider = createPlayerProvider();
+    const trigger = document.createElement('button');
+    const popover = createPopover();
+
+    popover.id = 'volume-popover';
+    popover.open = true;
+    popover.side = 'top';
+    popover.boundary = 'viewport';
+    trigger.setAttribute('commandfor', popover.id);
+
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue(makeDOMRect(100, 10, 40, 20));
+    vi.spyOn(popover, 'getBoundingClientRect').mockReturnValue(makeDOMRect(0, 0, 100, 60));
+    vi.spyOn(document.documentElement, 'getBoundingClientRect').mockReturnValue(makeDOMRect(0, 0, 300, 200));
+    Object.defineProperty(popover, 'offsetWidth', { configurable: true, value: 100 });
+    Object.defineProperty(popover, 'offsetHeight', { configurable: true, value: 60 });
+
+    document.body.append(provider);
+    provider.append(trigger, popover);
+    await popover.updateComplete;
+
+    expect(popover.getAttribute('data-side')).toBe('bottom');
   });
 });

--- a/packages/html/src/ui/volume-popover/volume-popover-element.ts
+++ b/packages/html/src/ui/volume-popover/volume-popover-element.ts
@@ -1,4 +1,4 @@
-import { VolumePopoverCore, VolumePopoverDataAttrs } from '@videojs/core';
+import { VolumePopoverCore, VolumePopoverStateDataAttrs } from '@videojs/core';
 import { applyStateDataAttrs, selectVolume } from '@videojs/core/dom';
 import type { PropertyValues } from '@videojs/element';
 import type { MediaVolumeState } from '@videojs/media';
@@ -16,21 +16,12 @@ const unavailableVolume: MediaVolumeState = {
   toggleMuted: () => false,
 };
 
-const volumePopoverStateDataAttrs = {
-  availability: VolumePopoverDataAttrs.availability,
-  hidden: VolumePopoverDataAttrs.hidden,
-} as const;
-
 /** A volume-aware popover that keeps its adjacent mute trigger available as a fallback. */
 export class VolumePopoverElement extends PopoverElement {
   static override readonly tagName = 'media-volume-popover';
 
   readonly #core = new VolumePopoverCore();
   readonly #volume = new PlayerController(this, playerContext, selectVolume);
-
-  protected override get triggerInteractionsEnabled(): boolean {
-    return (this.#volume.value ?? unavailableVolume).volumeAvailability === 'available';
-  }
 
   protected override update(changed: PropertyValues): void {
     super.update(changed);
@@ -48,9 +39,12 @@ export class VolumePopoverElement extends PopoverElement {
 
     const state = this.#core.getState();
 
-    applyStateDataAttrs(this, state, volumePopoverStateDataAttrs);
+    applyStateDataAttrs(this, state, VolumePopoverStateDataAttrs);
     this.hidden = state.hidden;
 
-    if (state.hidden) this.close();
+    if (state.hidden) {
+      this.close();
+      this.disconnectTrigger();
+    }
   }
 }

--- a/packages/html/src/ui/volume-popover/volume-popover-element.ts
+++ b/packages/html/src/ui/volume-popover/volume-popover-element.ts
@@ -1,5 +1,5 @@
 import { VolumePopoverCore, VolumePopoverDataAttrs } from '@videojs/core';
-import { applyElementProps, applyStateDataAttrs, selectVolume } from '@videojs/core/dom';
+import { applyStateDataAttrs, selectVolume } from '@videojs/core/dom';
 import type { PropertyValues } from '@videojs/element';
 import type { MediaVolumeState } from '@videojs/media';
 
@@ -16,12 +16,21 @@ const unavailableVolume: MediaVolumeState = {
   toggleMuted: () => false,
 };
 
+const volumePopoverStateDataAttrs = {
+  availability: VolumePopoverDataAttrs.availability,
+  hidden: VolumePopoverDataAttrs.hidden,
+} as const;
+
 /** A volume-aware popover that keeps its adjacent mute trigger available as a fallback. */
 export class VolumePopoverElement extends PopoverElement {
   static override readonly tagName = 'media-volume-popover';
 
   readonly #core = new VolumePopoverCore();
   readonly #volume = new PlayerController(this, playerContext, selectVolume);
+
+  protected override get triggerInteractionsEnabled(): boolean {
+    return (this.#volume.value ?? unavailableVolume).volumeAvailability === 'available';
+  }
 
   protected override update(changed: PropertyValues): void {
     super.update(changed);
@@ -39,19 +48,9 @@ export class VolumePopoverElement extends PopoverElement {
 
     const state = this.#core.getState();
 
-    applyStateDataAttrs(this, state, VolumePopoverDataAttrs);
+    applyStateDataAttrs(this, state, volumePopoverStateDataAttrs);
     this.hidden = state.hidden;
 
-    if (state.hidden) {
-      this.close();
-
-      if (this.triggerElement) {
-        applyElementProps(this.triggerElement, {
-          'aria-expanded': undefined,
-          'aria-haspopup': undefined,
-          'aria-controls': undefined,
-        });
-      }
-    }
+    if (state.hidden) this.close();
   }
 }

--- a/packages/react/src/ui/volume-popover/tests/volume-popover.test.tsx
+++ b/packages/react/src/ui/volume-popover/tests/volume-popover.test.tsx
@@ -1,5 +1,5 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { VolumePopover } from '..';
 import { createPlayerWrapper } from '../../../testing/mocks';
@@ -14,7 +14,14 @@ const availableVolume = {
   toggleMuted: () => false,
 };
 
-afterEach(cleanup);
+function makeDOMRect(x: number, y: number, width: number, height: number): DOMRect {
+  return new DOMRect(x, y, width, height);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe('VolumePopover', () => {
   it('opens its popup when volume level controls are available', async () => {
@@ -93,6 +100,37 @@ describe('VolumePopover', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('popup')).toBeNull();
       expect(screen.getByTestId('trigger').hasAttribute('aria-expanded')).toBe(false);
+    });
+  });
+
+  it('preserves the collision-adjusted side', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      if (this.dataset.testid === 'trigger') return makeDOMRect(100, 10, 40, 20);
+
+      if (this.dataset.testid === 'popup') return makeDOMRect(0, 0, 100, 60);
+
+      return makeDOMRect(0, 0, 300, 200);
+    });
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(function (this: HTMLElement) {
+      return this.dataset.testid === 'popup' ? 100 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function (this: HTMLElement) {
+      return this.dataset.testid === 'popup' ? 60 : 0;
+    });
+
+    const { Wrapper } = createPlayerWrapper(availableVolume);
+
+    render(
+      <Wrapper>
+        <VolumePopover.Root defaultOpen side="top" boundary="viewport">
+          <VolumePopover.Trigger data-testid="trigger">Volume</VolumePopover.Trigger>
+          <VolumePopover.Popup data-testid="popup">Slider</VolumePopover.Popup>
+        </VolumePopover.Root>
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('popup').getAttribute('data-side')).toBe('bottom');
     });
   });
 });

--- a/packages/react/src/ui/volume-popover/volume-popover-popup.tsx
+++ b/packages/react/src/ui/volume-popover/volume-popover-popup.tsx
@@ -1,14 +1,9 @@
-import { VolumePopoverDataAttrs } from '@videojs/core';
+import { VolumePopoverStateDataAttrs } from '@videojs/core';
 import { getStateDataAttrs } from '@videojs/core/dom';
 import { forwardRef } from 'react';
 
 import { PopoverPopup, type PopoverPopupProps } from '../popover/popover-popup';
 import { useVolumePopoverContext } from './context';
-
-const volumePopoverStateDataAttrs = {
-  availability: VolumePopoverDataAttrs.availability,
-  hidden: VolumePopoverDataAttrs.hidden,
-} as const;
 
 export interface VolumePopoverPopupProps extends PopoverPopupProps {}
 
@@ -18,7 +13,7 @@ export const VolumePopoverPopup = forwardRef<HTMLDivElement, VolumePopoverPopupP
     const { state } = useVolumePopoverContext();
     if (state.hidden) return null;
 
-    return <PopoverPopup ref={forwardedRef} {...getStateDataAttrs(state, volumePopoverStateDataAttrs)} {...props} />;
+    return <PopoverPopup ref={forwardedRef} {...getStateDataAttrs(state, VolumePopoverStateDataAttrs)} {...props} />;
   }
 );
 

--- a/packages/react/src/ui/volume-popover/volume-popover-popup.tsx
+++ b/packages/react/src/ui/volume-popover/volume-popover-popup.tsx
@@ -5,6 +5,11 @@ import { forwardRef } from 'react';
 import { PopoverPopup, type PopoverPopupProps } from '../popover/popover-popup';
 import { useVolumePopoverContext } from './context';
 
+const volumePopoverStateDataAttrs = {
+  availability: VolumePopoverDataAttrs.availability,
+  hidden: VolumePopoverDataAttrs.hidden,
+} as const;
+
 export interface VolumePopoverPopupProps extends PopoverPopupProps {}
 
 /** Positioned volume content. Omitted when volume level controls are unavailable. */
@@ -13,7 +18,7 @@ export const VolumePopoverPopup = forwardRef<HTMLDivElement, VolumePopoverPopupP
     const { state } = useVolumePopoverContext();
     if (state.hidden) return null;
 
-    return <PopoverPopup ref={forwardedRef} {...getStateDataAttrs(state, VolumePopoverDataAttrs)} {...props} />;
+    return <PopoverPopup ref={forwardedRef} {...getStateDataAttrs(state, volumePopoverStateDataAttrs)} {...props} />;
   }
 );
 


### PR DESCRIPTION
Refs #2378

Follow-up to:
- https://github.com/videojs/v10/pull/2378#discussion_r3857196747
- https://github.com/videojs/v10/pull/2378#discussion_r3857196755

## Summary

Fix post-merge VolumePopover regressions reported by Bugbot: preserve collision-adjusted placement and keep unavailable mute fallbacks free of popup behavior.

## Changes

- Keep positioned popover attributes owned by the base component
- Disable HTML popover listeners and ARIA when volume level controls are unavailable
- Add HTML and React regression coverage

## Testing

- `pnpm build:packages`
- `pnpm -F @videojs/html test`
- `pnpm -F @videojs/react test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:site`
- Browser smoke test of the React and HTML VolumePopover reference pages
