### PR TITLE
fix(packages): make html entries server importable

### DIFF
--- a/packages/element/src/reactive-element.ts
+++ b/packages/element/src/reactive-element.ts
@@ -7,6 +7,7 @@ interface ResolvedMeta {
 
 const cache = new WeakMap<typeof ReactiveElement, ResolvedMeta>();
 const propertyKeys = new Map<string, symbol>();
+const HTMLElementBase = globalThis.HTMLElement ?? class {};
 
 /**
  * Lightweight reactive custom element base class.
@@ -47,7 +48,7 @@ const propertyKeys = new Map<string, symbol>();
  *   }
  *   ```;
  */
-export class ReactiveElement extends HTMLElement {
+export class ReactiveElement extends HTMLElementBase {
   /**
    * User-supplied object that maps property names to {@linkcode PropertyDeclaration} objects containing options for
    * configuring reactive properties. When a reactive property is set the element will update and render.

--- a/packages/element/src/tests/server.test.ts
+++ b/packages/element/src/tests/server.test.ts
@@ -1,0 +1,10 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vite-plus/test';
+
+describe('ReactiveElement server import', () => {
+  it('imports without browser-only globals', async () => {
+    const { ReactiveElement } = await import('../reactive-element');
+
+    expect(ReactiveElement).toBeTypeOf('function');
+  });
+});

--- a/packages/html/src/define/tests/ssr-safety.test.ts
+++ b/packages/html/src/define/tests/ssr-safety.test.ts
@@ -1,21 +1,21 @@
-import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+// @vitest-environment node
+import { describe, expect, it } from 'vite-plus/test';
 
 describe('SSR-safe define imports', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.resetModules();
+  it('imports the package API without browser-only globals', async () => {
+    await expect(import('../../index')).resolves.toBeDefined();
   });
 
   it('imports video skin without browser-only globals', async () => {
-    vi.stubGlobal('customElements', undefined);
-    vi.stubGlobal('CSSStyleSheet', undefined);
-
     await expect(import('../video/skin')).resolves.toBeDefined();
   });
 
-  it('imports hls-video without customElements', async () => {
-    vi.stubGlobal('customElements', undefined);
-
+  it('imports hls-video without browser-only globals', async () => {
     await expect(import('../media/hls-video')).resolves.toBeDefined();
+  });
+
+  it('imports background videos without browser-only globals', async () => {
+    await expect(import('../background/video')).resolves.toBeDefined();
+    await expect(import('../media/hls-background-video')).resolves.toBeDefined();
   });
 });

--- a/packages/html/src/media/background-video/media.ts
+++ b/packages/html/src/media/background-video/media.ts
@@ -4,8 +4,10 @@ import { namedNodeMapToObject } from '@videojs/utils/dom';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 import { getTemplateHTML } from './template';
 
+const HTMLElementBase = globalThis.HTMLElement ?? class {};
+
 // Don't extend CustomMediaMixin to save some bytes, background videos don't need the full Media API.
-export class BackgroundVideo extends MediaAttachMixin(HTMLElement) {
+export class BackgroundVideo extends MediaAttachMixin(HTMLElementBase) {
   static shadowRootOptions = { mode: 'open' as ShadowRootMode };
   static getTemplateHTML = getTemplateHTML;
   static get observedAttributes() {

--- a/packages/html/src/media/hls-background-video/media.ts
+++ b/packages/html/src/media/hls-background-video/media.ts
@@ -6,10 +6,12 @@ import type { Constructor } from '@videojs/utils/types';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 import { getTemplateHTML } from '../background-video/template';
 
+const HTMLElementBase = globalThis.HTMLElement ?? class {};
+
 // `MediaAttachMixin` is typed as returning its base, so its `disconnectedCallback`
 // isn't visible for `super` to reach. `CustomElement` declares the lifecycle
 // callbacks this element overrides.
-const HlsBackgroundVideoBase = MediaAttachMixin(HTMLElement) as unknown as Constructor<CustomElement>;
+const HlsBackgroundVideoBase = MediaAttachMixin(HTMLElementBase) as unknown as Constructor<CustomElement>;
 
 /**
  * A muted, looping, chrome-less video over the SPF background-video engine.

--- a/packages/icons/src/element.ts
+++ b/packages/icons/src/element.ts
@@ -1,8 +1,10 @@
 export type IconMap = Readonly<Record<string, string>>;
 export type IconLoader = () => IconMap | Promise<IconMap>;
 
+const HTMLElementBase = globalThis.HTMLElement ?? class {};
+
 /** Renders registered SVG icon families in the light DOM. */
-export class MediaIconElement extends HTMLElement {
+export class MediaIconElement extends HTMLElementBase {
   static #families = new Map<string, Map<string, string>>();
   static #loaders = new Map<string, IconLoader>();
   static #loading = new Map<string, Promise<void>>();

--- a/packages/icons/src/tests/server.test.ts
+++ b/packages/icons/src/tests/server.test.ts
@@ -1,0 +1,10 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vite-plus/test';
+
+describe('MediaIconElement server import', () => {
+  it('imports without browser-only globals', async () => {
+    const { MediaIconElement } = await import('../element');
+
+    expect(MediaIconElement).toBeTypeOf('function');
+  });
+});


### PR DESCRIPTION
## Summary

Make HTML custom-element entry points safe to evaluate in server runtimes that do not provide DOM globals.

## Changes

- Use inert HTMLElement fallbacks for reactive, background-video, and icon element class definitions
- Run SSR import coverage in a real Node environment
- Cover package root, player/skin, HLS, background media, element, and icon imports

## Testing

- vp run @videojs/html#build
- pnpm -F @videojs/element test
- pnpm -F @videojs/icons test
- pnpm -F @videojs/html test
- pnpm typecheck
- Built HTML entry import sweep in bare Node; DASH and Shaka are intentionally handled separately