### PR TITLE
fix(media): make engine entries server importable

### DIFF
--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -33,6 +33,14 @@
       "development": "./dist/dev/dom.js",
       "default": "./dist/default/dom.js"
     },
+    "./dom/dash": {
+      "types": "./dist/dev/dom/dash/index.d.ts",
+      "browser": {
+        "development": "./dist/dev/dom/dash/index.js",
+        "default": "./dist/default/dom/dash/index.js"
+      },
+      "default": "./dist/default/dom/dash/server.js"
+    },
     "./dom/*": {
       "types": "./dist/dev/dom/*/index.d.ts",
       "development": "./dist/dev/dom/*/index.js",

--- a/packages/media/src/dom/dash/server.ts
+++ b/packages/media/src/dom/dash/server.ts
@@ -1,0 +1,44 @@
+import { MediaTracksMixin } from '../../core/media-tracks';
+import { HTMLVideoElementHost } from '../video-host';
+import type { DashMediaProps, DashSource } from './media';
+
+export type { DashEngineConfig, DashMediaProps, DashSource } from './media';
+
+export const dashMediaDefaultProps: DashMediaProps = {
+  src: '',
+  source: null,
+};
+
+const DashMediaHost = MediaTracksMixin(HTMLVideoElementHost);
+
+/** An inert DASH host used when the package is evaluated outside a browser. */
+export class DashMedia extends DashMediaHost implements DashMediaProps {
+  readonly engine = null;
+  #src = dashMediaDefaultProps.src;
+  #source: DashSource | null = dashMediaDefaultProps.source;
+
+  get src() {
+    return this.#src;
+  }
+
+  set src(value) {
+    const { engine } = this.#source ?? {};
+    const source: DashSource = { ...(engine && { engine }), ...(value && { src: value }) };
+
+    this.source = Object.keys(source).length > 0 ? source : null;
+  }
+
+  get source() {
+    return this.#source;
+  }
+
+  set source(value) {
+    const source = value ?? null;
+    if (source === this.#source) return;
+
+    this.#source = source;
+    this.#src = source?.src ?? '';
+
+    this.dispatchEvent(new Event('sourcechange'));
+  }
+}

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -7,7 +7,7 @@ import { isObject } from '@videojs/utils/predicate';
 // minus the ES5 down-compilation nothing this repo targets needs. Shaka ships
 // no `exports` map, so the deep path is public surface — and `dist/*.ui*` is
 // where the UI library lives; never import those.
-import shaka from 'shaka-player/dist/shaka-player.compiled-es2021';
+import shaka from 'shaka-player/dist/shaka-player.compiled-es2021.js';
 
 import type { DrmSystemsConfig } from '../../core/drm';
 import { MediaError } from '../../core/media-error';

--- a/packages/media/src/dom/tests/server-imports.test.ts
+++ b/packages/media/src/dom/tests/server-imports.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+/// <reference types="node" />
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { describe, expect, it } from 'vite-plus/test';
+
+const execFileAsync = promisify(execFile);
+
+async function importPackageEntry(specifier: string, exportName: string) {
+  const script = `const module = await import(${JSON.stringify(specifier)});
+if (typeof module[${JSON.stringify(exportName)}] !== 'function') process.exit(1);`;
+
+  await execFileAsync(process.execPath, ['--input-type=module', '--eval', script], {
+    cwd: new URL('../../../', import.meta.url),
+  });
+}
+
+async function resolveBrowserPackageEntry(specifier: string) {
+  const script = `console.log(import.meta.resolve(${JSON.stringify(specifier)}));`;
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ['--conditions=browser', '--input-type=module', '--eval', script],
+    { cwd: new URL('../../../', import.meta.url) }
+  );
+
+  return stdout.trim();
+}
+
+describe('server package imports', () => {
+  it('imports the published DASH entry without browser globals', async () => {
+    await importPackageEntry('@videojs/media/dom/dash', 'DashMedia');
+  });
+
+  it('resolves the DASH implementation in browser builds', async () => {
+    const entry = await resolveBrowserPackageEntry('@videojs/media/dom/dash');
+
+    expect(entry).toMatch(/\/dist\/default\/dom\/dash\/index\.js$/);
+  });
+
+  it('imports the published Shaka entry without browser globals', async () => {
+    await importPackageEntry('@videojs/media/dom/shaka', 'ShakaMedia');
+  });
+});

--- a/packages/media/vite.config.ts
+++ b/packages/media/vite.config.ts
@@ -17,6 +17,7 @@ const createPackConfig = (mode: PackageBuildMode): PackUserConfig => ({
     'dom/custom-media-element/index': './src/dom/custom-media-element/index.ts',
     'dom/media-played-ranges/index': './src/dom/media-played-ranges/index.ts',
     'dom/dash/index': './src/dom/dash/index.ts',
+    'dom/dash/server': './src/dom/dash/server.ts',
     'dom/hls-js/index': './src/dom/hls-js/index.ts',
     'dom/native-hls/index': './src/dom/native-hls/index.ts',
     'dom/cloudflare/index': './src/dom/cloudflare/index.ts',

--- a/site/src/content/docs/reference/dash-video.mdx
+++ b/site/src/content/docs/reference/dash-video.mdx
@@ -11,9 +11,8 @@ import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
 
-{/* React live demo disabled until #1343 (SSR-breaking media imports) is fixed; show source instead. */}
-import { TabsRoot, TabsList, Tab, TabsPanel } from "@/components/Tabs";
-import ServerCode from "@/components/Code/ServerCode.astro";
+{/* React demos */}
+import BasicUsageDemoReact from "@/components/docs/demos/dash-video/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/dash-video/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/dash-video/react/css/BasicUsage.css?raw";
 
@@ -29,21 +28,14 @@ DASH video element powered by [dash.js](https://github.com/Dash-Industry-Forum/d
 
 ### Basic Usage
 
-{/* React: source-only until #1343 is fixed. Restore <Demo> with <BasicUsageDemoReact client:idle /> afterward. */}
 <FrameworkCase frameworks={["react"]}>
   <StyleCase styles={["css"]}>
-    <TabsRoot client:idle>
-      <TabsList client:idle label="Basic usage source code">
-        <Tab client:idle value="App.tsx" initial>App.tsx</Tab>
-        <Tab client:idle value="App.css">App.css</Tab>
-      </TabsList>
-      <TabsPanel client:idle value="App.tsx" initial>
-        <ServerCode code={basicUsageReactTsx} lang="tsx" />
-      </TabsPanel>
-      <TabsPanel client:idle value="App.css">
-        <ServerCode code={basicUsageReactCss} lang="css" />
-      </TabsPanel>
-    </TabsRoot>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
   </StyleCase>
 </FrameworkCase>
 


### PR DESCRIPTION
## Summary

Keep DASH and Shaka media entries importable when Astro, Nuxt, SvelteKit, or another server runtime evaluates them without browser globals.

## Changes

- Route the DASH package export to an inert media host on servers and retain the real dash.js host under the browser condition
- Add the explicit .js extension required for Node to resolve Shaka Player published ESM
- Exercise built package exports in fresh Node processes and verify browser resolution still selects the DASH implementation

## Testing

- vp run @videojs/media#build
- pnpm -F @videojs/media test (44 files, 1,048 tests)
- pnpm typecheck
- pnpm check:workspace
- vp run @videojs/html#build
- vp run @videojs/react#build
- Bare Node imports of the built HTML and React DASH/Shaka entries

Closes #1343

This is independent of #2428, which handles the HTML custom-element DOM globals.