### PR TITLE
docs(packages): improve high-traffic API JSDoc

### DIFF
--- a/packages/html/src/define/media/dash-video.ts
+++ b/packages/html/src/define/media/dash-video.ts
@@ -1,6 +1,7 @@
 import { DashVideo } from '../../media/dash-video';
 import { safeDefine } from '../../registration/safe-define';
 
+/** MPEG-DASH media element powered by dash.js and registered as `<dash-video>`. */
 export class DashVideoElement extends DashVideo {
   static readonly tagName = 'dash-video';
 }

--- a/packages/html/src/define/media/hls-video.ts
+++ b/packages/html/src/define/media/hls-video.ts
@@ -1,6 +1,7 @@
 import { HlsVideo } from '../../media/hls-video';
 import { safeDefine } from '../../registration/safe-define';
 
+/** Lightweight SPF-backed HLS media element registered as `<hls-video>`. */
 export class HlsVideoElement extends HlsVideo {
   static readonly tagName = 'hls-video';
 }

--- a/packages/html/src/define/media/hlsjs-video.ts
+++ b/packages/html/src/define/media/hlsjs-video.ts
@@ -1,6 +1,7 @@
 import { HlsJsVideo } from '../../media/hlsjs-video';
 import { safeDefine } from '../../registration/safe-define';
 
+/** Cross-browser HLS media element powered by hls.js and registered as `<hlsjs-video>`. */
 export class HlsJsVideoElement extends HlsJsVideo {
   static readonly tagName = 'hlsjs-video';
 }

--- a/packages/html/src/define/media/native-hls-video.ts
+++ b/packages/html/src/define/media/native-hls-video.ts
@@ -1,6 +1,7 @@
 import { NativeHlsVideo } from '../../media/native-hls-video';
 import { safeDefine } from '../../registration/safe-define';
 
+/** Browser-native HLS media element registered as `<native-hls-video>`. */
 export class NativeHlsVideoElement extends NativeHlsVideo {
   static readonly tagName = 'native-hls-video';
 }

--- a/packages/html/src/presets/video/minimal-skin.ts
+++ b/packages/html/src/presets/video/minimal-skin.ts
@@ -342,6 +342,8 @@ function getTemplateHTML() {
  * Compact packaged video UI registered as `<video-minimal-skin>`.
  *
  * The shadow template includes `<media-container>`, controls, and styles. Place the media element in the default slot.
+ *
+ * @see {@link https://videojs.org/docs/framework/html/how-to/customize-skins | Customize skins}
  */
 export class MinimalVideoSkinElement extends SkinElement {
   static readonly tagName = 'video-minimal-skin';

--- a/packages/html/src/presets/video/minimal-skin.ts
+++ b/packages/html/src/presets/video/minimal-skin.ts
@@ -338,6 +338,11 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Compact packaged video UI registered as `<video-minimal-skin>`.
+ *
+ * The shadow template includes `<media-container>`, controls, and styles. Place the media element in the default slot.
+ */
 export class MinimalVideoSkinElement extends SkinElement {
   static readonly tagName = 'video-minimal-skin';
   static styles = createShadowStyle(styles);

--- a/packages/html/src/presets/video/player.ts
+++ b/packages/html/src/presets/video/player.ts
@@ -9,6 +9,12 @@ const { PlayerElement, PlayerController: VideoPlayerController } = createPlayer(
 /** Player controller bound to the standard video player store. */
 export const PlayerController = VideoPlayerController;
 
+/**
+ * Player-state provider registered as `<video-player>`.
+ *
+ * The element owns the configured video store but no layout. Put a skin or `<media-container>` inside it to provide the
+ * media, controls, and fullscreen target.
+ */
 export class VideoPlayerElement extends PlayerElement {
   static readonly tagName = 'video-player';
 }

--- a/packages/html/src/presets/video/skin.ts
+++ b/packages/html/src/presets/video/skin.ts
@@ -336,6 +336,11 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Packaged default video UI registered as `<video-skin>`.
+ *
+ * The shadow template includes `<media-container>`, controls, and styles. Place the media element in the default slot.
+ */
 export class VideoSkinElement extends SkinElement {
   static readonly tagName = 'video-skin';
   static styles = createShadowStyle(styles);

--- a/packages/html/src/presets/video/skin.ts
+++ b/packages/html/src/presets/video/skin.ts
@@ -340,6 +340,8 @@ function getTemplateHTML() {
  * Packaged default video UI registered as `<video-skin>`.
  *
  * The shadow template includes `<media-container>`, controls, and styles. Place the media element in the default slot.
+ *
+ * @see {@link https://videojs.org/docs/framework/html/how-to/customize-skins | Customize skins}
  */
 export class VideoSkinElement extends SkinElement {
   static readonly tagName = 'video-skin';

--- a/packages/react/src/media/video.tsx
+++ b/packages/react/src/media/video.tsx
@@ -4,8 +4,15 @@ import { forwardRef } from 'react';
 import { useMediaAttach } from '../player/context';
 import { useComposedRefs } from '../utils/use-composed-refs';
 
+/** Native `<video>` attributes and children forwarded to the rendered media element. */
 export interface VideoProps extends VideoHTMLAttributes<HTMLVideoElement> {}
 
+/**
+ * Renders a native `<video>` element and forwards its element ref.
+ *
+ * Inside a Player, the element is registered as the player's current media on mount and detached on unmount. It can
+ * also render independently when no Player context is present.
+ */
 export const Video = forwardRef<HTMLVideoElement, VideoProps>(function Video({ children, ...props }, ref) {
   const setMedia = useMediaAttach();
   const composedRef = useComposedRefs(ref, setMedia);

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -23,25 +23,45 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useDestroy } from '../utils/use-destroy';
 import { PlayerContextProvider, useMedia, usePlayerContext } from './context';
 
+/** Configures the feature-backed store and provider component created by {@link createPlayer}. */
 export interface CreatePlayerConfig<Features extends AnyPlayerFeature[]> {
+  /** Features combined into the player's store, state, actions, and configuration props. */
   features: Features;
+
+  /** Name shown for the generated provider component in development tools. */
   displayName?: string;
 }
 
+/** Props accepted by a generated Player provider. */
 export type PlayerProps<Config = object> = {
   [Key in keyof Config]?: Config[Key] | undefined;
 } & {
+  /** Content placed inside the player context. The provider does not render a host element of its own. */
   children: ReactNode;
 };
 
+/** The provider component and typed hooks produced by {@link createPlayer}. */
 export interface CreatePlayerResult<Store extends PlayerStore> {
+  /** Provides a new player store to its descendants without adding a layout element. */
   Player: FC<PlayerProps<InferPlayerConfig<Store>>>;
+
+  /** Accesses the configured store, or subscribes to a selected value from it. */
   usePlayer: UsePlayerHook<Store>;
+
+  /** Returns the media currently attached beneath the generated Player, or `null` before attachment. */
   useMedia: () => Media | null;
 }
 
+/** Typed player-store hook returned by {@link createPlayer}. */
 export type UsePlayerHook<Store extends PlayerStore> = {
+  /** Returns the configured player store. */
   (): Store;
+
+  /**
+   * Subscribes to a value derived from the player state.
+   *
+   * @param selector - Derives the value consumed by the calling component.
+   */
   <R>(selector: (state: InferStoreState<Store>) => R): R;
 };
 

--- a/packages/react/src/presets/types.ts
+++ b/packages/react/src/presets/types.ts
@@ -2,13 +2,18 @@ import type { CSSProperties, PropsWithChildren } from 'react';
 
 import type { Poster } from '@/ui/poster';
 
+/** Shared layout props for React skins, combined with any skin-specific props in `T`. */
 export type BaseSkinProps<T = unknown> = PropsWithChildren<
   T & {
+    /** Inline styles applied to the skin's Container. */
     style?: CSSProperties;
+
+    /** Class name applied to the skin's Container. */
     className?: string;
   }
 >;
 
+/** Shared props for video skins, including poster rendering customization. */
 export type BaseVideoSkinProps<T = unknown> = BaseSkinProps<T> & {
   /**
    * Draws the poster image, in place of the `<img>` the skin renders. The URL still comes from the player, as `src`
@@ -20,7 +25,7 @@ export type BaseVideoSkinProps<T = unknown> = BaseSkinProps<T> & {
    *     renderPoster={({ src, ...props }: ComponentProps<'img'>) =>
    *       src ? <Image {...props} src={src} alt="" fill /> : null
    *     }
-   *   />;
+   *   />
    *   ```;
    */
   renderPoster?: Poster.Props['render'];

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -337,6 +337,8 @@ function SettingsMenu(): ReactNode {
  *
  * Place a video media component in `children` and import `@videojs/react/video/minimal-skin.css` for the packaged
  * styles.
+ *
+ * @see {@link https://videojs.org/docs/framework/react/how-to/customize-skins | Customize skins}
  */
 export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
   const { children, className, renderPoster, style, ...rest } = props;

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -77,6 +77,7 @@ const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
+/** Props for the packaged minimal video skin. */
 export type MinimalVideoSkinProps = BaseVideoSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
@@ -331,6 +332,12 @@ function SettingsMenu(): ReactNode {
   );
 }
 
+/**
+ * Renders the compact packaged video UI and the Container that owns player layout and fullscreen.
+ *
+ * Place a video media component in `children` and import `@videojs/react/video/minimal-skin.css` for the packaged
+ * styles.
+ */
 export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
   const { children, className, renderPoster, style, ...rest } = props;
 

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -77,6 +77,7 @@ const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
+/** Props for the packaged default video skin. */
 export type VideoSkinProps = BaseVideoSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
@@ -390,6 +391,11 @@ function FullscreenControl() {
   );
 }
 
+/**
+ * Renders the packaged default video UI and the Container that owns player layout and fullscreen.
+ *
+ * Place a video media component in `children` and import `@videojs/react/video/skin.css` for the packaged styles.
+ */
 export function VideoSkin(props: VideoSkinProps): ReactNode {
   const { children, className, renderPoster, style, ...rest } = props;
 

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -395,6 +395,8 @@ function FullscreenControl() {
  * Renders the packaged default video UI and the Container that owns player layout and fullscreen.
  *
  * Place a video media component in `children` and import `@videojs/react/video/skin.css` for the packaged styles.
+ *
+ * @see {@link https://videojs.org/docs/framework/react/how-to/customize-skins | Customize skins}
  */
 export function VideoSkin(props: VideoSkinProps): ReactNode {
   const { children, className, renderPoster, style, ...rest } = props;


### PR DESCRIPTION
## Summary

- Improve public JSDoc for player creation, media attachment, presets, skins, and registered HTML media engines.
- Clarify ownership, lifecycle, refs, and engine distinctions without changing runtime signatures.

## Verification

- `CI=true vp run @videojs/react#build`
- `CI=true vp run @videojs/html#build`
- `CI=true pnpm typecheck`

Refs #1558

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>