### PR TITLE
docs(site): add Hotkey reference

### DIFF
--- a/packages/core/src/core/ui/hotkey/core.ts
+++ b/packages/core/src/core/ui/hotkey/core.ts
@@ -1,14 +1,20 @@
-import type { InputAction } from '../input-action/input-action';
+export type HotkeyActionName =
+  | 'togglePaused'
+  | 'toggleMuted'
+  | 'toggleFullscreen'
+  | 'toggleSubtitles'
+  | 'togglePictureInPicture'
+  | 'seekStep'
+  | 'volumeStep'
+  | 'speedUp'
+  | 'speedDown'
+  | 'seekToPercent';
 
 export interface HotkeyProps {
   /** Key pattern to match, such as `Space`, `ArrowRight`, or `Mod+k`. */
   keys: string;
-  /**
-   * Player action to run when the key pattern matches. Built-in actions are `togglePaused`, `toggleMuted`,
-   * `toggleFullscreen`, `toggleSubtitles`, `togglePictureInPicture`, `seekStep`, `seekToPercent`, `volumeStep`,
-   * `speedUp`, and `speedDown`.
-   */
-  action: InputAction;
+  /** Player action to run when the key pattern matches. */
+  action: HotkeyActionName;
   /** Numeric value passed to actions such as `seekStep`, `volumeStep`, and `seekToPercent`. */
   value?: number | undefined;
   /** Whether the hotkey is disabled. */

--- a/packages/core/src/core/ui/hotkey/core.ts
+++ b/packages/core/src/core/ui/hotkey/core.ts
@@ -1,9 +1,18 @@
 import type { InputAction } from '../input-action/input-action';
 
 export interface HotkeyProps {
+  /** Key pattern to match, such as `Space`, `ArrowRight`, or `Mod+k`. */
   keys: string;
+  /**
+   * Player action to run when the key pattern matches. Built-in actions are `togglePaused`, `toggleMuted`,
+   * `toggleFullscreen`, `toggleSubtitles`, `togglePictureInPicture`, `seekStep`, `seekToPercent`, `volumeStep`,
+   * `speedUp`, and `speedDown`.
+   */
   action: InputAction;
+  /** Numeric value passed to actions such as `seekStep`, `volumeStep`, and `seekToPercent`. */
   value?: number | undefined;
+  /** Whether the hotkey is disabled. */
   disabled?: boolean | undefined;
+  /** Whether to listen on the player container or the document. */
   target?: 'player' | 'document' | undefined;
 }

--- a/packages/core/src/core/ui/tests/input-actions.test-d.tsx
+++ b/packages/core/src/core/ui/tests/input-actions.test-d.tsx
@@ -1,0 +1,17 @@
+import type { HotkeyProps } from '../hotkey/core';
+
+const hotkey = {
+  keys: 'k',
+  action: 'togglePaused',
+} satisfies HotkeyProps;
+
+void hotkey;
+
+// @ts-expect-error - toggleControls is not implemented by Hotkey.
+const unsupportedHotkey = { keys: 'k', action: 'toggleControls' } satisfies HotkeyProps;
+
+// @ts-expect-error - Hotkey does not resolve custom store actions.
+const customHotkey = { keys: 'k', action: 'openTranscript' } satisfies HotkeyProps;
+
+void unsupportedHotkey;
+void customHotkey;

--- a/packages/core/src/dom/hotkey/actions.ts
+++ b/packages/core/src/dom/hotkey/actions.ts
@@ -1,5 +1,6 @@
 import { isUndefined } from '@videojs/utils/predicate';
 
+import type { HotkeyActionName } from '../../core/ui/hotkey/core';
 import { MEDIA_INPUT_ACTION_OVERRIDES } from '../media-actions';
 import type { AnyPlayerStore } from '../player';
 import {
@@ -11,17 +12,7 @@ import {
   selectVolume,
 } from '../store/selectors';
 
-export type HotkeyActionName =
-  | 'togglePaused'
-  | 'toggleMuted'
-  | 'toggleFullscreen'
-  | 'toggleSubtitles'
-  | 'togglePictureInPicture'
-  | 'seekStep'
-  | 'volumeStep'
-  | 'speedUp'
-  | 'speedDown'
-  | 'seekToPercent';
+export type { HotkeyActionName } from '../../core/ui/hotkey/core';
 
 export interface HotkeyActionContext {
   store: AnyPlayerStore;

--- a/packages/html/src/ui/hotkey/hotkey-element.ts
+++ b/packages/html/src/ui/hotkey/hotkey-element.ts
@@ -19,7 +19,7 @@ export class HotkeyElement extends UIElement {
   };
 
   keys: HotkeyProps['keys'] = '';
-  action: HotkeyProps['action'] = '';
+  action: HotkeyProps['action'] | '' = '';
   value: HotkeyProps['value'] = undefined;
   disabled: NonNullable<HotkeyProps['disabled']> = false;
   target: NonNullable<HotkeyProps['target']> = 'player';

--- a/site/src/components/docs/demos/hotkey/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/hotkey/html/css/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/hotkey/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/hotkey/html/css/BasicUsage.css
@@ -1,0 +1,42 @@
+.html-hotkey-basic {
+  position: relative;
+}
+
+.html-hotkey-basic video {
+  width: 100%;
+}
+
+.html-hotkey-basic__instructions {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+}
+
+.html-hotkey-basic__button {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  padding: 8px 20px;
+  color: black;
+  cursor: pointer;
+  background: rgb(255 255 255 / 80%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+}
+
+.html-hotkey-basic__button .show-when-paused,
+.html-hotkey-basic__button .show-when-playing,
+.html-hotkey-basic__button .show-when-ended {
+  display: none;
+}
+
+.html-hotkey-basic__button[data-paused]:not([data-ended]) .show-when-paused,
+.html-hotkey-basic__button:not([data-paused]) .show-when-playing,
+.html-hotkey-basic__button[data-ended] .show-when-ended {
+  display: inline;
+}

--- a/site/src/components/docs/demos/hotkey/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/hotkey/html/css/BasicUsage.html
@@ -1,0 +1,15 @@
+<video-player>
+  <media-container class="html-hotkey-basic">
+    <video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline></video>
+    <p class="html-hotkey-basic__instructions">Space: play/pause · M: mute · ←/→: seek</p>
+    <media-play-button class="html-hotkey-basic__button">
+      <span class="show-when-paused">Play</span>
+      <span class="show-when-playing">Pause</span>
+      <span class="show-when-ended">Replay</span>
+    </media-play-button>
+    <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
+    <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
+    <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
+    <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
+  </media-container>
+</video-player>

--- a/site/src/components/docs/demos/hotkey/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/hotkey/html/css/BasicUsage.ts
@@ -1,0 +1,3 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/hotkey';
+import '@videojs/html/ui/play-button';

--- a/site/src/components/docs/demos/hotkey/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/hotkey/react/css/BasicUsage.css
@@ -1,0 +1,30 @@
+.react-hotkey-basic {
+  position: relative;
+}
+
+.react-hotkey-basic video {
+  width: 100%;
+}
+
+.react-hotkey-basic__instructions {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+}
+
+.react-hotkey-basic__button {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  padding: 8px 20px;
+  color: black;
+  cursor: pointer;
+  background: rgb(255 255 255 / 80%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+}

--- a/site/src/components/docs/demos/hotkey/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/hotkey/react/css/BasicUsage.tsx
@@ -1,0 +1,25 @@
+import { Container, createPlayer, Hotkey, PlayButton } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="react-hotkey-basic">
+        <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline />
+        <p className="react-hotkey-basic__instructions">Space: play/pause · M: mute · ←/→: seek</p>
+        <PlayButton
+          className="react-hotkey-basic__button"
+          render={(props, state) => (
+            <button {...props}>{state.ended ? 'Replay' : state.paused ? 'Play' : 'Pause'}</button>
+          )}
+        />
+        <Hotkey keys="Space" action="togglePaused" />
+        <Hotkey keys="m" action="toggleMuted" />
+        <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
+        <Hotkey keys="ArrowRight" action="seekStep" value={5} />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/content/docs/reference/hotkey.mdx
+++ b/site/src/content/docs/reference/hotkey.mdx
@@ -1,0 +1,99 @@
+---
+title: Hotkey
+frameworkTitle:
+  html: media-hotkey
+description: Register a keyboard shortcut that invokes a player action
+---
+
+import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+import StyleCase from "@/components/docs/StyleCase.astro";
+import Demo from "@/components/docs/demos/Demo.astro";
+
+{/* React demo */}
+import BasicUsageDemoReact from "@/components/docs/demos/hotkey/react/css/BasicUsage";
+import basicUsageReactTsx from "@/components/docs/demos/hotkey/react/css/BasicUsage.tsx?raw";
+import basicUsageReactCss from "@/components/docs/demos/hotkey/react/css/BasicUsage.css?raw";
+
+{/* HTML demo */}
+import BasicUsageDemoHtml from "@/components/docs/demos/hotkey/html/css/BasicUsage.astro";
+import basicUsageHtml from "@/components/docs/demos/hotkey/html/css/BasicUsage.html?raw";
+import basicUsageHtmlCss from "@/components/docs/demos/hotkey/html/css/BasicUsage.css?raw";
+import basicUsageHtmlTs from "@/components/docs/demos/hotkey/html/css/BasicUsage.ts?raw";
+
+## Anatomy
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Hotkey keys="Space" action="togglePaused" />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<media-hotkey keys="Space" action="togglePaused"></media-hotkey>
+```
+</FrameworkCase>
+
+## Behavior
+
+`Hotkey` is a behavior component: it renders no visible interface. Place it inside a `Container` to register one key pattern and player action. By default, the shortcut responds while the player container has focus. Set `target="document"` only when the shortcut should apply across the entire document.
+
+Key patterns are case-insensitive and may use:
+
+- Named keys such as `Space`, `ArrowLeft`, and `ArrowRight`.
+- Exact modifiers such as `Ctrl+k`, `Shift+f`, `Alt+m`, and `Meta+k`.
+- `Mod` for `Meta` on macOS and `Ctrl` elsewhere.
+- The special `0-9` range for digit-based seeking.
+
+The following player actions are built in:
+
+| Action | Behavior | `value` |
+| --- | --- | --- |
+| `togglePaused` | Toggle play and pause | Not used |
+| `toggleMuted` | Toggle mute | Not used |
+| `toggleFullscreen` | Enter or exit fullscreen | Not used |
+| `toggleSubtitles` | Show or hide subtitles | Not used |
+| `togglePictureInPicture` | Enter or exit picture-in-picture | Not used |
+| `seekStep` | Seek relative to the current time | Seconds to seek; use a negative number to seek backward |
+| `volumeStep` | Adjust the current volume | Volume delta, such as `0.05` or `-0.05` |
+| `speedUp` | Select the next configured playback rate | Not used |
+| `speedDown` | Select the previous configured playback rate | Not used |
+| `seekToPercent` | Seek to a percentage of the duration | Percentage from 0 to 100; when omitted with `keys="0-9"`, the pressed digit supplies it |
+
+Toggle actions ignore held-key repeats. Step, rate, and percentage actions may repeat. A matched shortcut prevents the browser's default behavior. Unmodified shortcuts are ignored in editable fields, and <kbd>Space</kbd> or <kbd>Enter</kbd> still activates focused buttons, links, and sliders normally.
+
+## Accessibility
+
+Hotkeys supplement operable controls; they should never be the only way to perform an action. Built-in buttons use matching hotkey registrations to expose `aria-keyshortcuts`, and their tooltips can display the registered shortcut.
+
+## Examples
+
+### Basic Usage
+
+This player uses <kbd>Space</kbd> to play or pause, <kbd>M</kbd> to mute, and the arrow keys to seek by five seconds. Click the player first to focus its container.
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageHtml, lang: "html" },
+      { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+      { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<ComponentReference component="Hotkey" />

--- a/site/src/content/docs/reference/hotkey.mdx
+++ b/site/src/content/docs/reference/hotkey.mdx
@@ -6,6 +6,7 @@ description: Register a keyboard shortcut that invokes a player action
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -37,7 +38,7 @@ import basicUsageHtmlTs from "@/components/docs/demos/hotkey/html/css/BasicUsage
 
 ## Behavior
 
-`Hotkey` is a behavior component: it renders no visible interface. Place it inside a `Container` to register one key pattern and player action. By default, the shortcut responds while the player container has focus. Set `target="document"` only when the shortcut should apply across the entire document.
+`Hotkey` is a behavior component: it renders no visible interface. Place it inside a <DocsLink slug="reference/player-container">Container</DocsLink> to register one key pattern and player action. By default, the shortcut responds while the player container has focus. Set `target="document"` only when the shortcut should apply across the entire document.
 
 Key patterns are case-insensitive and may use:
 
@@ -46,20 +47,7 @@ Key patterns are case-insensitive and may use:
 - `Mod` for `Meta` on macOS and `Ctrl` elsewhere.
 - The special `0-9` range for digit-based seeking.
 
-The following player actions are built in:
-
-| Action | Behavior | `value` |
-| --- | --- | --- |
-| `togglePaused` | Toggle play and pause | Not used |
-| `toggleMuted` | Toggle mute | Not used |
-| `toggleFullscreen` | Enter or exit fullscreen | Not used |
-| `toggleSubtitles` | Show or hide subtitles | Not used |
-| `togglePictureInPicture` | Enter or exit picture-in-picture | Not used |
-| `seekStep` | Seek relative to the current time | Seconds to seek; use a negative number to seek backward |
-| `volumeStep` | Adjust the current volume | Volume delta, such as `0.05` or `-0.05` |
-| `speedUp` | Select the next configured playback rate | Not used |
-| `speedDown` | Select the previous configured playback rate | Not used |
-| `seekToPercent` | Seek to a percentage of the duration | Percentage from 0 to 100; when omitted with `keys="0-9"`, the pressed digit supplies it |
+Choose an `action` from the API reference below. Pass `value` as seconds for `seekStep`, a volume delta such as `0.05` or `-0.05` for `volumeStep`, or a percentage from 0 to 100 for `seekToPercent`. When `value` is omitted from `seekToPercent` with `keys="0-9"`, the pressed digit supplies the percentage.
 
 Toggle actions ignore held-key repeats. Step, rate, and percentage actions may repeat. A matched shortcut prevents the browser's default behavior. Unmodified shortcuts are ignored in editable fields, and <kbd>Space</kbd> or <kbd>Enter</kbd> still activates focused buttons, links, and sliders normally.
 

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -119,6 +119,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/error-dialog' },
           { slug: 'reference/fullscreen-button' },
           { slug: 'reference/google-cast' },
+          { slug: 'reference/hotkey' },
           { slug: 'reference/menu' },
           { slug: 'reference/mute-button' },
           { slug: 'reference/mux-data' },


### PR DESCRIPTION
## Summary

- Add the missing Hotkey reference page, React and HTML demos, and sidebar entry.
- Document the runtime-supported actions, matching rules, targets, repeat behavior, and accessibility contract.

## Verification

- `CI=true pnpm -F site astro check`
- `CI=true pnpm -F site api-docs`

Closes #2268

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>