### PR TITLE
docs(site): add Gesture reference

### DIFF
--- a/packages/core/src/core/ui/gesture/core.ts
+++ b/packages/core/src/core/ui/gesture/core.ts
@@ -5,10 +5,20 @@ export type GesturePointerType = 'mouse' | 'touch' | 'pen';
 export type GestureRegion = 'left' | 'center' | 'right';
 
 export interface GestureProps {
+  /** Gesture to recognize. */
   type: GestureType;
+  /**
+   * Player action to run when the gesture is recognized. Built-in actions are `togglePaused`, `toggleMuted`,
+   * `toggleFullscreen`, `toggleSubtitles`, `togglePictureInPicture`, `toggleControls`, `seekStep`, `volumeStep`,
+   * `speedUp`, and `speedDown`.
+   */
   action: InputAction;
+  /** Numeric value passed to actions such as `seekStep` and `volumeStep`. */
   value?: number | undefined;
+  /** Pointer type that may activate the gesture. All pointer types are accepted when omitted. */
   pointer?: GesturePointerType | undefined;
+  /** Optional horizontal part of the container that may activate the gesture. */
   region?: GestureRegion | undefined;
+  /** Whether the gesture is disabled. */
   disabled?: boolean | undefined;
 }

--- a/packages/core/src/core/ui/gesture/core.ts
+++ b/packages/core/src/core/ui/gesture/core.ts
@@ -1,18 +1,23 @@
-import type { InputAction } from '../input-action/input-action';
-
 export type GestureType = 'tap' | 'doubletap';
 export type GesturePointerType = 'mouse' | 'touch' | 'pen';
 export type GestureRegion = 'left' | 'center' | 'right';
+export type GestureActionName =
+  | 'togglePaused'
+  | 'toggleMuted'
+  | 'toggleFullscreen'
+  | 'toggleSubtitles'
+  | 'togglePictureInPicture'
+  | 'toggleControls'
+  | 'seekStep'
+  | 'volumeStep'
+  | 'speedUp'
+  | 'speedDown';
 
 export interface GestureProps {
   /** Gesture to recognize. */
   type: GestureType;
-  /**
-   * Player action to run when the gesture is recognized. Built-in actions are `togglePaused`, `toggleMuted`,
-   * `toggleFullscreen`, `toggleSubtitles`, `togglePictureInPicture`, `toggleControls`, `seekStep`, `volumeStep`,
-   * `speedUp`, and `speedDown`.
-   */
-  action: InputAction;
+  /** Built-in player action or same-named custom store action to run when the gesture is recognized. */
+  action: GestureActionName | (string & {});
   /** Numeric value passed to actions such as `seekStep` and `volumeStep`. */
   value?: number | undefined;
   /** Pointer type that may activate the gesture. All pointer types are accepted when omitted. */

--- a/packages/core/src/core/ui/tests/gesture-actions.test-d.tsx
+++ b/packages/core/src/core/ui/tests/gesture-actions.test-d.tsx
@@ -1,0 +1,14 @@
+import type { GestureProps } from '../gesture/core';
+
+const builtInGesture = {
+  type: 'tap',
+  action: 'toggleControls',
+} satisfies GestureProps;
+
+const customGesture = {
+  type: 'doubletap',
+  action: 'openTranscript',
+} satisfies GestureProps;
+
+void builtInGesture;
+void customGesture;

--- a/packages/core/src/dom/gesture/actions.ts
+++ b/packages/core/src/dom/gesture/actions.ts
@@ -1,19 +1,10 @@
 import { isFunction } from '@videojs/utils/predicate';
 
+import type { GestureActionName } from '../../core/ui/gesture/core';
 import { MEDIA_INPUT_ACTION_OVERRIDES } from '../media-actions';
 import type { AnyPlayerStore } from '../player';
 
-export type GestureActionName =
-  | 'togglePaused'
-  | 'toggleMuted'
-  | 'toggleFullscreen'
-  | 'toggleSubtitles'
-  | 'togglePictureInPicture'
-  | 'toggleControls'
-  | 'seekStep'
-  | 'volumeStep'
-  | 'speedUp'
-  | 'speedDown';
+export type { GestureActionName } from '../../core/ui/gesture/core';
 
 export interface GestureActionContext {
   store: AnyPlayerStore;

--- a/site/src/components/docs/demos/gesture/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/gesture/html/css/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/gesture/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/gesture/html/css/BasicUsage.css
@@ -1,0 +1,43 @@
+.html-gesture-basic {
+  position: relative;
+}
+
+.html-gesture-basic video {
+  width: 100%;
+}
+
+.html-gesture-basic__instructions {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  pointer-events: none;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+}
+
+.html-gesture-basic__button {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  padding: 8px 20px;
+  color: black;
+  cursor: pointer;
+  background: rgb(255 255 255 / 80%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+}
+
+.html-gesture-basic__button .show-when-paused,
+.html-gesture-basic__button .show-when-playing,
+.html-gesture-basic__button .show-when-ended {
+  display: none;
+}
+
+.html-gesture-basic__button[data-paused]:not([data-ended]) .show-when-paused,
+.html-gesture-basic__button:not([data-paused]) .show-when-playing,
+.html-gesture-basic__button[data-ended] .show-when-ended {
+  display: inline;
+}

--- a/site/src/components/docs/demos/gesture/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/gesture/html/css/BasicUsage.html
@@ -1,0 +1,15 @@
+<video-player>
+  <media-container class="html-gesture-basic">
+    <video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline></video>
+    <p class="html-gesture-basic__instructions">Click: play/pause · Double-click: −10s · fullscreen · +10s</p>
+    <media-play-button class="html-gesture-basic__button">
+      <span class="show-when-paused">Play</span>
+      <span class="show-when-playing">Pause</span>
+      <span class="show-when-ended">Replay</span>
+    </media-play-button>
+    <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>
+    <media-gesture type="doubletap" action="seekStep" value="-10" region="left"></media-gesture>
+    <media-gesture type="doubletap" action="toggleFullscreen" region="center"></media-gesture>
+    <media-gesture type="doubletap" action="seekStep" value="10" region="right"></media-gesture>
+  </media-container>
+</video-player>

--- a/site/src/components/docs/demos/gesture/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/gesture/html/css/BasicUsage.ts
@@ -1,0 +1,3 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/gesture';
+import '@videojs/html/ui/play-button';

--- a/site/src/components/docs/demos/gesture/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/gesture/react/css/BasicUsage.css
@@ -1,0 +1,31 @@
+.react-gesture-basic {
+  position: relative;
+}
+
+.react-gesture-basic video {
+  width: 100%;
+}
+
+.react-gesture-basic__instructions {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  pointer-events: none;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+}
+
+.react-gesture-basic__button {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  padding: 8px 20px;
+  color: black;
+  cursor: pointer;
+  background: rgb(255 255 255 / 80%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+}

--- a/site/src/components/docs/demos/gesture/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/gesture/react/css/BasicUsage.tsx
@@ -1,0 +1,25 @@
+import { Container, createPlayer, Gesture, PlayButton } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="react-gesture-basic">
+        <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline />
+        <p className="react-gesture-basic__instructions">Click: play/pause · Double-click: −10s · fullscreen · +10s</p>
+        <PlayButton
+          className="react-gesture-basic__button"
+          render={(props, state) => (
+            <button {...props}>{state.ended ? 'Replay' : state.paused ? 'Play' : 'Pause'}</button>
+          )}
+        />
+        <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
+        <Gesture type="doubletap" action="seekStep" value={-10} region="left" />
+        <Gesture type="doubletap" action="toggleFullscreen" region="center" />
+        <Gesture type="doubletap" action="seekStep" value={10} region="right" />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/content/docs/reference/gesture.mdx
+++ b/site/src/content/docs/reference/gesture.mdx
@@ -6,6 +6,7 @@ description: Map tap and double-tap gestures to player actions
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -43,7 +44,7 @@ import basicUsageHtmlTs from "@/components/docs/demos/gesture/html/css/BasicUsag
 
 ## Behavior
 
-`Gesture` is a behavior component: it renders no visible interface. Place it inside a `Container` to map a `tap` or `doubletap` gesture to a player action. A tap must use the primary pointer and complete within 250 milliseconds. When a matching double-tap gesture exists, the first tap waits briefly to see whether a second tap follows.
+`Gesture` is a behavior component: it renders no visible interface. Place it inside a <DocsLink slug="reference/player-container">Container</DocsLink> to map a `tap` or `doubletap` gesture to a player action. A tap must use the primary pointer and complete within 250 milliseconds. When a matching double-tap gesture exists, the first tap waits briefly to see whether a second tap follows.
 
 Use `pointer` to accept only `mouse`, `touch`, or `pen` input. Use `region` to divide the container horizontally:
 
@@ -54,22 +55,7 @@ Use `pointer` to accept only `mouse`, `touch`, or `pen` input. Use `region` to d
 
 An unregional gesture acts as a fallback outside the active regions. When several registrations match the same gesture, the first registration wins.
 
-The following player actions are built in:
-
-| Action | Behavior | `value` |
-| --- | --- | --- |
-| `togglePaused` | Toggle play and pause | Not used |
-| `toggleMuted` | Toggle mute | Not used |
-| `toggleFullscreen` | Enter or exit fullscreen | Not used |
-| `toggleSubtitles` | Show or hide subtitles | Not used |
-| `togglePictureInPicture` | Enter or exit picture-in-picture | Not used |
-| `toggleControls` | Show or hide the controls | Not used |
-| `seekStep` | Seek relative to the current time | Seconds to seek; use a negative number to seek backward |
-| `volumeStep` | Adjust the current volume | Volume delta, such as `0.05` or `-0.05` |
-| `speedUp` | Select the next configured playback rate | Not used |
-| `speedDown` | Select the previous configured playback rate | Not used |
-
-An application-defined action name may call a same-named action on the player store. Unknown action names do nothing and warn in development.
+Choose a built-in `action` from the API reference below, or use an application-defined name to call a same-named action on the player store. Pass `value` as seconds for `seekStep` or as a volume delta such as `0.05` or `-0.05` for `volumeStep`. Unknown action names do nothing and warn in development.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/gesture.mdx
+++ b/site/src/content/docs/reference/gesture.mdx
@@ -1,0 +1,107 @@
+---
+title: Gesture
+frameworkTitle:
+  html: media-gesture
+description: Map tap and double-tap gestures to player actions
+---
+
+import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+import StyleCase from "@/components/docs/StyleCase.astro";
+import Demo from "@/components/docs/demos/Demo.astro";
+
+{/* React demo */}
+import BasicUsageDemoReact from "@/components/docs/demos/gesture/react/css/BasicUsage";
+import basicUsageReactTsx from "@/components/docs/demos/gesture/react/css/BasicUsage.tsx?raw";
+import basicUsageReactCss from "@/components/docs/demos/gesture/react/css/BasicUsage.css?raw";
+
+{/* HTML demo */}
+import BasicUsageDemoHtml from "@/components/docs/demos/gesture/html/css/BasicUsage.astro";
+import basicUsageHtml from "@/components/docs/demos/gesture/html/css/BasicUsage.html?raw";
+import basicUsageHtmlCss from "@/components/docs/demos/gesture/html/css/BasicUsage.css?raw";
+import basicUsageHtmlTs from "@/components/docs/demos/gesture/html/css/BasicUsage.ts?raw";
+
+## Anatomy
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Gesture type="doubletap" region="right" pointer="touch" action="seekStep" value={10} />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<media-gesture
+  type="doubletap"
+  region="right"
+  pointer="touch"
+  action="seekStep"
+  value="10"
+></media-gesture>
+```
+</FrameworkCase>
+
+## Behavior
+
+`Gesture` is a behavior component: it renders no visible interface. Place it inside a `Container` to map a `tap` or `doubletap` gesture to a player action. A tap must use the primary pointer and complete within 250 milliseconds. When a matching double-tap gesture exists, the first tap waits briefly to see whether a second tap follows.
+
+Use `pointer` to accept only `mouse`, `touch`, or `pen` input. Use `region` to divide the container horizontally:
+
+- Left and right regions split the container into halves.
+- Left, center, and right regions split it into thirds.
+- A center-only region covers the full container.
+- A single left or right region covers that half of the container.
+
+An unregional gesture acts as a fallback outside the active regions. When several registrations match the same gesture, the first registration wins.
+
+The following player actions are built in:
+
+| Action | Behavior | `value` |
+| --- | --- | --- |
+| `togglePaused` | Toggle play and pause | Not used |
+| `toggleMuted` | Toggle mute | Not used |
+| `toggleFullscreen` | Enter or exit fullscreen | Not used |
+| `toggleSubtitles` | Show or hide subtitles | Not used |
+| `togglePictureInPicture` | Enter or exit picture-in-picture | Not used |
+| `toggleControls` | Show or hide the controls | Not used |
+| `seekStep` | Seek relative to the current time | Seconds to seek; use a negative number to seek backward |
+| `volumeStep` | Adjust the current volume | Volume delta, such as `0.05` or `-0.05` |
+| `speedUp` | Select the next configured playback rate | Not used |
+| `speedDown` | Select the previous configured playback rate | Not used |
+
+An application-defined action name may call a same-named action on the player store. Unknown action names do nothing and warn in development.
+
+## Accessibility
+
+Gestures supplement visible, keyboard-operable controls; they should never be the only way to perform an action. Gestures ignore pointer activity that begins on interactive controls, links, form fields, menu items, or elements marked with `data-interactive`.
+
+## Examples
+
+### Basic Usage
+
+This example follows the common video-player pattern: click to play or pause, double-click the left or right side to seek ten seconds, and double-click the center to toggle fullscreen.
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageHtml, lang: "html" },
+      { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+      { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<ComponentReference component="Gesture" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -118,6 +118,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/dialog' },
           { slug: 'reference/error-dialog' },
           { slug: 'reference/fullscreen-button' },
+          { slug: 'reference/gesture' },
           { slug: 'reference/google-cast' },
           { slug: 'reference/hotkey' },
           { slug: 'reference/menu' },


### PR DESCRIPTION
## Summary

- Add the missing Gesture reference page, React and HTML demos, and sidebar entry.
- Document timing, regions, pointer filters, action behavior, event matching, and accessibility constraints.

## Verification

- `CI=true pnpm -F site astro check`
- `CI=true pnpm -F site api-docs`

Closes #2267

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>