### PR TITLE
fix(element): preserve props across late registration

### DIFF
--- a/apps/e2e/apps/vite/src/late-element-registration.html
+++ b/apps/e2e/apps/vite/src/late-element-registration.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Late element registration</title>
+  </head>
+  <body>
+    <late-reactive-element></late-reactive-element>
+    <script type="module" src="/late-element-registration.ts"></script>
+  </body>
+</html>

--- a/apps/e2e/apps/vite/src/late-element-registration.ts
+++ b/apps/e2e/apps/vite/src/late-element-registration.ts
@@ -1,0 +1,45 @@
+import { ReactiveElement } from '@videojs/html';
+
+interface LateReactiveElement extends ReactiveElement {
+  label: string;
+  connectedLabel: string | undefined;
+  renderedLabel: string | undefined;
+  updateCount: number;
+}
+
+declare global {
+  interface Window {
+    lateRegistrationComplete: Promise<LateReactiveElement>;
+  }
+}
+
+const element = document.querySelector<LateReactiveElement>('late-reactive-element');
+if (!element) throw new Error('Late reactive element was not found');
+
+element.label = 'pre-upgrade';
+
+class TestElement extends ReactiveElement {
+  static override properties = {
+    label: { type: String },
+  };
+
+  label = 'default';
+  connectedLabel: string | undefined;
+  renderedLabel: string | undefined;
+  updateCount = 0;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.connectedLabel = this.label;
+  }
+
+  protected override update(): void {
+    this.renderedLabel = this.label;
+    this.updateCount++;
+  }
+}
+
+customElements.define('late-reactive-element', TestElement);
+
+element.label = 'newer';
+window.lateRegistrationComplete = element.updateComplete.then(() => element);

--- a/apps/e2e/tests/late-element-registration.spec.ts
+++ b/apps/e2e/tests/late-element-registration.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+
+test('preserves reactive properties across late custom element registration', async ({ page }) => {
+  await page.goto('/late-element-registration.html');
+
+  const initial = await page.evaluate(async () => {
+    const element = await window.lateRegistrationComplete;
+
+    return {
+      connectedLabel: element.connectedLabel,
+      label: element.label,
+      ownsLabel: Object.hasOwn(element, 'label'),
+      renderedLabel: element.renderedLabel,
+      updateCount: element.updateCount,
+    };
+  });
+
+  expect(initial).toEqual({
+    connectedLabel: 'pre-upgrade',
+    label: 'newer',
+    ownsLabel: false,
+    renderedLabel: 'newer',
+    updateCount: 1,
+  });
+
+  const afterUpdate = await page.evaluate(async () => {
+    const element = await window.lateRegistrationComplete;
+
+    element.label = 'later';
+    await element.updateComplete;
+
+    return {
+      label: element.label,
+      renderedLabel: element.renderedLabel,
+      updateCount: element.updateCount,
+    };
+  });
+
+  expect(afterUpdate).toEqual({
+    label: 'later',
+    renderedLabel: 'later',
+    updateCount: 2,
+  });
+});

--- a/packages/element/src/reactive-element.ts
+++ b/packages/element/src/reactive-element.ts
@@ -64,6 +64,7 @@ export class ReactiveElement extends HTMLElement {
   #controllers: Set<ReactiveController> = new Set();
   #changedProperties: PropertyValues = new Map();
   #instanceProperties: Map<string, unknown> | undefined;
+  #propertiesUpgraded = false;
 
   /**
    * Promise that gates the first update until `connectedCallback`. Also used to serialize updates — each
@@ -135,6 +136,7 @@ export class ReactiveElement extends HTMLElement {
 
   /** On first connection, enables updating and notifies controllers. */
   connectedCallback(): void {
+    this.#upgradeProperties();
     this.enableUpdating(true);
 
     for (const c of this.#controllers) {
@@ -182,7 +184,7 @@ export class ReactiveElement extends HTMLElement {
    * any configured property options are honored.
    */
   requestUpdate(name?: string, oldValue?: unknown): void {
-    if (name !== undefined) {
+    if (name !== undefined && !this.#changedProperties.has(name)) {
       this.#changedProperties.set(name, oldValue);
     }
 
@@ -249,15 +251,6 @@ export class ReactiveElement extends HTMLElement {
     // This can happen if `performUpdate` is called early to "flush"
     // the update.
     if (!this.isUpdatePending) return;
-
-    // Restore saved instance properties on first update.
-    if (!this.hasUpdated && this.#instanceProperties) {
-      for (const [name, value] of this.#instanceProperties) {
-        (this as Record<string, unknown>)[name] = value;
-      }
-
-      this.#instanceProperties = undefined;
-    }
 
     const changed = this.#changedProperties;
 
@@ -329,6 +322,33 @@ export class ReactiveElement extends HTMLElement {
    */
   get updateComplete(): Promise<boolean> {
     return this.#updatePromise;
+  }
+
+  /**
+   * Replays properties set before registration through their reactive accessors. This runs after subclass fields have
+   * initialized but before connection lifecycle consumers, so user values win over defaults and are immediately
+   * usable.
+   */
+  #upgradeProperties(): void {
+    if (this.#propertiesUpgraded) return;
+
+    this.#propertiesUpgraded = true;
+
+    const { props } = resolve(this.constructor as typeof ReactiveElement);
+
+    for (const name of props.keys()) {
+      const hasSavedValue = this.#instanceProperties?.has(name) ?? false;
+      const hasOwnValue = Object.hasOwn(this, name);
+      if (!hasSavedValue && !hasOwnValue) continue;
+
+      const value = hasSavedValue ? this.#instanceProperties?.get(name) : Reflect.get(this, name);
+
+      if (hasOwnValue) Reflect.deleteProperty(this, name);
+
+      Reflect.set(this, name, value);
+    }
+
+    this.#instanceProperties = undefined;
   }
 }
 

--- a/packages/element/src/tests/reactive-element.test.ts
+++ b/packages/element/src/tests/reactive-element.test.ts
@@ -229,6 +229,39 @@ describe('ReactiveElement properties', () => {
     expect(changed.has('disabled')).toBe(true);
   });
 
+  it('preserves the first old value when batching changes to the same property', async () => {
+    const update = vi.fn();
+
+    class TestElement extends ReactiveElement {
+      static override properties = {
+        label: { type: String },
+      };
+      label = 'default';
+
+      protected override update(changed: PropertyValues) {
+        super.update(changed);
+        update(changed);
+      }
+    }
+
+    const el = createElement(TestElement);
+
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    update.mockClear();
+
+    el.label = 'first';
+    el.label = 'second';
+    await el.updateComplete;
+
+    expect(update).toHaveBeenCalledOnce();
+    const changed = update.mock.calls[0]![0] as PropertyValues;
+
+    expect(el.label).toBe('second');
+    expect(changed.get('label')).toBe('default');
+  });
+
   it('does not trigger update when value is unchanged', async () => {
     const update = vi.fn();
 
@@ -647,7 +680,49 @@ describe('ReactiveElement property inheritance', () => {
 });
 
 describe('ReactiveElement upgrade', () => {
-  it('preserves properties set before upgrade', async () => {
+  it('restores own properties before connected lifecycle consumers run', async () => {
+    let connectedLabel: string | undefined;
+    let controllerLabel: string | undefined;
+
+    class TestElement extends ReactiveElement {
+      static override properties = {
+        label: { type: String },
+      };
+      label = 'default';
+
+      constructor() {
+        super();
+        this.addController({
+          hostConnected: () => (controllerLabel = this.label),
+        });
+      }
+
+      override connectedCallback() {
+        super.connectedCallback();
+        connectedLabel = this.label;
+      }
+    }
+
+    const tag = uniqueTag('connect-lifecycle-el');
+
+    customElements.define(tag, TestElement);
+
+    // SAFETY: The tag was registered with TestElement immediately above.
+    const el = document.createElement(tag) as TestElement;
+
+    Object.defineProperty(el, 'label', {
+      value: 'pre-connect',
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+    document.body.appendChild(el);
+
+    await vi.waitFor(() => expect(connectedLabel).toBe('pre-connect'));
+    expect(controllerLabel).toBe('pre-connect');
+  });
+
+  it('does not overwrite properties set after connection but before the first update', async () => {
     const update = vi.fn();
 
     class TestElement extends ReactiveElement {
@@ -662,20 +737,72 @@ describe('ReactiveElement upgrade', () => {
       }
     }
 
-    const tag = uniqueTag('upgrade-el');
+    const tag = uniqueTag('connect-el');
+
+    customElements.define(tag, TestElement);
+
+    // SAFETY: The tag was registered with TestElement immediately above.
     const el = document.createElement(tag) as TestElement;
 
-    // Set property before defining custom element
-    (el as unknown as Record<string, unknown>).label = 'pre-upgrade';
     document.body.appendChild(el);
+    el.label = 'newer';
+    await el.updateComplete;
 
-    // Define after (upgrade scenario)
-    customElements.define(tag, class extends TestElement {});
+    expect(el.label).toBe('newer');
+    expect(update).toHaveBeenLastCalledWith('newer');
 
-    // Wait for upgrade and first update
-    await new Promise((r) => setTimeout(r, 10));
+    update.mockClear();
+    el.label = 'later';
+    await el.updateComplete;
 
-    expect(el.label).toBe('pre-upgrade');
-    expect(update).toHaveBeenCalled();
+    expect(update).toHaveBeenCalledOnce();
+    expect(update).toHaveBeenCalledWith('later');
+  });
+
+  it('activates reactive accessors shadowed by native class fields', async () => {
+    const update = vi.fn();
+
+    class TestElement extends ReactiveElement {
+      static override properties = {
+        label: { type: String },
+      };
+      declare label: string;
+
+      constructor() {
+        super();
+
+        // Native class fields use DefineField semantics rather than invoking a prototype setter.
+        Object.defineProperty(this, 'label', {
+          value: 'default',
+          writable: true,
+          configurable: true,
+          enumerable: true,
+        });
+      }
+
+      protected override update() {
+        update(this.label);
+      }
+    }
+
+    const tag = uniqueTag('upgrade-class-field-el');
+
+    customElements.define(tag, TestElement);
+
+    // SAFETY: The tag was registered with TestElement immediately above.
+    const el = document.createElement(tag) as TestElement;
+
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    expect(Object.hasOwn(el, 'label')).toBe(false);
+    expect(el.label).toBe('default');
+
+    update.mockClear();
+    el.label = 'changed';
+    await el.updateComplete;
+
+    expect(update).toHaveBeenCalledOnce();
+    expect(update).toHaveBeenCalledWith('changed');
   });
 });

--- a/packages/html/src/player/tests/create-player.test.ts
+++ b/packages/html/src/player/tests/create-player.test.ts
@@ -298,6 +298,32 @@ describe('createPlayer', () => {
     player.remove();
   });
 
+  it('applies property configuration that shadowed an accessor before connection', async () => {
+    const { ProviderMixin } = createPlayer({ features: [features.orientationLock] });
+    const ProviderElement = ProviderMixin(UIElement);
+    const tagName = `test-shadowed-config-provider-${tagCounter++}`;
+
+    customElements.define(tagName, ProviderElement);
+
+    // SAFETY: The tag was registered with ProviderElement immediately above.
+    const player = document.createElement(tagName) as InstanceType<typeof ProviderElement>;
+
+    Object.defineProperty(player, 'orientationLockType', {
+      value: 'portrait',
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+    document.body.append(player);
+
+    await vi.waitFor(() => expect(player.store.orientationLockType).toBe('portrait'));
+
+    player.orientationLockType = 'natural';
+    await player.updateComplete;
+
+    expect(player.store.orientationLockType).toBe('natural');
+  });
+
   it('leaves config attributes inert when their feature is absent', () => {
     const { ProviderMixin } = createPlayer({ features: backgroundFeatures });
     const ProviderElement = ProviderMixin(UIElement);

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -150,8 +150,8 @@ export function createProviderMixin<Store extends PlayerStore>(
 
       override connectedCallback() {
         this.#connected = true;
-        this.#syncInitialConfig();
         super.connectedCallback();
+        this.#syncInitialConfig();
         this.#playerProvider.setValue(this.store);
         this.#publishMedia();
         this.#publishContainer();


### PR DESCRIPTION
## Summary

Preserve JavaScript properties assigned before custom element registration and make them available before connection lifecycle consumers initialize. This fixes player configuration being read from defaults when an element is registered after markup or property assignment.

## Changes

- Replay saved pre-registration values through ReactiveElement accessors on first connection
- Remove native class-field shadows and keep newer assignments made before the first render
- Preserve the first old value when repeated property writes are batched
- Sync provider configuration after reactive properties have been activated
- Cover the behavior with base-element, provider-integration, and real-browser tests

<details>
<summary>Implementation choice</summary>

The existing first-render replay is too late: connected callbacks and controllers have already read defaults, and a write after registration can be overwritten. Constructor-only replay is too early because subclass fields initialize afterward and may shadow the accessor again. Per-component upgrade helpers would duplicate the workaround and still depend on component lifecycle ordering.

The selected one-time ReactiveElement connection step runs after subclass construction but before controllers and subclass post-super connection work. It gives pre-registration values precedence over class defaults while subsequent writes continue through the installed reactive accessor.

</details>

## Testing

- pnpm -F @videojs/element test src/tests/reactive-element.test.ts
- pnpm -F @videojs/html test src/player/tests/create-player.test.ts
- pnpm typecheck
- pnpm lint
- pnpm exec vp run @videojs/html#build
- pnpm --dir apps/e2e e2e tests/late-element-registration.spec.ts --project=vite-chromium
- pnpm --dir apps/e2e e2e tests/late-element-registration.spec.ts --project=vite-webkit