### PR TITLE
docs(site): explain custom element lifecycle

### DIFF
--- a/site/src/content/docs/concepts/custom-element-lifecycle.mdx
+++ b/site/src/content/docs/concepts/custom-element-lifecycle.mdx
@@ -1,0 +1,77 @@
+---
+title: Custom element lifecycle
+description: How Video.js HTML elements connect, disconnect, and permanently release resources.
+---
+
+import Aside from '@/components/Aside.astro';
+import DocsLink from '@/components/docs/DocsLink.astro';
+
+A custom element can leave the document without being finished. Video.js separates temporary disconnection from permanent destruction so DOM moves and framework reconciliation do not discard reusable state.
+
+## Choose a base
+
+Choose the narrowest base that provides the lifecycle your element needs:
+
+| Base | Lifecycle behavior | Typical use |
+| --- | --- | --- |
+| `HTMLElement` | Browser custom element callbacks only | Elements that manage their own state and cleanup |
+| `ReactiveElement` | Reactive properties, batched updates, and reactive controller callbacks | Reactive elements that do not need Video.js's permanent destruction lifecycle |
+| `UIElement` | `ReactiveElement` plus the `DestroyMixin` lifecycle | Custom player controls and other interactive player UI |
+| `CustomMediaElement(...)` with `MediaAttachMixin` | An `HTMLElement`-based media host lifecycle plus player registration | Custom playback engines and media elements |
+| `PlayerElement` | The `UIElement` lifecycle plus store context and attachment ownership | Player roots |
+
+Use `UIElement` for most custom controls. Built-in custom media elements compose `CustomMediaElement(...)` with <DocsLink slug="reference/media-attach-mixin">`MediaAttachMixin`</DocsLink>. Player roots use the configured <DocsLink slug="reference/player">`PlayerElement`</DocsLink> returned by `createPlayer`. Keep those specialized bases because they own registration and cleanup beyond rendering.
+
+## Clean up each connection
+
+The browser can call `connectedCallback()` and `disconnectedCallback()` many times for the same element. Start listeners, observers, and other connection-scoped work when the element connects. Stop that work when it disconnects. Call the superclass lifecycle methods so reactive controllers and inherited cleanup also run:
+
+```ts
+import { UIElement } from '@videojs/html';
+
+class StatusElement extends UIElement {
+  #disconnect: AbortController | null = null;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.#disconnect = new AbortController();
+    window.addEventListener('resize', this.#onResize, {
+      signal: this.#disconnect.signal,
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+  }
+
+  #onResize = () => this.requestUpdate();
+}
+```
+
+Reserve `destroyCallback()` for resources that should survive a temporary disconnect, such as an owned store or imperative player API. Overrides must call `super.destroyCallback()` so registered controllers receive `hostDestroyed()`.
+
+## Understand permanent destruction
+
+`UIElement` applies `DestroyMixin`. When it disconnects, the mixin waits for two animation frames and checks `isConnected`. Synchronous moves and brief reparenting that reconnect before the second frame keep the element alive. If it remains disconnected, `destroy()` marks it as destroyed and calls `destroyCallback()` once.
+
+After destruction, the mixin's connection path and update execution no-op. Repeated `destroy()` calls also no-op. Do not reinsert a destroyed instance; create a new element instead. Subclass lifecycle code should still call its superclass methods and can check the public `destroyed` flag when it needs an explicit guard.
+
+Add `keep-alive` to disable automatic destruction for an element that intentionally remains detached longer than two frames. The attribute does not disable manual cleanup: calling `destroy()` still permanently destroys the element.
+
+<Aside type="caution">
+`keep-alive` makes your code responsible for calling `destroy()` when the element is no longer needed.
+</Aside>
+
+## Specialized resource owners
+
+`PlayerElement` follows the `UIElement` lifecycle. It detaches the store's current media target immediately in `disconnectedCallback()`, but keeps the store so a brief move can reconnect with its state intact. It destroys the store only from `destroyCallback()`.
+
+`CustomMediaElement` has a separate lifecycle because it extends `HTMLElement`, not `UIElement`. On disconnect, it queues one microtask and destroys its media host only if the element is still disconnected. This protects a synchronous reparent, but not a longer detached interval. Its `keep-alive` attribute skips that automatic media-host destruction.
+
+## See also
+
+- <DocsLink slug="how-to/build-your-own-component">Build your own UI component</DocsLink>
+- <DocsLink slug="reference/player">`PlayerElement`</DocsLink>
+- <DocsLink slug="reference/media-attach-mixin">`MediaAttachMixin`</DocsLink>

--- a/site/src/content/docs/concepts/custom-element-lifecycle.mdx
+++ b/site/src/content/docs/concepts/custom-element-lifecycle.mdx
@@ -1,28 +1,16 @@
 ---
 title: Custom element lifecycle
-description: How Video.js HTML elements connect, disconnect, and permanently release resources.
+description: Choose the right Video.js HTML base class and clean up custom elements when they leave the page.
 ---
 
 import Aside from '@/components/Aside.astro';
 import DocsLink from '@/components/docs/DocsLink.astro';
 
-A custom element can leave the document without being finished. Video.js separates temporary disconnection from permanent destruction so DOM moves and framework reconciliation do not discard reusable state.
+This guide is for developers creating custom elements with `@videojs/html`. If you only compose or style Video.js's built-in elements, you do not need to manage this lifecycle yourself.
 
-## Choose a base
+For most custom controls, extend `UIElement`, clean up listeners and observers in `disconnectedCallback()`, and call the matching superclass callbacks. Read the advanced sections if you are building a player root or media element, or if an element must remain alive while detached.
 
-Choose the narrowest base that provides the lifecycle your element needs:
-
-| Base | Lifecycle behavior | Typical use |
-| --- | --- | --- |
-| `HTMLElement` | Browser custom element callbacks only | Elements that manage their own state and cleanup |
-| `ReactiveElement` | Reactive properties, batched updates, and reactive controller callbacks | Reactive elements that do not need Video.js's permanent destruction lifecycle |
-| `UIElement` | `ReactiveElement` plus the `DestroyMixin` lifecycle | Custom player controls and other interactive player UI |
-| `CustomMediaElement(...)` with `MediaAttachMixin` | An `HTMLElement`-based media host lifecycle plus player registration | Custom playback engines and media elements |
-| `PlayerElement` | The `UIElement` lifecycle plus store context and attachment ownership | Player roots |
-
-Use `UIElement` for most custom controls. Built-in custom media elements compose `CustomMediaElement(...)` with <DocsLink slug="reference/media-attach-mixin">`MediaAttachMixin`</DocsLink>. Player roots use the configured <DocsLink slug="reference/player">`PlayerElement`</DocsLink> returned by `createPlayer`. Keep those specialized bases because they own registration and cleanup beyond rendering.
-
-## Clean up each connection
+## Clean up when the element disconnects
 
 The browser can call `connectedCallback()` and `disconnectedCallback()` many times for the same element. Start listeners, observers, and other connection-scoped work when the element connects. Stop that work when it disconnects. Call the superclass lifecycle methods so reactive controllers and inherited cleanup also run:
 
@@ -50,13 +38,21 @@ class StatusElement extends UIElement {
 }
 ```
 
-Reserve `destroyCallback()` for resources that should survive a temporary disconnect, such as an owned store or imperative player API. Overrides must call `super.destroyCallback()` so registered controllers receive `hostDestroyed()`.
+This cleanup runs every time the element leaves the document, including when an application moves the same element and later reconnects it.
 
-## Understand permanent destruction
+## Advanced lifecycle details
 
-`UIElement` applies `DestroyMixin`. When it disconnects, the mixin waits for two animation frames and checks `isConnected`. Synchronous moves and brief reparenting that reconnect before the second frame keep the element alive. If it remains disconnected, `destroy()` marks it as destroyed and calls `destroyCallback()` once.
+The rest of this page covers permanent destruction, longer detached periods, player roots, and custom media elements. Most custom controls only need the connection cleanup above.
+
+### Release resources permanently
+
+`UIElement` waits for two animation frames after disconnection before it calls `destroy()`. Synchronous moves and brief reparenting that reconnect before the second frame keep the element alive.
+
+Reserve `destroyCallback()` for resources that should survive a temporary disconnect, such as an owned store or imperative player API. Call `super.destroyCallback()` so registered controllers also release their resources.
 
 After destruction, the mixin's connection path and update execution no-op. Repeated `destroy()` calls also no-op. Do not reinsert a destroyed instance; create a new element instead. Subclass lifecycle code should still call its superclass methods and can check the public `destroyed` flag when it needs an explicit guard.
+
+### Keep an element alive while detached
 
 Add `keep-alive` to disable automatic destruction for an element that intentionally remains detached longer than two frames. The attribute does not disable manual cleanup: calling `destroy()` still permanently destroys the element.
 
@@ -64,11 +60,27 @@ Add `keep-alive` to disable automatic destruction for an element that intentiona
 `keep-alive` makes your code responsible for calling `destroy()` when the element is no longer needed.
 </Aside>
 
-## Specialized resource owners
+### Choose a specialized base
+
+Choose the narrowest base that provides the lifecycle your element needs:
+
+| Base | Lifecycle behavior | Typical use |
+| --- | --- | --- |
+| `HTMLElement` | Browser custom element callbacks only | Elements that manage their own state and cleanup |
+| `ReactiveElement` | Reactive properties, batched updates, and reactive controller callbacks | Reactive elements that do not need permanent destruction |
+| `UIElement` | `ReactiveElement` plus delayed permanent destruction | Custom player controls and other interactive player UI |
+| `CustomMediaElement(...)` with `MediaAttachMixin` | A media host lifecycle plus player registration | Custom playback engines and media elements |
+| `PlayerElement` | The `UIElement` lifecycle plus store context and attachment ownership | Player roots |
+
+Use `UIElement` for most custom controls. Use the specialized bases when your element owns a player store or media provider.
+
+### Specialized resource owners
 
 `PlayerElement` follows the `UIElement` lifecycle. It detaches the store's current media target immediately in `disconnectedCallback()`, but keeps the store so a brief move can reconnect with its state intact. It destroys the store only from `destroyCallback()`.
 
-`CustomMediaElement` has a separate lifecycle because it extends `HTMLElement`, not `UIElement`. On disconnect, it queues one microtask and destroys its media host only if the element is still disconnected. This protects a synchronous reparent, but not a longer detached interval. Its `keep-alive` attribute skips that automatic media-host destruction.
+Built-in custom media elements compose `CustomMediaElement(...)` with <DocsLink slug="reference/media-attach-mixin">`MediaAttachMixin`</DocsLink>. `CustomMediaElement` queues one microtask after disconnection and destroys its media host only if it remains disconnected. This protects a synchronous move, but not a longer detached period. Its `keep-alive` attribute skips that automatic media-host destruction.
+
+Player roots use the configured <DocsLink slug="reference/player">`PlayerElement`</DocsLink> returned by `createPlayer`.
 
 ## See also
 

--- a/site/src/content/docs/how-to/build-your-own-component.mdx
+++ b/site/src/content/docs/how-to/build-your-own-component.mdx
@@ -143,7 +143,7 @@ class SkipIntroButtonElement extends UIElement {
 }
 ```
 
-`UIElement` treats disconnection as temporary before it permanently destroys owned resources. See <DocsLink slug="concepts/custom-element-lifecycle">Custom element lifecycle</DocsLink> for cleanup patterns, required superclass calls, and the `keep-alive` escape hatch.
+If your element starts listeners, observers, or other work, see <DocsLink slug="concepts/custom-element-lifecycle">Custom element lifecycle</DocsLink> for how to clean it up when the element is removed from the page.
 
 </FrameworkCase>
 

--- a/site/src/content/docs/how-to/build-your-own-component.mdx
+++ b/site/src/content/docs/how-to/build-your-own-component.mdx
@@ -143,6 +143,8 @@ class SkipIntroButtonElement extends UIElement {
 }
 ```
 
+`UIElement` treats disconnection as temporary before it permanently destroys owned resources. See <DocsLink slug="concepts/custom-element-lifecycle">Custom element lifecycle</DocsLink> for cleanup patterns, required superclass calls, and the `keep-alive` escape hatch.
+
 </FrameworkCase>
 
 ## Make it accessible

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -60,6 +60,12 @@ export const sidebar: Sidebar = [
       { slug: 'concepts/mux-data' },
       { slug: 'concepts/security' },
       { slug: 'concepts/i18n', sidebarLabel: 'Internationalization' },
+      {
+        sidebarLabel: 'Advanced',
+        frameworks: ['html'],
+        defaultOpen: false,
+        contents: [{ slug: 'concepts/custom-element-lifecycle' }],
+      },
     ],
   },
   {

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -60,12 +60,7 @@ export const sidebar: Sidebar = [
       { slug: 'concepts/mux-data' },
       { slug: 'concepts/security' },
       { slug: 'concepts/i18n', sidebarLabel: 'Internationalization' },
-      {
-        sidebarLabel: 'Advanced',
-        frameworks: ['html'],
-        defaultOpen: false,
-        contents: [{ slug: 'concepts/custom-element-lifecycle' }],
-      },
+      { slug: 'concepts/custom-element-lifecycle', frameworks: ['html'] },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Add an HTML-focused custom element lifecycle concept page.
- Explain disconnect cleanup, delayed permanent destruction, reparenting, keep-alive behavior, and provider detach versus store destruction.

## Verification

- `CI=true pnpm -F site test src/tests/sidebar.test.ts`
- `CI=true pnpm -F @videojs/element test`
- `CI=true pnpm -F @videojs/media test`

Closes #1034

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>