### PR TITLE
docs(site): add StatusIndicator reference

### DIFF
--- a/packages/core/src/core/ui/status-indicator/core.ts
+++ b/packages/core/src/core/ui/status-indicator/core.ts
@@ -12,17 +12,26 @@ import {
 import { deriveStatus } from './status-indicator-status';
 
 export interface StatusIndicatorProps extends IndicatorCoreProps {
+  /** Input actions allowed to open the indicator. All supported actions are allowed when omitted. */
   actions?: readonly InputAction[] | undefined;
+  /** Internal translated label overrides supplied by framework adapters. */
   labels?: Partial<InputIndicatorLabels> | undefined;
 }
 
 export interface StatusIndicatorState extends IndicatorLifecycleState {
+  /** Whether the indicator is open. */
+  open: boolean;
+  /** Increments each time a supported input action updates the indicator. */
+  generation: number;
+  /** Predicted visual status for the handled input action. */
   status: ReturnType<typeof deriveStatus> extends infer Details
     ? Details extends { status: infer Status }
       ? Status | null
       : never
     : never;
+  /** Translated label for the predicted status. */
   label: string | null;
+  /** Predicted volume percentage for volume actions, otherwise `null`. */
   value: string | null;
 }
 

--- a/packages/core/src/core/ui/status-indicator/data.ts
+++ b/packages/core/src/core/ui/status-indicator/data.ts
@@ -2,8 +2,12 @@ import type { StateAttrMap } from '../types';
 import type { StatusIndicatorState } from './core';
 
 export const StatusIndicatorDataAttrs = {
+  /** Present while the indicator is open. */
   open: 'data-open',
+  /** Predicted visual status for the handled input action. */
   status: 'data-status',
+  /** Present during the open transition. */
   transitionStarting: 'data-starting-style',
+  /** Present during the close transition. */
   transitionEnding: 'data-ending-style',
 } as const satisfies StateAttrMap<StatusIndicatorState>;

--- a/packages/core/src/core/ui/status-indicator/status-indicator-status.ts
+++ b/packages/core/src/core/ui/status-indicator/status-indicator-status.ts
@@ -15,12 +15,17 @@ export type IndicatorStatus =
   | 'pip'
   | 'exit-pip';
 
+/** Predicted display details for a supported status-indicator action. */
 export interface StatusDetails {
+  /** Visual status corresponding to the predicted post-action state. */
   status: IndicatorStatus;
+  /** Translated label for the predicted status. */
   label: string;
+  /** Predicted volume percentage for volume actions, otherwise `null`. */
   value: string | null;
 }
 
+/** Derives the predicted visual status from an input action and its pre-action media snapshot. */
 export function deriveStatus(
   event: InputActionEvent,
   snapshot: MediaSnapshot,
@@ -73,6 +78,7 @@ export function deriveStatus(
   }
 }
 
+/** Returns the volume percentage when present, then the translated status label. */
 export function getStatusIndicatorDisplayValue(state: { value: string | null; label: string | null }): string {
   return state.value ?? state.label ?? '';
 }

--- a/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.astro
@@ -1,0 +1,10 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+import './BasicUsage.css';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import './BasicUsage.ts';
+</script>

--- a/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.css
@@ -1,0 +1,107 @@
+.html-status-indicator-basic {
+  position: relative;
+}
+
+.html-status-indicator-basic:focus-visible {
+  outline: 3px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.html-status-indicator-basic video {
+  display: block;
+  width: 100%;
+}
+
+.html-status-indicator-basic__instructions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  left: 10px;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  text-align: center;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+}
+
+.html-status-indicator-basic__indicator {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: grid;
+  min-width: 92px;
+  padding: 16px;
+  color: white;
+  pointer-events: none;
+  background: rgb(0 0 0 / 72%);
+  border-radius: 12px;
+  place-items: center;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 160ms ease-in-out,
+    scale 160ms ease-in-out;
+}
+
+.html-status-indicator-basic__indicator::before {
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.html-status-indicator-basic__indicator[data-status="play"]::before {
+  content: "▶";
+}
+
+.html-status-indicator-basic__indicator[data-status="pause"]::before {
+  content: "Ⅱ";
+}
+
+.html-status-indicator-basic__indicator[data-status="volume-off"]::before {
+  content: "🔇";
+}
+
+.html-status-indicator-basic__indicator[data-status="volume-low"]::before {
+  content: "🔉";
+}
+
+.html-status-indicator-basic__indicator[data-status="volume-high"]::before {
+  content: "🔊";
+}
+
+.html-status-indicator-basic__indicator[data-status="captions-on"]::before,
+.html-status-indicator-basic__indicator[data-status="captions-off"]::before {
+  content: "CC";
+}
+
+.html-status-indicator-basic__indicator[data-status="captions-off"]::before {
+  text-decoration: line-through;
+}
+
+.html-status-indicator-basic__indicator[data-status="fullscreen"]::before {
+  content: "⛶";
+}
+
+.html-status-indicator-basic__indicator[data-status="exit-fullscreen"]::before {
+  content: "⊠";
+}
+
+.html-status-indicator-basic__indicator[data-status="pip"]::before,
+.html-status-indicator-basic__indicator[data-status="exit-pip"]::before {
+  content: "▣";
+}
+
+.html-status-indicator-basic__indicator[data-status="exit-pip"]::before {
+  text-decoration: line-through;
+}
+
+.html-status-indicator-basic__indicator[data-starting-style],
+.html-status-indicator-basic__indicator[data-ending-style] {
+  opacity: 0;
+  scale: 0.85;
+}
+
+.html-status-indicator-basic__value {
+  margin-top: 8px;
+  font-variant-numeric: tabular-nums;
+}

--- a/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.html
@@ -1,0 +1,22 @@
+<video-player>
+  <media-container class="html-status-indicator-basic" tabindex="0">
+    <video src="{{VJS10_DEMO_VIDEO_MP4}}" autoplay muted playsinline loop>
+      <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srclang="en" label="English" />
+    </video>
+    <p class="html-status-indicator-basic__instructions">
+      Focus the player · K: play/pause · M: mute · F: fullscreen · C: captions · I: picture-in-picture
+    </p>
+    <media-status-indicator
+      class="html-status-indicator-basic__indicator"
+      actions="togglePaused toggleMuted toggleSubtitles toggleFullscreen togglePictureInPicture"
+      aria-hidden="true"
+    >
+      <media-status-indicator-value class="html-status-indicator-basic__value"></media-status-indicator-value>
+    </media-status-indicator>
+    <media-hotkey keys="k" action="togglePaused"></media-hotkey>
+    <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
+    <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
+    <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
+    <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
+  </media-container>
+</video-player>

--- a/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.ts
@@ -1,0 +1,3 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/hotkey';
+import '@videojs/html/ui/status-indicator';

--- a/site/src/components/docs/demos/status-indicator/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/status-indicator/react/css/BasicUsage.css
@@ -1,0 +1,107 @@
+.react-status-indicator-basic {
+  position: relative;
+}
+
+.react-status-indicator-basic:focus-visible {
+  outline: 3px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.react-status-indicator-basic video {
+  display: block;
+  width: 100%;
+}
+
+.react-status-indicator-basic__instructions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  left: 10px;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  text-align: center;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+}
+
+.react-status-indicator-basic__indicator {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: grid;
+  min-width: 92px;
+  padding: 16px;
+  color: white;
+  pointer-events: none;
+  background: rgb(0 0 0 / 72%);
+  border-radius: 12px;
+  place-items: center;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 160ms ease-in-out,
+    scale 160ms ease-in-out;
+}
+
+.react-status-indicator-basic__indicator::before {
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.react-status-indicator-basic__indicator[data-status="play"]::before {
+  content: "▶";
+}
+
+.react-status-indicator-basic__indicator[data-status="pause"]::before {
+  content: "Ⅱ";
+}
+
+.react-status-indicator-basic__indicator[data-status="volume-off"]::before {
+  content: "🔇";
+}
+
+.react-status-indicator-basic__indicator[data-status="volume-low"]::before {
+  content: "🔉";
+}
+
+.react-status-indicator-basic__indicator[data-status="volume-high"]::before {
+  content: "🔊";
+}
+
+.react-status-indicator-basic__indicator[data-status="captions-on"]::before,
+.react-status-indicator-basic__indicator[data-status="captions-off"]::before {
+  content: "CC";
+}
+
+.react-status-indicator-basic__indicator[data-status="captions-off"]::before {
+  text-decoration: line-through;
+}
+
+.react-status-indicator-basic__indicator[data-status="fullscreen"]::before {
+  content: "⛶";
+}
+
+.react-status-indicator-basic__indicator[data-status="exit-fullscreen"]::before {
+  content: "⊠";
+}
+
+.react-status-indicator-basic__indicator[data-status="pip"]::before,
+.react-status-indicator-basic__indicator[data-status="exit-pip"]::before {
+  content: "▣";
+}
+
+.react-status-indicator-basic__indicator[data-status="exit-pip"]::before {
+  text-decoration: line-through;
+}
+
+.react-status-indicator-basic__indicator[data-starting-style],
+.react-status-indicator-basic__indicator[data-ending-style] {
+  opacity: 0;
+  scale: 0.85;
+}
+
+.react-status-indicator-basic__value {
+  margin-top: 8px;
+  font-variant-numeric: tabular-nums;
+}

--- a/site/src/components/docs/demos/status-indicator/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/status-indicator/react/css/BasicUsage.tsx
@@ -1,0 +1,41 @@
+import { Container, createPlayer, Hotkey, StatusIndicator } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+import './BasicUsage.css';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+const statusActions = [
+  'togglePaused',
+  'toggleMuted',
+  'toggleSubtitles',
+  'toggleFullscreen',
+  'togglePictureInPicture',
+] as const;
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="react-status-indicator-basic" tabIndex={0}>
+        <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop>
+          <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
+        </Video>
+        <p className="react-status-indicator-basic__instructions">
+          Focus the player · K: play/pause · M: mute · F: fullscreen · C: captions · I: picture-in-picture
+        </p>
+        <StatusIndicator.Root
+          className="react-status-indicator-basic__indicator"
+          actions={statusActions}
+          aria-hidden="true"
+        >
+          <StatusIndicator.Value className="react-status-indicator-basic__value" />
+        </StatusIndicator.Root>
+        <Hotkey keys="k" action="togglePaused" />
+        <Hotkey keys="m" action="toggleMuted" />
+        <Hotkey keys="f" action="toggleFullscreen" />
+        <Hotkey keys="c" action="toggleSubtitles" />
+        <Hotkey keys="i" action="togglePictureInPicture" />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/content/docs/reference/status-indicator.mdx
+++ b/site/src/content/docs/reference/status-indicator.mdx
@@ -1,0 +1,156 @@
+---
+title: StatusIndicator
+frameworkTitle:
+  html: media-status-indicator
+description: Display temporary visual feedback for keyboard and gesture actions
+---
+
+import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+import StyleCase from "@/components/docs/StyleCase.astro";
+import Demo from "@/components/docs/demos/Demo.astro";
+
+{/* React demo */}
+import BasicUsageDemoReact from "@/components/docs/demos/status-indicator/react/css/BasicUsage";
+import basicUsageReactTsx from "@/components/docs/demos/status-indicator/react/css/BasicUsage.tsx?raw";
+import basicUsageReactCss from "@/components/docs/demos/status-indicator/react/css/BasicUsage.css?raw";
+
+{/* HTML demo */}
+import BasicUsageDemoHtml from "@/components/docs/demos/status-indicator/html/css/BasicUsage.astro";
+import basicUsageHtml from "@/components/docs/demos/status-indicator/html/css/BasicUsage.html?raw";
+import basicUsageHtmlCss from "@/components/docs/demos/status-indicator/html/css/BasicUsage.css?raw";
+import basicUsageHtmlTs from "@/components/docs/demos/status-indicator/html/css/BasicUsage.ts?raw";
+
+## Anatomy
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<StatusIndicator.Root>
+  <StatusIndicator.Value />
+</StatusIndicator.Root>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<media-status-indicator>
+  <media-status-indicator-value></media-status-indicator-value>
+</media-status-indicator>
+```
+</FrameworkCase>
+
+## Behavior
+
+`StatusIndicator` displays feedback for actions emitted by a <DocsLink slug="reference/hotkey">`Hotkey`</DocsLink> or <DocsLink slug="reference/gesture">`Gesture`</DocsLink> in the same player `Container`. It does not react to buttons, direct player-store changes, or media state changes on their own.
+
+The input event arrives before its action is resolved. The indicator uses the media snapshot from that moment to predict the next visual status:
+
+| Action | `data-status` | Value |
+| --- | --- | --- |
+| `togglePaused` | `"play"` or `"pause"` | Translated playing or paused label |
+| `toggleMuted` | `"volume-off"`, `"volume-low"`, or `"volume-high"` | Predicted volume percentage |
+| `volumeStep` | `"volume-off"`, `"volume-low"`, or `"volume-high"` | Predicted volume percentage |
+| `toggleSubtitles` | `"captions-on"` or `"captions-off"` | Translated captions label |
+| `toggleFullscreen` | `"fullscreen"` or `"exit-fullscreen"` | Translated fullscreen label |
+| `togglePictureInPicture` | `"pip"` or `"exit-pip"` | Translated picture-in-picture label |
+
+`toggleSubtitles` is ignored when the player reports that no captions or subtitles are available. Seek actions, `toggleControls`, playback-rate actions, and custom actions do not open this indicator.
+
+Use `actions` to allow only some of the supported actions. Omitting it allows all supported actions.
+
+<FrameworkCase frameworks={["react"]}>
+Pass a readonly array of action names:
+
+```tsx
+<StatusIndicator.Root actions={["togglePaused", "toggleMuted"]}>
+  <StatusIndicator.Value />
+</StatusIndicator.Root>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+Set the `actions` attribute to action names separated by commas, whitespace, or both:
+
+```html
+<media-status-indicator actions="togglePaused, toggleMuted">
+  <media-status-indicator-value></media-status-indicator-value>
+</media-status-indicator>
+```
+</FrameworkCase>
+
+The indicator closes after `closeDelay`, which defaults to 800 milliseconds. A repeated handled action updates the current value and restarts that close timer without replaying the entry transition. React stops rendering the Root after its close transition. The HTML custom element remains in the document with `hidden` until the next handled action.
+
+## Styling
+
+| Attribute | Values | Description |
+| --- | --- | --- |
+| `data-open` | Present / absent | Present while the indicator is open |
+| `data-status` | `"play"`, `"pause"`, `"volume-off"`, `"volume-low"`, `"volume-high"`, `"captions-on"`, `"captions-off"`, `"fullscreen"`, `"exit-fullscreen"`, `"pip"`, or `"exit-pip"` | Predicted status for the handled action |
+| `data-starting-style` | Present / absent | Present during the open transition |
+| `data-ending-style` | Present / absent | Present during the close transition |
+
+Use `data-status` to select an icon or other visual treatment, and use the transition attributes for entry and exit styles.
+
+<FrameworkCase frameworks={["html"]}>
+```css
+media-status-indicator[data-status="play"] {
+  color: green;
+}
+
+media-status-indicator[data-starting-style],
+media-status-indicator[data-ending-style] {
+  opacity: 0;
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+React renders standard DOM elements. Add a `className` to the Root:
+
+```css
+.status-indicator[data-status="play"] {
+  color: green;
+}
+
+.status-indicator[data-starting-style],
+.status-indicator[data-ending-style] {
+  opacity: 0;
+}
+```
+</FrameworkCase>
+
+## Accessibility
+
+`StatusIndicator` is visual feedback and does not create a live region. Keep every action available through keyboard-operable controls, and pair the player with <DocsLink slug="reference/status-announcer">`StatusAnnouncer`</DocsLink> when state changes should be announced to screen readers. Do not make `StatusIndicator.Value` a live region.
+
+## Examples
+
+### Basic Usage
+
+Focus the player, then press <kbd>K</kbd> to play or pause, <kbd>M</kbd> to mute, <kbd>F</kbd> for fullscreen, <kbd>C</kbd> for captions, or <kbd>I</kbd> for picture-in-picture.
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageHtml, lang: "html" },
+      { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+      { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<ComponentReference component="StatusIndicator" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -136,6 +136,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/seek-indicator' },
           { slug: 'reference/slider' },
           { slug: 'reference/status-announcer' },
+          { slug: 'reference/status-indicator' },
           { slug: 'reference/thumbnail' },
           { slug: 'reference/time' },
           { slug: 'reference/time-slider' },


### PR DESCRIPTION
## Summary

- Add the missing StatusIndicator reference page, React and HTML demos, and sidebar entry.
- Document supported input actions, predicted statuses, filtering syntax, presence transitions, and visual-only semantics.

## Verification

- `CI=true pnpm -F site astro check`
- `CI=true pnpm -F site api-docs`

Closes #2058

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>