### PR TITLE
docs(site): add SeekIndicator reference

### DIFF
--- a/packages/core/src/core/ui/seek-indicator/core.ts
+++ b/packages/core/src/core/ui/seek-indicator/core.ts
@@ -10,13 +10,25 @@ import {
   isSeekIndicatorAction,
 } from './seek-indicator-status';
 
-export interface SeekIndicatorProps extends IndicatorCoreProps {}
+export interface SeekIndicatorProps extends IndicatorCoreProps {
+  /** Delay in milliseconds before the indicator closes. */
+  closeDelay?: number | undefined;
+}
 
 export interface SeekIndicatorState extends IndicatorLifecycleState {
+  /** Whether the indicator is open. */
+  open: boolean;
+  /** Increments each time a seek input action updates the indicator. */
+  generation: number;
+  /** Direction of the seek, or `null` when the target does not change the current time. */
   direction: IndicatorDirection | null;
+  /** Number of same-direction seek steps accumulated in the current display. */
   count: number;
+  /** Absolute number of seconds accumulated from seek-step actions. */
   seekTotal: number;
+  /** Accumulated seek-step label, or `null` for percentage seeks. */
   value: string | null;
+  /** Formatted current time captured when the input action occurred. */
   currentTime: string;
 }
 

--- a/packages/core/src/core/ui/seek-indicator/data.ts
+++ b/packages/core/src/core/ui/seek-indicator/data.ts
@@ -2,8 +2,12 @@ import type { StateAttrMap } from '../types';
 import type { SeekIndicatorState } from './core';
 
 export const SeekIndicatorDataAttrs = {
+  /** Present while the indicator is open. */
   open: 'data-open',
+  /** Direction of the seek as `"forward"` or `"backward"`. */
   direction: 'data-direction',
+  /** Present during the open transition. */
   transitionStarting: 'data-starting-style',
+  /** Present during the close transition. */
   transitionEnding: 'data-ending-style',
 } as const satisfies StateAttrMap<SeekIndicatorState>;

--- a/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.astro
@@ -1,0 +1,10 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+import './BasicUsage.css';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import './BasicUsage.ts';
+</script>

--- a/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.css
@@ -1,0 +1,80 @@
+.html-seek-indicator-basic {
+  position: relative;
+}
+
+.html-seek-indicator-basic:focus-visible {
+  outline: 3px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.html-seek-indicator-basic video {
+  display: block;
+  width: 100%;
+}
+
+.html-seek-indicator-basic__instructions {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  text-align: center;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+  translate: -50%;
+}
+
+.html-seek-indicator-basic__indicator {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: grid;
+  min-width: 72px;
+  padding: 16px;
+  color: white;
+  pointer-events: none;
+  background: rgb(0 0 0 / 72%);
+  border-radius: 9999px;
+  place-items: center;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 160ms ease-in-out,
+    scale 160ms ease-in-out;
+}
+
+.html-seek-indicator-basic__indicator::before {
+  font-size: 24px;
+  line-height: 1;
+  content: "↔";
+}
+
+.html-seek-indicator-basic__indicator[data-direction="backward"] {
+  right: auto;
+  left: 16px;
+  transform: translateY(-50%);
+}
+
+.html-seek-indicator-basic__indicator[data-direction="backward"]::before {
+  content: "↶";
+}
+
+.html-seek-indicator-basic__indicator[data-direction="forward"] {
+  right: 16px;
+  left: auto;
+  transform: translateY(-50%);
+}
+
+.html-seek-indicator-basic__indicator[data-direction="forward"]::before {
+  content: "↷";
+}
+
+.html-seek-indicator-basic__indicator[data-starting-style],
+.html-seek-indicator-basic__indicator[data-ending-style] {
+  opacity: 0;
+  scale: 0.85;
+}
+
+.html-seek-indicator-basic__value {
+  font-variant-numeric: tabular-nums;
+}

--- a/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.html
@@ -1,0 +1,12 @@
+<video-player>
+  <media-container class="html-seek-indicator-basic" tabindex="0">
+    <video src="{{VJS10_DEMO_VIDEO_MP4}}" autoplay muted playsinline loop></video>
+    <p class="html-seek-indicator-basic__instructions">Focus the player · ←/→: seek 10s · 0–9: seek to percent</p>
+    <media-seek-indicator class="html-seek-indicator-basic__indicator" aria-hidden="true">
+      <media-seek-indicator-value class="html-seek-indicator-basic__value"></media-seek-indicator-value>
+    </media-seek-indicator>
+    <media-hotkey keys="ArrowLeft" action="seekStep" value="-10"></media-hotkey>
+    <media-hotkey keys="ArrowRight" action="seekStep" value="10"></media-hotkey>
+    <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
+  </media-container>
+</video-player>

--- a/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.ts
@@ -1,0 +1,3 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/hotkey';
+import '@videojs/html/ui/seek-indicator';

--- a/site/src/components/docs/demos/seek-indicator/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/seek-indicator/react/css/BasicUsage.css
@@ -1,0 +1,80 @@
+.react-seek-indicator-basic {
+  position: relative;
+}
+
+.react-seek-indicator-basic:focus-visible {
+  outline: 3px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.react-seek-indicator-basic video {
+  display: block;
+  width: 100%;
+}
+
+.react-seek-indicator-basic__instructions {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  text-align: center;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+  translate: -50%;
+}
+
+.react-seek-indicator-basic__indicator {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: grid;
+  min-width: 72px;
+  padding: 16px;
+  color: white;
+  pointer-events: none;
+  background: rgb(0 0 0 / 72%);
+  border-radius: 9999px;
+  place-items: center;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 160ms ease-in-out,
+    scale 160ms ease-in-out;
+}
+
+.react-seek-indicator-basic__indicator::before {
+  font-size: 24px;
+  line-height: 1;
+  content: "↔";
+}
+
+.react-seek-indicator-basic__indicator[data-direction="backward"] {
+  right: auto;
+  left: 16px;
+  transform: translateY(-50%);
+}
+
+.react-seek-indicator-basic__indicator[data-direction="backward"]::before {
+  content: "↶";
+}
+
+.react-seek-indicator-basic__indicator[data-direction="forward"] {
+  right: 16px;
+  left: auto;
+  transform: translateY(-50%);
+}
+
+.react-seek-indicator-basic__indicator[data-direction="forward"]::before {
+  content: "↷";
+}
+
+.react-seek-indicator-basic__indicator[data-starting-style],
+.react-seek-indicator-basic__indicator[data-ending-style] {
+  opacity: 0;
+  scale: 0.85;
+}
+
+.react-seek-indicator-basic__value {
+  font-variant-numeric: tabular-nums;
+}

--- a/site/src/components/docs/demos/seek-indicator/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/seek-indicator/react/css/BasicUsage.tsx
@@ -1,0 +1,25 @@
+import { Container, createPlayer, Hotkey, SeekIndicator } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+import './BasicUsage.css';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="react-seek-indicator-basic" tabIndex={0}>
+        <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <p className="react-seek-indicator-basic__instructions">
+          Focus the player · ←/→: seek 10s · 0–9: seek to percent
+        </p>
+        <SeekIndicator.Root className="react-seek-indicator-basic__indicator" aria-hidden="true">
+          <SeekIndicator.Value className="react-seek-indicator-basic__value" />
+        </SeekIndicator.Root>
+        <Hotkey keys="ArrowLeft" action="seekStep" value={-10} />
+        <Hotkey keys="ArrowRight" action="seekStep" value={10} />
+        <Hotkey keys="0-9" action="seekToPercent" />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/content/docs/reference/seek-indicator.mdx
+++ b/site/src/content/docs/reference/seek-indicator.mdx
@@ -1,0 +1,138 @@
+---
+title: SeekIndicator
+frameworkTitle:
+  html: media-seek-indicator
+description: A temporary visual indicator for keyboard and gesture seeking
+---
+
+import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+import StyleCase from "@/components/docs/StyleCase.astro";
+import Demo from "@/components/docs/demos/Demo.astro";
+
+{/* React demo */}
+import BasicUsageDemoReact from "@/components/docs/demos/seek-indicator/react/css/BasicUsage";
+import basicUsageReactTsx from "@/components/docs/demos/seek-indicator/react/css/BasicUsage.tsx?raw";
+import basicUsageReactCss from "@/components/docs/demos/seek-indicator/react/css/BasicUsage.css?raw";
+
+{/* HTML demo */}
+import BasicUsageDemoHtml from "@/components/docs/demos/seek-indicator/html/css/BasicUsage.astro";
+import basicUsageHtml from "@/components/docs/demos/seek-indicator/html/css/BasicUsage.html?raw";
+import basicUsageHtmlCss from "@/components/docs/demos/seek-indicator/html/css/BasicUsage.css?raw";
+import basicUsageHtmlTs from "@/components/docs/demos/seek-indicator/html/css/BasicUsage.ts?raw";
+
+## Anatomy
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<SeekIndicator.Root>
+  <SeekIndicator.Value />
+</SeekIndicator.Root>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<media-seek-indicator>
+  <media-seek-indicator-value></media-seek-indicator-value>
+</media-seek-indicator>
+```
+</FrameworkCase>
+
+## Behavior
+
+`SeekIndicator` displays feedback for seek actions emitted by a <DocsLink slug="reference/hotkey">`Hotkey`</DocsLink> or <DocsLink slug="reference/gesture">`Gesture`</DocsLink> in the same player `Container`. It does not react to current-time changes or seek commands invoked directly through the player store.
+
+| Action | Direction | Value |
+| --- | --- | --- |
+| `seekStep` | The sign of `value` determines `forward` or `backward` | The absolute number of seconds, such as `10s` |
+| `seekToPercent` | The target percentage is compared with the current time | The formatted current time when the action occurred |
+
+Rapid `seekStep` actions in the same direction accumulate while the indicator is open. For example, two 10-second forward actions display `20s`. Changing direction or using `seekToPercent` starts a new display. During a rapid sequence, another full step is not added when it would pass the start or duration boundary.
+
+For `seekToPercent`, pass a percentage from 0 to 100 as `value`. A `Hotkey` with `keys="0-9"` can omit `value`; the pressed digit maps to 0%, 10%, and so on through 90%.
+
+The indicator closes after `closeDelay`, which defaults to 800 milliseconds. React stops rendering the Root after its close transition. The HTML custom element remains in the document with `hidden` until the next handled seek action.
+
+## Styling
+
+| Attribute | Values | Description |
+| --- | --- | --- |
+| `data-open` | Present / absent | Present while the indicator is open |
+| `data-direction` | `"forward"` \| `"backward"` | Direction of the handled seek |
+| `data-starting-style` | Present / absent | Present during the open transition |
+| `data-ending-style` | Present / absent | Present during the close transition |
+
+Position the Root from `data-direction` and use the transition attributes for entry and exit styles.
+
+<FrameworkCase frameworks={["html"]}>
+```css
+media-seek-indicator[data-direction="backward"] {
+  left: 1rem;
+}
+
+media-seek-indicator[data-direction="forward"] {
+  right: 1rem;
+}
+
+media-seek-indicator[data-starting-style],
+media-seek-indicator[data-ending-style] {
+  opacity: 0;
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+React renders standard DOM elements. Add a `className` to the Root:
+
+```css
+.seek-indicator[data-direction="backward"] {
+  left: 1rem;
+}
+
+.seek-indicator[data-direction="forward"] {
+  right: 1rem;
+}
+
+.seek-indicator[data-starting-style],
+.seek-indicator[data-ending-style] {
+  opacity: 0;
+}
+```
+</FrameworkCase>
+
+## Accessibility
+
+`SeekIndicator` is visual feedback and does not create a live region. Keep the same seek operation available through keyboard-operable controls, and pair it with `StatusAnnouncer` when changes should be announced to screen readers. Do not make `SeekIndicator.Value` a live region because rapid seek input would produce repeated announcements.
+
+## Examples
+
+### Basic Usage
+
+Focus the player, then press the left or right arrow key to seek by ten seconds. Press a digit from 0 through 9 to seek to a percentage of the duration.
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageHtml, lang: "html" },
+      { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+      { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<ComponentReference component="SeekIndicator" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -133,6 +133,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/poster' },
           { slug: 'reference/quality-radio-group' },
           { slug: 'reference/seek-button' },
+          { slug: 'reference/seek-indicator' },
           { slug: 'reference/slider' },
           { slug: 'reference/thumbnail' },
           { slug: 'reference/time' },


### PR DESCRIPTION
## Summary

- Add the missing SeekIndicator reference page, React and HTML demos, and sidebar entry.
- Document supported input actions, accumulation, direction, presence transitions, data attributes, and visual-only semantics.

## Verification

- `CI=true pnpm -F site astro check`
- `CI=true pnpm -F site api-docs`

Closes #2056

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>