### PR TITLE
docs(site): correct player container references

### DIFF
--- a/packages/core/src/core/ui/slider/core.ts
+++ b/packages/core/src/core/ui/slider/core.ts
@@ -30,7 +30,7 @@ export interface SliderProps {
 export type SliderPreviewOverflow = 'clamp' | 'visible';
 
 export interface SliderPreviewProps {
-  /** Whether the preview is clamped to the slider bounds. */
+  /** How the preview handles slider boundaries. `clamp` keeps it within bounds; `visible` lets it extend past them. */
   overflow?: SliderPreviewOverflow | undefined;
 }
 

--- a/site/src/content/docs/reference/player-container.mdx
+++ b/site/src/content/docs/reference/player-container.mdx
@@ -138,7 +138,7 @@ Media discovery is handled by the player provider, not the container. Custom med
 The container is where user intent enters the player. It listens for physical interaction on its surface and translates that into player behavior:
 
 - **User activity** — Mouse movement, touch, and keyboard activity within the container drive idle detection. This is how controls know when to show and hide.
-- **Gestures** — Click-to-play, double-click fullscreen, swipe to seek, and other touch/mouse gestures. Configured via the `Gesture` component.
+- **Gestures** — Tap and double-tap actions, optionally limited by pointer type and left, center, or right region. Configured via the <DocsLink slug="reference/gesture">`Gesture`</DocsLink> component.
 - **Keyboard controls** — Spacebar to play/pause, arrow keys to seek, and other keyboard shortcuts scoped to the container. Configured via the `Hotkey` component.
 
 ## Relationship to skins


### PR DESCRIPTION
## Summary

- Correct the PlayerContainer gesture example and its current container behavior.
- Remove stale SliderPreview guidance that no longer matches the implementation.

## Verification

- `CI=true pnpm -F site astro check`

Closes #2270

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>