### PR TITLE
docs(site): add installation next steps

### DIFF
--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -213,8 +213,6 @@ That's it! You now have a working Video.js player.
 
 <DocsLinkCard slug="concepts/bundlers" description="Check bundler compatibility">Bundlers</DocsLinkCard>
 
-<DocsLinkCard slug="concepts/skins" anchor="styling" description="Some skins expose CSS custom properties">Skins</DocsLinkCard>
-
 <DocsLinkCard slug="concepts/security" description="Configure Content Security Policy for your player">Content Security Policy</DocsLinkCard>
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -197,9 +197,7 @@ That's it! You now have a working Video.js player.
 
 ## Choose what to do next
 
-<DocsLinkCard slug="concepts/skins" description="Choose a packaged skin or learn when to eject one">Skins</DocsLinkCard>
-
-<DocsLinkCard slug="concepts/media-sources" description="Understand source selection and playback engine options">Media sources</DocsLinkCard>
+<DocsLinkCard slug="how-to/customize-skins" description="Customize a packaged skin or eject it for full control">Customize skins</DocsLinkCard>
 
 <DocsLinkCard slug="concepts/overview" anchor="ui-components" description="Explore the building blocks used by skins and custom controls">UI components</DocsLinkCard>
 

--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -193,7 +193,19 @@ Add it to your components folder in a new file.
 
 </div>
 
-## See also
+That's it! You now have a working Video.js player.
+
+## Choose what to do next
+
+<DocsLinkCard slug="concepts/skins" description="Choose a packaged skin or learn when to eject one">Skins</DocsLinkCard>
+
+<DocsLinkCard slug="concepts/media-sources" description="Understand source selection and playback engine options">Media sources</DocsLinkCard>
+
+<DocsLinkCard slug="concepts/overview" anchor="ui-components" description="Explore the building blocks used by skins and custom controls">UI components</DocsLinkCard>
+
+<DocsLinkCard slug="how-to/build-your-own-component" description="Connect custom UI to player state and actions">Build your own component</DocsLinkCard>
+
+## Prepare for production
 
 <DocsLinkCard slug="concepts/browser-support" description="Check supported browsers and rendering environments">Browser support</DocsLinkCard>
 
@@ -203,14 +215,10 @@ Add it to your components folder in a new file.
 
 <DocsLinkCard slug="concepts/skins" anchor="styling" description="Some skins expose CSS custom properties">Skins</DocsLinkCard>
 
-<DocsLinkCard slug="concepts/security" description="Configure Content Security Policy for your player">Security</DocsLinkCard>
+<DocsLinkCard slug="concepts/security" description="Configure Content Security Policy for your player">Content Security Policy</DocsLinkCard>
 
 <FrameworkCase frameworks={["html"]}>
 <DocsLinkCard slug="how-to/self-host-the-player" description="Serve the player from your own origin for offline or restricted-network deployments">Self-host the player</DocsLinkCard>
 </FrameworkCase>
-
-----
-
-That's it! You now have a fully functional Video.js player. Go forth and play.
 
 Something not quite right? You can [submit an issue](https://github.com/videojs/v10/issues) and ask for help, or explore [other support options](/html5-video-support).


### PR DESCRIPTION
## Summary

- Add a clear next step after installing the Video.js packages.
- Point readers to the first player setup path for their framework.

## Verification

- `CI=true pnpm -F site astro check`

Closes #1189

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>