### PR TITLE
docs(site): link contributor guide in sidebar

### DIFF
--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -80,6 +80,7 @@ export const sidebar: Sidebar = [
       { slug: 'how-to/add-a-background-video' },
       { slug: 'how-to/build-your-own-component' },
       { slug: 'how-to/self-host-the-player', frameworks: ['html'] },
+      { href: 'https://github.com/videojs/v10/blob/main/CONTRIBUTING.md', sidebarLabel: 'Contribute to Video.js' },
       {
         sidebarLabel: 'Internationalization',
         defaultOpen: false,


### PR DESCRIPTION
## Summary

- Add the repository contributor guide to the documentation sidebar.
- Make the existing contribution workflow discoverable from the site.

## Verification

- `CI=true pnpm -F site astro check`

Closes #968

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>