### PR TITLE
fix(site): scope component props by framework

### DIFF
--- a/packages/core/src/core/ui/poster/core.ts
+++ b/packages/core/src/core/ui/poster/core.ts
@@ -24,6 +24,7 @@ export interface PosterState {
 
 /** Framework-neutral poster component props. */
 export interface PosterProps {
+  /** Image URL for the React poster. HTML authors set the source on the child image instead. */
   src?: string | undefined;
 }
 

--- a/site/scripts/api-docs-builder/src/pipeline.ts
+++ b/site/scripts/api-docs-builder/src/pipeline.ts
@@ -412,6 +412,12 @@ function buildSingleComponentReference(source: ComponentSource, program: OxcProj
   };
 
   if (htmlData) {
+    for (const [name, prop] of Object.entries(result.props)) {
+      if (!htmlData.properties.includes(name)) prop.frameworks = ['react'];
+    }
+  }
+
+  if (htmlData) {
     result.platforms.html = { tagName: htmlData.tagName };
   }
 
@@ -450,6 +456,12 @@ function buildMultiPartReference(
         cssCustomProperties: cssVarsData ? buildCSSVars(cssVarsData) : {},
         platforms: { react: {} },
       };
+
+      if (htmlData) {
+        for (const [name, prop] of Object.entries(partRef.props)) {
+          if (!htmlData.properties.includes(name)) prop.frameworks = ['react'];
+        }
+      }
 
       if (!partRef.description) delete partRef.description;
 

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -171,6 +171,7 @@ describe('Component pipeline (end-to-end)', () => {
       expect(ref.props.onPressedChange).toMatchObject({
         type: 'function',
         description: 'Callback when pressed state changes.',
+        frameworks: ['react'],
       });
       expect(ref.props.onPressedChange!.detailedType).toBeDefined();
 

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/toggle-button/toggle-button-element.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/toggle-button/toggle-button-element.ts
@@ -6,4 +6,9 @@
 
 export class ToggleButtonElement {
   static readonly tagName = 'media-toggle-button';
+
+  static readonly properties = {
+    disabled: { type: Boolean },
+    label: { type: String },
+  };
 }


### PR DESCRIPTION
## Summary

- Filter extracted component props by their React and HTML availability.
- Keep adapter-internal props out of framework surfaces that do not expose them.

## Verification

- `CI=true pnpm -F site test scripts/api-docs-builder/src/tests/e2e.test.ts`
- `CI=true pnpm typecheck`

Closes #2271

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>