### PR TITLE
docs(site): standardize component reference imports

### DIFF
--- a/.agents/skills/write-api-reference/references/mdx-structure.md
+++ b/.agents/skills/write-api-reference/references/mdx-structure.md
@@ -24,6 +24,7 @@ description: A button component for muting and unmuting audio playback
 ```
 frontmatter
 imports (React demos, HTML demos)
+## Import
 ## Anatomy
 ## Behavior       (if applicable)
 ## Styling        (if applicable)
@@ -35,6 +36,17 @@ imports (React demos, HTML demos)
 ```
 
 ## Imports Section
+
+Every component page begins with a reader-facing import section:
+
+```mdx
+## Import
+
+<ComponentImports component="MuteButton" html="mute-button" />
+```
+
+The helper renders the named `@videojs/react` export for React readers and the
+`@videojs/html/ui/{name}` side-effect registration import for HTML readers.
 
 ### React demo imports
 
@@ -217,6 +229,7 @@ Every component reference MDX needs these at the top of the imports:
 
 ```mdx
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";

--- a/site/src/components/docs/api-reference/ComponentImports.astro
+++ b/site/src/components/docs/api-reference/ComponentImports.astro
@@ -1,0 +1,37 @@
+---
+import type { BundledLanguage } from 'shiki';
+
+import ServerCode from '@/components/Code/ServerCode.astro';
+import CodeFrame from '@/components/typography/CodeFrame.astro';
+import FrameworkCase from '../FrameworkCase.astro';
+
+interface Props {
+  component: string;
+  html: string;
+}
+
+const { component, html } = Astro.props;
+
+const imports: Array<{ code: string; framework: 'react' | 'html'; lang: BundledLanguage }> = [
+  {
+    code: `import { ${component} } from '@videojs/react';`,
+    framework: 'react',
+    lang: 'tsx',
+  },
+  {
+    code: `import '@videojs/html/ui/${html}';`,
+    framework: 'html',
+    lang: 'ts',
+  },
+];
+---
+
+{
+  imports.map(({ code, framework, lang }) => (
+    <FrameworkCase frameworks={[framework]}>
+      <CodeFrame lang={lang}>
+        <ServerCode code={code} lang={lang} />
+      </CodeFrame>
+    </FrameworkCase>
+  ))
+}

--- a/site/src/content/docs/reference/airplay-button.mdx
+++ b/site/src/content/docs/reference/airplay-button.mdx
@@ -6,6 +6,7 @@ description: Accessible AirPlay toggle button that opens the WebKit playback tar
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/airplay-button/html/css/
 import basicUsageHtml from "@/components/docs/demos/airplay-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/airplay-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/airplay-button/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="AirPlayButton" html="airplay-button" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/alert-dialog.mdx
+++ b/site/src/content/docs/reference/alert-dialog.mdx
@@ -6,6 +6,7 @@ description: A modal alert dialog for urgent messages that require acknowledgeme
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/alert-dialog/html/css/Ba
 import basicUsageHtml from "@/components/docs/demos/alert-dialog/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/alert-dialog/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/alert-dialog/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="AlertDialog" html="alert-dialog" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/audio-track-radio-group.mdx
+++ b/site/src/content/docs/reference/audio-track-radio-group.mdx
@@ -6,6 +6,7 @@ description: A menu radio group for selecting an audio track
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -23,6 +24,10 @@ import basicUsageHtmlCss from "@/components/docs/demos/audio-track-radio-group/h
 import basicUsageHtmlTs from "@/components/docs/demos/audio-track-radio-group/html/css/BasicUsage.ts?raw";
 
 Creates radio items from the player audio track state and selects the enabled track.
+
+## Import
+
+<ComponentImports component="AudioTrackRadioGroup" html="audio-track-radio-group" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/buffering-indicator.mdx
+++ b/site/src/content/docs/reference/buffering-indicator.mdx
@@ -6,6 +6,7 @@ description: Loading indicator that displays when the video player is buffering 
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -20,6 +21,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/buffering-indicator/html
 import basicUsageHtml from "@/components/docs/demos/buffering-indicator/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/buffering-indicator/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/buffering-indicator/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="BufferingIndicator" html="buffering-indicator" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/captions-button.mdx
+++ b/site/src/content/docs/reference/captions-button.mdx
@@ -6,6 +6,7 @@ description: Accessible captions toggle button with availability detection and s
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -20,6 +21,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/captions-button/html/css
 import basicUsageHtml from "@/components/docs/demos/captions-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/captions-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/captions-button/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="CaptionsButton" html="captions-button" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/captions-radio-group.mdx
+++ b/site/src/content/docs/reference/captions-radio-group.mdx
@@ -6,6 +6,7 @@ description: A menu radio group for selecting caption and subtitle tracks
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -23,6 +24,10 @@ import basicUsageHtmlCss from "@/components/docs/demos/captions-radio-group/html
 import basicUsageHtmlTs from "@/components/docs/demos/captions-radio-group/html/css/BasicUsage.ts?raw";
 
 Creates radio items from the player text track state and selects the showing caption or subtitle track.
+
+## Import
+
+<ComponentImports component="CaptionsRadioGroup" html="captions-radio-group" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/cast-button.mdx
+++ b/site/src/content/docs/reference/cast-button.mdx
@@ -6,6 +6,7 @@ description: Accessible Cast toggle button with state reflection and keyboard su
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/cast-button/html/css/Bas
 import basicUsageHtml from "@/components/docs/demos/cast-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/cast-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/cast-button/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="CastButton" html="cast-button" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/controls.mdx
+++ b/site/src/content/docs/reference/controls.mdx
@@ -6,6 +6,7 @@ description: Container component for composing and auto-hiding video player cont
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -20,6 +21,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/controls/html/css/BasicU
 import basicUsageHtml from "@/components/docs/demos/controls/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/controls/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/controls/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="Controls" html="controls" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/dialog.mdx
+++ b/site/src/content/docs/reference/dialog.mdx
@@ -6,6 +6,7 @@ description: A modal dialog for application content, including players opened fr
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/dialog/html/css/BasicUsa
 import basicUsageHtml from "@/components/docs/demos/dialog/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/dialog/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/dialog/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="Dialog" html="dialog" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/error-dialog.mdx
+++ b/site/src/content/docs/reference/error-dialog.mdx
@@ -6,6 +6,7 @@ description: An alert dialog that presents and dismisses playback errors
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/error-dialog/html/css/Ba
 import basicUsageHtml from "@/components/docs/demos/error-dialog/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/error-dialog/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/error-dialog/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="ErrorDialog" html="error-dialog" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/fullscreen-button.mdx
+++ b/site/src/content/docs/reference/fullscreen-button.mdx
@@ -6,6 +6,7 @@ description: Accessible fullscreen toggle button with keyboard support and state
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -20,6 +21,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/fullscreen-button/html/c
 import basicUsageHtml from "@/components/docs/demos/fullscreen-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/fullscreen-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/fullscreen-button/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="FullscreenButton" html="fullscreen-button" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/gesture.mdx
+++ b/site/src/content/docs/reference/gesture.mdx
@@ -6,6 +6,7 @@ description: Map tap and double-tap gestures to player actions
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/gesture/html/css/BasicUs
 import basicUsageHtml from "@/components/docs/demos/gesture/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/gesture/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/gesture/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="Gesture" html="gesture" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/hotkey.mdx
+++ b/site/src/content/docs/reference/hotkey.mdx
@@ -6,6 +6,7 @@ description: Register a keyboard shortcut that invokes a player action
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/hotkey/html/css/BasicUsa
 import basicUsageHtml from "@/components/docs/demos/hotkey/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/hotkey/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/hotkey/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="Hotkey" html="hotkey" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/menu.mdx
+++ b/site/src/content/docs/reference/menu.mdx
@@ -6,6 +6,7 @@ description: A composable menu component for settings, option selection, and act
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/menu/html/css/BasicUsage
 import basicUsageHtml from "@/components/docs/demos/menu/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/menu/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/menu/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="Menu" html="menu" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/mute-button.mdx
+++ b/site/src/content/docs/reference/mute-button.mdx
@@ -6,6 +6,7 @@ description: Accessible mute/unmute button with keyboard support and volume stat
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -31,6 +32,10 @@ import VolumeLevelsDemoHtml from "@/components/docs/demos/mute-button/html/css/V
 import volumeLevelsHtml from "@/components/docs/demos/mute-button/html/css/VolumeLevels.html?raw";
 import volumeLevelsHtmlCss from "@/components/docs/demos/mute-button/html/css/VolumeLevels.css?raw";
 import volumeLevelsHtmlTs from "@/components/docs/demos/mute-button/html/css/VolumeLevels.ts?raw";
+
+## Import
+
+<ComponentImports component="MuteButton" html="mute-button" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/pip-button.mdx
+++ b/site/src/content/docs/reference/pip-button.mdx
@@ -6,6 +6,7 @@ description: Accessible picture-in-picture toggle button with keyboard support a
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -20,6 +21,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/pip-button/html/css/Basi
 import basicUsageHtml from "@/components/docs/demos/pip-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/pip-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/pip-button/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="PiPButton" html="pip-button" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/play-button.mdx
+++ b/site/src/content/docs/reference/play-button.mdx
@@ -6,6 +6,7 @@ description: Accessible play/pause button with keyboard support and customizable
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -20,6 +21,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/play-button/html/css/Bas
 import basicUsageHtml from "@/components/docs/demos/play-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/play-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/play-button/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="PlayButton" html="play-button" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/playback-rate-button.mdx
+++ b/site/src/content/docs/reference/playback-rate-button.mdx
@@ -6,6 +6,7 @@ description: A button that cycles through playback speed rates
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -20,6 +21,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/playback-rate-button/htm
 import basicUsageHtml from "@/components/docs/demos/playback-rate-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/playback-rate-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/playback-rate-button/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="PlaybackRateButton" html="playback-rate-button" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/playback-rate-radio-group.mdx
+++ b/site/src/content/docs/reference/playback-rate-radio-group.mdx
@@ -6,6 +6,7 @@ description: A menu radio group for selecting playback speed
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -23,6 +24,10 @@ import basicUsageHtmlCss from "@/components/docs/demos/playback-rate-radio-group
 import basicUsageHtmlTs from "@/components/docs/demos/playback-rate-radio-group/html/css/BasicUsage.ts?raw";
 
 Creates radio items from the player playback rate state and selects the playback speed.
+
+## Import
+
+<ComponentImports component="PlaybackRateRadioGroup" html="playback-rate-radio-group" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/popover.mdx
+++ b/site/src/content/docs/reference/popover.mdx
@@ -6,6 +6,7 @@ description: A popover component for displaying contextual content anchored to a
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/popover/html/css/BasicUs
 import basicUsageHtml from "@/components/docs/demos/popover/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/popover/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/popover/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="Popover" html="popover" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/poster.mdx
+++ b/site/src/content/docs/reference/poster.mdx
@@ -6,6 +6,7 @@ description: Poster image component that displays a thumbnail until video playba
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -20,6 +21,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/poster/html/css/BasicUsa
 import basicUsageHtml from "@/components/docs/demos/poster/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/poster/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/poster/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="Poster" html="poster" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/quality-radio-group.mdx
+++ b/site/src/content/docs/reference/quality-radio-group.mdx
@@ -6,6 +6,7 @@ description: A menu radio group for selecting video quality
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -23,6 +24,10 @@ import basicUsageHtmlCss from "@/components/docs/demos/quality-radio-group/html/
 import basicUsageHtmlTs from "@/components/docs/demos/quality-radio-group/html/css/BasicUsage.ts?raw";
 
 Creates radio items from the player video rendition state and selects automatic or manual quality.
+
+## Import
+
+<ComponentImports component="QualityRadioGroup" html="quality-radio-group" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/seek-button.mdx
+++ b/site/src/content/docs/reference/seek-button.mdx
@@ -6,6 +6,7 @@ description: Accessible seek button for skipping forward or backward by a config
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -20,6 +21,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/seek-button/html/css/Bas
 import basicUsageHtml from "@/components/docs/demos/seek-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/seek-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/seek-button/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="SeekButton" html="seek-button" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/seek-indicator.mdx
+++ b/site/src/content/docs/reference/seek-indicator.mdx
@@ -6,6 +6,7 @@ description: A temporary visual indicator for keyboard and gesture seeking
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/seek-indicator/html/css/
 import basicUsageHtml from "@/components/docs/demos/seek-indicator/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/seek-indicator/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/seek-indicator/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="SeekIndicator" html="seek-indicator" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/slider.mdx
+++ b/site/src/content/docs/reference/slider.mdx
@@ -6,6 +6,7 @@ description: A composable slider component with track, fill, thumb, preview, and
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -30,6 +31,10 @@ import WithPreviewDemoHtml from "@/components/docs/demos/slider/html/css/WithPre
 import withPreviewHtml from "@/components/docs/demos/slider/html/css/WithPreview.html?raw";
 import withPreviewHtmlCss from "@/components/docs/demos/slider/html/css/WithPreview.css?raw";
 import withPreviewHtmlTs from "@/components/docs/demos/slider/html/css/WithPreview.ts?raw";
+
+## Import
+
+<ComponentImports component="Slider" html="slider" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/status-announcer.mdx
+++ b/site/src/content/docs/reference/status-announcer.mdx
@@ -6,6 +6,7 @@ description: Announce player state changes through a persistent status live regi
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/status-announcer/html/cs
 import basicUsageHtml from "@/components/docs/demos/status-announcer/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/status-announcer/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/status-announcer/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="StatusAnnouncer" html="status-announcer" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/status-indicator.mdx
+++ b/site/src/content/docs/reference/status-indicator.mdx
@@ -6,6 +6,7 @@ description: Display temporary visual feedback for keyboard and gesture actions
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/status-indicator/html/cs
 import basicUsageHtml from "@/components/docs/demos/status-indicator/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/status-indicator/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/status-indicator/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="StatusIndicator" html="status-indicator" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/thumbnail.mdx
+++ b/site/src/content/docs/reference/thumbnail.mdx
@@ -6,6 +6,7 @@ description: Time-based thumbnail preview component for timeline scrubbing and h
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -70,6 +71,10 @@ That track is cross-origin, and a cross-origin `<track>` only loads when the med
 </FrameworkCase>
 
 A same-origin track needs none of this.
+
+## Import
+
+<ComponentImports component="Thumbnail" html="thumbnail" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/time-slider.mdx
+++ b/site/src/content/docs/reference/time-slider.mdx
@@ -6,6 +6,7 @@ description: A slider component for seeking through media playback time
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -27,6 +28,10 @@ import WithChaptersDemoHtml from "@/components/docs/demos/time-slider/html/css/W
 import withChaptersHtml from "@/components/docs/demos/time-slider/html/css/WithChapters.html?raw";
 import withChaptersHtmlCss from "@/components/docs/demos/time-slider/html/css/WithChapters.css?raw";
 import withChaptersHtmlTs from "@/components/docs/demos/time-slider/html/css/WithChapters.ts?raw";
+
+## Import
+
+<ComponentImports component="TimeSlider" html="time-slider" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/time.mdx
+++ b/site/src/content/docs/reference/time.mdx
@@ -6,6 +6,7 @@ description: Time display components for showing current time, duration, and rem
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -52,6 +53,10 @@ import CustomNegativeSignDemoHtml from "@/components/docs/demos/time/html/css/Cu
 import customNegativeSignHtml from "@/components/docs/demos/time/html/css/CustomNegativeSign.html?raw";
 import customNegativeSignHtmlCss from "@/components/docs/demos/time/html/css/CustomNegativeSign.css?raw";
 import customNegativeSignHtmlTs from "@/components/docs/demos/time/html/css/CustomNegativeSign.ts?raw";
+
+## Import
+
+<ComponentImports component="Time" html="time" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/title.mdx
+++ b/site/src/content/docs/reference/title.mdx
@@ -6,6 +6,7 @@ description: Displays the resolved content title for the current media
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/title/html/css/BasicUsag
 import basicUsageHtml from "@/components/docs/demos/title/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/title/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/title/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="Title" html="title" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/tooltip.mdx
+++ b/site/src/content/docs/reference/tooltip.mdx
@@ -6,6 +6,7 @@ description: A tooltip component for displaying contextual labels on hover and f
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -30,6 +31,10 @@ import GroupingDemoHtml from "@/components/docs/demos/tooltip/html/css/Grouping.
 import groupingHtml from "@/components/docs/demos/tooltip/html/css/Grouping.html?raw";
 import groupingHtmlCss from "@/components/docs/demos/tooltip/html/css/Grouping.css?raw";
 import groupingHtmlTs from "@/components/docs/demos/tooltip/html/css/Grouping.ts?raw";
+
+## Import
+
+<ComponentImports component="Tooltip" html="tooltip" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/volume-indicator.mdx
+++ b/site/src/content/docs/reference/volume-indicator.mdx
@@ -6,6 +6,7 @@ description: Display temporary visual feedback for keyboard and gesture volume a
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/volume-indicator/html/cs
 import basicUsageHtml from "@/components/docs/demos/volume-indicator/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/volume-indicator/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/volume-indicator/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="VolumeIndicator" html="volume-indicator" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/volume-popover.mdx
+++ b/site/src/content/docs/reference/volume-popover.mdx
@@ -6,6 +6,7 @@ description: A volume-aware popover that keeps mute available when volume level 
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
@@ -21,6 +22,10 @@ import BasicUsageDemoHtml from "@/components/docs/demos/volume-popover/html/css/
 import basicUsageHtml from "@/components/docs/demos/volume-popover/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/volume-popover/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/volume-popover/html/css/BasicUsage.ts?raw";
+
+## Import
+
+<ComponentImports component="VolumePopover" html="volume-popover" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -6,6 +6,7 @@ description: A slider component for controlling media playback volume
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -20,6 +21,10 @@ import WithPartsDemoHtml from "@/components/docs/demos/volume-slider/html/css/Wi
 import withPartsHtml from "@/components/docs/demos/volume-slider/html/css/WithParts.html?raw";
 import withPartsHtmlCss from "@/components/docs/demos/volume-slider/html/css/WithParts.css?raw";
 import withPartsHtmlTs from "@/components/docs/demos/volume-slider/html/css/WithParts.ts?raw";
+
+## Import
+
+<ComponentImports component="VolumeSlider" html="volume-slider" />
 
 ## Anatomy
 

--- a/site/src/content/docs/reference/write-references.mdx
+++ b/site/src/content/docs/reference/write-references.mdx
@@ -156,6 +156,7 @@ Use `frameworkTitle` to show the HTML custom element tag name when the HTML fram
 
 ```tsx
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
 
@@ -187,14 +188,23 @@ import basicUsageHtmlTs from "@/components/docs/demos/{name}/html/css/BasicUsage
 
 After imports, the page follows this order:
 
-1. **Anatomy** — show part nesting with self-closing placeholders for each framework using `<FrameworkCase>`, following the [Base UI anatomy convention](https://base-ui.com/react/overview/quick-start). No hooks, state, handlers, or option mapping — working code belongs in Examples.
-2. **Prose sections** (optional, as needed):
+1. **Import** — render the public React export and HTML registration module with `<ComponentImports>`.
+2. **Anatomy** — show part nesting with self-closing placeholders for each framework using `<FrameworkCase>`, following the [Base UI anatomy convention](https://base-ui.com/react/overview/quick-start). No hooks, state, handlers, or option mapping — working code belongs in Examples.
+3. **Prose sections** (optional, as needed):
    - **Behavior** — state transitions, timing, interaction logic
    - **Styling** — data attribute CSS selectors
    - **Accessibility** — ARIA attributes, keyboard interactions
    - Other sections as appropriate
-3. **Examples** — at least BasicUsage, wrapped in `<Demo>` with `<FrameworkCase>`
-4. **`<ComponentReference />`** — renders the generated JSON as props, state, and data attribute tables
+4. **Examples** — at least BasicUsage, wrapped in `<Demo>` with `<FrameworkCase>`
+5. **`<ComponentReference />`** — renders the generated JSON as props, state, and data attribute tables
+
+```mdx
+## Import
+
+<ComponentImports component="PlayButton" html="play-button" />
+```
+
+`component` is the named export from `@videojs/react`. `html` is the suffix of the side-effect registration import from `@videojs/html/ui/`.
 
 ```mdx
 <ComponentReference component="PlayButton" />

--- a/site/src/utils/docs/__tests__/component-reference-imports.test.ts
+++ b/site/src/utils/docs/__tests__/component-reference-imports.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const referenceDirectory = resolve(process.cwd(), 'src/content/docs/reference');
+const componentImport = 'import ComponentImports from "@/components/docs/api-reference/ComponentImports.astro";';
+
+describe('component reference imports', () => {
+  it('documents the public import before component anatomy', () => {
+    const componentReferences = readdirSync(referenceDirectory)
+      .filter((file) => file.endsWith('.mdx') && file !== 'write-references.mdx')
+      .map((file) => ({
+        file,
+        source: readFileSync(resolve(referenceDirectory, file), 'utf8'),
+      }))
+      .filter(({ source }) => source.includes('<ComponentReference component="'));
+
+    expect(componentReferences.length).toBeGreaterThan(0);
+
+    for (const { file, source } of componentReferences) {
+      expect(source, file).toContain(componentImport);
+      expect(source, file).toMatch(/## Import\n\n<ComponentImports component="[^"]+" html="[^"]+" \/>/);
+      expect(source.indexOf('## Import'), file).toBeLessThan(source.indexOf('## Anatomy'));
+      expect(source.indexOf('## Anatomy'), file).toBeLessThan(source.indexOf('<ComponentReference component="'));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a consistent Import section to every generated component reference page
- show the public React named export and HTML side-effect registration module through one shared component
- update reference-authoring guidance and add regression coverage so future component pages keep the convention

## Verification

- `CI=true pnpm -F site test src/utils/docs/__tests__/component-reference-imports.test.ts`
- `CI=true pnpm -F site astro check`
- `CI=true pnpm check:workspace`
- `env -u SENTRY_AUTH_TOKEN CI=true pnpm build:site`
- `git diff --check`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>