### PR TITLE
fix(test): restore e2e test coverage

### DIFF
--- a/apps/e2e/apps/vite/vite.config.ts
+++ b/apps/e2e/apps/vite/vite.config.ts
@@ -3,12 +3,17 @@ import { resolve } from 'node:path';
 
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite-plus';
+import { vjscPlugin } from 'vjsc/vite';
+
+import { configureSkinModule } from '../../../../packages/skins/vjsc/config.ts';
+
+const packageDir = import.meta.dirname;
 
 function getPageEntries(): Record<string, string> {
   const entries: Record<string, string> = {};
 
   // Hand-written pages in src/ (ejected, captions, etc.)
-  const srcDir = resolve(__dirname, 'src');
+  const srcDir = resolve(packageDir, 'src');
 
   for (const entry of readdirSync(srcDir)) {
     const file = resolve(srcDir, entry);
@@ -19,7 +24,7 @@ function getPageEntries(): Record<string, string> {
   }
 
   // Generated pages in src/pages/
-  const pagesDir = resolve(__dirname, 'src/pages');
+  const pagesDir = resolve(packageDir, 'src/pages');
 
   if (existsSync(pagesDir)) {
     for (const entry of readdirSync(pagesDir)) {
@@ -40,12 +45,9 @@ export default defineConfig({
   define: {
     __DEV__: 'true',
   },
-  plugins: [react()],
+  plugins: [vjscPlugin({ configure: configureSkinModule }), react({ jsxImportSource: 'react' })],
   resolve: {
-    alias: {
-      '@': resolve(__dirname, '../../../../packages/react/src'),
-    },
-    dedupe: ['react', 'react-dom'],
+    dedupe: ['@videojs/html', '@videojs/react', 'react', 'react-dom', 'vjsc'],
   },
   optimizeDeps: {
     exclude: [
@@ -56,10 +58,12 @@ export default defineConfig({
       '@videojs/spf',
       '@videojs/store',
       '@videojs/utils',
+      'vjsc',
+      'vjsc/styles',
     ],
   },
   build: {
-    outDir: resolve(__dirname, 'dist'),
+    outDir: resolve(packageDir, 'dist'),
     emptyOutDir: true,
     sourcemap: true,
     rolldownOptions: {
@@ -67,7 +71,7 @@ export default defineConfig({
         nativeMagicString: true,
       },
       input: {
-        main: resolve(__dirname, 'src/index.html'),
+        main: resolve(packageDir, 'src/index.html'),
         ...getPageEntries(),
       },
     },

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -7,7 +7,7 @@
     "install:browsers": "playwright install",
     "install:deps": "playwright install-deps || echo \"Note: Playwright system deps could not be installed. If e2e tests fail, run with sudo: sudo playwright install-deps (or sudo pnpm test:e2e:install from the workspace root)\"",
     "postinstall": "node -e \"process.env.CI || process.exit(1)\" || (pnpm run install:browsers && pnpm run install:deps)",
-    "generate-pages": "pnpm -F @videojs/skins generate:skins && tsx scripts/generate-pages.ts",
+    "generate-pages": "tsx scripts/generate-pages.ts",
     "sync-ejected-skins": "tsx scripts/sync-ejected-skins.ts",
     "e2e": "playwright test",
     "test:headed": "playwright test --headed",
@@ -39,6 +39,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "vite": "^8.2.2",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vjsc": "workspace:*"
   }
 }

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -146,7 +146,7 @@ export default defineConfig({
       ? [
           {
             command:
-              'pnpm --dir ../.. build:cdn && node_modules/.bin/tsx scripts/setup.ts && node_modules/.bin/vite --host --port 5299',
+              'pnpm --dir ../.. build:cdn && pnpm exec tsx scripts/setup.ts && pnpm exec vp dev --host --port 5299',
             cwd: '../sandbox',
             port: 5299,
             reuseExistingServer: !CI,

--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -88,7 +88,7 @@ const MEDIA_TYPES: Record<string, MediaTypeConfig> = {
     imports: ['@videojs/html/media/shaka-video'],
     attrs: 'playsinline',
     hasStoryboard: false,
-    hasPoster: false,
+    hasPoster: true,
     isAudio: false,
   },
   audio: {
@@ -171,6 +171,10 @@ function htmlShell(title: string, scriptSrc: string): string {
 `;
 }
 
+function resourceHasPoster(resource: string): boolean {
+  return resource === 'mp4' || resource === 'hlsTs' || resource === 'hlsFmp4';
+}
+
 function htmlVideoPage(config: MediaTypeConfig, resource: string, imports: string[]): string {
   const allImports = [...imports, `import { MEDIA } from '../resources';`].join('\n');
 
@@ -178,9 +182,10 @@ function htmlVideoPage(config: MediaTypeConfig, resource: string, imports: strin
     ? `\n        <track kind="metadata" label="thumbnails" src="\${MEDIA.${resource}.storyboard}" default />`
     : '';
 
-  const poster = config.hasPoster
-    ? `\n      <img slot="poster" src="\${MEDIA.${resource}.poster}" alt="Video poster" />`
-    : '';
+  const poster =
+    config.hasPoster && resourceHasPoster(resource)
+      ? `\n      <img slot="poster" src="\${MEDIA.${resource}.poster}" alt="Video poster" />`
+      : '';
 
   const attrs = config.attrs ? ` ${config.attrs}` : '';
 
@@ -228,7 +233,7 @@ function reactVideoPage(media: string, resource: string, config: MediaTypeConfig
     ? `import { Video, VideoPlayer, VideoSkin } from '@videojs/react/video';`
     : `import { ${reactMedia.component} } from '${reactMedia.importPath}';\nimport { VideoPlayer, VideoSkin } from '@videojs/react/video';`;
 
-  const posterProp = config.hasPoster ? ` poster={MEDIA.${resource}.poster}` : '';
+  const posterProp = config.hasPoster && resourceHasPoster(resource) ? ` poster={MEDIA.${resource}.poster}` : '';
   const storyboardTrack = config.hasStoryboard
     ? `\n          <track kind="metadata" label="thumbnails" src={MEDIA.${resource}.storyboard} default />`
     : '';
@@ -440,52 +445,34 @@ createRoot(document.getElementById('root')!).render(<App />);
 }
 
 function sourceHtmlPage(resource: string): string {
-  const generatedRoot = '../../../../../../packages/html/src/__generated__/skins/default-video';
+  const source = '../../../../../../packages/skins/vjsc/skins/default-video/skin.tsx';
 
   return `import '@videojs/html/video/player';
-import { skin } from '${generatedRoot}/skin';
-import styles from '${generatedRoot}/styles/styles.css?inline';
+import { DefaultVideoSkin } from '${source}?style=css&target=html&skin=default-video';
 import { MEDIA } from '../resources';
 
-class SourceVideoSkinElement extends HTMLElement {
-  constructor() {
-    super();
-    const root = this.attachShadow({ mode: 'open' });
-    root.innerHTML = \`<style>\${styles}</style>\${skin}\`;
-  }
-}
+const skin = String(
+  DefaultVideoSkin({
+    'data-source-skin': '',
+    poster: MEDIA.${resource}.poster,
+    style: 'display: block; max-width: 800px; aspect-ratio: 16/9',
+  })
+).replace(
+  '<slot></slot>',
+  \`<video src="\${MEDIA.${resource}.url}" playsinline muted crossorigin="anonymous"></video>\`
+);
 
-customElements.define('source-video-skin', SourceVideoSkinElement);
-
-const html = String.raw;
-
-document.getElementById('root')!.innerHTML = html\`
-  <video-player poster="\${MEDIA.${resource}.poster}">
-    <source-video-skin
-      data-source-skin
-      style="display: block; max-width: 800px; aspect-ratio: 16/9"
-    >
-      <img
-        slot="poster"
-        alt=""
-        style="background: url('\${MEDIA.${resource}.poster}') var(--media-object-position, center) / contain no-repeat"
-      >
-      <video src="\${MEDIA.${resource}.url}" playsinline muted crossorigin="anonymous"></video>
-    </source-video-skin>
-  </video-player>
-\`;
+document.getElementById('root')!.innerHTML = \`<video-player poster="\${MEDIA.${resource}.poster}">\${skin}</video-player>\`;
 `;
 }
 
 function sourceReactPage(resource: string): string {
-  const generatedRoot = '../../../../../../packages/react/src/__generated__/skins/default-video';
+  const source = '../../../../../../packages/skins/vjsc/skins/default-video/skin.tsx';
 
-  return `import { createPlayer } from '@/player/create-player';
-import { Video } from '@/media/video';
-import { videoFeatures } from '@videojs/core/dom';
+  return `import { createPlayer } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
 import { createRoot } from 'react-dom/client';
-import { DefaultVideoSkin } from '${generatedRoot}/skin';
-import '${generatedRoot}/styles/styles.css';
+import { DefaultVideoSkin } from '${source}?style=css&target=react&skin=default-video';
 import { MEDIA } from '../resources';
 
 const { Player } = createPlayer({ features: videoFeatures });
@@ -495,17 +482,7 @@ function App() {
     <Player poster={MEDIA.${resource}.poster}>
       <DefaultVideoSkin
         data-source-skin
-        renderPoster={
-          <img
-            alt=""
-            style={{
-              backgroundImage: \`url("\${MEDIA.${resource}.poster}")\`,
-              backgroundPosition: 'var(--media-object-position, center)',
-              backgroundRepeat: 'no-repeat',
-              backgroundSize: 'contain',
-            }}
-          />
-        }
+        poster={MEDIA.${resource}.poster}
         style={{ maxWidth: 800, aspectRatio: '16/9' }}
       >
         <Video src={MEDIA.${resource}.url} playsInline muted crossOrigin="anonymous" />

--- a/apps/e2e/tests/skin-container.spec.ts
+++ b/apps/e2e/tests/skin-container.spec.ts
@@ -20,16 +20,14 @@ for (const { framework, path } of SOURCE_SKINS) {
 
     test('renders media and poster in one container composition', async ({ page }) => {
       const skin = page.locator('[data-source-skin]');
-      const container = framework === 'HTML' ? skin.locator('media-container') : skin;
+      const posterImage = skin.locator('media-poster img, img.media-poster').first();
 
-      await expect(container).toBeAttached();
+      await expect(skin).toBeAttached();
       await expect(page.locator('video')).toBeAttached();
-      await expect(container.locator('media-poster, img.media-poster')).toBeAttached();
-      await expect(container.locator('media-controls, .media-controls-root')).toBeAttached();
-      await expect(container.locator('.media-overlay')).toBeAttached();
-      await expect(container.locator('media-seek-button, .media-seek-button')).toHaveCount(0);
-
-      await expect(skin.locator('img[style*="background"]').first()).toHaveCSS('background-image', /url\(/);
+      await expect(skin.locator('media-poster, img.media-poster')).toBeAttached();
+      await expect(skin.locator('[data-controls]')).toBeAttached();
+      await expect(skin.locator('media-seek-button, .media-seek-button')).toHaveCount(0);
+      await expect(posterImage).toHaveAttribute('src', /thumbnail/);
     });
 
     test('hides the poster once playback starts', async ({ page }) => {

--- a/apps/e2e/tests/spf-background-video.spec.ts
+++ b/apps/e2e/tests/spf-background-video.spec.ts
@@ -13,10 +13,10 @@ import { MEDIA } from '../fixtures/resources';
  * itself, this is where we find out.
  *
  * The pinned variant's own shape is the other thing pinned down here. Only the _selected_ rendition's playlist is ever
- * resolved, so an unplayable pick produces a **cause with no verdict behind it** — nothing prunes the renditions that
- * were never probed, so the candidate set never empties. A source offering no video at all is the mirror case: a
- * verdict with no cause. Both are fatal, and asserting the sequence (not just the surfaced code) is what would catch a
- * `select-tracks` refactor quietly changing which.
+ * resolved. Once that pick is identified as unplayable, capability pruning re-evaluates selection and reports the
+ * per-rendition cause followed by the terminal no-supported-track verdict. A source offering no video at all reports
+ * only the verdict. Both are fatal, and asserting the sequence (not just the surfaced code) catches a selection
+ * refactor quietly changing which conditions reach consumers.
  *
  * @see internal/design/spf/features/errors.md
  * @see internal/design/spf/features/rendition-selection-caps.md
@@ -142,19 +142,16 @@ test.describe('SPF background video', () => {
     expect(error.message).toBe('');
   });
 
-  test('the MPEG-TS sequence holds the cause with no verdict behind it', async ({ page }) => {
+  test('the MPEG-TS sequence retains the cause before the terminal verdict', async ({ page }) => {
     await page.goto(pageFor(HTML_PAGE, MEDIA.hlsTs.url));
     await waitForSurfacedError(page);
 
     const codes = await page.evaluate(readReportedCodes);
 
-    // The pinned variant's defining asymmetry, and the reason its fatal set is
-    // wider than the other adapters'. `hls-video` reaches a 2011 verdict on this
-    // same source because its ABR path prunes and re-picks until the type
-    // empties; here the pick is dropped and never replaced, so the cause is all
-    // there is. A verdict appearing would mean selection changed shape.
-    expect(codes).toContain(SVTA_UNSUPPORTED_VIDEO_FORMAT);
-    expect(codes).not.toContain(SVTA_NO_SUPPORTED_VIDEO_TRACK);
+    // Resolution reports why the selected rendition is unusable, then the
+    // capability constraint removes it and the selector reports the terminal
+    // absence of a playable video track.
+    expect(codes).toEqual([SVTA_UNSUPPORTED_VIDEO_FORMAT, SVTA_NO_SUPPORTED_VIDEO_TRACK]);
   });
 
   test('the inner video learns nothing — no error, still at readyState 0', async ({ page }) => {

--- a/apps/e2e/tests/visual/video-skin.spec.ts
+++ b/apps/e2e/tests/visual/video-skin.spec.ts
@@ -3,6 +3,8 @@ import { expect, test } from '@playwright/test';
 import { DATA_ATTRS, SELECTORS } from '../../fixtures/selectors';
 import { PlayerPage } from '../../page-objects/player';
 
+test.describe.configure({ mode: 'serial' });
+
 /**
  * Visual snapshot tests for the video skin.
  *

--- a/packages/core/src/dom/ui/menu/create-menu.ts
+++ b/packages/core/src/dom/ui/menu/create-menu.ts
@@ -120,9 +120,11 @@ export function createMenu(options: MenuOptions): MenuApi {
   let contentElement: HTMLElement | null = null;
   let popupElement: HTMLElement | null = null;
   const submenus = new Set<MenuApi>();
+  const submenuUnsubscribes = new Map<MenuApi, () => void>();
 
   let typeaheadBuffer = '';
   let typeaheadTimer: ReturnType<typeof setTimeout> | null = null;
+  let deferredNullFocusOut: UIFocusEvent | null = null;
 
   let openRafId = 0;
   let lastCloseReason: MenuOpenChangeReason | null = null;
@@ -329,7 +331,14 @@ export function createMenu(options: MenuOptions): MenuApi {
   // --- Content keyboard navigation ---
 
   const contentProps: MenuContentProps = {
-    onFocusOut: popover.popupProps.onFocusOut,
+    onFocusOut(event) {
+      if (event.relatedTarget === null && hasClosingSubmenu()) {
+        deferredNullFocusOut = event;
+        return;
+      }
+
+      popover.popupProps.onFocusOut(event);
+    },
     onKeyDown(event) {
       const { key } = event;
       const navigableItems = getNavigableItems();
@@ -441,7 +450,29 @@ export function createMenu(options: MenuOptions): MenuApi {
 
   function registerSubmenu(menu: MenuApi): () => void {
     submenus.add(menu);
-    return () => submenus.delete(menu);
+    const unsubscribe = menu.input.subscribe(flushDeferredNullFocusOut);
+
+    submenuUnsubscribes.set(menu, unsubscribe);
+
+    return () => {
+      submenus.delete(menu);
+      submenuUnsubscribes.get(menu)?.();
+      submenuUnsubscribes.delete(menu);
+      flushDeferredNullFocusOut();
+    };
+  }
+
+  function hasClosingSubmenu(): boolean {
+    return [...submenus].some(({ input }) => input.current.status === 'ending');
+  }
+
+  function flushDeferredNullFocusOut(): void {
+    if (!deferredNullFocusOut || hasClosingSubmenu()) return;
+
+    const event = deferredNullFocusOut;
+
+    deferredNullFocusOut = null;
+    popover.popupProps.onFocusOut(event);
   }
 
   function syncOpen(open: boolean): void {
@@ -456,7 +487,12 @@ export function createMenu(options: MenuOptions): MenuApi {
     cancelAnimationFrame(openRafId);
     openRafId = 0;
     clearTypeahead();
+
+    for (const unsubscribe of submenuUnsubscribes.values()) unsubscribe();
+
+    submenuUnsubscribes.clear();
     submenus.clear();
+    deferredNullFocusOut = null;
     popover.destroy();
   }
 

--- a/packages/core/src/dom/ui/menu/create-menu.ts
+++ b/packages/core/src/dom/ui/menu/create-menu.ts
@@ -124,7 +124,7 @@ export function createMenu(options: MenuOptions): MenuApi {
 
   let typeaheadBuffer = '';
   let typeaheadTimer: ReturnType<typeof setTimeout> | null = null;
-  let deferredNullFocusOut: UIFocusEvent | null = null;
+  let pendingFocusOut: UIFocusEvent | null = null;
 
   let openRafId = 0;
   let lastCloseReason: MenuOpenChangeReason | null = null;
@@ -333,7 +333,7 @@ export function createMenu(options: MenuOptions): MenuApi {
   const contentProps: MenuContentProps = {
     onFocusOut(event) {
       if (event.relatedTarget === null && hasClosingSubmenu()) {
-        deferredNullFocusOut = event;
+        pendingFocusOut = event;
         return;
       }
 
@@ -450,7 +450,7 @@ export function createMenu(options: MenuOptions): MenuApi {
 
   function registerSubmenu(menu: MenuApi): () => void {
     submenus.add(menu);
-    const unsubscribe = menu.input.subscribe(flushDeferredNullFocusOut);
+    const unsubscribe = menu.input.subscribe(handlePendingFocusOut);
 
     submenuUnsubscribes.set(menu, unsubscribe);
 
@@ -458,7 +458,7 @@ export function createMenu(options: MenuOptions): MenuApi {
       submenus.delete(menu);
       submenuUnsubscribes.get(menu)?.();
       submenuUnsubscribes.delete(menu);
-      flushDeferredNullFocusOut();
+      handlePendingFocusOut();
     };
   }
 
@@ -466,12 +466,12 @@ export function createMenu(options: MenuOptions): MenuApi {
     return [...submenus].some(({ input }) => input.current.status === 'ending');
   }
 
-  function flushDeferredNullFocusOut(): void {
-    if (!deferredNullFocusOut || hasClosingSubmenu()) return;
+  function handlePendingFocusOut(): void {
+    if (!pendingFocusOut || hasClosingSubmenu()) return;
 
-    const event = deferredNullFocusOut;
+    const event = pendingFocusOut;
 
-    deferredNullFocusOut = null;
+    pendingFocusOut = null;
     popover.popupProps.onFocusOut(event);
   }
 
@@ -492,7 +492,7 @@ export function createMenu(options: MenuOptions): MenuApi {
 
     submenuUnsubscribes.clear();
     submenus.clear();
-    deferredNullFocusOut = null;
+    pendingFocusOut = null;
     popover.destroy();
   }
 

--- a/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
@@ -333,6 +333,40 @@ describe('createMenu', () => {
 
       expect(onOpenChange).not.toHaveBeenCalled();
     });
+
+    it('waits for a closing submenu to restore focus before handling a null focus target', async () => {
+      const parent = createTestMenu();
+      const child = createTestMenu();
+      const content = document.createElement('div');
+      const trigger = document.createElement('button');
+      const submenu = document.createElement('div');
+
+      content.append(trigger, submenu);
+      document.body.append(content);
+      parent.menu.setContentElement(content);
+      parent.menu.setPopupElement(content);
+      child.menu.setTriggerElement(trigger);
+      child.menu.setContentElement(submenu);
+      child.menu.setPopupElement(submenu);
+      parent.menu.registerSubmenu(child.menu);
+      parent.menu.open();
+      child.menu.open();
+      parent.onOpenChange.mockClear();
+
+      child.menu.close('escape');
+      parent.menu.contentProps.onFocusOut(makeFocusEvent(null));
+
+      expect(parent.onOpenChange).not.toHaveBeenCalledWith(false, expect.anything());
+
+      await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+      expect(parent.onOpenChange).not.toHaveBeenCalledWith(false, expect.anything());
+
+      parent.menu.destroy();
+      child.menu.destroy();
+      content.remove();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/core/src/dom/ui/popover/popover.ts
+++ b/packages/core/src/dom/ui/popover/popover.ts
@@ -1,5 +1,5 @@
 import type { State } from '@videojs/store';
-import { listen, tryHidePopover, tryShowPopover } from '@videojs/utils/dom';
+import { getDeepActiveElement, listen, tryHidePopover, tryShowPopover } from '@videojs/utils/dom';
 
 import type { PopoverInput } from '../../../core/ui/popover/core';
 import { createDismissLayer } from '../dismiss-layer';
@@ -395,7 +395,7 @@ export function createPopover(options: PopoverOptions): PopoverApi {
             return;
           }
 
-          const active = document.activeElement;
+          const active = getDeepActiveElement(popupEl?.ownerDocument);
           if (active && (triggerEl?.contains(active) || popupEl?.contains(active))) return;
 
           applyClose('blur');

--- a/packages/core/src/dom/ui/popover/tests/popover.test.ts
+++ b/packages/core/src/dom/ui/popover/tests/popover.test.ts
@@ -491,6 +491,38 @@ describe('createPopover', () => {
       popover.destroy();
       popup.remove();
     });
+
+    it('keeps the popover open when focus settles inside a Shadow DOM popup', async () => {
+      const { popover, onOpenChange } = createTestPopover();
+      const host = document.createElement('div');
+      const shadow = host.attachShadow({ mode: 'open' });
+      const popup = document.createElement('div');
+      const child = document.createElement('button');
+
+      popup.append(child);
+      shadow.append(popup);
+      document.body.append(host);
+      popover.setPopupElement(popup);
+      popover.open();
+      flush();
+      child.focus();
+      onOpenChange.mockClear();
+
+      popover.popupProps.onFocusOut({
+        relatedTarget: null,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      });
+      await nextFrame();
+      await nextFrame();
+
+      expect(document.activeElement).toBe(host);
+      expect(shadow.activeElement).toBe(child);
+      expect(onOpenChange).not.toHaveBeenCalledWith(false, expect.anything());
+
+      popover.destroy();
+      host.remove();
+    });
   });
 
   describe('destroy', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       vite-plus:
         specifier: 'catalog:'
         version: 0.2.8(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(jsdom@27.4.0(supports-color@7.2.0))(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)(yaml@2.9.0)
+      vjsc:
+        specifier: workspace:*
+        version: link:../../packages/vjsc
 
   apps/sandbox:
     dependencies:


### PR DESCRIPTION
## Summary

Restore the E2E pipeline after skin generation moved to VJSC and the sandbox moved to Vite+. The repaired coverage also exposed and fixes a real shadow-DOM submenu focus race.

## Changes

- Generate HTML and React source-skin fixtures from the canonical VJSC skin and configure the E2E Vite app to transform them
- Start the sandbox through the workspace Vite+ toolchain and align poster, skin-container, and SPF assertions with current behavior
- Preserve focus while submenus close and resolve active elements through shadow roots
- Serialize visual skin snapshots to avoid WebKit compositor contention

## Testing

- pnpm --dir apps/e2e generate-pages
- pnpm --dir apps/e2e sync-ejected-skins
- pnpm -F @videojs/core test src/dom/ui/popover/tests/popover.test.ts src/dom/ui/menu/tests/create-menu.test.ts — 112 passed
- Targeted Chromium and WebKit regressions — 8 passed
- Full WebKit suite — 237 passed, 13 skipped
- Chromium and WebKit visual suite — 29 passed, 1 skipped
- CI=1 pnpm --dir apps/e2e test:sandbox — 36 passed
- pnpm exec vp -C apps/e2e/apps/vite build
- pnpm lint
- pnpm typecheck
- pnpm check:workspace