### PR TITLE
feat(site): generate component event references

### DIFF
--- a/packages/html/src/ui/alert-dialog/alert-dialog-element.ts
+++ b/packages/html/src/ui/alert-dialog/alert-dialog-element.ts
@@ -2,7 +2,11 @@ import { AlertDialogCore, AlertDialogDataAttrs } from '@videojs/core';
 
 import { DialogElementBase } from '../dialog/dialog-element';
 
-/** A modal dialog with alert semantics. */
+/**
+ * A modal dialog with alert semantics.
+ *
+ * @fires open-change - Fired when the dialog's open state changes.
+ */
 export class AlertDialogElement extends DialogElementBase {
   static readonly tagName = 'media-alert-dialog';
 

--- a/packages/html/src/ui/menu/menu-checkbox-item-element.ts
+++ b/packages/html/src/ui/menu/menu-checkbox-item-element.ts
@@ -5,6 +5,7 @@ import { ContextConsumer } from '@videojs/element/context';
 import { UIElement } from '../ui-element';
 import { menuContext } from './context';
 
+/** @fires checked-change - Fired when the checked state changes. */
 export class MenuCheckboxItemElement extends UIElement {
   static readonly tagName = 'media-menu-checkbox-item';
 

--- a/packages/html/src/ui/menu/menu-element.ts
+++ b/packages/html/src/ui/menu/menu-element.ts
@@ -27,7 +27,11 @@ import { PositionController } from '../position-controller';
 import { UIElement } from '../ui-element';
 import { menuContext } from './context';
 
-/** Root menu state and positioned popup. Content pages are direct children. */
+/**
+ * Root menu state and positioned popup. Content pages are direct children.
+ *
+ * @fires open-change - Fired before the menu's open state changes. Cancel the event to prevent the change.
+ */
 export class MenuElement extends UIElement {
   static readonly tagName: string = 'media-menu';
 

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -19,6 +19,7 @@ import { popupGroupContext } from '../../player/popup-group-context';
 import { PositionController } from '../position-controller';
 import { UIElement } from '../ui-element';
 
+/** @fires open-change - Fired when the popover's open state changes. */
 export class PopoverElement extends UIElement {
   static readonly tagName: string = 'media-popover';
 

--- a/packages/html/src/ui/radio-group/radio-group-element.ts
+++ b/packages/html/src/ui/radio-group/radio-group-element.ts
@@ -4,6 +4,7 @@ import { ContextProvider } from '@videojs/element/context';
 import { UIElement } from '../ui-element';
 import { radioGroupContext } from './context';
 
+/** @fires value-change - Fired when the selected value changes. */
 export class RadioGroupElement extends UIElement {
   static override properties = {
     value: { type: String },

--- a/packages/html/src/ui/slider/slider-element.ts
+++ b/packages/html/src/ui/slider/slider-element.ts
@@ -19,6 +19,12 @@ import { PlayerController } from '../../player/player-controller';
 import { UIElement } from '../ui-element';
 import { sliderContext } from './context';
 
+/**
+ * @fires value-change - Fired while the slider value changes during an interaction.
+ * @fires value-commit - Fired when an interaction commits the slider value.
+ * @fires drag-start - Fired when a pointer drag starts.
+ * @fires drag-end - Fired when a pointer drag ends.
+ */
 export class SliderElement extends UIElement {
   static readonly tagName = 'media-slider';
 

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -24,6 +24,10 @@ import { PlayerController } from '../../player/player-controller';
 import { sliderContext } from '../slider/context';
 import { UIElement } from '../ui-element';
 
+/**
+ * @fires drag-start - Fired when a pointer drag starts.
+ * @fires drag-end - Fired when a pointer drag ends.
+ */
 export class TimeSliderElement extends UIElement {
   static readonly tagName = 'media-time-slider';
 

--- a/packages/html/src/ui/tooltip/tooltip-element.ts
+++ b/packages/html/src/ui/tooltip/tooltip-element.ts
@@ -46,6 +46,7 @@ function isLabelTrigger(el: HTMLElement): el is TriggerElement {
   return '$state' in el;
 }
 
+/** @fires open-change - Fired when the tooltip's open state changes. */
 export class TooltipElement extends UIElement {
   static readonly tagName = 'media-tooltip';
 

--- a/packages/html/src/ui/volume-slider/volume-slider-element.ts
+++ b/packages/html/src/ui/volume-slider/volume-slider-element.ts
@@ -22,6 +22,10 @@ import { PlayerController } from '../../player/player-controller';
 import { sliderContext } from '../slider/context';
 import { UIElement } from '../ui-element';
 
+/**
+ * @fires drag-start - Fired when a pointer drag starts.
+ * @fires drag-end - Fired when a pointer drag ends.
+ */
 export class VolumeSliderElement extends UIElement {
   static readonly tagName = 'media-volume-slider';
 

--- a/site/scripts/api-docs-builder/src/event-handler.ts
+++ b/site/scripts/api-docs-builder/src/event-handler.ts
@@ -1,0 +1,84 @@
+import type { OxcProject } from './oxc-project.js';
+import { parseJSDoc, sourceText, staticName, walkAst } from './oxc-project.js';
+
+/** Collect event descriptions declared with `@fires event-name - Description`. */
+export function collectFires(files: readonly string[], project: OxcProject): Map<string, string> {
+  const fires = new Map<string, string>();
+
+  for (const filePath of files) {
+    const file = project.source(filePath);
+    if (!file) continue;
+
+    for (const comment of file.comments) {
+      if (comment.type !== 'Block' || !comment.value.startsWith('*')) continue;
+
+      for (const value of parseJSDoc(comment.value).tags.get('fires') ?? []) {
+        const match = value.match(/^(\S+)\s*(?:-\s*)?(.*)$/s);
+
+        if (match?.[1] && !fires.has(match[1])) fires.set(match[1], match[2]?.trim() ?? '');
+      }
+    }
+  }
+
+  return fires;
+}
+
+/** Collect literal event names dispatched by the given source files. */
+export function collectDispatchedEvents(files: readonly string[], project: OxcProject): Set<string> {
+  const events = new Set<string>();
+
+  for (const filePath of files) {
+    const file = project.source(filePath);
+    if (!file) continue;
+
+    walkAst(file.program, (node) => {
+      if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name === 'emit') {
+        const argument = node.arguments[0];
+        const eventName = argument?.type === 'Literal' ? staticName(argument) : undefined;
+
+        if (eventName) events.add(eventName);
+      }
+
+      if (
+        node.type === 'CallExpression' &&
+        node.callee.type === 'MemberExpression' &&
+        !node.callee.computed &&
+        node.callee.property.type === 'Identifier' &&
+        node.callee.property.name === 'dispatchEvent'
+      ) {
+        const event = node.arguments[0];
+
+        if (
+          event?.type !== 'NewExpression' ||
+          event.callee.type !== 'Identifier' ||
+          !['Event', 'CustomEvent'].includes(event.callee.name)
+        ) {
+          return;
+        }
+
+        const argument = event.arguments[0];
+        const eventName = argument?.type === 'Literal' ? staticName(argument) : undefined;
+
+        if (eventName) events.add(eventName);
+      }
+
+      if (node.type === 'ForOfStatement' && node.right.type === 'ArrayExpression') {
+        const variable =
+          node.left.type === 'VariableDeclaration'
+            ? staticName(node.left.declarations[0]?.id)
+            : node.left.type === 'Identifier'
+              ? node.left.name
+              : undefined;
+        if (!variable || !sourceText(file, node.body).includes(`Event(${variable})`)) return;
+
+        for (const element of node.right.elements) {
+          const eventName = element?.type === 'Literal' ? staticName(element) : undefined;
+
+          if (eventName) events.add(eventName);
+        }
+      }
+    });
+  }
+
+  return events;
+}

--- a/site/scripts/api-docs-builder/src/html-handler.ts
+++ b/site/scripts/api-docs-builder/src/html-handler.ts
@@ -1,3 +1,4 @@
+import { collectDispatchedEvents, collectFires } from './event-handler.js';
 import type { OxcProject } from './oxc-project.js';
 import { staticName, unwrapExpression, unwrapObjectExpression } from './oxc-project.js';
 import type { HtmlExtraction } from './types.js';
@@ -53,5 +54,15 @@ export function extractHtml(
     }
   }
 
-  return tagName ? { tagName, properties: [...properties] } : null;
+  const files = [...new Set(hierarchy.map(({ file }) => file.filePath))];
+  const fires = collectFires(files, project);
+  const events = [...collectDispatchedEvents(files, project)]
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => {
+      const description = fires.get(name);
+
+      return description ? { name, description } : { name };
+    });
+
+  return tagName ? { tagName, properties: [...properties], events } : null;
 }

--- a/site/scripts/api-docs-builder/src/media-element-handler.ts
+++ b/site/scripts/api-docs-builder/src/media-element-handler.ts
@@ -13,13 +13,13 @@ import type {
 } from 'oxc-parser';
 
 import { extractCSSVars } from './css-vars-handler.js';
+import { collectDispatchedEvents, collectFires } from './event-handler.js';
 import { abbreviateType, formatDetailedType } from './formatter.js';
 import type { NamedDeclaration, OxcProject, ResolvedMember, ResolvedType, SourceFile } from './oxc-project.js';
 import {
   expressionText,
   getJSDocDescription,
   OxcProject as Project,
-  parseJSDoc,
   sourceText,
   staticName,
   unwrapExpression,
@@ -1083,77 +1083,6 @@ function extractEventsFromTypes(filePath: string, interfaceName: string, project
 
     return name ? [name] : [];
   });
-}
-
-function collectFires(files: readonly string[], project: OxcProject): Map<string, string> {
-  const fires = new Map<string, string>();
-
-  for (const filePath of files) {
-    const file = project.source(filePath);
-    if (!file) continue;
-
-    for (const comment of file.comments) {
-      if (comment.type !== 'Block' || !comment.value.startsWith('*')) continue;
-
-      for (const value of parseJSDoc(comment.value).tags.get('fires') ?? []) {
-        const match = value.match(/^(\S+)\s*(?:-\s*)?(.*)$/s);
-
-        if (match?.[1] && !fires.has(match[1])) fires.set(match[1], match[2]?.trim() ?? '');
-      }
-    }
-  }
-
-  return fires;
-}
-
-function collectDispatchedEvents(files: readonly string[], project: OxcProject): Set<string> {
-  const events = new Set<string>();
-
-  for (const filePath of files) {
-    const file = project.source(filePath);
-    if (!file) continue;
-
-    walkAst(file.program, (node) => {
-      if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name === 'emit') {
-        const argument = node.arguments[0];
-
-        if (argument?.type === 'Literal' && typeof argument.value === 'string') events.add(argument.value);
-      }
-
-      if (
-        node.type === 'CallExpression' &&
-        node.callee.type === 'MemberExpression' &&
-        !node.callee.computed &&
-        node.callee.property.type === 'Identifier' &&
-        node.callee.property.name === 'dispatchEvent'
-      ) {
-        const event = node.arguments[0];
-
-        if (event?.type !== 'NewExpression' || event.callee.type !== 'Identifier' || event.callee.name !== 'Event')
-          return;
-
-        const argument = event.arguments[0];
-
-        if (argument?.type === 'Literal' && typeof argument.value === 'string') events.add(argument.value);
-      }
-
-      if (node.type === 'ForOfStatement' && node.right.type === 'ArrayExpression') {
-        const variable =
-          node.left.type === 'VariableDeclaration'
-            ? staticName(node.left.declarations[0]?.id)
-            : node.left.type === 'Identifier'
-              ? node.left.name
-              : undefined;
-        if (!variable || !sourceText(file, node.body).includes(`Event(${variable})`)) return;
-
-        for (const element of node.right.elements) {
-          if (element?.type === 'Literal' && typeof element.value === 'string') events.add(element.value);
-        }
-      }
-    });
-  }
-
-  return events;
 }
 
 function collectNativeMemberNames(): Set<string> {

--- a/site/scripts/api-docs-builder/src/pipeline.ts
+++ b/site/scripts/api-docs-builder/src/pipeline.ts
@@ -26,6 +26,7 @@ import type {
   DataAttrDef,
   DataAttrsExtraction,
   ExtraDataAttrsSource,
+  HtmlExtraction,
   PartReference,
   PartSource,
   PropDef,
@@ -120,6 +121,14 @@ export function buildCSSVars(cssVarsData: CSSVarsExtraction): Record<string, CSS
   }
 
   return cssCustomProperties;
+}
+
+function buildHtmlPlatform(htmlData: HtmlExtraction): NonNullable<PartReference['platforms']['html']> {
+  const platform: NonNullable<PartReference['platforms']['html']> = { tagName: htmlData.tagName };
+
+  if (htmlData.events.length > 0) platform.events = htmlData.events;
+
+  return platform;
 }
 
 // ─── Discovery ─────────────────────────────────────────────────────
@@ -412,7 +421,7 @@ function buildSingleComponentReference(source: ComponentSource, program: OxcProj
   };
 
   if (htmlData) {
-    result.platforms.html = { tagName: htmlData.tagName };
+    result.platforms.html = buildHtmlPlatform(htmlData);
   }
 
   if (result.description === undefined) delete result.description;
@@ -454,7 +463,7 @@ function buildMultiPartReference(
       if (!partRef.description) delete partRef.description;
 
       if (htmlData) {
-        partRef.platforms.html = { tagName: htmlData.tagName };
+        partRef.platforms.html = buildHtmlPlatform(htmlData);
       }
 
       partsRecord[part.kebab] = partRef;
@@ -489,7 +498,7 @@ function buildMultiPartReference(
       if (!partRef.description) delete partRef.description;
 
       if (htmlData) {
-        partRef.platforms.html = { tagName: htmlData.tagName };
+        partRef.platforms.html = buildHtmlPlatform(htmlData);
       }
 
       partsRecord[part.kebab] = partRef;

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -203,7 +203,10 @@ describe('Component pipeline (end-to-end)', () => {
 
       // ── Platforms ──
       // HTML element exists → platforms.html with tagName
-      expect(ref.platforms.html).toEqual({ tagName: 'media-toggle-button' });
+      expect(ref.platforms.html).toEqual({
+        tagName: 'media-toggle-button',
+        events: [{ name: 'pressed-change', description: 'Emitted when the pressed state changes.' }],
+      });
     });
   });
 

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -205,7 +205,20 @@ describe('Component pipeline (end-to-end)', () => {
       // HTML element exists → platforms.html with tagName
       expect(ref.platforms.html).toEqual({
         tagName: 'media-toggle-button',
-        events: [{ name: 'pressed-change', description: 'Emitted when the pressed state changes.' }],
+        events: [
+          { name: 'focus-change' },
+          { name: 'pressed-change', description: 'Emitted when the pressed state changes.' },
+        ],
+      });
+    });
+
+    it('detects literal dispatches without @fires and uses @fires only for descriptions', () => {
+      const events = findComponent('ToggleButton')!.reference.platforms.html?.events;
+
+      expect(events).toContainEqual({ name: 'focus-change' });
+      expect(events).toContainEqual({
+        name: 'pressed-change',
+        description: 'Emitted when the pressed state changes.',
       });
     });
   });

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/toggle-button/toggle-button-element.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/toggle-button/toggle-button-element.ts
@@ -4,7 +4,7 @@
  * Exercises: static tagName extraction for platforms.html.
  */
 
-export class ToggleButtonElement {
+export class ToggleButtonElement extends EventTarget {
   static readonly tagName = 'media-toggle-button';
 
   /** @fires pressed-change - Emitted when the pressed state changes. */

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/toggle-button/toggle-button-element.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/toggle-button/toggle-button-element.ts
@@ -11,4 +11,8 @@ export class ToggleButtonElement extends EventTarget {
   announcePressed(pressed: boolean) {
     this.dispatchEvent(new CustomEvent('pressed-change', { detail: { pressed }, bubbles: true }));
   }
+
+  announceFocus() {
+    this.dispatchEvent(new Event('focus-change'));
+  }
 }

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/toggle-button/toggle-button-element.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/toggle-button/toggle-button-element.ts
@@ -6,4 +6,9 @@
 
 export class ToggleButtonElement {
   static readonly tagName = 'media-toggle-button';
+
+  /** @fires pressed-change - Emitted when the pressed state changes. */
+  announcePressed(pressed: boolean) {
+    this.dispatchEvent(new CustomEvent('pressed-change', { detail: { pressed }, bubbles: true }));
+  }
 }

--- a/site/scripts/api-docs-builder/src/types.ts
+++ b/site/scripts/api-docs-builder/src/types.ts
@@ -2,6 +2,8 @@
  * Re-export types from the shared schema. The shared schema in src/types/component-reference.ts is the single source of
  * truth.
  */
+import type { ComponentEventDef } from '../../../src/types/component-reference.js';
+
 export type {
   ComponentReference,
   ComponentEventDef,

--- a/site/scripts/api-docs-builder/src/types.ts
+++ b/site/scripts/api-docs-builder/src/types.ts
@@ -4,6 +4,7 @@
  */
 export type {
   ComponentReference,
+  ComponentEventDef,
   CSSVarDef,
   DataAttrDef,
   PartReference,
@@ -112,4 +113,5 @@ export interface CSSVarsExtraction {
 export interface HtmlExtraction {
   tagName: string;
   properties: string[];
+  events: ComponentEventDef[];
 }

--- a/site/src/components/docs/api-reference/ApiEventsTable.astro
+++ b/site/src/components/docs/api-reference/ApiEventsTable.astro
@@ -1,0 +1,37 @@
+---
+import MarkdownCode from '@/components/typography/MarkdownCode.astro';
+import Table from '@/components/typography/Table.astro';
+import Tbody from '@/components/typography/Tbody.astro';
+import Td from '@/components/typography/Td.astro';
+import Th from '@/components/typography/Th.astro';
+import Thead from '@/components/typography/Thead.astro';
+import Tr from '@/components/typography/Tr.astro';
+import type { ComponentEventDef } from '@/types/component-reference';
+
+interface Props {
+  events: ComponentEventDef[];
+}
+
+const { events } = Astro.props;
+---
+
+<Table maxWidth={false} outerClass="my-6">
+  <Thead>
+    <Tr>
+      <Th>Event</Th>
+      <Th>Description</Th>
+    </Tr>
+  </Thead>
+  <Tbody>
+    {
+      events.map((event) => (
+        <Tr>
+          <Td class="align-top">
+            <MarkdownCode>{event.name}</MarkdownCode>
+          </Td>
+          <Td class="align-top">{event.description ?? ''}</Td>
+        </Tr>
+      ))
+    }
+  </Tbody>
+</Table>

--- a/site/src/components/docs/api-reference/ComponentReference.astro
+++ b/site/src/components/docs/api-reference/ComponentReference.astro
@@ -13,6 +13,7 @@ import { createComponentReferenceModel } from '@/utils/componentReferenceModel';
 import FrameworkCase from '../FrameworkCase.astro';
 import ApiCSSVarsTable from './ApiCSSVarsTable.astro';
 import ApiDataAttrsTable from './ApiDataAttrsTable.astro';
+import ApiEventsTable from './ApiEventsTable.astro';
 import ApiPropsTable from './ApiPropsTable.astro';
 import ApiStateTable from './ApiStateTable.astro';
 import InlineMarkdown from './InlineMarkdown.astro';
@@ -47,6 +48,9 @@ const singleDataAttributesSection = !apiReferenceModel.hasParts
 const singleCssCustomPropertiesSection = !apiReferenceModel.hasParts
   ? apiReferenceModel.sections.find((section) => section.key === 'cssCustomProperties')
   : null;
+const singleEventsSection = !apiReferenceModel.hasParts
+  ? apiReferenceModel.sections.find((section) => section.key === 'events')
+  : null;
 ---
 
 <ContentWidth>
@@ -66,6 +70,9 @@ const singleCssCustomPropertiesSection = !apiReferenceModel.hasParts
         );
         const partCssCustomPropertiesSection = part.sections.find(
           (section) => section.key === "cssCustomProperties",
+        );
+        const partEventsSection = part.sections.find(
+          (section) => section.key === "events",
         );
 
         return (
@@ -143,6 +150,13 @@ const singleCssCustomPropertiesSection = !apiReferenceModel.hasParts
                 />
               </>
             )}
+
+            {partEventsSection && part.data.platforms.html?.events && (
+              <FrameworkCase frameworks={["html"]}>
+                <H4 id={partEventsSection.id}>{partEventsSection.title}</H4>
+                <ApiEventsTable events={part.data.platforms.html.events} />
+              </FrameworkCase>
+            )}
           </FrameworkCase>
         );
       })
@@ -204,6 +218,13 @@ const singleCssCustomPropertiesSection = !apiReferenceModel.hasParts
               componentName={component}
             />
           </>
+        )}
+
+        {singleEventsSection && apiReferenceModel.data.platforms.html?.events && (
+          <FrameworkCase frameworks={["html"]}>
+            <H3 id={singleEventsSection.id}>{singleEventsSection.title}</H3>
+            <ApiEventsTable events={apiReferenceModel.data.platforms.html.events} />
+          </FrameworkCase>
         )}
       </>
     )

--- a/site/src/types/component-reference.ts
+++ b/site/src/types/component-reference.ts
@@ -31,6 +31,11 @@ export const CSSVarDefSchema = z.object({
   description: z.string(),
 });
 
+export const ComponentEventDefSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+
 export const PartReferenceSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
@@ -42,6 +47,7 @@ export const PartReferenceSchema = z.object({
     html: z
       .object({
         tagName: z.string(),
+        events: z.array(ComponentEventDefSchema).optional(),
       })
       .optional(),
     react: z.object({}).optional(),
@@ -56,5 +62,6 @@ export type PropDef = z.infer<typeof PropDefSchema>;
 export type StateDef = z.infer<typeof StateDefSchema>;
 export type DataAttrDef = z.infer<typeof DataAttrDefSchema>;
 export type CSSVarDef = z.infer<typeof CSSVarDefSchema>;
+export type ComponentEventDef = z.infer<typeof ComponentEventDefSchema>;
 export type PartReference = z.infer<typeof PartReferenceSchema>;
 export type ComponentReference = z.infer<typeof ComponentReferenceSchema>;

--- a/site/src/utils/componentReferenceModel.ts
+++ b/site/src/utils/componentReferenceModel.ts
@@ -80,7 +80,7 @@ function createSections(
   source: PartReference | ComponentReference,
   options: { forPart: true; partId: string } | { forPart: false }
 ): ApiReferenceSection[] {
-  return API_REFERENCE_SUBSECTIONS.flatMap((definition) => {
+  const sections = API_REFERENCE_SUBSECTIONS.flatMap((definition) => {
     if (!hasEntries(source[definition.key])) {
       return [];
     }
@@ -116,6 +116,22 @@ function createSections(
       },
     ];
   });
+
+  if (source.platforms.html?.events?.length) {
+    const section: ApiReferenceSection = {
+      key: 'events',
+      title: 'Events',
+      id: options.forPart ? `${options.partId}-events` : 'events',
+      depth: options.forPart ? 4 : 3,
+      frameworks: ['html'],
+    };
+
+    if (options.forPart) section.tocKind = 'api-reference-subsection';
+
+    sections.push(section);
+  }
+
+  return sections;
 }
 
 export function createComponentReferenceModel(

--- a/site/src/utils/componentReferenceModel.ts
+++ b/site/src/utils/componentReferenceModel.ts
@@ -80,7 +80,7 @@ function createSections(
   source: PartReference | ComponentReference,
   options: { forPart: true; partId: string } | { forPart: false }
 ): ApiReferenceSection[] {
-  const sections = API_REFERENCE_SUBSECTIONS.flatMap((definition) => {
+  const sections: ApiReferenceSection[] = API_REFERENCE_SUBSECTIONS.flatMap((definition) => {
     if (!hasEntries(source[definition.key])) {
       return [];
     }

--- a/site/src/utils/tests/componentReferenceModel.test.ts
+++ b/site/src/utils/tests/componentReferenceModel.test.ts
@@ -49,6 +49,40 @@ describe('createComponentReferenceModel', () => {
     });
   });
 
+  it('adds an HTML-only events section', () => {
+    const apiReference = {
+      name: 'Slider',
+      props: {},
+      state: {},
+      dataAttributes: {},
+      cssCustomProperties: {},
+      platforms: {
+        html: {
+          tagName: 'media-slider',
+          events: [{ name: 'value-change', description: 'Fired when the value changes.' }],
+        },
+      },
+    } satisfies ComponentReference;
+
+    const model = createComponentReferenceModel('Slider', apiReference);
+
+    expect(model?.sections).toEqual([
+      {
+        key: 'events',
+        title: 'Events',
+        id: 'events',
+        depth: 3,
+        frameworks: ['html'],
+      },
+    ]);
+    expect(buildComponentReferenceTocHeadings(model)).toContainEqual({
+      depth: 3,
+      text: 'Events',
+      slug: 'events',
+      frameworks: ['html'],
+    });
+  });
+
   it('builds a multi-part model with framework-specific labels and H4 section ids', () => {
     const apiReference = {
       name: 'Controls',


### PR DESCRIPTION
## Summary

- Extract typed custom-element event metadata for component references.
- Render component event tables alongside generated props, states, and CSS APIs.

## Verification

- `CI=true pnpm -F site test scripts/api-docs-builder/src/tests/e2e.test.ts`
- `CI=true pnpm typecheck`

Closes #1426

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>