### PR TITLE
docs(site): clarify HTML player contexts

### DIFF
--- a/site/src/content/docs/reference/media-attach-mixin.mdx
+++ b/site/src/content/docs/reference/media-attach-mixin.mdx
@@ -43,8 +43,7 @@ export class BackgroundVideo extends MediaAttachMixin(HTMLElement) {
 
 ## Factory function
 
-{/* TODO: link mediaContext to concept page once written (https://github.com/videojs/v10/issues/1033) */}
-`MediaAttachMixin` is pre-configured with the default `mediaContext`. To use a different context, call `createMediaAttachMixin`:
+`MediaAttachMixin` is pre-configured with the default `mediaContext` published by <DocsLink slug="reference/player">`PlayerElement`</DocsLink>. Call `createMediaAttachMixin` only when a custom player publishes a matching custom `MediaContext`:
 
 ```ts
 import { createMediaAttachMixin } from '@videojs/html';

--- a/site/src/content/docs/reference/player-container.mdx
+++ b/site/src/content/docs/reference/player-container.mdx
@@ -78,6 +78,8 @@ class MyContainer extends ContainerElement {}
 customElements.define('my-container', MyContainer);
 ```
 
+Extending `ContainerElement` automatically registers the element with the nearest player when it connects and releases that registration when it disconnects.
+
 Import `@videojs/html/ui/container` when you only need to register the standard `<media-container>` element.
 </FrameworkCase>
 

--- a/site/src/content/docs/reference/player-context.mdx
+++ b/site/src/content/docs/reference/player-context.mdx
@@ -6,7 +6,9 @@ description: The default player context instance for consuming the player store 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 
-`playerContext` is a Web Components context token that carries the player store through the DOM tree. Player elements publish the store to this context, and consumer elements such as <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink> and <DocsLink slug="reference/player-container">`ContainerElement`</DocsLink> read from it.
+`playerContext` is a Web Components context token that carries the player store through the DOM tree. Player elements publish the store to this context, and consumers such as <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink> read from it. Video.js contexts follow the Web Components Community Group [Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md), so providers and consumers communicate with standard context request events instead of requiring a specific element hierarchy.
+
+`playerContext` carries player state and actions. <DocsLink slug="reference/player-container">`ContainerElement`</DocsLink> registers the player's visual container through `containerContext`, not `playerContext`; its internal `PlayerController` separately consumes `playerContext` for controls state.
 
 Pass it as the second argument to `PlayerController`:
 


### PR DESCRIPTION
## Summary

- Correct the ProviderMixin, PlayerContext, MediaAttachMixin, and PlayerContainer context relationships.
- Document automatic registration and reattachment using the shipped WCCG Context Protocol behavior.

## Verification

- `CI=true pnpm -F site astro check`

Closes #1033

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>