### PR TITLE
refactor(site): complete TypeScript migration

### DIFF
--- a/packages/cli/src/commands/tests/docs.test.ts
+++ b/packages/cli/src/commands/tests/docs.test.ts
@@ -223,13 +223,14 @@ describe('handleDocs', () => {
     });
 
     describe('HTML framework', () => {
-      it('generates npm installation with JS imports and HTML sections', async () => {
+      it('generates npm installation with TypeScript imports and HTML sections', async () => {
         await handleDocs(htmlFlags(), ['how-to/installation']);
         const out = output();
 
         expect(out).toContain('## Install Video.js');
         expect(out).toContain('npm install @videojs/html');
-        expect(out).toContain('## JavaScript imports');
+        expect(out).toContain('## TypeScript imports');
+        expect(out).toContain('```ts');
         expect(out).toContain('## HTML');
         expect(out).toContain('<video-player>');
         expect(out).not.toContain('<!-- cli:replace');
@@ -239,13 +240,13 @@ describe('handleDocs', () => {
         expect(out).toContain('## Next steps');
       });
 
-      it('generates CDN installation without JS imports section', async () => {
+      it('generates CDN installation without TypeScript imports section', async () => {
         await handleDocs(htmlFlags({ 'install-method': 'cdn' }), ['how-to/installation']);
         const out = output();
 
         expect(out).toContain('## Install Video.js');
         expect(out).toContain('<script');
-        expect(out).not.toContain('## JavaScript imports');
+        expect(out).not.toContain('## TypeScript imports');
         expect(out).toContain('## HTML');
       });
 

--- a/packages/cli/src/site-modules.d.ts
+++ b/packages/cli/src/site-modules.d.ts
@@ -49,6 +49,11 @@ declare module '@/utils/installation/codegen' {
     installMethod: InstallMethod;
   }
 
+  export interface HTMLUsageCode {
+    html: string;
+    imports?: string;
+  }
+
   type ValidationResult = { valid: true } | { valid: false; reason: string };
 
   export function validateInstallationOptions(opts: InstallationOptions): ValidationResult;
@@ -62,7 +67,7 @@ declare module '@/utils/installation/codegen' {
 
   export function generateHTMLUsageCode(
     opts: Pick<InstallationOptions, 'useCase' | 'skin' | 'renderer' | 'sourceUrl' | 'installMethod'>
-  ): { html: string; js?: string };
+  ): HTMLUsageCode;
 
   export function generateReactCreateCode(
     opts: Pick<InstallationOptions, 'useCase' | 'skin' | 'renderer'>

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -31,9 +31,9 @@ function formatHTMLInstallation(opts: InstallationOptions): string {
     sections.push(`\`\`\`bash\n${install[opts.installMethod]}\n\`\`\``);
   }
 
-  if (usage.js) {
-    sections.push('\n## JavaScript imports\n');
-    sections.push(`\`\`\`javascript\n${usage.js}\n\`\`\``);
+  if (usage.imports) {
+    sections.push('\n## TypeScript imports\n');
+    sections.push(`\`\`\`ts\n${usage.imports}\n\`\`\``);
   }
 
   sections.push('\n## HTML\n');

--- a/packages/cli/src/utils/tests/format.test.ts
+++ b/packages/cli/src/utils/tests/format.test.ts
@@ -23,22 +23,23 @@ const baseReact: InstallationOptions = {
 };
 
 describe('formatInstallationCode', () => {
-  it('formats HTML + npm with install, JS imports, and HTML sections', () => {
+  it('formats HTML + npm with install, TypeScript imports, and HTML sections', () => {
     const result = formatInstallationCode(baseHTML);
 
     expect(result).toContain('## Install Video.js');
     expect(result).toContain('npm install @videojs/html');
-    expect(result).toContain('## JavaScript imports');
+    expect(result).toContain('## TypeScript imports');
+    expect(result).toContain('```ts');
     expect(result).toContain('## HTML');
     expect(result).toContain('<video-player>');
   });
 
-  it('formats HTML + CDN without JS imports section', () => {
+  it('formats HTML + CDN without TypeScript imports section', () => {
     const result = formatInstallationCode({ ...baseHTML, installMethod: 'cdn' });
 
     expect(result).toContain('## Install Video.js');
     expect(result).toContain('<script');
-    expect(result).not.toContain('## JavaScript imports');
+    expect(result).not.toContain('## TypeScript imports');
     expect(result).toContain('## HTML');
   });
 

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -5,7 +5,7 @@ This file contains site-specific gotchas. Read `site/README.md`, `site/package.j
 ## Sources of truth
 
 - Commands and versions: `package.json`
-- Astro/Vite/Markdown configuration: `astro.config.mjs`
+- Astro/Vite/Markdown configuration: `astro.config.ts`
 - Content schemas: `src/content.config.ts`
 - Framework/style support and type guards: `src/types/docs.ts`
 - Sidebar and route availability: `src/docs.config.ts`
@@ -56,7 +56,7 @@ pnpm -F site astro check
 
 ## Site-specific gotchas
 
-- `astro.config.mjs` has a root `vite.optimizeDeps` block that can shadow renderer-provided includes. Keep React client dependencies in its explicit `include` list when changing renderer setup.
+- `astro.config.ts` has a root `vite.optimizeDeps` block that can shadow renderer-provided includes. Keep React client dependencies in its explicit `include` list when changing renderer setup.
 - Markdown uses Satteri MDAST plugins, not remark/rehype plugins. Add transformations with `defineMdastPlugin` and write derived frontmatter through `ctx.data.astro.frontmatter`.
 - Shiki highlighting is configured independently from the Markdown processor.
 - React context does not cross Astro islands.

--- a/site/README.md
+++ b/site/README.md
@@ -33,7 +33,7 @@ Mostly a standard [Astro](https://astro.build/) project.
 │  ├── content.config.ts     # Content collection schemas
 │  ├── docs.config.ts        # Docs sidebar structure
 │  └── test-setup.ts         # Vitest setup
-├── astro.config.mjs
+├── astro.config.ts
 ├── AGENTS.md                # Agent guidance and site-specific gotchas
 ├── package.json
 ├── README.md
@@ -83,7 +83,7 @@ On each release, the CD workflow force-pushes `main` to `site/v10`, keeping prod
 
 ## Environment Variables
 
-The installation page's video uploader uses OAuth + Mux. The environment schema in [`astro.config.mjs`](astro.config.mjs) is the current variable list. The site works without these variables; the uploader is simply unavailable.
+The installation page's video uploader uses OAuth + Mux. The environment schema in [`astro.config.ts`](astro.config.ts) is the current variable list. The site works without these variables; the uploader is simply unavailable.
 
 ## Technology Stack
 
@@ -174,7 +174,7 @@ See [`scripts/api-docs-builder/README.md`](scripts/api-docs-builder/README.md) f
 
 ## Markdown plugins
 
-Astro uses the Satteri Markdown processor with custom MDAST plugins configured in [`astro.config.mjs`](astro.config.mjs):
+Astro uses the Satteri Markdown processor with custom MDAST plugins configured in [`astro.config.ts`](astro.config.ts):
 
 - [`satteriConditionalHeadings`](src/utils/satteriConditionalHeadings.ts) tracks conditional headings and generated API-reference headings.
 - [`satteriReadingTime`](src/utils/satteriReadingTime.ts) derives reading-time frontmatter.

--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -1,5 +1,3 @@
-// @ts-check
-
 import process from 'node:process';
 
 import { satteri } from '@astrojs/markdown-satteri';

--- a/site/src/components/Code/clientHighlighter.ts
+++ b/site/src/components/Code/clientHighlighter.ts
@@ -1,8 +1,8 @@
 import bash from 'shiki/langs/bash.mjs';
 import css from 'shiki/langs/css.mjs';
 import html from 'shiki/langs/html.mjs';
-import javascript from 'shiki/langs/javascript.mjs';
 import tsx from 'shiki/langs/tsx.mjs';
+import ts from 'shiki/langs/typescript.mjs';
 
 import createHighlighter, { getOrCreateCachedHighlighter } from './createHighlighter';
 
@@ -17,7 +17,7 @@ import createHighlighter, { getOrCreateCachedHighlighter } from './createHighlig
 // it a head start before `client:idle` hydration kicks in.
 // ClientCode.tsx consumes this via React 19's `use()` hook + Suspense.
 const highlighterPromise = getOrCreateCachedHighlighter('client', () =>
-  createHighlighter({ langs: [bash, html, tsx, css, javascript] })
+  createHighlighter({ langs: [bash, html, ts, tsx, css] })
 );
 
 export function getClientHighlighter() {

--- a/site/src/components/docs/api-reference/MediaReference.astro
+++ b/site/src/components/docs/api-reference/MediaReference.astro
@@ -21,8 +21,7 @@ if (!ref) return;
 const model = createMediaReferenceModel(media, ref);
 if (!model) return;
 
-const platform = model.platforms[framework];
-if (!platform) return;
+if (framework === 'react' && !model.platforms.react) return;
 
 // Engine prose comes from the page as `engine-<key>` slots: the paragraph that
 // names the provider's own docs belongs with the page, not the generator. Slot
@@ -44,17 +43,17 @@ for (const engine of model.engines) {
       <HtmlMediaReference
         media={media}
         mediaType={ref.mediaType}
-        data={platform.data}
-        sections={platform.sections}
+        data={model.platforms.html.data}
+        sections={model.platforms.html.sections}
         engines={model.engines}
         engineOptions={ref.engineOptions ?? {}}
         engineProse={engineProse}
       />
     ) : (
-      <ReactMediaReference
+      model.platforms.react && <ReactMediaReference
         media={media}
-        data={platform.data}
-        sections={platform.sections}
+        data={model.platforms.react.data}
+        sections={model.platforms.react.sections}
         engines={model.engines}
         engineOptions={ref.engineOptions ?? {}}
         engineProse={engineProse}

--- a/site/src/components/installation/HTMLInstallTabsClient.tsx
+++ b/site/src/components/installation/HTMLInstallTabsClient.tsx
@@ -23,7 +23,7 @@ export default function HTMLInstallTabs({ cdnMedia }: HTMLInstallTabsProps) {
   const supportsCdn = rendererSupportsCdn($renderer, cdnMedia);
 
   // Mirror the active install-method tab into the store so the usage code block
-  // can react (e.g. CDN omits the JS imports). Observing from the stable
+  // can react (e.g. CDN omits the TypeScript imports). Observing from the stable
   // wrapper rather than the tabs root means the observer survives the keyed
   // remount below, so it never needs to re-attach.
   useEffect(() => {

--- a/site/src/components/installation/HTMLUsageCodeBlock.tsx
+++ b/site/src/components/installation/HTMLUsageCodeBlock.tsx
@@ -22,15 +22,15 @@ export default function HTMLUsageCodeBlock() {
 
   return (
     <>
-      {result.js && (
+      {result.imports && (
         <TabsRoot maxWidth={false}>
           <TabsList label="HTML implementation">
-            <Tab value="javascript" initial>
-              JavaScript
+            <Tab value="typescript" initial>
+              TypeScript
             </Tab>
           </TabsList>
-          <TabsPanel value="javascript" initial>
-            <ClientCode code={result.js} lang="javascript" />
+          <TabsPanel value="typescript" initial>
+            <ClientCode code={result.imports} lang="ts" />
           </TabsPanel>
         </TabsRoot>
       )}

--- a/site/src/content/docs/concepts/ui-components.mdx
+++ b/site/src/content/docs/concepts/ui-components.mdx
@@ -99,9 +99,9 @@ Some components also expose **CSS custom properties** for continuous values like
 
 ### Add icons
 
-Import `@videojs/html/icons/element` once in your app's JavaScript to register `<media-icon>`. Choose an icon with `name`. Set `family="minimal"` to use the Minimal skin's icon designs. You can also use your own text or SVG.
+Import `@videojs/html/icons/element` once in your `app.ts` to register `<media-icon>`. Choose an icon with `name`. Set `family="minimal"` to use the Minimal skin's icon designs. You can also use your own text or SVG.
 
-```js
+```ts
 import '@videojs/html/icons/element';
 ```
 

--- a/site/src/pages/changelog/rss.xml.ts
+++ b/site/src/pages/changelog/rss.xml.ts
@@ -1,9 +1,10 @@
 import rss from '@astrojs/rss';
+import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 
 import { SITE_TITLE } from '@/consts';
 
-export async function GET(context) {
+export const GET: APIRoute = async (context) => {
   const entries = (await getCollection('changelog')).sort(
     (a, b) =>
       b.data.date.valueOf() - a.data.date.valueOf() ||
@@ -22,4 +23,4 @@ export async function GET(context) {
       link: `/changelog/${entry.id}`,
     })),
   });
-}
+};

--- a/site/src/pages/changelog/rss.xml.ts
+++ b/site/src/pages/changelog/rss.xml.ts
@@ -14,7 +14,7 @@ export const GET: APIRoute = async (context) => {
   return rss({
     title: `${SITE_TITLE} Changelog`,
     description: 'New features, fixes, and improvements in every Video.js release',
-    site: context.site,
+    site: context.site!,
     trailingSlash: false,
     items: entries.map((entry) => ({
       title: `v${entry.data.version}`,

--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -1,10 +1,11 @@
 import rss from '@astrojs/rss';
+import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 
 import { SITE_DESCRIPTION, SITE_TITLE } from '@/consts';
 
 // TODO cache idk this can be static
-export async function GET(context) {
+export const GET: APIRoute = async (context) => {
   const posts = (await getCollection('blog'))
     .filter((post) => !post.data.devOnly || import.meta.env.DEV)
     .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
@@ -19,4 +20,4 @@ export async function GET(context) {
       link: `/blog/${post.id}`,
     })),
   });
-}
+};

--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -13,7 +13,7 @@ export const GET: APIRoute = async (context) => {
   return rss({
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
-    site: context.site,
+    site: context.site!,
     trailingSlash: false,
     items: posts.map((post) => ({
       ...post.data,

--- a/site/src/utils/featureReferenceModel.ts
+++ b/site/src/utils/featureReferenceModel.ts
@@ -1,7 +1,7 @@
 /**
  * Centralized feature API reference subsection definitions.
  *
- * Mirrors componentReferenceModel.js for feature APIs. Produces heading/id data consumed by both FeatureReference.astro
+ * Mirrors componentReferenceModel.ts for feature APIs. Produces heading/id data consumed by both FeatureReference.astro
  * and satteriConditionalHeadings.
  *
  * Structure:
@@ -18,14 +18,37 @@
  * publishes back.
  */
 
-function hasEntries(value) {
-  return Object.keys(value ?? {}).length > 0;
+import type { FeatureReference } from '@/types/feature-reference';
+
+import type { TocHeading } from './componentReferenceModel';
+
+type FeatureReferenceSectionKey = 'config' | 'state' | 'actions';
+
+export interface FeatureReferenceSection {
+  key: FeatureReferenceSectionKey;
+  title: string;
+  id: string;
+  depth: number;
 }
 
-export function createFeatureReferenceModel(name, ref) {
+export interface FeatureReferenceModel {
+  name: string;
+  description: FeatureReference['description'];
+  heading: { id: string; depth: number; text: string };
+  sections: FeatureReferenceSection[];
+  data: FeatureReference;
+}
+
+type FeatureEntries = FeatureReference['config'] | FeatureReference['state'] | FeatureReference['actions'];
+
+function hasEntries(value: FeatureEntries): boolean {
+  return Object.keys(value).length > 0;
+}
+
+export function createFeatureReferenceModel(name: string, ref: FeatureReference | null): FeatureReferenceModel | null {
   if (!ref) return null;
 
-  const sections = [];
+  const sections: FeatureReferenceSection[] = [];
 
   if (hasEntries(ref.config)) {
     sections.push({ key: 'config', title: 'Configuration', id: 'configuration', depth: 3 });
@@ -48,7 +71,7 @@ export function createFeatureReferenceModel(name, ref) {
   };
 }
 
-export function buildFeatureReferenceTocHeadings(model) {
+export function buildFeatureReferenceTocHeadings(model: FeatureReferenceModel | null): TocHeading[] {
   if (!model) return [];
 
   const headings = [

--- a/site/src/utils/installation/__tests__/codegen.test.ts
+++ b/site/src/utils/installation/__tests__/codegen.test.ts
@@ -104,18 +104,18 @@ describe('generateHTMLUsageCode', () => {
     expect(result.html).toContain('playsinline');
   });
 
-  it('includes JS imports when not CDN', () => {
+  it('includes TypeScript imports when not CDN', () => {
     const result = generateHTMLUsageCode(baseHTML);
 
-    expect(result.js).toBeDefined();
-    expect(result.js).toContain("import '@videojs/html/video/player'");
-    expect(result.js).toContain("import '@videojs/html/video/skin'");
+    expect(result.imports).toBeDefined();
+    expect(result.imports).toContain("import '@videojs/html/video/player'");
+    expect(result.imports).toContain("import '@videojs/html/video/skin'");
   });
 
-  it('omits JS imports when CDN', () => {
+  it('omits TypeScript imports when CDN', () => {
     const result = generateHTMLUsageCode({ ...baseHTML, installMethod: 'cdn' });
 
-    expect(result.js).toBeUndefined();
+    expect(result.imports).toBeUndefined();
   });
 
   it('uses audio tags for audio use case', () => {
@@ -145,10 +145,10 @@ describe('generateHTMLUsageCode', () => {
     expect(result.html).toContain('<background-video-skin>');
   });
 
-  it('includes HLS media import in JS', () => {
+  it('includes the HLS media TypeScript import', () => {
     const result = generateHTMLUsageCode({ ...baseHTML, renderer: 'hls' });
 
-    expect(result.js).toContain("import '@videojs/html/media/hlsjs-video'");
+    expect(result.imports).toContain("import '@videojs/html/media/hlsjs-video'");
   });
 
   it('uses the dash-video tag, playsinline, and media import for DASH', () => {
@@ -157,7 +157,7 @@ describe('generateHTMLUsageCode', () => {
     expect(result.html).toContain('<dash-video src=');
     expect(result.html).toContain('playsinline');
     expect(result.html).toContain('.mpd');
-    expect(result.js).toContain("import '@videojs/html/media/dash-video'");
+    expect(result.imports).toContain("import '@videojs/html/media/dash-video'");
   });
 
   it('uses the mux-video tag, playsinline, and media import for Mux video', () => {
@@ -165,7 +165,7 @@ describe('generateHTMLUsageCode', () => {
 
     expect(result.html).toContain('<mux-video src=');
     expect(result.html).toContain('playsinline');
-    expect(result.js).toContain("import '@videojs/html/media/mux-video'");
+    expect(result.imports).toContain("import '@videojs/html/media/mux-video'");
   });
 
   it('uses the vimeo-video tag and media import, without playsinline (iframe)', () => {
@@ -174,7 +174,7 @@ describe('generateHTMLUsageCode', () => {
     expect(result.html).toContain('<vimeo-video src=');
     expect(result.html).not.toContain('playsinline');
     expect(result.html).toContain('vimeo.com');
-    expect(result.js).toContain("import '@videojs/html/media/vimeo-video'");
+    expect(result.imports).toContain("import '@videojs/html/media/vimeo-video'");
   });
 
   it('uses the embed-provider tags and media imports, without playsinline (iframe)', () => {
@@ -191,7 +191,7 @@ describe('generateHTMLUsageCode', () => {
       expect(result.html).toContain(`<${tag} src=`);
       expect(result.html).not.toContain('playsinline');
       expect(result.html).toContain(urlPart);
-      expect(result.js).toContain(`import '@videojs/html/media/${tag}'`);
+      expect(result.imports).toContain(`import '@videojs/html/media/${tag}'`);
     }
   });
 
@@ -206,7 +206,7 @@ describe('generateHTMLUsageCode', () => {
     expect(result.html).toContain('<spotify-audio src=');
     expect(result.html).not.toContain('playsinline');
     expect(result.html).toContain('open.spotify.com');
-    expect(result.js).toContain("import '@videojs/html/media/spotify-audio'");
+    expect(result.imports).toContain("import '@videojs/html/media/spotify-audio'");
   });
 
   it('uses the mux-audio tag without playsinline for the audio use case', () => {
@@ -219,14 +219,14 @@ describe('generateHTMLUsageCode', () => {
 
     expect(result.html).toContain('<mux-audio src=');
     expect(result.html).not.toContain('playsinline');
-    expect(result.js).toContain("import '@videojs/html/media/mux-audio'");
+    expect(result.imports).toContain("import '@videojs/html/media/mux-audio'");
   });
 
   it('uses minimal skin tag', () => {
     const result = generateHTMLUsageCode({ ...baseHTML, skin: 'minimal-video' });
 
     expect(result.html).toContain('<video-minimal-skin>');
-    expect(result.js).toContain("import '@videojs/html/video/minimal-skin'");
+    expect(result.imports).toContain("import '@videojs/html/video/minimal-skin'");
   });
 
   it('omits skin tag and skin import when skin is none', () => {
@@ -234,8 +234,8 @@ describe('generateHTMLUsageCode', () => {
 
     expect(result.html).toContain('<video-player>');
     expect(result.html).not.toContain('<video-skin>');
-    expect(result.js).toContain("import '@videojs/html/video/player'");
-    expect(result.js).not.toContain("import '@videojs/html/video/skin'");
+    expect(result.imports).toContain("import '@videojs/html/video/player'");
+    expect(result.imports).not.toContain("import '@videojs/html/video/skin'");
   });
 
   it('uses custom source URL when provided', () => {
@@ -257,9 +257,9 @@ describe('generateHTMLUsageCode', () => {
     expect(result.html).toContain('<live-video-skin>');
     expect(result.html).toContain('<hlsjs-video src=');
     expect(result.html).toContain('playsinline');
-    expect(result.js).toContain("import '@videojs/html/live-video/player'");
-    expect(result.js).toContain("import '@videojs/html/live-video/skin'");
-    expect(result.js).toContain("import '@videojs/html/media/hlsjs-video'");
+    expect(result.imports).toContain("import '@videojs/html/live-video/player'");
+    expect(result.imports).toContain("import '@videojs/html/live-video/skin'");
+    expect(result.imports).toContain("import '@videojs/html/media/hlsjs-video'");
   });
 
   it('uses the minimal live video skin tag', () => {
@@ -271,7 +271,7 @@ describe('generateHTMLUsageCode', () => {
     });
 
     expect(result.html).toContain('<live-video-minimal-skin>');
-    expect(result.js).toContain("import '@videojs/html/live-video/minimal-skin'");
+    expect(result.imports).toContain("import '@videojs/html/live-video/minimal-skin'");
   });
 
   it('omits the skin for a headless live video player', () => {
@@ -279,8 +279,8 @@ describe('generateHTMLUsageCode', () => {
 
     expect(result.html).toContain('<live-video-player>');
     expect(result.html).not.toContain('<live-video-skin>');
-    expect(result.js).toContain("import '@videojs/html/live-video/player'");
-    expect(result.js).not.toContain("import '@videojs/html/live-video/skin'");
+    expect(result.imports).toContain("import '@videojs/html/live-video/player'");
+    expect(result.imports).not.toContain("import '@videojs/html/live-video/skin'");
   });
 
   it('uses live-audio tags and imports without playsinline', () => {
@@ -295,9 +295,9 @@ describe('generateHTMLUsageCode', () => {
     expect(result.html).toContain('<live-audio-skin>');
     expect(result.html).toContain('<mux-audio src=');
     expect(result.html).not.toContain('playsinline');
-    expect(result.js).toContain("import '@videojs/html/live-audio/player'");
-    expect(result.js).toContain("import '@videojs/html/live-audio/skin'");
-    expect(result.js).toContain("import '@videojs/html/media/mux-audio'");
+    expect(result.imports).toContain("import '@videojs/html/live-audio/player'");
+    expect(result.imports).toContain("import '@videojs/html/live-audio/skin'");
+    expect(result.imports).toContain("import '@videojs/html/media/mux-audio'");
   });
 
   it('defaults live use cases to a live source URL', () => {

--- a/site/src/utils/installation/codegen.ts
+++ b/site/src/utils/installation/codegen.ts
@@ -28,6 +28,11 @@ export interface InstallationOptions {
   installMethod: InstallMethod;
 }
 
+export interface HTMLUsageCode {
+  html: string;
+  imports?: string;
+}
+
 type ValidationResult = { valid: true } | { valid: false; reason: string };
 
 export function validateInstallationOptions(opts: InstallationOptions): ValidationResult {
@@ -213,7 +218,7 @@ ${skinMediaComment}
 </${playerTag}>`;
 }
 
-function generateHTMLJSImports(useCase: UseCase, skin: Skin, renderer: Renderer): string {
+function generateHTMLImports(useCase: UseCase, skin: Skin, renderer: Renderer): string {
   if (useCase === 'background-video') {
     const mediaSubpath = getMediaSubpath(renderer);
     const mediaImport = mediaSubpath ? `\nimport '@videojs/html/media/${mediaSubpath}';` : '';
@@ -237,11 +242,12 @@ import '@videojs/html/${group}/${getSkinFile(skin)}';${mediaImport}`;
 
 export function generateHTMLUsageCode(
   opts: Pick<InstallationOptions, 'useCase' | 'skin' | 'renderer' | 'sourceUrl' | 'installMethod'>
-): { html: string; js?: string } {
+): HTMLUsageCode {
   const html = generateHTMLMarkup(opts.useCase, opts.skin, opts.renderer, opts.sourceUrl);
-  const js = opts.installMethod !== 'cdn' ? generateHTMLJSImports(opts.useCase, opts.skin, opts.renderer) : undefined;
+  const imports =
+    opts.installMethod !== 'cdn' ? generateHTMLImports(opts.useCase, opts.skin, opts.renderer) : undefined;
 
-  return { html, js };
+  return { html, imports };
 }
 
 // ---------------------------------------------------------------------------

--- a/site/src/utils/mediaReferenceModel.ts
+++ b/site/src/utils/mediaReferenceModel.ts
@@ -54,12 +54,14 @@ interface MediaSubsectionDefinition<Reference> {
  * Options under `source.engine`, shared by both platforms: the structured source has the same shape in HTML and React,
  * so the section is defined once and placed after the properties or props it extends.
  */
-const ENGINE_OPTIONS_SUBSECTION: MediaSubsectionDefinition<unknown> = Object.freeze({
-  key: 'engineOptions',
-  title: 'Engine options',
-  id: 'engine-options',
-  isEmpty: (_platform, ref) => Object.keys(ref.engineOptions ?? {}).length === 0,
-});
+function createEngineOptionsSubsection<Reference>(): MediaSubsectionDefinition<Reference> {
+  return Object.freeze({
+    key: 'engineOptions',
+    title: 'Engine options',
+    id: 'engine-options',
+    isEmpty: (_platform: Reference, ref: MediaReference) => Object.keys(ref.engineOptions ?? {}).length === 0,
+  });
+}
 
 const HTML_SUBSECTIONS: readonly MediaSubsectionDefinition<HtmlMediaReference>[] = Object.freeze([
   {
@@ -76,7 +78,7 @@ const HTML_SUBSECTIONS: readonly MediaSubsectionDefinition<HtmlMediaReference>[]
     isEmpty: (html) =>
       Object.keys(html.properties?.definitions ?? {}).length === 0 && (html.properties?.native ?? []).length === 0,
   },
-  ENGINE_OPTIONS_SUBSECTION,
+  createEngineOptionsSubsection<HtmlMediaReference>(),
   {
     key: 'methods',
     title: 'Methods',
@@ -104,7 +106,7 @@ const REACT_SUBSECTIONS: readonly MediaSubsectionDefinition<ReactMediaReference>
     id: 'props',
     isEmpty: (react) => !react.acceptsNativeProps && Object.keys(react.props ?? {}).length === 0,
   },
-  ENGINE_OPTIONS_SUBSECTION,
+  createEngineOptionsSubsection<ReactMediaReference>(),
   {
     key: 'ref',
     title: 'Ref',
@@ -184,7 +186,7 @@ export function createMediaReferenceModel(mediaName: string, ref: MediaReference
 export function buildMediaReferenceTocHeadings(model: MediaReferenceModel | null): TocHeading[] {
   if (!model) return [];
 
-  const headings = [
+  const headings: TocHeading[] = [
     {
       depth: model.heading.depth,
       text: model.heading.text,

--- a/site/src/utils/mediaReferenceModel.ts
+++ b/site/src/utils/mediaReferenceModel.ts
@@ -1,17 +1,67 @@
 /** Centralized media API subsection definitions shared by the renderer and the generated table of contents. */
 
+import type { HtmlMediaReference, MediaReference, ReactMediaReference } from '@/types/media-reference';
+
+import type { TocHeading } from './componentReferenceModel';
+
+type MediaReferenceSectionKey =
+  | 'attributes'
+  | 'properties'
+  | 'engineOptions'
+  | 'methods'
+  | 'events'
+  | 'cssCustomProperties'
+  | 'props'
+  | 'ref';
+
+export interface MediaReferenceSection {
+  key: MediaReferenceSectionKey;
+  title: string;
+  id: string;
+  depth: number;
+}
+
+export interface MediaReferenceEngine {
+  key: string;
+  id: string;
+  title: string;
+}
+
+interface MediaPlatformModel<Reference> {
+  sections: MediaReferenceSection[];
+  data: Reference;
+}
+
+export interface MediaReferenceModel {
+  mediaName: string;
+  engines: MediaReferenceEngine[];
+  heading: { id: string; depth: number; text: string };
+  platforms: {
+    html: MediaPlatformModel<HtmlMediaReference>;
+    react?: MediaPlatformModel<ReactMediaReference>;
+  };
+  data: MediaReference;
+}
+
+interface MediaSubsectionDefinition<Reference> {
+  key: MediaReferenceSectionKey;
+  title: string;
+  id: string;
+  isEmpty: (source: Reference, ref: MediaReference) => boolean;
+}
+
 /**
  * Options under `source.engine`, shared by both platforms: the structured source has the same shape in HTML and React,
  * so the section is defined once and placed after the properties or props it extends.
  */
-const ENGINE_OPTIONS_SUBSECTION = Object.freeze({
+const ENGINE_OPTIONS_SUBSECTION: MediaSubsectionDefinition<unknown> = Object.freeze({
   key: 'engineOptions',
   title: 'Engine options',
   id: 'engine-options',
   isEmpty: (_platform, ref) => Object.keys(ref.engineOptions ?? {}).length === 0,
 });
 
-const HTML_SUBSECTIONS = Object.freeze([
+const HTML_SUBSECTIONS: readonly MediaSubsectionDefinition<HtmlMediaReference>[] = Object.freeze([
   {
     key: 'attributes',
     title: 'Attributes',
@@ -47,7 +97,7 @@ const HTML_SUBSECTIONS = Object.freeze([
   },
 ]);
 
-const REACT_SUBSECTIONS = Object.freeze([
+const REACT_SUBSECTIONS: readonly MediaSubsectionDefinition<ReactMediaReference>[] = Object.freeze([
   {
     key: 'props',
     title: 'Props',
@@ -69,7 +119,11 @@ const REACT_SUBSECTIONS = Object.freeze([
   },
 ]);
 
-function createSections(definitions, source, ref) {
+function createSections<Reference>(
+  definitions: readonly MediaSubsectionDefinition<Reference>[],
+  source: Reference,
+  ref: MediaReference
+): MediaReferenceSection[] {
   return definitions.flatMap((definition) => {
     if (definition.isEmpty(source, ref)) return [];
 
@@ -88,7 +142,7 @@ function createSections(definitions, source, ref) {
  * One entry per engine under `source.engine`, in the order the generator emitted them. Ids are lowercased so `hlsJs`
  * and `nativeHls` anchor predictably; titles are the exact path a reader types.
  */
-function createEngines(ref) {
+function createEngines(ref: MediaReference): MediaReferenceEngine[] {
   return Object.keys(ref.engineOptions ?? {}).map((key) => ({
     key,
     id: `engine-options-${key.toLowerCase()}`,
@@ -96,10 +150,23 @@ function createEngines(ref) {
   }));
 }
 
-export function createMediaReferenceModel(mediaName, ref) {
+export function createMediaReferenceModel(mediaName: string, ref: MediaReference | null): MediaReferenceModel | null {
   if (!ref) return null;
 
   const engines = createEngines(ref);
+  const platforms: MediaReferenceModel['platforms'] = {
+    html: {
+      sections: createSections(HTML_SUBSECTIONS, ref.platforms.html, ref),
+      data: ref.platforms.html,
+    },
+  };
+
+  if (ref.platforms.react) {
+    platforms.react = {
+      sections: createSections(REACT_SUBSECTIONS, ref.platforms.react, ref),
+      data: ref.platforms.react,
+    };
+  }
 
   return {
     mediaName,
@@ -109,25 +176,12 @@ export function createMediaReferenceModel(mediaName, ref) {
       depth: 2,
       text: 'API Reference',
     },
-    platforms: {
-      html: {
-        sections: createSections(HTML_SUBSECTIONS, ref.platforms.html, ref),
-        data: ref.platforms.html,
-      },
-      ...(ref.platforms.react
-        ? {
-            react: {
-              sections: createSections(REACT_SUBSECTIONS, ref.platforms.react, ref),
-              data: ref.platforms.react,
-            },
-          }
-        : {}),
-    },
+    platforms,
     data: ref,
   };
 }
 
-export function buildMediaReferenceTocHeadings(model) {
+export function buildMediaReferenceTocHeadings(model: MediaReferenceModel | null): TocHeading[] {
   if (!model) return [];
 
   const headings = [
@@ -138,7 +192,7 @@ export function buildMediaReferenceTocHeadings(model) {
     },
   ];
 
-  for (const framework of ['html', 'react']) {
+  for (const framework of ['html', 'react'] as const) {
     const platform = model.platforms[framework];
     if (!platform) continue;
 

--- a/site/src/utils/satteriConditionalHeadings.ts
+++ b/site/src/utils/satteriConditionalHeadings.ts
@@ -187,7 +187,8 @@ function injectFeatureReferenceHeadings(node: MdxJsxFlowElement, headings: Condi
   const json = readRefJson(FEATURE_REF_DIR, featureName);
   if (!json) return;
 
-  const model = createFeatureReferenceModel(featureName, json);
+  // SAFETY: This JSON is emitted by the feature-reference builder with the same schema consumed by the site.
+  const model = createFeatureReferenceModel(featureName, json as Parameters<typeof createFeatureReferenceModel>[1]);
 
   headings.push(...buildFeatureReferenceTocHeadings(model));
 }
@@ -212,7 +213,8 @@ function injectMediaReferenceHeadings(node: MdxJsxFlowElement, headings: Conditi
   const json = readRefJson(MEDIA_REF_DIR, resolveReferenceSlug(mediaName));
   if (!json) return;
 
-  const model = createMediaReferenceModel(mediaName, json);
+  // SAFETY: This JSON is emitted by the media-reference builder with the same schema consumed by the site.
+  const model = createMediaReferenceModel(mediaName, json as Parameters<typeof createMediaReferenceModel>[1]);
 
   headings.push(...buildMediaReferenceTocHeadings(model));
 }

--- a/site/src/utils/tests/mediaReferenceModel.test.ts
+++ b/site/src/utils/tests/mediaReferenceModel.test.ts
@@ -56,7 +56,7 @@ describe('createMediaReferenceModel', () => {
   });
 
   it('uses the HTML API subsection order', () => {
-    const model = createMediaReferenceModel('HlsJsVideo', makeRef());
+    const model = createMediaReferenceModel('HlsJsVideo', makeRef())!;
 
     expect(model.platforms.html.sections.map((section) => section.key)).toEqual([
       'attributes',
@@ -68,7 +68,7 @@ describe('createMediaReferenceModel', () => {
   });
 
   it('places engine options after the properties they extend', () => {
-    const model = createMediaReferenceModel('HlsJsVideo', makeRef({ engineOptions: ENGINE_OPTIONS }));
+    const model = createMediaReferenceModel('HlsJsVideo', makeRef({ engineOptions: ENGINE_OPTIONS }))!;
 
     expect(model.platforms.html.sections.map((section) => section.key)).toEqual([
       'attributes',
@@ -78,7 +78,7 @@ describe('createMediaReferenceModel', () => {
       'events',
       'cssCustomProperties',
     ]);
-    expect(model.platforms.react.sections.map((section) => section.key)).toEqual([
+    expect(model.platforms.react!.sections.map((section) => section.key)).toEqual([
       'props',
       'engineOptions',
       'ref',
@@ -87,17 +87,17 @@ describe('createMediaReferenceModel', () => {
   });
 
   it('omits engine options for a media with no structured source', () => {
-    const model = createMediaReferenceModel('HlsJsVideo', makeRef());
+    const model = createMediaReferenceModel('HlsJsVideo', makeRef())!;
 
     expect(model.engines).toEqual([]);
 
-    for (const platform of ['html', 'react']) {
-      expect(model.platforms[platform].sections.map((section) => section.key)).not.toContain('engineOptions');
+    for (const platform of ['html', 'react'] as const) {
+      expect(model.platforms[platform]!.sections.map((section) => section.key)).not.toContain('engineOptions');
     }
   });
 
   it('describes one engine per key under source.engine', () => {
-    const model = createMediaReferenceModel('HlsJsVideo', makeRef({ engineOptions: ENGINE_OPTIONS }));
+    const model = createMediaReferenceModel('HlsJsVideo', makeRef({ engineOptions: ENGINE_OPTIONS }))!;
 
     expect(model.engines).toEqual([
       { key: 'hlsJs', id: 'engine-options-hlsjs', title: 'source.engine.hlsJs' },
@@ -106,35 +106,35 @@ describe('createMediaReferenceModel', () => {
   });
 
   it('uses React-specific props and ref sections', () => {
-    const model = createMediaReferenceModel('HlsJsVideo', makeRef());
+    const model = createMediaReferenceModel('HlsJsVideo', makeRef())!;
 
-    expect(model.platforms.react.sections.map((section) => section.key)).toEqual(['props', 'ref', 'events']);
+    expect(model.platforms.react!.sections.map((section) => section.key)).toEqual(['props', 'ref', 'events']);
   });
 
   it('keeps the React props section when only standard native props are accepted', () => {
     const ref = makeRef();
 
     ref.platforms.react!.props = {};
-    const model = createMediaReferenceModel('HlsJsVideo', ref);
+    const model = createMediaReferenceModel('HlsJsVideo', ref)!;
 
-    expect(model.platforms.react.sections.some((section) => section.key === 'props')).toBe(true);
+    expect(model.platforms.react!.sections.some((section) => section.key === 'props')).toBe(true);
   });
 
   it('omits the React props section when the component accepts no props', () => {
     const ref = makeRef();
 
-    ref.platforms.react.acceptsNativeProps = false;
+    ref.platforms.react!.acceptsNativeProps = false;
     ref.platforms.react!.props = {};
-    const model = createMediaReferenceModel('HlsJsVideo', ref);
+    const model = createMediaReferenceModel('HlsJsVideo', ref)!;
 
-    expect(model.platforms.react.sections.some((section) => section.key === 'props')).toBe(false);
+    expect(model.platforms.react!.sections.some((section) => section.key === 'props')).toBe(false);
   });
 
   it('drops an empty HTML section', () => {
     const ref = makeRef();
 
     ref.platforms.html.properties = { definitions: {}, native: [] };
-    const model = createMediaReferenceModel('HlsJsVideo', ref);
+    const model = createMediaReferenceModel('HlsJsVideo', ref)!;
 
     expect(model.platforms.html.sections.some((section) => section.key === 'properties')).toBe(false);
   });
@@ -143,7 +143,7 @@ describe('createMediaReferenceModel', () => {
     const ref = makeRef();
 
     ref.platforms.html.properties.definitions = {};
-    const model = createMediaReferenceModel('HlsJsVideo', ref);
+    const model = createMediaReferenceModel('HlsJsVideo', ref)!;
 
     expect(model.platforms.html.sections.some((section) => section.key === 'properties')).toBe(true);
   });
@@ -152,9 +152,9 @@ describe('createMediaReferenceModel', () => {
     const ref = makeRef();
 
     ref.platforms.react!.acceptsNativeProps = false;
-    const model = createMediaReferenceModel('HlsJsVideo', ref);
+    const model = createMediaReferenceModel('HlsJsVideo', ref)!;
 
-    expect(model.platforms.react.sections.some((section) => section.key === 'events')).toBe(false);
+    expect(model.platforms.react!.sections.some((section) => section.key === 'events')).toBe(false);
   });
 });
 

--- a/site/src/utils/tests/mediaReferenceModel.test.ts
+++ b/site/src/utils/tests/mediaReferenceModel.test.ts
@@ -1,9 +1,10 @@
-// @ts-nocheck — the model is plain JS shared with satteriConditionalHeadings
 import { describe, expect, it } from 'vite-plus/test';
+
+import type { MediaReference } from '@/types/media-reference';
 
 import { buildMediaReferenceTocHeadings, createMediaReferenceModel } from '../mediaReferenceModel';
 
-function makeRef(overrides = {}) {
+function makeRef(overrides: Partial<MediaReference> = {}): MediaReference {
   return {
     name: 'HlsJsVideo',
     tagName: 'hlsjs-video',
@@ -47,7 +48,7 @@ function makeRef(overrides = {}) {
 const ENGINE_OPTIONS = {
   hlsJs: [{ name: 'maxBufferLength', type: 'number', description: 'Buffer length.' }],
   nativeHls: [{ name: 'drmSystems', type: 'object' }],
-};
+} satisfies NonNullable<MediaReference['engineOptions']>;
 
 describe('createMediaReferenceModel', () => {
   it('returns null without a reference', () => {
@@ -113,7 +114,7 @@ describe('createMediaReferenceModel', () => {
   it('keeps the React props section when only standard native props are accepted', () => {
     const ref = makeRef();
 
-    ref.platforms.react.props = {};
+    ref.platforms.react!.props = {};
     const model = createMediaReferenceModel('HlsJsVideo', ref);
 
     expect(model.platforms.react.sections.some((section) => section.key === 'props')).toBe(true);
@@ -123,7 +124,7 @@ describe('createMediaReferenceModel', () => {
     const ref = makeRef();
 
     ref.platforms.react.acceptsNativeProps = false;
-    ref.platforms.react.props = {};
+    ref.platforms.react!.props = {};
     const model = createMediaReferenceModel('HlsJsVideo', ref);
 
     expect(model.platforms.react.sections.some((section) => section.key === 'props')).toBe(false);
@@ -150,7 +151,7 @@ describe('createMediaReferenceModel', () => {
   it('omits React events when the component does not accept native media props', () => {
     const ref = makeRef();
 
-    ref.platforms.react.acceptsNativeProps = false;
+    ref.platforms.react!.acceptsNativeProps = false;
     const model = createMediaReferenceModel('HlsJsVideo', ref);
 
     expect(model.platforms.react.sections.some((section) => section.key === 'events')).toBe(false);


### PR DESCRIPTION
## Summary

- Move the remaining site configuration, RSS routes, and generated-reference models to TypeScript.
- Use TypeScript examples and declarations consistently across installation, CLI, and scoped UI component documentation.

## Verification

- `CI=true pnpm typecheck`
- `CI=true pnpm lint`
- `CI=true pnpm check:workspace`
- `env -u SENTRY_AUTH_TOKEN CI=true pnpm build:site`

Closes #1104

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>