### PR TITLE
docs(site): remove redundant page openings

### DIFF
--- a/site/src/content/docs/concepts/browser-support.mdx
+++ b/site/src/content/docs/concepts/browser-support.mdx
@@ -5,7 +5,7 @@ description: Browsers and rendering environments supported by Video.js 10
 
 import Aside from '@/components/Aside.astro';
 
-Video.js 10 targets modern browsers. This page describes the supported browser baseline and other rendering environments.
+Support starts with an evergreen browser baseline and extends to the rendering environments described below.
 
 ## Browser baseline
 

--- a/site/src/content/docs/reference/cloudflare-video.mdx
+++ b/site/src/content/docs/reference/cloudflare-video.mdx
@@ -22,7 +22,7 @@ import basicUsageHtml from "@/components/docs/demos/cloudflare-video/html/css/Ba
 import basicUsageHtmlCss from "@/components/docs/demos/cloudflare-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/cloudflare-video/html/css/BasicUsage.ts?raw";
 
-Video component that plays [Cloudflare Stream](https://developers.cloudflare.com/stream/) videos through the Stream player embed. Cloudflare's own chrome stays hidden by default, so it drops into a <DocsLink slug="concepts/skins">player skin</DocsLink> like any other media component; set `controls` to use Cloudflare's UI instead.
+[Cloudflare Stream](https://developers.cloudflare.com/stream/) runs in an embedded player. Its own chrome stays hidden by default, so it drops into a <DocsLink slug="concepts/skins">player skin</DocsLink> like any other media component; set `controls` to use Cloudflare's UI instead.
 
 ## Load a source
 

--- a/site/src/content/docs/reference/shaka-video.mdx
+++ b/site/src/content/docs/reference/shaka-video.mdx
@@ -22,7 +22,7 @@ import basicUsageHtml from "@/components/docs/demos/shaka-video/html/css/BasicUs
 import basicUsageHtmlCss from "@/components/docs/demos/shaka-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/shaka-video/html/css/BasicUsage.ts?raw";
 
-Video element powered by [Shaka Player](https://github.com/shaka-project/shaka-player). One element plays DASH, HLS, and progressive files, and it's the media component to reach for when you need DRM.
+Choose [Shaka Player](https://github.com/shaka-project/shaka-player) when one media component needs to play DASH, HLS, and progressive files, or when playback requires DRM.
 
 ## Load a source
 

--- a/site/src/content/docs/reference/spotify-audio.mdx
+++ b/site/src/content/docs/reference/spotify-audio.mdx
@@ -22,7 +22,7 @@ import basicUsageHtml from "@/components/docs/demos/spotify-audio/html/css/Basic
 import basicUsageHtmlCss from "@/components/docs/demos/spotify-audio/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/spotify-audio/html/css/BasicUsage.ts?raw";
 
-Audio component that plays Spotify content through the [Spotify embed](https://developer.spotify.com/documentation/embeds): tracks, episodes, albums, playlists, shows, and artists. Podcast episodes play in full for signed-out listeners; music plays as a preview until the listener logs in to Spotify.
+The [Spotify embed](https://developer.spotify.com/documentation/embeds) accepts tracks, episodes, albums, playlists, shows, and artists. Podcast episodes play in full for signed-out listeners; music plays as a preview until the listener logs in to Spotify.
 
 ## Load a source
 

--- a/site/src/content/docs/reference/tiktok-video.mdx
+++ b/site/src/content/docs/reference/tiktok-video.mdx
@@ -22,7 +22,7 @@ import basicUsageHtml from "@/components/docs/demos/tiktok-video/html/css/BasicU
 import basicUsageHtmlCss from "@/components/docs/demos/tiktok-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/tiktok-video/html/css/BasicUsage.ts?raw";
 
-Video component that plays TikTok videos through the [TikTok embed player](https://developers.tiktok.com/doc/embed-player). TikTok videos are portrait, and the player won't draw its chrome below 325×578, so the element starts at that size rather than the usual 300×150.
+The [TikTok embed player](https://developers.tiktok.com/doc/embed-player) expects portrait video and won't draw its chrome below 325×578, so the element starts at that size rather than the usual 300×150.
 
 ## Load a source
 

--- a/site/src/content/docs/reference/twitch-video.mdx
+++ b/site/src/content/docs/reference/twitch-video.mdx
@@ -22,7 +22,7 @@ import basicUsageHtml from "@/components/docs/demos/twitch-video/html/css/BasicU
 import basicUsageHtmlCss from "@/components/docs/demos/twitch-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/twitch-video/html/css/BasicUsage.ts?raw";
 
-Video component that plays Twitch videos and live channels through the [Twitch embed player](https://dev.twitch.tv/docs/embed/video-and-clips/). Twitch's own chrome stays hidden by default, so it drops into a <DocsLink slug="concepts/skins">player skin</DocsLink> like any other media component; set `controls` to use Twitch's UI instead.
+The [Twitch embed player](https://dev.twitch.tv/docs/embed/video-and-clips/) handles both recorded videos and live channels. Its own chrome stays hidden by default, so it drops into a <DocsLink slug="concepts/skins">player skin</DocsLink> like any other media component; set `controls` to use Twitch's UI instead.
 
 ## Load a source
 

--- a/site/src/content/docs/reference/vimeo-video.mdx
+++ b/site/src/content/docs/reference/vimeo-video.mdx
@@ -22,9 +22,7 @@ import basicUsageHtml from "@/components/docs/demos/vimeo-video/html/css/BasicUs
 import basicUsageHtmlCss from "@/components/docs/demos/vimeo-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/vimeo-video/html/css/BasicUsage.ts?raw";
 
-Video component that plays Vimeo videos and live events through the [Vimeo player SDK](https://developer.vimeo.com/player/sdk). Vimeo's own chrome stays hidden by default, so it drops into a <DocsLink slug="concepts/skins">player skin</DocsLink> like any other media component; set `controls` to use Vimeo's UI instead.
-
-Of the embed-backed media components, this one comes closest to a native `<video>`: volume, mute, playback rate, seeking, looping, and picture-in-picture all work, and the embed pushes real events instead of being polled.
+Of the embed-backed media components, the [Vimeo player SDK](https://developer.vimeo.com/player/sdk) comes closest to a native `<video>`: volume, mute, playback rate, seeking, looping, and picture-in-picture all work, and the embed pushes real events instead of being polled. Vimeo's own chrome stays hidden by default, so it drops into a <DocsLink slug="concepts/skins">player skin</DocsLink> like any other media component; set `controls` to use Vimeo's UI instead.
 
 ## Load a source
 

--- a/site/src/content/docs/reference/youtube-video.mdx
+++ b/site/src/content/docs/reference/youtube-video.mdx
@@ -22,7 +22,7 @@ import basicUsageHtml from "@/components/docs/demos/youtube-video/html/css/Basic
 import basicUsageHtmlCss from "@/components/docs/demos/youtube-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/youtube-video/html/css/BasicUsage.ts?raw";
 
-Video component that plays YouTube videos and playlists through the [YouTube IFrame player](https://developers.google.com/youtube/iframe_api_reference). YouTube's own chrome stays hidden by default, so it drops into a <DocsLink slug="concepts/skins">player skin</DocsLink> like any other media component; set `controls` to use YouTube's UI instead.
+The [YouTube IFrame player](https://developers.google.com/youtube/iframe_api_reference) keeps its own chrome hidden by default, so it drops into a <DocsLink slug="concepts/skins">player skin</DocsLink> like any other media component; set `controls` to use YouTube's UI instead.
 
 ## Load a source
 


### PR DESCRIPTION
## Summary

- Tighten repeated page introductions where the title and first sentence say the same thing.
- Preserve the reader-facing context that remains useful.

## Verification

- `CI=true pnpm -F site astro check`

Closes #1062

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>