### PR TITLE
docs(site): add native Video and Audio references

### DIFF
--- a/site/src/components/docs/demos/audio/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/audio/html/css/BasicUsage.astro
@@ -1,0 +1,10 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+import './BasicUsage.css';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import './BasicUsage.ts';
+</script>

--- a/site/src/components/docs/demos/audio/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/audio/html/css/BasicUsage.css
@@ -1,0 +1,12 @@
+.html-audio-basic {
+  display: grid;
+  width: 100%;
+  padding: 24px;
+  background: #e5e7eb;
+  border-radius: 8px;
+  place-items: center;
+}
+
+.html-audio-basic__media {
+  width: 100%;
+}

--- a/site/src/components/docs/demos/audio/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/audio/html/css/BasicUsage.html
@@ -1,0 +1,7 @@
+<audio-player>
+  <media-container class="html-audio-basic">
+    <audio class="html-audio-basic__media" controls preload="metadata">
+      <source src="{{VJS10_DEMO_VIDEO_MP4}}" />
+    </audio>
+  </media-container>
+</audio-player>

--- a/site/src/components/docs/demos/audio/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/audio/html/css/BasicUsage.ts
@@ -1,0 +1,1 @@
+import '@videojs/html/audio/player';

--- a/site/src/components/docs/demos/audio/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/audio/react/css/BasicUsage.css
@@ -1,0 +1,12 @@
+.react-audio-basic {
+  display: grid;
+  width: 100%;
+  padding: 24px;
+  background: #e5e7eb;
+  border-radius: 8px;
+  place-items: center;
+}
+
+.react-audio-basic__media {
+  width: 100%;
+}

--- a/site/src/components/docs/demos/audio/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/audio/react/css/BasicUsage.tsx
@@ -1,0 +1,18 @@
+import { Container, createPlayer } from '@videojs/react';
+import { Audio, audioFeatures } from '@videojs/react/audio';
+
+import './BasicUsage.css';
+
+const { Player } = createPlayer({ features: audioFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="react-audio-basic">
+        <Audio className="react-audio-basic__media" controls preload="metadata">
+          <source src="{{VJS10_DEMO_VIDEO_MP4}}" />
+        </Audio>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/audio/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/audio/react/css/BasicUsage.tsx
@@ -1,18 +1,16 @@
-import { Container, createPlayer } from '@videojs/react';
-import { Audio, audioFeatures } from '@videojs/react/audio';
+import { Container } from '@videojs/react';
+import { Audio, AudioPlayer } from '@videojs/react/audio';
 
 import './BasicUsage.css';
 
-const { Player } = createPlayer({ features: audioFeatures });
-
 export default function BasicUsage() {
   return (
-    <Player>
+    <AudioPlayer>
       <Container className="react-audio-basic">
         <Audio className="react-audio-basic__media" controls preload="metadata">
           <source src="{{VJS10_DEMO_VIDEO_MP4}}" />
         </Audio>
       </Container>
-    </Player>
+    </AudioPlayer>
   );
 }

--- a/site/src/components/docs/demos/video/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/video/html/css/BasicUsage.astro
@@ -1,0 +1,10 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+import './BasicUsage.css';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import './BasicUsage.ts';
+</script>

--- a/site/src/components/docs/demos/video/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/video/html/css/BasicUsage.css
@@ -1,0 +1,12 @@
+.html-video-basic {
+  width: 100%;
+  overflow: hidden;
+  background: black;
+  border-radius: 8px;
+}
+
+.html-video-basic__media {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}

--- a/site/src/components/docs/demos/video/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/video/html/css/BasicUsage.html
@@ -1,0 +1,8 @@
+<video-player>
+  <media-container class="html-video-basic">
+    <video class="html-video-basic__media" controls playsinline preload="metadata">
+      <source src="{{VJS10_DEMO_VIDEO_MP4}}" type="video/mp4" />
+      <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srclang="en" label="English" />
+    </video>
+  </media-container>
+</video-player>

--- a/site/src/components/docs/demos/video/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/video/html/css/BasicUsage.ts
@@ -1,0 +1,1 @@
+import '@videojs/html/video/player';

--- a/site/src/components/docs/demos/video/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/video/react/css/BasicUsage.css
@@ -1,0 +1,12 @@
+.react-video-basic {
+  width: 100%;
+  overflow: hidden;
+  background: black;
+  border-radius: 8px;
+}
+
+.react-video-basic__media {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}

--- a/site/src/components/docs/demos/video/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/video/react/css/BasicUsage.tsx
@@ -1,0 +1,19 @@
+import { Container, createPlayer } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+import './BasicUsage.css';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="react-video-basic">
+        <Video className="react-video-basic__media" controls playsInline preload="metadata">
+          <source src="{{VJS10_DEMO_VIDEO_MP4}}" type="video/mp4" />
+          <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
+        </Video>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/video/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/video/react/css/BasicUsage.tsx
@@ -1,19 +1,17 @@
-import { Container, createPlayer } from '@videojs/react';
-import { Video, videoFeatures } from '@videojs/react/video';
+import { Container } from '@videojs/react';
+import { Video, VideoPlayer } from '@videojs/react/video';
 
 import './BasicUsage.css';
 
-const { Player } = createPlayer({ features: videoFeatures });
-
 export default function BasicUsage() {
   return (
-    <Player>
+    <VideoPlayer>
       <Container className="react-video-basic">
         <Video className="react-video-basic__media" controls playsInline preload="metadata">
           <source src="{{VJS10_DEMO_VIDEO_MP4}}" type="video/mp4" />
           <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
         </Video>
       </Container>
-    </Player>
+    </VideoPlayer>
   );
 }

--- a/site/src/content/docs/reference/audio.mdx
+++ b/site/src/content/docs/reference/audio.mdx
@@ -71,7 +71,13 @@ Place a native `<audio>` anywhere inside `<audio-player>`. It becomes that playe
 
 Video.js does not replace the native audio API. Use `src` for one URL or add child [`<source>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source) when the browser should choose between candidates. See <DocsLink slug="concepts/media-sources">Media sources</DocsLink> when you need an HLS, Mux, Spotify, or other playback adapter.
 
-React forwards native attributes, event handlers, and children to the `<audio>`, and its `ref` resolves to the `HTMLAudioElement`.
+<FrameworkCase frameworks={["react"]}>
+`Audio` forwards native attributes, event handlers, and children to the underlying `<audio>`. Its `ref` resolves to the `HTMLAudioElement`.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+`<audio>` is the native element itself. Set its attributes and properties, listen for native media events, and access it through an `HTMLAudioElement` reference.
+</FrameworkCase>
 
 See MDN for the complete [`<audio>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/audio), [`HTMLAudioElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement), and shared [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) APIs.
 

--- a/site/src/content/docs/reference/audio.mdx
+++ b/site/src/content/docs/reference/audio.mdx
@@ -24,10 +24,10 @@ import basicUsageHtmlTs from "@/components/docs/demos/audio/html/css/BasicUsage.
 ## Import
 
 <FrameworkCase frameworks={["react"]}>
-Import `Audio` and the matching feature bundle from the audio preset:
+Import `Audio` from the audio preset:
 
 ```tsx
-import { Audio, audioFeatures } from '@videojs/react/audio';
+import { Audio } from '@videojs/react/audio';
 ```
 </FrameworkCase>
 
@@ -57,33 +57,21 @@ import '@videojs/html/audio/player';
 ```
 </FrameworkCase>
 
-## Player registration
+## Use with a player
 
 <FrameworkCase frameworks={["react"]}>
-Place `Audio` inside the `Player` returned by `createPlayer({ features: audioFeatures })`. On mount, its composed ref registers the native `HTMLAudioElement` as that Player's media provider. Replacing or unmounting it detaches the previous element. Outside a Player, `Audio` still renders a standalone native `<audio>` without creating or attaching a Video.js store.
+Place `Audio` anywhere inside an `AudioPlayer`, or inside another Video.js `Player` configured for audio. It becomes that player's media provider automatically. Outside a player, `Audio` behaves as a standalone native `<audio>`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-Place a native `<audio>` anywhere under `<audio-player>`. The player observes its full descendant subtree and attaches the first native `<video>` or `<audio>` in document order. Adding, removing, or replacing native media causes the provider to update and detach the previous element when necessary.
-
-A registered custom media component takes precedence over a descendant native element. If the custom media unregisters, the player can fall back to the first native media element still in its subtree.
+Place a native `<audio>` anywhere inside `<audio-player>`. It becomes that player's media provider automatically.
 </FrameworkCase>
 
-## Sources and tracks
+## Native behavior
 
-Use the native `src` property for one URL or add child [`<source>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source) when the browser should choose between candidates. Browser media support determines which native sources can play; see <DocsLink slug="concepts/media-sources">Media sources</DocsLink> when you need an HLS, Mux, Spotify, or other playback adapter.
+Video.js does not replace the native audio API. Use `src` for one URL or add child [`<source>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source) when the browser should choose between candidates. See <DocsLink slug="concepts/media-sources">Media sources</DocsLink> when you need an HLS, Mux, Spotify, or other playback adapter.
 
-React forwards `Audio` children unchanged, so native source markup uses its regular React DOM props. In the example below, the shared demo MP4 supplies its audio track. The `<source>` intentionally omits `type` because the URL points to the full MP4 container, not an audio-only asset.
-
-## Native API
-
-<FrameworkCase frameworks={["react"]}>
-`AudioProps` extends React's `AudioHTMLAttributes<HTMLAudioElement>`. Native attributes, event handlers, and children pass through to the `<audio>`, and `ref` resolves to its `HTMLAudioElement`. Use that ref for native properties and methods.
-</FrameworkCase>
-
-<FrameworkCase frameworks={["html"]}>
-The element is an ordinary `HTMLAudioElement`; Video.js does not wrap or replace its native DOM API.
-</FrameworkCase>
+React forwards native attributes, event handlers, and children to the `<audio>`, and its `ref` resolves to the `HTMLAudioElement`.
 
 See MDN for the complete [`<audio>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/audio), [`HTMLAudioElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement), and shared [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) APIs.
 
@@ -91,7 +79,7 @@ See MDN for the complete [`<audio>` element](https://developer.mozilla.org/en-US
 
 ### Basic Usage
 
-This native audio element uses a child source and browser controls while also providing media to the surrounding Video.js player.
+This native audio element uses a child source and browser controls while providing media to the surrounding Video.js player. The shared demo MP4 supplies its audio track, so the `<source>` does not claim an audio-only MIME type.
 
 <FrameworkCase frameworks={["react"]}>
   <StyleCase styles={["css"]}>

--- a/site/src/content/docs/reference/audio.mdx
+++ b/site/src/content/docs/reference/audio.mdx
@@ -1,0 +1,117 @@
+---
+title: Audio
+frameworkTitle:
+  html: audio
+description: Native audio playback that can provide media to a Video.js player
+---
+
+import DocsLink from "@/components/docs/DocsLink.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+import StyleCase from "@/components/docs/StyleCase.astro";
+import Demo from "@/components/docs/demos/Demo.astro";
+
+{/* React demo */}
+import BasicUsageDemoReact from "@/components/docs/demos/audio/react/css/BasicUsage";
+import basicUsageReactTsx from "@/components/docs/demos/audio/react/css/BasicUsage.tsx?raw";
+import basicUsageReactCss from "@/components/docs/demos/audio/react/css/BasicUsage.css?raw";
+
+{/* HTML demo */}
+import BasicUsageDemoHtml from "@/components/docs/demos/audio/html/css/BasicUsage.astro";
+import basicUsageHtml from "@/components/docs/demos/audio/html/css/BasicUsage.html?raw";
+import basicUsageHtmlCss from "@/components/docs/demos/audio/html/css/BasicUsage.css?raw";
+import basicUsageHtmlTs from "@/components/docs/demos/audio/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<FrameworkCase frameworks={["react"]}>
+Import `Audio` and the matching feature bundle from the audio preset:
+
+```tsx
+import { Audio, audioFeatures } from '@videojs/react/audio';
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+The media element is the browser's native `<audio>`. Import the audio player registration when it should provide media to Video.js:
+
+```ts
+import '@videojs/html/audio/player';
+```
+</FrameworkCase>
+
+## Anatomy
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Audio>
+  <source />
+</Audio>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<audio>
+  <source />
+</audio>
+```
+</FrameworkCase>
+
+## Player registration
+
+<FrameworkCase frameworks={["react"]}>
+Place `Audio` inside the `Player` returned by `createPlayer({ features: audioFeatures })`. On mount, its composed ref registers the native `HTMLAudioElement` as that Player's media provider. Replacing or unmounting it detaches the previous element. Outside a Player, `Audio` still renders a standalone native `<audio>` without creating or attaching a Video.js store.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+Place a native `<audio>` anywhere under `<audio-player>`. The player observes its full descendant subtree and attaches the first native `<video>` or `<audio>` in document order. Adding, removing, or replacing native media causes the provider to update and detach the previous element when necessary.
+
+A registered custom media component takes precedence over a descendant native element. If the custom media unregisters, the player can fall back to the first native media element still in its subtree.
+</FrameworkCase>
+
+## Sources and tracks
+
+Use the native `src` property for one URL or add child [`<source>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source) when the browser should choose between candidates. Browser media support determines which native sources can play; see <DocsLink slug="concepts/media-sources">Media sources</DocsLink> when you need an HLS, Mux, Spotify, or other playback adapter.
+
+React forwards `Audio` children unchanged, so native source markup uses its regular React DOM props. In the example below, the shared demo MP4 supplies its audio track. The `<source>` intentionally omits `type` because the URL points to the full MP4 container, not an audio-only asset.
+
+## Native API
+
+<FrameworkCase frameworks={["react"]}>
+`AudioProps` extends React's `AudioHTMLAttributes<HTMLAudioElement>`. Native attributes, event handlers, and children pass through to the `<audio>`, and `ref` resolves to its `HTMLAudioElement`. Use that ref for native properties and methods.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+The element is an ordinary `HTMLAudioElement`; Video.js does not wrap or replace its native DOM API.
+</FrameworkCase>
+
+See MDN for the complete [`<audio>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/audio), [`HTMLAudioElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement), and shared [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) APIs.
+
+## Examples
+
+### Basic Usage
+
+This native audio element uses a child source and browser controls while also providing media to the surrounding Video.js player.
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageHtml, lang: "html" },
+      { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+      { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>

--- a/site/src/content/docs/reference/video.mdx
+++ b/site/src/content/docs/reference/video.mdx
@@ -24,10 +24,10 @@ import basicUsageHtmlTs from "@/components/docs/demos/video/html/css/BasicUsage.
 ## Import
 
 <FrameworkCase frameworks={["react"]}>
-Import `Video` and the matching feature bundle from the video preset:
+Import `Video` from the video preset:
 
 ```tsx
-import { Video, videoFeatures } from '@videojs/react/video';
+import { Video } from '@videojs/react/video';
 ```
 </FrameworkCase>
 
@@ -59,33 +59,21 @@ import '@videojs/html/video/player';
 ```
 </FrameworkCase>
 
-## Player registration
+## Use with a player
 
 <FrameworkCase frameworks={["react"]}>
-Place `Video` inside the `Player` returned by `createPlayer({ features: videoFeatures })`. On mount, its composed ref registers the native `HTMLVideoElement` as that Player's media provider. Replacing or unmounting it detaches the previous element. Outside a Player, `Video` still renders a standalone native `<video>` without creating or attaching a Video.js store.
+Place `Video` anywhere inside a `VideoPlayer`, or inside another Video.js `Player` configured for video. It becomes that player's media provider automatically. Outside a player, `Video` behaves as a standalone native `<video>`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-Place a native `<video>` anywhere under `<video-player>`. The player observes its full descendant subtree and attaches the first native `<video>` or `<audio>` in document order. Adding, removing, or replacing native media causes the provider to update and detach the previous element when necessary.
-
-A registered custom media component takes precedence over a descendant native element. If the custom media unregisters, the player can fall back to the first native media element still in its subtree.
+Place a native `<video>` anywhere inside `<video-player>`. It becomes that player's media provider automatically.
 </FrameworkCase>
 
-## Sources and tracks
+## Native behavior
 
-Use the native `src` property for one URL or add child [`<source>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source) when the browser should choose between candidates. Browser media support determines which native sources can play; see <DocsLink slug="concepts/media-sources">Media sources</DocsLink> when you need an HLS, DASH, Mux, or other playback adapter.
+Video.js does not replace the native video API. Use `src` for one URL or add child [`<source>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source) when the browser should choose between candidates. See <DocsLink slug="concepts/media-sources">Media sources</DocsLink> when you need an HLS, DASH, Mux, or other playback adapter.
 
-Add native [`<track>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track) for captions, subtitles, chapters, descriptions, or metadata. React forwards `Video` children unchanged, so `<source>` and `<track>` use their regular React DOM props such as `srcLang` and `default`.
-
-## Native API
-
-<FrameworkCase frameworks={["react"]}>
-`VideoProps` extends React's `VideoHTMLAttributes<HTMLVideoElement>`. Native attributes, event handlers, and children pass through to the `<video>`, and `ref` resolves to its `HTMLVideoElement`. Use that ref for native properties and methods.
-</FrameworkCase>
-
-<FrameworkCase frameworks={["html"]}>
-The element is an ordinary `HTMLVideoElement`; Video.js does not wrap or replace its native DOM API.
-</FrameworkCase>
+Add native [`<track>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track) for captions, subtitles, chapters, descriptions, or metadata. React forwards native attributes, event handlers, and children to the `<video>`, and its `ref` resolves to the `HTMLVideoElement`.
 
 See MDN for the complete [`<video>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video), [`HTMLVideoElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement), and shared [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) APIs.
 

--- a/site/src/content/docs/reference/video.mdx
+++ b/site/src/content/docs/reference/video.mdx
@@ -73,7 +73,15 @@ Place a native `<video>` anywhere inside `<video-player>`. It becomes that playe
 
 Video.js does not replace the native video API. Use `src` for one URL or add child [`<source>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source) when the browser should choose between candidates. See <DocsLink slug="concepts/media-sources">Media sources</DocsLink> when you need an HLS, DASH, Mux, or other playback adapter.
 
-Add native [`<track>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track) for captions, subtitles, chapters, descriptions, or metadata. React forwards native attributes, event handlers, and children to the `<video>`, and its `ref` resolves to the `HTMLVideoElement`.
+Add native [`<track>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track) for captions, subtitles, chapters, descriptions, or metadata.
+
+<FrameworkCase frameworks={["react"]}>
+`Video` forwards native attributes, event handlers, and children to the underlying `<video>`. Its `ref` resolves to the `HTMLVideoElement`.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+`<video>` is the native element itself. Set its attributes and properties, listen for native media events, and access it through an `HTMLVideoElement` reference.
+</FrameworkCase>
 
 See MDN for the complete [`<video>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video), [`HTMLVideoElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement), and shared [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) APIs.
 

--- a/site/src/content/docs/reference/video.mdx
+++ b/site/src/content/docs/reference/video.mdx
@@ -1,0 +1,119 @@
+---
+title: Video
+frameworkTitle:
+  html: video
+description: Native video playback that can provide media to a Video.js player
+---
+
+import DocsLink from "@/components/docs/DocsLink.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+import StyleCase from "@/components/docs/StyleCase.astro";
+import Demo from "@/components/docs/demos/Demo.astro";
+
+{/* React demo */}
+import BasicUsageDemoReact from "@/components/docs/demos/video/react/css/BasicUsage";
+import basicUsageReactTsx from "@/components/docs/demos/video/react/css/BasicUsage.tsx?raw";
+import basicUsageReactCss from "@/components/docs/demos/video/react/css/BasicUsage.css?raw";
+
+{/* HTML demo */}
+import BasicUsageDemoHtml from "@/components/docs/demos/video/html/css/BasicUsage.astro";
+import basicUsageHtml from "@/components/docs/demos/video/html/css/BasicUsage.html?raw";
+import basicUsageHtmlCss from "@/components/docs/demos/video/html/css/BasicUsage.css?raw";
+import basicUsageHtmlTs from "@/components/docs/demos/video/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<FrameworkCase frameworks={["react"]}>
+Import `Video` and the matching feature bundle from the video preset:
+
+```tsx
+import { Video, videoFeatures } from '@videojs/react/video';
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+The media element is the browser's native `<video>`. Import the video player registration when it should provide media to Video.js:
+
+```ts
+import '@videojs/html/video/player';
+```
+</FrameworkCase>
+
+## Anatomy
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Video>
+  <source />
+  <track />
+</Video>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<video>
+  <source />
+  <track />
+</video>
+```
+</FrameworkCase>
+
+## Player registration
+
+<FrameworkCase frameworks={["react"]}>
+Place `Video` inside the `Player` returned by `createPlayer({ features: videoFeatures })`. On mount, its composed ref registers the native `HTMLVideoElement` as that Player's media provider. Replacing or unmounting it detaches the previous element. Outside a Player, `Video` still renders a standalone native `<video>` without creating or attaching a Video.js store.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+Place a native `<video>` anywhere under `<video-player>`. The player observes its full descendant subtree and attaches the first native `<video>` or `<audio>` in document order. Adding, removing, or replacing native media causes the provider to update and detach the previous element when necessary.
+
+A registered custom media component takes precedence over a descendant native element. If the custom media unregisters, the player can fall back to the first native media element still in its subtree.
+</FrameworkCase>
+
+## Sources and tracks
+
+Use the native `src` property for one URL or add child [`<source>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source) when the browser should choose between candidates. Browser media support determines which native sources can play; see <DocsLink slug="concepts/media-sources">Media sources</DocsLink> when you need an HLS, DASH, Mux, or other playback adapter.
+
+Add native [`<track>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track) for captions, subtitles, chapters, descriptions, or metadata. React forwards `Video` children unchanged, so `<source>` and `<track>` use their regular React DOM props such as `srcLang` and `default`.
+
+## Native API
+
+<FrameworkCase frameworks={["react"]}>
+`VideoProps` extends React's `VideoHTMLAttributes<HTMLVideoElement>`. Native attributes, event handlers, and children pass through to the `<video>`, and `ref` resolves to its `HTMLVideoElement`. Use that ref for native properties and methods.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+The element is an ordinary `HTMLVideoElement`; Video.js does not wrap or replace its native DOM API.
+</FrameworkCase>
+
+See MDN for the complete [`<video>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video), [`HTMLVideoElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement), and shared [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) APIs.
+
+## Examples
+
+### Basic Usage
+
+This native video uses a child source, captions track, and browser controls while also providing media to the surrounding Video.js player.
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageHtml, lang: "html" },
+      { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+      { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -152,6 +152,7 @@ export const sidebar: Sidebar = [
         defaultOpen: false,
         llmsDescription: 'API Reference for media components that handle streaming protocols and media playback.',
         contents: [
+          { slug: 'reference/audio' },
           { slug: 'reference/background-video' },
           { slug: 'reference/cloudflare-video' },
           { slug: 'reference/dash-video' },
@@ -167,6 +168,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/spotify-audio' },
           { slug: 'reference/tiktok-video' },
           { slug: 'reference/twitch-video' },
+          { slug: 'reference/video' },
           { slug: 'reference/vimeo-video' },
           { slug: 'reference/youtube-video' },
         ],


### PR DESCRIPTION
## Summary

- Add hand-authored Video and Audio reference pages with React and HTML demos.
- Document native element composition, player registration, source and track children, provider precedence, and native APIs.

## Verification

- `CI=true pnpm -F site astro check`
- `CI=true pnpm -F @videojs/react test src/media/tests/video.test.tsx src/media/tests/audio.test.tsx`
- `CI=true pnpm -F @videojs/html test src/player/tests/create-player.test.ts`

Closes #1758

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>