### PR TITLE
docs(site): add StatusAnnouncer reference

### DIFF
--- a/packages/core/src/core/ui/status-announcer/core.ts
+++ b/packages/core/src/core/ui/status-announcer/core.ts
@@ -13,7 +13,7 @@ export interface StatusAnnouncerProps extends IndicatorCoreProps {
   closeDelay?: number | undefined;
   /** Overrides for the translated announcement labels. */
   labels?: Partial<StatusAnnouncerLabels> | undefined;
-  /** Internal gate used by platform adapters to suppress debounced seek and volume announcements. */
+  /** Whether debounced seek and volume changes should be announced. */
   shouldAnnounce?: (() => boolean) | undefined;
 }
 

--- a/packages/core/src/core/ui/status-announcer/core.ts
+++ b/packages/core/src/core/ui/status-announcer/core.ts
@@ -9,13 +9,18 @@ import { deriveStatusAnnouncement, deriveVolumeAnnouncement } from './status-ann
 const ANNOUNCEMENT_DEBOUNCE = 200;
 
 export interface StatusAnnouncerProps extends IndicatorCoreProps {
+  /** Delay in milliseconds before the current announcement label is cleared. */
+  closeDelay?: number | undefined;
+  /** Overrides for the translated announcement labels. */
   labels?: Partial<StatusAnnouncerLabels> | undefined;
-  /** Whether debounced seek and volume changes should be announced. */
+  /** Internal gate used by platform adapters to suppress debounced seek and volume announcements. */
   shouldAnnounce?: (() => boolean) | undefined;
 }
 
 export interface StatusAnnouncerState {
+  /** Increments for each announcement so repeated labels replace the live-region content. */
   generation: number;
+  /** Current announcement text, or `null` when the live region is empty. */
   label: string | null;
 }
 

--- a/packages/core/src/core/ui/status-announcer/status-announcer-labels.ts
+++ b/packages/core/src/core/ui/status-announcer/status-announcer-labels.ts
@@ -13,11 +13,15 @@ import {
 } from '../indicator/indicator-labels';
 
 export interface StatusAnnouncerLabels extends InputIndicatorLabels {
+  /** Formats an announcement containing the current volume value. */
   volumeWithValue: (value: string) => string;
+  /** Formats an announcement containing the completed seek time. */
   seekedTo: (time: number) => string;
+  /** Formats an announcement containing the current playback rate. */
   playbackRate: (rate: string) => string;
 }
 
+/** Default English labels used when no translated labels are provided. */
 export const DEFAULT_STATUS_ANNOUNCER_LABELS: StatusAnnouncerLabels = {
   ...DEFAULT_INPUT_INDICATOR_LABELS,
   volumeWithValue: (value) => translateText(valueText, { value }),
@@ -25,7 +29,7 @@ export const DEFAULT_STATUS_ANNOUNCER_LABELS: StatusAnnouncerLabels = {
   playbackRate: (rate) => translateText(rateText, { rate }),
 };
 
-/** Adds the parameterized labels used by status announcements. */
+/** Creates translated labels for status, volume, seek, and playback-rate announcements. */
 export function createStatusAnnouncerLabels(translator: Translator, locale = DEFAULT_LOCALE): StatusAnnouncerLabels {
   return {
     ...createInputIndicatorLabels(translator),

--- a/packages/core/src/core/ui/status-announcer/status-announcer-status.ts
+++ b/packages/core/src/core/ui/status-announcer/status-announcer-status.ts
@@ -2,6 +2,7 @@ import type { MediaSnapshot } from '../input-action/input-action';
 import { formatVolumeValue } from '../volume-indicator/volume-indicator-status';
 import { DEFAULT_STATUS_ANNOUNCER_LABELS, type StatusAnnouncerLabels } from './status-announcer-labels';
 
+/** Derives the immediate announcement for changed playback, captions, presentation, and playback-rate state. */
 export function deriveStatusAnnouncement(
   previous: MediaSnapshot,
   snapshot: MediaSnapshot,
@@ -32,6 +33,7 @@ export function deriveStatusAnnouncement(
   return announcements.length > 0 ? announcements.join('. ') : null;
 }
 
+/** Derives the announcement for changed volume or mute state. */
 export function deriveVolumeAnnouncement(
   previous: MediaSnapshot,
   snapshot: MediaSnapshot,

--- a/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.astro
@@ -1,0 +1,10 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+import './BasicUsage.css';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import './BasicUsage.ts';
+</script>

--- a/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.css
@@ -1,0 +1,127 @@
+.html-status-announcer-basic {
+  position: relative;
+}
+
+.html-status-announcer-basic video {
+  display: block;
+  width: 100%;
+}
+
+.html-status-announcer-basic__instructions {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+}
+
+.html-status-announcer-basic__controls {
+  position: absolute;
+  right: 12px;
+  bottom: 36px;
+  left: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.html-status-announcer-basic__button {
+  padding: 7px 14px;
+  color: black;
+  cursor: pointer;
+  background: rgb(255 255 255 / 85%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+}
+
+.html-status-announcer-basic__button .show-when-paused,
+.html-status-announcer-basic__button .show-when-playing,
+.html-status-announcer-basic__button .show-when-ended,
+.html-status-announcer-basic__button .show-when-muted,
+.html-status-announcer-basic__button .show-when-unmuted {
+  display: none;
+}
+
+.html-status-announcer-basic__button[data-paused]:not([data-ended]) .show-when-paused,
+.html-status-announcer-basic__button:not([data-paused]) .show-when-playing,
+.html-status-announcer-basic__button[data-ended] .show-when-ended,
+.html-status-announcer-basic__button[data-muted] .show-when-muted,
+.html-status-announcer-basic__button:not([data-muted]) .show-when-unmuted {
+  display: inline;
+}
+
+.html-status-announcer-basic__volume-slider,
+.html-status-announcer-basic__time-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 20px;
+  cursor: pointer;
+}
+
+.html-status-announcer-basic__volume-slider {
+  width: 100px;
+}
+
+.html-status-announcer-basic__time-slider {
+  position: absolute;
+  right: 12px;
+  bottom: 8px;
+  left: 12px;
+}
+
+.html-status-announcer-basic__track {
+  position: absolute;
+  right: 0;
+  left: 0;
+  height: 5px;
+  overflow: hidden;
+  background: rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+}
+
+.html-status-announcer-basic__buffer,
+.html-status-announcer-basic__fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.html-status-announcer-basic__buffer {
+  width: var(--media-slider-buffer);
+  background: rgb(255 255 255 / 30%);
+}
+
+.html-status-announcer-basic__fill {
+  width: var(--media-slider-fill);
+  background: white;
+}
+
+.html-status-announcer-basic__thumb {
+  position: absolute;
+  left: var(--media-slider-fill);
+  width: 14px;
+  height: 14px;
+  background: white;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 40%);
+  translate: -50%;
+}
+
+.html-status-announcer-basic__announcer {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+}

--- a/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.html
@@ -1,0 +1,31 @@
+<video-player>
+  <media-container class="html-status-announcer-basic">
+    <video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline></video>
+    <p class="html-status-announcer-basic__instructions">These controls announce status changes to screen readers.</p>
+    <div class="html-status-announcer-basic__controls">
+      <media-play-button class="html-status-announcer-basic__button">
+        <span class="show-when-paused">Play</span>
+        <span class="show-when-playing">Pause</span>
+        <span class="show-when-ended">Replay</span>
+      </media-play-button>
+      <media-mute-button class="html-status-announcer-basic__button">
+        <span class="show-when-muted">Unmute</span>
+        <span class="show-when-unmuted">Mute</span>
+      </media-mute-button>
+      <media-volume-slider class="html-status-announcer-basic__volume-slider">
+        <media-slider-track class="html-status-announcer-basic__track">
+          <media-slider-fill class="html-status-announcer-basic__fill"></media-slider-fill>
+        </media-slider-track>
+        <media-slider-thumb class="html-status-announcer-basic__thumb"></media-slider-thumb>
+      </media-volume-slider>
+    </div>
+    <media-time-slider class="html-status-announcer-basic__time-slider">
+      <media-slider-track class="html-status-announcer-basic__track">
+        <media-slider-buffer class="html-status-announcer-basic__buffer"></media-slider-buffer>
+        <media-slider-fill class="html-status-announcer-basic__fill"></media-slider-fill>
+      </media-slider-track>
+      <media-slider-thumb class="html-status-announcer-basic__thumb"></media-slider-thumb>
+    </media-time-slider>
+    <media-status-announcer class="html-status-announcer-basic__announcer"></media-status-announcer>
+  </media-container>
+</video-player>

--- a/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.ts
@@ -1,0 +1,6 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/mute-button';
+import '@videojs/html/ui/play-button';
+import '@videojs/html/ui/status-announcer';
+import '@videojs/html/ui/time-slider';
+import '@videojs/html/ui/volume-slider';

--- a/site/src/components/docs/demos/status-announcer/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/status-announcer/react/css/BasicUsage.css
@@ -1,0 +1,111 @@
+.react-status-announcer-basic {
+  position: relative;
+}
+
+.react-status-announcer-basic video {
+  display: block;
+  width: 100%;
+}
+
+.react-status-announcer-basic__instructions {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+}
+
+.react-status-announcer-basic__controls {
+  position: absolute;
+  right: 12px;
+  bottom: 36px;
+  left: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.react-status-announcer-basic__button {
+  padding: 7px 14px;
+  color: black;
+  cursor: pointer;
+  background: rgb(255 255 255 / 85%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+}
+
+.react-status-announcer-basic__volume-slider,
+.react-status-announcer-basic__time-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 20px;
+  cursor: pointer;
+}
+
+.react-status-announcer-basic__volume-slider {
+  width: 100px;
+}
+
+.react-status-announcer-basic__time-slider {
+  position: absolute;
+  right: 12px;
+  bottom: 8px;
+  left: 12px;
+}
+
+.react-status-announcer-basic__track {
+  position: absolute;
+  right: 0;
+  left: 0;
+  height: 5px;
+  overflow: hidden;
+  background: rgb(255 255 255 / 30%);
+  border-radius: 9999px;
+}
+
+.react-status-announcer-basic__buffer,
+.react-status-announcer-basic__fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.react-status-announcer-basic__buffer {
+  width: var(--media-slider-buffer);
+  background: rgb(255 255 255 / 30%);
+}
+
+.react-status-announcer-basic__fill {
+  width: var(--media-slider-fill);
+  background: white;
+}
+
+.react-status-announcer-basic__thumb {
+  position: absolute;
+  left: var(--media-slider-fill);
+  width: 14px;
+  height: 14px;
+  background: white;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 40%);
+  translate: -50%;
+}
+
+.react-status-announcer-basic__announcer {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+}

--- a/site/src/components/docs/demos/status-announcer/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/status-announcer/react/css/BasicUsage.tsx
@@ -1,0 +1,53 @@
+import {
+  Container,
+  createPlayer,
+  MuteButton,
+  PlayButton,
+  StatusAnnouncer,
+  TimeSlider,
+  VolumeSlider,
+} from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+import './BasicUsage.css';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="react-status-announcer-basic">
+        <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline />
+        <p className="react-status-announcer-basic__instructions">
+          These controls announce status changes to screen readers.
+        </p>
+        <div className="react-status-announcer-basic__controls">
+          <PlayButton
+            className="react-status-announcer-basic__button"
+            render={(props, state) => (
+              <button {...props}>{state.ended ? 'Replay' : state.paused ? 'Play' : 'Pause'}</button>
+            )}
+          />
+          <MuteButton
+            className="react-status-announcer-basic__button"
+            render={(props, state) => <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>}
+          />
+          <VolumeSlider.Root className="react-status-announcer-basic__volume-slider">
+            <VolumeSlider.Track className="react-status-announcer-basic__track">
+              <VolumeSlider.Fill className="react-status-announcer-basic__fill" />
+            </VolumeSlider.Track>
+            <VolumeSlider.Thumb className="react-status-announcer-basic__thumb" />
+          </VolumeSlider.Root>
+        </div>
+        <TimeSlider.Root className="react-status-announcer-basic__time-slider">
+          <TimeSlider.Track className="react-status-announcer-basic__track">
+            <TimeSlider.Buffer className="react-status-announcer-basic__buffer" />
+            <TimeSlider.Fill className="react-status-announcer-basic__fill" />
+          </TimeSlider.Track>
+          <TimeSlider.Thumb className="react-status-announcer-basic__thumb" />
+        </TimeSlider.Root>
+        <StatusAnnouncer className="react-status-announcer-basic__announcer" />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/content/docs/reference/seek-indicator.mdx
+++ b/site/src/content/docs/reference/seek-indicator.mdx
@@ -104,7 +104,7 @@ React renders standard DOM elements. Add a `className` to the Root:
 
 ## Accessibility
 
-`SeekIndicator` is visual feedback and does not create a live region. Keep the same seek operation available through keyboard-operable controls, and pair it with `StatusAnnouncer` when changes should be announced to screen readers. Do not make `SeekIndicator.Value` a live region because rapid seek input would produce repeated announcements.
+`SeekIndicator` is visual feedback and does not create a live region. Keep the same seek operation available through keyboard-operable controls, and pair it with <DocsLink slug="reference/status-announcer">`StatusAnnouncer`</DocsLink> when changes should be announced to screen readers. Do not make `SeekIndicator.Value` a live region because rapid seek input would produce repeated announcements.
 
 ## Examples
 

--- a/site/src/content/docs/reference/status-announcer.mdx
+++ b/site/src/content/docs/reference/status-announcer.mdx
@@ -1,0 +1,141 @@
+---
+title: StatusAnnouncer
+frameworkTitle:
+  html: media-status-announcer
+description: Announce player state changes through a persistent status live region
+---
+
+import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+import StyleCase from "@/components/docs/StyleCase.astro";
+import Demo from "@/components/docs/demos/Demo.astro";
+
+{/* React demo */}
+import BasicUsageDemoReact from "@/components/docs/demos/status-announcer/react/css/BasicUsage";
+import basicUsageReactTsx from "@/components/docs/demos/status-announcer/react/css/BasicUsage.tsx?raw";
+import basicUsageReactCss from "@/components/docs/demos/status-announcer/react/css/BasicUsage.css?raw";
+
+{/* HTML demo */}
+import BasicUsageDemoHtml from "@/components/docs/demos/status-announcer/html/css/BasicUsage.astro";
+import basicUsageHtml from "@/components/docs/demos/status-announcer/html/css/BasicUsage.html?raw";
+import basicUsageHtmlCss from "@/components/docs/demos/status-announcer/html/css/BasicUsage.css?raw";
+import basicUsageHtmlTs from "@/components/docs/demos/status-announcer/html/css/BasicUsage.ts?raw";
+
+## Anatomy
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<StatusAnnouncer />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<media-status-announcer></media-status-announcer>
+```
+</FrameworkCase>
+
+## Behavior
+
+`StatusAnnouncer` watches player-store snapshots, so it reports changes made by buttons, sliders, custom controls, or direct player actions. It does not depend on <DocsLink slug="reference/hotkey">`Hotkey`</DocsLink> or <DocsLink slug="reference/gesture">`Gesture`</DocsLink> events.
+
+The first snapshot establishes a baseline without announcing it. Later changes are handled in two groups:
+
+| Timing | Changes |
+| --- | --- |
+| Immediate | Playing or paused, captions on or off, fullscreen entered or exited, picture-in-picture entered or exited, and playback rate |
+| Debounced by 200 milliseconds | The final volume or mute value and the final time after a completed seek |
+
+Regular playback-time updates are ignored. A seek announcement is queued only after `seeking` changes from `true` to `false` at a different time. When several immediate states change in one snapshot, their translated labels are combined into one announcement.
+
+The component always renders with `role="status"`. Its `[data-status-announcer-content]` child is replaced for every announcement, including repeated text, so assistive technology receives a fresh live-region change. After `closeDelay`, which defaults to 800 milliseconds, the label is cleared while the status region remains rendered.
+
+Announcements use the active Video.js locale and translations.
+
+<FrameworkCase frameworks={["react"]}>
+Use the `labels` prop to override individual translated labels for one announcer.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+The custom element receives labels from the nearest player i18n context.
+</FrameworkCase>
+
+## Styling
+
+`StatusAnnouncer` is not visually hidden by the primitive. Apply a visually-hidden class while keeping it in the accessibility tree. Do not use `display: none`, `visibility: hidden`, or the `hidden` attribute.
+
+<FrameworkCase frameworks={["html"]}>
+```css
+media-status-announcer {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+Add a `className` to the component:
+
+```css
+.status-announcer {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+}
+```
+</FrameworkCase>
+
+## Accessibility
+
+The `status` role provides implicit polite live-region behavior, so the component does not add an explicit `aria-live` attribute. Keep one announcer inside each player `Container` whose state changes should be reported.
+
+Debounced volume and completed-seek announcements are suppressed while an element with `role="slider"` inside the same Container has focus. The focused slider provides its own value feedback, and suppressing the separate status message avoids duplicate announcements. A focused slider outside that Container does not suppress it.
+
+Use <DocsLink slug="reference/seek-indicator">`SeekIndicator`</DocsLink> for temporary visual seek feedback. Keep that visual value out of a live region; `StatusAnnouncer` owns the accessible announcement.
+
+## Examples
+
+### Basic Usage
+
+Use the playback button for an immediate announcement and the mute button for a debounced announcement. The sliders provide their own focused value feedback, so `StatusAnnouncer` suppresses its duplicate volume and completed-seek message.
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageHtml, lang: "html" },
+      { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+      { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<ComponentReference component="StatusAnnouncer" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -135,6 +135,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/seek-button' },
           { slug: 'reference/seek-indicator' },
           { slug: 'reference/slider' },
+          { slug: 'reference/status-announcer' },
           { slug: 'reference/thumbnail' },
           { slug: 'reference/time' },
           { slug: 'reference/time-slider' },


### PR DESCRIPTION
## Summary

- Add the missing StatusAnnouncer reference page, React and HTML demos, and sidebar entry.
- Document store-driven announcements, debounce and clear timing, slider suppression, translation, and required visually-hidden styling.

## Verification

- `CI=true pnpm -F site astro check`
- `CI=true pnpm -F site api-docs`

Closes #2057

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>