### PR TITLE
docs(site): add useContainer reference

### DIFF
--- a/site/src/content/docs/reference/use-container.mdx
+++ b/site/src/content/docs/reference/use-container.mdx
@@ -1,0 +1,35 @@
+---
+title: useContainer
+description: Hook to access the media container from the nearest Player
+---
+
+import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+
+`useContainer` returns the `MediaContainer` registered with the nearest `Player`. It returns `null` until the container mounts, or whenever that player has no registered container.
+
+## Import
+
+```tsx
+import { useContainer } from "@videojs/react";
+```
+
+## Usage
+
+Call `useContainer` from a component rendered inside `Player`:
+
+```tsx title="ContainerStatus.tsx"
+import { useContainer } from "@videojs/react";
+
+export function ContainerStatus() {
+  const container = useContainer();
+
+  return <output>{container ? "Player container ready" : "Mounting container"}</output>;
+}
+```
+
+Calling this hook outside `Player` throws because it reads through `usePlayerContext`. If a component can also work outside a player, use `useOptionalContainer` instead.
+
+`useContainer` reads the registered container. <DocsLink slug="reference/use-container-attach">`useContainerAttach`</DocsLink> returns the setter used to register a custom container and is only needed when replacing the built-in `Container`.
+
+<UtilReference util="useContainer" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -213,6 +213,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/player-controller', frameworks: ['html'] },
           { slug: 'reference/use-player', frameworks: ['react'] },
           { slug: 'reference/use-media', frameworks: ['react'] },
+          { slug: 'reference/use-container', frameworks: ['react'] },
           { slug: 'reference/use-store', frameworks: ['react'] },
           { slug: 'reference/create-i18n' },
           { slug: 'reference/use-translator', frameworks: ['react'] },


### PR DESCRIPTION
## Summary

- Add the missing useContainer utility reference and usage guidance.
- Explain required versus optional container lookup and the nearest-container boundary.

## Verification

- `CI=true pnpm -F site astro check`
- `CI=true pnpm -F site api-docs`

Closes #1184

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>