### PR TITLE
docs(site): add VolumeIndicator reference

### DIFF
--- a/packages/core/src/core/ui/volume-indicator/core.ts
+++ b/packages/core/src/core/ui/volume-indicator/core.ts
@@ -12,14 +12,24 @@ import {
 } from './volume-indicator-status';
 
 export interface VolumeIndicatorProps extends IndicatorCoreProps {
+  /** Internal translated label overrides supplied by framework adapters. */
   labels?: Partial<InputIndicatorLabels> | undefined;
 }
 
 export interface VolumeIndicatorState extends IndicatorLifecycleState {
+  /** Whether the indicator is open. */
+  open: boolean;
+  /** Increments each time a volume input action updates the indicator. */
+  generation: number;
+  /** Predicted volume level after the input action. */
   level: IndicatorVolumeLevel | null;
+  /** Predicted volume formatted as a percentage. */
   value: string | null;
+  /** Predicted volume percentage used by the Fill part. */
   fill: string | null;
+  /** Whether a downward step tried to move past minimum volume. */
   min: boolean;
+  /** Whether an upward step tried to move past maximum volume. */
   max: boolean;
 }
 

--- a/packages/core/src/core/ui/volume-indicator/data.ts
+++ b/packages/core/src/core/ui/volume-indicator/data.ts
@@ -2,10 +2,16 @@ import type { StateAttrMap } from '../types';
 import type { VolumeIndicatorState } from './core';
 
 export const VolumeIndicatorDataAttrs = {
+  /** Present while the indicator is open. */
   open: 'data-open',
+  /** Predicted volume level as `"off"`, `"low"`, or `"high"`. */
   level: 'data-level',
+  /** Present briefly when a downward step cannot lower the volume further. */
   min: 'data-min',
+  /** Present briefly when an upward step cannot raise the volume further. */
   max: 'data-max',
+  /** Present during the open transition. */
   transitionStarting: 'data-starting-style',
+  /** Present during the close transition. */
   transitionEnding: 'data-ending-style',
 } as const satisfies StateAttrMap<VolumeIndicatorState>;

--- a/packages/core/src/core/ui/volume-indicator/vars.ts
+++ b/packages/core/src/core/ui/volume-indicator/vars.ts
@@ -1,3 +1,4 @@
 export const VolumeIndicatorCSSVars = {
+  /** Current predicted volume percentage, set on the Fill part. */
   fill: '--media-volume-fill',
 } as const;

--- a/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.astro
@@ -1,0 +1,10 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+import './BasicUsage.css';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import './BasicUsage.ts';
+</script>

--- a/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.css
@@ -1,0 +1,120 @@
+.html-volume-indicator-basic {
+  position: relative;
+}
+
+.html-volume-indicator-basic:focus-visible {
+  outline: 3px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.html-volume-indicator-basic video {
+  display: block;
+  width: 100%;
+}
+
+.html-volume-indicator-basic__instructions {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  text-align: center;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+  translate: -50%;
+}
+
+.html-volume-indicator-basic__indicator {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: grid;
+  min-width: 220px;
+  padding: 18px 20px 34px;
+  color: white;
+  pointer-events: none;
+  background: rgb(0 0 0 / 72%);
+  border-radius: 12px;
+  place-items: center;
+  translate: -50% -50%;
+  transition:
+    opacity 160ms ease-in-out,
+    scale 160ms ease-in-out;
+}
+
+.html-volume-indicator-basic__indicator::before {
+  margin-bottom: 12px;
+  font-size: 28px;
+  line-height: 1;
+}
+
+.html-volume-indicator-basic__indicator[data-level="off"]::before {
+  content: "🔇";
+}
+
+.html-volume-indicator-basic__indicator[data-level="low"]::before {
+  content: "🔉";
+}
+
+.html-volume-indicator-basic__indicator[data-level="high"]::before {
+  content: "🔊";
+}
+
+.html-volume-indicator-basic__fill {
+  position: relative;
+  width: 180px;
+  height: 10px;
+  background: rgb(255 255 255 / 25%);
+  border-radius: 9999px;
+}
+
+.html-volume-indicator-basic__fill::before {
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: var(--media-volume-fill, 0%);
+  content: "";
+  background: currentColor;
+  border-radius: inherit;
+  transition: width 160ms linear;
+}
+
+.html-volume-indicator-basic__value {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  font-variant-numeric: tabular-nums;
+  translate: -50%;
+}
+
+.html-volume-indicator-basic__indicator[data-starting-style],
+.html-volume-indicator-basic__indicator[data-ending-style] {
+  opacity: 0;
+  scale: 0.85;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .html-volume-indicator-basic__indicator[data-min],
+  .html-volume-indicator-basic__indicator[data-max] {
+    animation: html-volume-indicator-basic-shake 300ms linear;
+  }
+}
+
+@keyframes html-volume-indicator-basic-shake {
+  20% {
+    translate: calc(-50% - 8px) -50%;
+  }
+
+  40% {
+    translate: calc(-50% + 6px) -50%;
+  }
+
+  60% {
+    translate: calc(-50% - 4px) -50%;
+  }
+
+  80% {
+    translate: calc(-50% + 2px) -50%;
+  }
+}

--- a/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.html
@@ -1,0 +1,14 @@
+<video-player>
+  <media-container class="html-volume-indicator-basic" tabindex="0">
+    <video src="{{VJS10_DEMO_VIDEO_MP4}}" autoplay muted playsinline loop></video>
+    <p class="html-volume-indicator-basic__instructions">Focus the player · M: mute · ↑/↓: volume ±5%</p>
+    <media-volume-indicator class="html-volume-indicator-basic__indicator" aria-hidden="true">
+      <media-volume-indicator-fill class="html-volume-indicator-basic__fill">
+        <media-volume-indicator-value class="html-volume-indicator-basic__value"></media-volume-indicator-value>
+      </media-volume-indicator-fill>
+    </media-volume-indicator>
+    <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
+    <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
+    <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+  </media-container>
+</video-player>

--- a/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.ts
@@ -1,0 +1,7 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/hotkey';
+import '@videojs/html/ui/volume-indicator';
+
+const video = document.querySelector<HTMLVideoElement>('.html-volume-indicator-basic video');
+
+if (video) video.volume = 0.5;

--- a/site/src/components/docs/demos/volume-indicator/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/volume-indicator/react/css/BasicUsage.css
@@ -1,0 +1,120 @@
+.react-volume-indicator-basic {
+  position: relative;
+}
+
+.react-volume-indicator-basic:focus-visible {
+  outline: 3px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.react-volume-indicator-basic video {
+  display: block;
+  width: 100%;
+}
+
+.react-volume-indicator-basic__instructions {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  padding: 6px 10px;
+  margin: 0;
+  color: white;
+  text-align: center;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+  translate: -50%;
+}
+
+.react-volume-indicator-basic__indicator {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: grid;
+  min-width: 220px;
+  padding: 18px 20px 34px;
+  color: white;
+  pointer-events: none;
+  background: rgb(0 0 0 / 72%);
+  border-radius: 12px;
+  place-items: center;
+  translate: -50% -50%;
+  transition:
+    opacity 160ms ease-in-out,
+    scale 160ms ease-in-out;
+}
+
+.react-volume-indicator-basic__indicator::before {
+  margin-bottom: 12px;
+  font-size: 28px;
+  line-height: 1;
+}
+
+.react-volume-indicator-basic__indicator[data-level="off"]::before {
+  content: "🔇";
+}
+
+.react-volume-indicator-basic__indicator[data-level="low"]::before {
+  content: "🔉";
+}
+
+.react-volume-indicator-basic__indicator[data-level="high"]::before {
+  content: "🔊";
+}
+
+.react-volume-indicator-basic__fill {
+  position: relative;
+  width: 180px;
+  height: 10px;
+  background: rgb(255 255 255 / 25%);
+  border-radius: 9999px;
+}
+
+.react-volume-indicator-basic__fill::before {
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: var(--media-volume-fill, 0%);
+  content: "";
+  background: currentColor;
+  border-radius: inherit;
+  transition: width 160ms linear;
+}
+
+.react-volume-indicator-basic__value {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  font-variant-numeric: tabular-nums;
+  translate: -50%;
+}
+
+.react-volume-indicator-basic__indicator[data-starting-style],
+.react-volume-indicator-basic__indicator[data-ending-style] {
+  opacity: 0;
+  scale: 0.85;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .react-volume-indicator-basic__indicator[data-min],
+  .react-volume-indicator-basic__indicator[data-max] {
+    animation: react-volume-indicator-basic-shake 300ms linear;
+  }
+}
+
+@keyframes react-volume-indicator-basic-shake {
+  20% {
+    translate: calc(-50% - 8px) -50%;
+  }
+
+  40% {
+    translate: calc(-50% + 6px) -50%;
+  }
+
+  60% {
+    translate: calc(-50% - 4px) -50%;
+  }
+
+  80% {
+    translate: calc(-50% + 2px) -50%;
+  }
+}

--- a/site/src/components/docs/demos/volume-indicator/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/volume-indicator/react/css/BasicUsage.tsx
@@ -1,0 +1,34 @@
+import { Container, createPlayer, Hotkey, VolumeIndicator } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+import './BasicUsage.css';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="react-volume-indicator-basic" tabIndex={0}>
+        <Video
+          ref={(video) => {
+            if (video) video.volume = 0.5;
+          }}
+          src="{{VJS10_DEMO_VIDEO_MP4}}"
+          autoPlay
+          muted
+          playsInline
+          loop
+        />
+        <p className="react-volume-indicator-basic__instructions">Focus the player · M: mute · ↑/↓: volume ±5%</p>
+        <VolumeIndicator.Root className="react-volume-indicator-basic__indicator" aria-hidden="true">
+          <VolumeIndicator.Fill className="react-volume-indicator-basic__fill">
+            <VolumeIndicator.Value className="react-volume-indicator-basic__value" />
+          </VolumeIndicator.Fill>
+        </VolumeIndicator.Root>
+        <Hotkey keys="m" action="toggleMuted" />
+        <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
+        <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/content/docs/reference/volume-indicator.mdx
+++ b/site/src/content/docs/reference/volume-indicator.mdx
@@ -1,0 +1,141 @@
+---
+title: VolumeIndicator
+frameworkTitle:
+  html: media-volume-indicator
+description: Display temporary visual feedback for keyboard and gesture volume actions
+---
+
+import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+import StyleCase from "@/components/docs/StyleCase.astro";
+import Demo from "@/components/docs/demos/Demo.astro";
+
+{/* React demo */}
+import BasicUsageDemoReact from "@/components/docs/demos/volume-indicator/react/css/BasicUsage";
+import basicUsageReactTsx from "@/components/docs/demos/volume-indicator/react/css/BasicUsage.tsx?raw";
+import basicUsageReactCss from "@/components/docs/demos/volume-indicator/react/css/BasicUsage.css?raw";
+
+{/* HTML demo */}
+import BasicUsageDemoHtml from "@/components/docs/demos/volume-indicator/html/css/BasicUsage.astro";
+import basicUsageHtml from "@/components/docs/demos/volume-indicator/html/css/BasicUsage.html?raw";
+import basicUsageHtmlCss from "@/components/docs/demos/volume-indicator/html/css/BasicUsage.css?raw";
+import basicUsageHtmlTs from "@/components/docs/demos/volume-indicator/html/css/BasicUsage.ts?raw";
+
+## Anatomy
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<VolumeIndicator.Root>
+  <VolumeIndicator.Fill>
+    <VolumeIndicator.Value />
+  </VolumeIndicator.Fill>
+</VolumeIndicator.Root>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<media-volume-indicator>
+  <media-volume-indicator-fill>
+    <media-volume-indicator-value></media-volume-indicator-value>
+  </media-volume-indicator-fill>
+</media-volume-indicator>
+```
+</FrameworkCase>
+
+## Behavior
+
+`VolumeIndicator` displays feedback for `toggleMuted` and `volumeStep` actions emitted by a <DocsLink slug="reference/hotkey">`Hotkey`</DocsLink> or <DocsLink slug="reference/gesture">`Gesture`</DocsLink> in the same player `Container`. It does not react to mute buttons, volume sliders, direct player-store changes, or volume changes on their own.
+
+The input event arrives before its action is resolved. The indicator uses the media snapshot from that moment to predict the next mute state and volume. `toggleMuted` predicts the opposite mute state. `volumeStep` adds its `value` to the snapshot volume and clamps the result from 0 to 1. A step whose clamped result is above 0 also predicts that mute will clear.
+
+The Root exposes the predicted level:
+
+| `data-level` | Predicted state |
+| --- | --- |
+| `"off"` | Muted or volume is 0 |
+| `"low"` | Unmuted volume is greater than 0 and at most 0.5 |
+| `"high"` | Unmuted volume is greater than 0.5 |
+
+`Value` displays the rounded percentage from 0% through 100%. `Fill` receives the same percentage through `--media-volume-fill`. Nest `Value` inside `Fill` so the progress treatment and text form one visual unit.
+
+The indicator closes after `closeDelay`, which defaults to 800 milliseconds. Repeated handled actions update the current value and restart that close timer without replaying the entry transition. Each update uses the latest media snapshot; the component does not independently accumulate volume steps. React stops rendering the Root after its close transition. The HTML custom element remains in the document with `hidden` until the next handled action.
+
+When a nonzero `volumeStep` cannot move past an already-clamped edge, `data-min` or `data-max` is present for 300 milliseconds. Hitting the same edge again briefly clears the attribute, then restores it on the next task so a CSS boundary animation can restart. Merely reaching 0% or 100% does not trigger the boundary attribute until another step tries to move farther.
+
+## Styling
+
+| Attribute | Values | Description |
+| --- | --- | --- |
+| `data-open` | Present / absent | Present while the indicator is open |
+| `data-level` | `"off"`, `"low"`, or `"high"` | Predicted volume level |
+| `data-min` | Present / absent | Present briefly after a blocked downward step at minimum volume |
+| `data-max` | Present / absent | Present briefly after a blocked upward step at maximum volume |
+| `data-starting-style` | Present / absent | Present during the open transition |
+| `data-ending-style` | Present / absent | Present during the close transition |
+
+`--media-volume-fill` is set on the Fill part, not the Root. Read it from a Fill selector when sizing a progress treatment.
+
+<FrameworkCase frameworks={["html"]}>
+```css
+media-volume-indicator-fill::before {
+  width: var(--media-volume-fill, 0%);
+}
+
+media-volume-indicator[data-starting-style],
+media-volume-indicator[data-ending-style] {
+  opacity: 0;
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+React renders standard DOM elements. Add separate `className` values to the Root and Fill:
+
+```css
+.volume-indicator__fill::before {
+  width: var(--media-volume-fill, 0%);
+}
+
+.volume-indicator[data-starting-style],
+.volume-indicator[data-ending-style] {
+  opacity: 0;
+}
+```
+</FrameworkCase>
+
+## Accessibility
+
+`VolumeIndicator` is visual feedback and does not create a live region. Keep volume and mute available through keyboard-operable controls, and pair the player with <DocsLink slug="reference/status-announcer">`StatusAnnouncer`</DocsLink> when state changes should be announced to screen readers. Do not make `VolumeIndicator.Value` a live region.
+
+## Examples
+
+### Basic Usage
+
+Focus the player, then press <kbd>M</kbd> to mute or unmute. Use <kbd>Arrow Up</kbd> and <kbd>Arrow Down</kbd> to adjust volume by 5%.
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageHtml, lang: "html" },
+      { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+      { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<ComponentReference component="VolumeIndicator" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -142,6 +142,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/time-slider' },
           { slug: 'reference/title' },
           { slug: 'reference/tooltip' },
+          { slug: 'reference/volume-indicator' },
           { slug: 'reference/volume-popover' },
           { slug: 'reference/volume-slider' },
         ],


### PR DESCRIPTION
## Summary

- Add the missing VolumeIndicator reference page, React and HTML demos, and sidebar entry.
- Document predicted volume state, boundary pulses, fill ownership, data attributes, and visual-only semantics.

## Verification

- `CI=true pnpm -F site astro check`
- `CI=true pnpm -F site api-docs`

Closes #2059

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>