### PR TITLE
fix(vjsc): clear stale generated styles during vite hmr

### DIFF
--- a/packages/skins/vjsc/gaps.md
+++ b/packages/skins/vjsc/gaps.md
@@ -43,3 +43,21 @@ This file tracks observable behavior in `packages/skins/src` that is not yet imp
 - Gap: Legacy dialogs shorten their exit transition by 100ms with a 50ms minimum, while VJSC uses the full configured duration for both entry and exit.
 - Affected: Default and Minimal Audio and Video skins; HTML and React targets; CSS and Tailwind outputs.
 - Recommendation: Apply the shortened duration to VJSC dialog ending styles and verify entry and exit timing across the skin matrix.
+
+## Deferred anatomy considerations
+
+These selectors currently preserve observable parity. Keep them as known ownership concerns rather than introducing new anatomy solely to remove a diagnostic warning.
+
+### Poster image ownership
+
+- Source: `packages/skins/src/*/css/components/poster.css` and `packages/skins/vjsc/styles/layout/poster.styles.ts`
+- Gap: No observable parity gap is known, but the VJSC Poster root sizes authored `img` and Shadow DOM `::slotted(img)` descendants through structural selectors. An explicit image part would need to preserve target-specific and optional Shadow DOM rendering.
+- Affected: Default and Minimal skins; HTML and React targets; CSS and Tailwind outputs.
+- Recommendation: Hold the current selectors until Poster target markup and Shadow DOM requirements are settled. If ownership becomes a practical problem, evaluate `Poster.Image` across both targets rather than adding a styling-only wrapper.
+
+### Thumbnail loading ownership
+
+- Source: `packages/skins/src/*/css/components/thumbnail.css` and `packages/skins/vjsc/styles/sliders/thumbnail.styles.ts`
+- Gap: No observable parity gap is known, but VJSC infers thumbnail loading from descendant image state with `has-*` and `group-has-*` selectors. Isolated transforms can emit these local selectors, though the styles remain coupled to rendered child markup.
+- Affected: Default and Minimal skins; HTML and React targets; CSS and Tailwind outputs.
+- Recommendation: Hold new anatomy until loading behavior or target markup needs to change. Then consider propagating loading state to the Thumbnail root or adding explicit image and spinner parts, with generated-output and matrix verification.

--- a/packages/skins/vjsc/tests/vite-hmr.test.ts
+++ b/packages/skins/vjsc/tests/vite-hmr.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
+import { isObject, isString, isUndefined } from '@videojs/utils/predicate';
 import react from '@vitejs/plugin-react';
 import { createServer, type ViteDevServer } from 'vite';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -74,7 +75,7 @@ describe('Skins Vite HMR', () => {
     send.mockClear();
     await fixture.update(fixture.styles, styleSource('bg-preview'));
     await invalidate(server, fixture.styles, [cssUrl, tailwindUrl]);
-    await vi.waitFor(() => expect(send.mock.calls.some(isHmrCall)).toBe(true));
+    await vi.waitFor(() => expect(send.mock.calls.some(isGeneratedCssHmrCall)).toBe(true));
 
     const updatedCss = await transformedCode(server, cssUrl);
     const updatedTailwind = await transformedCode(server, tailwindUrl);
@@ -86,7 +87,20 @@ describe('Skins Vite HMR', () => {
     expect(updatedCss).not.toContain(initialCssRequest);
     expect(updatedCssRequest).not.toBe(initialCssRequest);
     expect(updatedCssModule).toContain('background-color:');
-    await expect(loadedCss(server, initialCssRequest)).rejects.toThrow();
+    expect(await loadedCssSource(server, initialCssRequest)).toBe('');
+    expect(send.mock.calls.some(isFullReloadCall)).toBe(false);
+
+    send.mockClear();
+    await fixture.update(fixture.styles, styleSource('text-preview'));
+    await invalidate(server, fixture.styles, [cssUrl, tailwindUrl]);
+    await vi.waitFor(() => expect(send.mock.calls.some(isGeneratedCssHmrCall)).toBe(true));
+
+    const restoredCss = await transformedCode(server, cssUrl);
+
+    expect(virtualCssRequest(restoredCss)).toBe(initialCssRequest);
+    expect(await loadedCssSource(server, initialCssRequest)).toContain('color:');
+    expect(await loadedCssSource(server, updatedCssRequest)).toBe('');
+    expect(send.mock.calls.some(isFullReloadCall)).toBe(false);
 
     send.mockClear();
     await fixture.update(fixture.design, designSource('#040506'));
@@ -141,7 +155,7 @@ async function createFixture() {
 }
 
 function componentSource(marker: string): string {
-  return `import styles from './fixture.styles';\nexport const marker = '${marker}';\nexport function Fixture() { return <div className={styles.root} />; }\n`;
+  return `import styles from './fixture.styles';\nexport const marker = '${marker}';\nexport function Fixture() { return <div className={styles.root} />; }\nif (import.meta.hot) import.meta.hot.accept();\n`;
 }
 
 function styleSource(utility: string): string {
@@ -173,17 +187,24 @@ function virtualCssRequest(code: string): string {
   const request = code.match(/["'](\/@id\/__x00__virtual:vjsc\/css\/[^"']+)["']/)?.[1];
   if (!request) throw new Error('Expected transformed source to import virtual VJSC CSS.');
 
-  return request;
+  return request.replace(/\?t=\d+$/, '');
 }
 
 async function loadedCss(server: ViteDevServer, request: string): Promise<string> {
+  const code = await loadedCssSource(server, request);
+  if (!code) throw new Error(`Vite loaded empty CSS for \`${request}\`.`);
+
+  return code;
+}
+
+async function loadedCssSource(server: ViteDevServer, request: string): Promise<string> {
   const publicId = request.replace('/@id/__x00__', '');
   const resolved = await server.pluginContainer.resolveId(publicId);
   if (!resolved) throw new Error(`Vite did not resolve \`${publicId}\`.`);
 
   const loaded = await server.pluginContainer.load(resolved.id);
-  const code = typeof loaded === 'string' ? loaded : loaded?.code;
-  if (!code) throw new Error(`Vite did not load \`${resolved.id}\`.`);
+  const code = isString(loaded) ? loaded : loaded?.code;
+  if (isUndefined(code)) throw new Error(`Vite did not load \`${resolved.id}\`.`);
 
   return code;
 }
@@ -206,10 +227,18 @@ async function invalidate(server: ViteDevServer, file: string, urls: readonly st
 function isHmrCall(call: readonly unknown[]): boolean {
   const payload = call[0];
 
-  return (
-    typeof payload === 'object' &&
-    payload !== null &&
-    'type' in payload &&
-    (payload.type === 'update' || payload.type === 'full-reload')
-  );
+  return isObject(payload) && 'type' in payload && (payload.type === 'update' || payload.type === 'full-reload');
+}
+
+function isGeneratedCssHmrCall(call: readonly unknown[]): boolean {
+  const payload = call[0];
+  if (!isObject(payload) || !('type' in payload) || payload.type !== 'update') return false;
+
+  return JSON.stringify(payload).includes('virtual:vjsc/css');
+}
+
+function isFullReloadCall(call: readonly unknown[]): boolean {
+  const payload = call[0];
+
+  return isObject(payload) && 'type' in payload && payload.type === 'full-reload';
 }

--- a/packages/vjsc/src/plugins/style.ts
+++ b/packages/vjsc/src/plugins/style.ts
@@ -54,11 +54,21 @@ interface StyleBinding {
 }
 
 interface VirtualCssModule {
-  readonly source: string;
+  source: string;
   readonly owners: Set<string>;
 }
 
-export function stylePlugin(config: StylePluginConfig, diagnostics: VjscDiagnosticsOptions = {}): Plugin {
+export interface StylePluginLifecycle {
+  readonly retainReleasedCss: boolean;
+  onCssChange(id: string): void;
+  onOwnerTransform(id: string, watchFiles: readonly string[]): void;
+}
+
+export function stylePlugin(
+  config: StylePluginConfig,
+  diagnostics: VjscDiagnosticsOptions = {},
+  lifecycle?: StylePluginLifecycle
+): Plugin {
   const designs = new Map<string, Promise<CachedDesignSystem>>();
   const manifests = new Map<string, CachedManifest>();
   const cssById = new Map<string, VirtualCssModule>();
@@ -89,22 +99,26 @@ export function stylePlugin(config: StylePluginConfig, diagnostics: VjscDiagnost
         const options = typeof config === 'function' ? await config({ id, ...parseModuleId(id) }) : config;
 
         if (!options || !transform.ast || !transform.magicString) {
-          replaceVirtualCss(cssById, cssByOwner, id, []);
+          replaceVirtualCss(cssById, cssByOwner, id, [], lifecycle);
           return null;
         }
+
+        lifecycle?.onOwnerTransform(id, []);
 
         const filename = moduleFilename(id);
         const files = importedStyleFiles(filename, transform.ast);
 
         if (files.length === 0) {
-          replaceVirtualCss(cssById, cssByOwner, id, []);
+          replaceVirtualCss(cssById, cssByOwner, id, [], lifecycle);
           return null;
         }
 
         const manifest = options.manifest ?? (await cachedManifest(manifests, files));
 
+        lifecycle?.onOwnerTransform(id, manifest.watchFiles);
+
         if (manifest.rules.length === 0) {
-          replaceVirtualCss(cssById, cssByOwner, id, []);
+          replaceVirtualCss(cssById, cssByOwner, id, [], lifecycle);
           return null;
         }
 
@@ -121,7 +135,7 @@ export function stylePlugin(config: StylePluginConfig, diagnostics: VjscDiagnost
 
         if (referencedRules.size === 0) {
           report();
-          replaceVirtualCss(cssById, cssByOwner, id, []);
+          replaceVirtualCss(cssById, cssByOwner, id, [], lifecycle);
           return null;
         }
 
@@ -144,6 +158,8 @@ export function stylePlugin(config: StylePluginConfig, diagnostics: VjscDiagnost
 
           cachedDesign.versions = await fileVersions(cachedDesign.design.watchFiles);
 
+          lifecycle?.onOwnerTransform(id, [...new Set([...manifest.watchFiles, ...cachedDesign.design.watchFiles])]);
+
           for (const file of cachedDesign.design.watchFiles) this.addWatchFile(file);
 
           const imports: string[] = [];
@@ -165,11 +181,11 @@ export function stylePlugin(config: StylePluginConfig, diagnostics: VjscDiagnost
             imports.push(`import ${JSON.stringify(publicId)};`);
           }
 
-          replaceVirtualCss(cssById, cssByOwner, id, modules);
+          replaceVirtualCss(cssById, cssByOwner, id, modules, lifecycle);
           insertModuleImports(transform.ast, transform.magicString, imports);
         } else {
           report();
-          replaceVirtualCss(cssById, cssByOwner, id, []);
+          replaceVirtualCss(cssById, cssByOwner, id, [], lifecycle);
         }
 
         return { code: transform.magicString };
@@ -219,7 +235,8 @@ function replaceVirtualCss(
   cssById: Map<string, VirtualCssModule>,
   cssByOwner: Map<string, ReadonlySet<string>>,
   owner: string,
-  modules: readonly (readonly [id: string, source: string])[]
+  modules: readonly (readonly [id: string, source: string])[],
+  lifecycle?: StylePluginLifecycle
 ): void {
   const nextIds = new Set(modules.map(([id]) => id));
 
@@ -230,7 +247,16 @@ function replaceVirtualCss(
 
     module?.owners.delete(owner);
 
-    if (module?.owners.size === 0) cssById.delete(id);
+    if (module?.owners.size !== 0) continue;
+
+    if (module && lifecycle?.retainReleasedCss) {
+      if (module.source !== '') {
+        module.source = '';
+        lifecycle.onCssChange(id);
+      }
+    } else {
+      cssById.delete(id);
+    }
   }
 
   for (const [id, source] of modules) {
@@ -238,8 +264,14 @@ function replaceVirtualCss(
 
     if (module) {
       module.owners.add(owner);
+
+      if (module.source !== source) {
+        module.source = source;
+        lifecycle?.onCssChange(id);
+      }
     } else {
       cssById.set(id, { source, owners: new Set([owner]) });
+      lifecycle?.onCssChange(id);
     }
   }
 

--- a/packages/vjsc/src/plugins/vjsc.ts
+++ b/packages/vjsc/src/plugins/vjsc.ts
@@ -9,7 +9,7 @@ import { componentModulesPlugin } from './component-modules';
 import { type ComponentTargetSelection, componentTargetPlugin, primitiveTargetPlugin } from './component-target';
 import { htmlRuntimePlugin } from './html-runtime';
 import { reactTargetPropsPlugin } from './react-target-props';
-import { stylePlugin } from './style';
+import { stylePlugin, type StylePluginLifecycle } from './style';
 import { targetImportCleanupPlugin } from './target-import-cleanup';
 import { targetJsxPlugin } from './target-jsx';
 import { targetTransformPlugin } from './target-transform';
@@ -50,7 +50,7 @@ export function vjscPlugin(options: VjscPluginOptions): Plugin[] {
   return createVjscPluginPipeline(options);
 }
 
-export function createVjscPluginPipeline(options: VjscPluginOptions): Plugin[] {
+export function createVjscPluginPipeline(options: VjscPluginOptions, styleLifecycle?: StylePluginLifecycle): Plugin[] {
   const configurations = new Map<string, VjscModuleConfig | null>();
   const configure = (module: VjscModule): VjscModuleConfig | null => {
     if (configurations.has(module.id)) return configurations.get(module.id) ?? null;
@@ -75,7 +75,7 @@ export function createVjscPluginPipeline(options: VjscPluginOptions): Plugin[] {
     htmlRuntimePlugin(),
     componentMetaPlugin(),
     targetJsxPlugin({ targets }),
-    stylePlugin((module) => configure(module)?.styles ?? null, options.diagnostics),
+    stylePlugin((module) => configure(module)?.styles ?? null, options.diagnostics, styleLifecycle),
     targetTransformPlugin({ targets }),
     targetTypePlugin({ targets }),
     primitiveTargetPlugin({ targets }),

--- a/packages/vjsc/src/vite/index.ts
+++ b/packages/vjsc/src/vite/index.ts
@@ -1,10 +1,13 @@
 import { createVjscPluginPipeline, type VjscPluginOptions } from '../plugins/vjsc';
 import { type ViteOxcPlugin, viteOxcPlugin } from './oxc';
+import { createViteStyleHmr } from './style-hmr';
 
 export type { VjscModule, VjscModuleConfig, VjscPluginOptions } from '../plugins/vjsc';
 export type { ComplexSelectorDiagnosticLevel, VjscDiagnosticsOptions } from '../styles/diagnostics';
 
 /** Create the Vite-adapted VJSC compiler pipeline. */
 export function vjscPlugin(options: VjscPluginOptions): ViteOxcPlugin[] {
-  return createVjscPluginPipeline(options).map(viteOxcPlugin);
+  const styleHmr = createViteStyleHmr();
+
+  return [...createVjscPluginPipeline(options, styleHmr.lifecycle).map(viteOxcPlugin), styleHmr.plugin];
 }

--- a/packages/vjsc/src/vite/style-hmr.ts
+++ b/packages/vjsc/src/vite/style-hmr.ts
@@ -1,0 +1,118 @@
+import type { StylePluginLifecycle } from '../plugins/style';
+import { toPosixPath } from '../utils/path';
+import type { ViteOxcPlugin } from './oxc';
+
+interface ViteModuleNode {
+  readonly id: string | null;
+  readonly url: string;
+}
+
+interface LoadedViteModuleNode extends ViteModuleNode {
+  readonly id: string;
+}
+
+interface ViteTransformResult {
+  readonly code: string;
+}
+
+interface ViteHotUpdateContext {
+  readonly environment: {
+    readonly moduleGraph: {
+      getModuleById(id: string): ViteModuleNode | undefined;
+      invalidateModule(module: ViteModuleNode, seen: Set<ViteModuleNode>, timestamp: number, isHmr: boolean): void;
+    };
+    transformRequest(url: string): Promise<ViteTransformResult | null>;
+    waitForRequestsIdle(id?: string): Promise<void>;
+  };
+}
+
+interface ViteHotUpdateOptions {
+  readonly type: 'create' | 'update' | 'delete';
+  readonly file: string;
+  readonly timestamp: number;
+  readonly modules: ViteModuleNode[];
+}
+
+interface ViteStyleHmr {
+  readonly lifecycle: StylePluginLifecycle;
+  readonly plugin: ViteOxcPlugin;
+}
+
+interface ViteStyleHmrPlugin extends ViteOxcPlugin {
+  readonly hotUpdate: {
+    readonly order: 'pre';
+    handler(this: ViteHotUpdateContext, options: ViteHotUpdateOptions): Promise<readonly ViteModuleNode[] | undefined>;
+  };
+}
+
+/** Keep generated CSS synchronized when a VJSC owner is replaced in place. */
+export function createViteStyleHmr(): ViteStyleHmr {
+  const owners = new Set<string>();
+  const ownerWatchFiles = new Map<string, ReadonlySet<string>>();
+  const changedCss = new Set<string>();
+  let collecting = false;
+
+  const lifecycle: StylePluginLifecycle = {
+    retainReleasedCss: true,
+    onCssChange(id) {
+      if (collecting) changedCss.add(id);
+    },
+    onOwnerTransform(id, watchFiles) {
+      owners.add(id);
+      ownerWatchFiles.set(id, new Set(watchFiles.map(toPosixPath)));
+    },
+  };
+  const plugin: ViteStyleHmrPlugin = {
+    name: 'vjsc:style-hmr',
+    enforce: 'pre',
+    hotUpdate: {
+      order: 'pre',
+      async handler(this: ViteHotUpdateContext, options: ViteHotUpdateOptions) {
+        if (options.type !== 'update') return;
+
+        const changedFile = toPosixPath(options.file);
+        const dependencyOwners = [...ownerWatchFiles]
+          .filter(([, watchFiles]) => watchFiles.has(changedFile))
+          .map(([id]) => this.environment.moduleGraph.getModuleById(id))
+          .filter(isTrackedOwner);
+        const affectedOwners = uniqueLoadedModules([...options.modules.filter(isTrackedOwner), ...dependencyOwners]);
+        if (affectedOwners.length === 0) return;
+
+        changedCss.clear();
+        collecting = true;
+
+        try {
+          for (const module of affectedOwners) {
+            this.environment.moduleGraph.invalidateModule(module, new Set(), options.timestamp, true);
+          }
+
+          for (const module of affectedOwners) await this.environment.transformRequest(module.url);
+
+          await Promise.all(affectedOwners.map((module) => this.environment.waitForRequestsIdle(module.id)));
+        } finally {
+          collecting = false;
+        }
+
+        const cssModules = [...changedCss]
+          .map((id) => this.environment.moduleGraph.getModuleById(`\0${id}`))
+          .filter((module): module is ViteModuleNode => module !== undefined);
+
+        return uniqueModules([...options.modules, ...cssModules]);
+      },
+    },
+  };
+
+  return { lifecycle, plugin };
+
+  function isTrackedOwner(module: ViteModuleNode | undefined): module is LoadedViteModuleNode {
+    return module !== undefined && module.id !== null && owners.has(module.id);
+  }
+}
+
+function uniqueModules(modules: readonly ViteModuleNode[]): ViteModuleNode[] {
+  return [...new Map(modules.map((module) => [module.id, module])).values()];
+}
+
+function uniqueLoadedModules(modules: readonly LoadedViteModuleNode[]): LoadedViteModuleNode[] {
+  return [...new Map(modules.map((module) => [module.id, module])).values()];
+}


### PR DESCRIPTION
Closes #2260

## Summary

Complete the VJSC development-workflow validation and fix stale generated CSS during Vite HMR. Style edits now update or prune content-hashed virtual CSS without a full reload, including when a file returns to an earlier state.

## Changes

- Add a Vite-specific style lifecycle that retransforms affected VJSC owners and includes changed virtual CSS in the HMR update
- Retain released CSS modules as empty during serve so removed rules are cleared from the browser
- Cover the A → B → A regression and reject full reloads in the HMR fixture
- Record poster-image and thumbnail-loading anatomy as deferred parity considerations

<details>
<summary>Manual validation</summary>

- Rendered all eight React/HTML × Default/Minimal × CSS/Tailwind skin variants
- Verified component, style, and theme/design edits update in place
- Verified removed style properties do not remain stale
- Verified compiler-config changes restart the server and recover at the same URL
- Verified React and HTML settings menus open
- Verified the production skin build emits source maps

</details>

## Testing

- `pnpm -F @videojs/skins test vite-hmr.test.ts`
- `pnpm -F vjsc test`
- `pnpm -F @videojs/skins test`
- `pnpm typecheck`
- `pnpm -C packages/vjsc exec vp pack`
- `node packages/vjsc/scripts/check-exports.mjs`
- `pnpm -C packages/skins exec vp -C dev build`
- `pnpm lint:fix:file packages/skins/vjsc/gaps.md packages/skins/vjsc/tests/vite-hmr.test.ts packages/vjsc/src/plugins/style.ts packages/vjsc/src/plugins/vjsc.ts packages/vjsc/src/vite/index.ts packages/vjsc/src/vite/style-hmr.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are scoped to optional Vite dev HMR wiring; production builds without `StylePluginLifecycle` keep the prior virtual CSS lifecycle.
> 
> **Overview**
> Fixes **stale VJSC-generated CSS** during Vite dev HMR so style edits update or drop rules without a full page reload, including when utilities change and later revert (A → B → A).
> 
> The style plugin gains an optional **`StylePluginLifecycle`**: in serve mode it can **retain released virtual CSS modules with empty source** (instead of deleting them) and notify when CSS or owner watch files change. A new **`vjsc:style-hmr`** Vite plugin hooks that lifecycle, **retransforms affected style owners** on watched file updates, and **pushes changed `virtual:vjsc/css` modules** into the HMR payload.
> 
> **`vite-hmr.test.ts`** now asserts generated-CSS HMR (not full reload), empty stale virtual modules, and restored hashes when styles return to an earlier state. **`gaps.md`** adds deferred notes on poster image and thumbnail loading anatomy (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acba4e0bb701af4bc50b8861d81543042fa18023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->