### PR TITLE
docs(site): document Menu data-item hook

### DIFF
--- a/site/src/content/docs/reference/menu.mdx
+++ b/site/src/content/docs/reference/menu.mdx
@@ -116,6 +116,8 @@ Use data attributes to style open state, highlighted items, selected radio items
 
 The root `Menu.Popup` or `<media-menu>` receives `data-open`, `data-side`, and `data-align`. Each Content receives menu state such as `data-open` and `data-submenu`; a Content with an open logical child receives `data-child-open`.
 
+Every navigable item receives `data-item`. Use `[data-item]` when one rule should target regular, radio, checkbox, and submenu-trigger items together.
+
 <FrameworkCase frameworks={["react"]}>
   ```css
   .menu-popup[data-open] {


### PR DESCRIPTION
## Summary

- Document the data-item styling hook on menu items.
- Show how authored menu content participates in menu item layout and state styling.

## Verification

- `CI=true pnpm -F site astro check`

Closes #1834

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>