### PR TITLE
docs(site): clarify TimeSlider chapter ranges

### DIFF
--- a/site/src/content/docs/reference/time-slider.mdx
+++ b/site/src/content/docs/reference/time-slider.mdx
@@ -62,7 +62,7 @@ import withChaptersHtmlTs from "@/components/docs/demos/time-slider/html/css/Wit
   ```
 </FrameworkCase>
 
-Add `Chapters` to progressively divide the track when a default `kind="chapters"` text track is available.
+Add `Chapters` to render normalized ranges across the full track. A default `kind="chapters"` text track subdivides those ranges with chapter cues.
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx

--- a/site/src/content/docs/reference/time-slider.mdx
+++ b/site/src/content/docs/reference/time-slider.mdx
@@ -62,7 +62,7 @@ import withChaptersHtmlTs from "@/components/docs/demos/time-slider/html/css/Wit
   ```
 </FrameworkCase>
 
-Add `Chapters` to render normalized ranges across the full track. A default `kind="chapters"` text track subdivides those ranges with chapter cues.
+Add `Chapters` to divide the slider track into sections. Each cue in the default `kind="chapters"` text track marks a chapter. Without chapter cues, one section covers the full slider.
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx


### PR DESCRIPTION
## Summary

- Explain how TimeSlider derives chapter ranges from chapter cues.
- Clarify the fallback behavior when chapter cues do not cover the full timeline.

## Verification

- `CI=true pnpm -F site astro check`

Closes #2205

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>