### PR TITLE
fix(html): remove tailwind skin elements

### DIFF
--- a/apps/sandbox/app/shared/html/skins.ts
+++ b/apps/sandbox/app/shared/html/skins.ts
@@ -1,11 +1,6 @@
 import type { Skin, Styling } from '@app/types';
 
-import {
-  CSS_SKIN_TAGS,
-  LIVE_VIDEO_CSS_SKIN_TAGS,
-  LIVE_VIDEO_TAILWIND_SKIN_TAGS,
-  TAILWIND_SKIN_TAGS,
-} from './skin-tags';
+import { CSS_SKIN_TAGS, LIVE_VIDEO_CSS_SKIN_TAGS } from './skin-tags';
 import { loadAudioStylesheets, loadVideoStylesheets } from './stylesheets';
 
 async function loadVideoCssSkin(skin: Skin): Promise<string> {
@@ -33,39 +28,15 @@ async function loadAudioCssSkin(skin: Skin): Promise<string> {
 }
 
 async function loadVideoTailwindSkin(skin: Skin): Promise<string> {
-  if (skin === 'default') {
-    await import('@videojs/html/video/skin.tailwind');
-    const { VideoSkinTailwindElement } = await import('@videojs/html/video');
-    const { getTailwindStyles } = await import('./tailwind-setup');
+  const { loadSandboxVideoTailwindSkin } = await import('./tailwind-skins');
 
-    VideoSkinTailwindElement.styles = getTailwindStyles();
-  } else {
-    await import('@videojs/html/video/minimal-skin.tailwind');
-    const { MinimalVideoSkinTailwindElement } = await import('@videojs/html/video');
-    const { getTailwindStyles } = await import('./tailwind-setup');
-
-    MinimalVideoSkinTailwindElement.styles = getTailwindStyles();
-  }
-
-  return TAILWIND_SKIN_TAGS[skin].video;
+  return loadSandboxVideoTailwindSkin(skin);
 }
 
 async function loadAudioTailwindSkin(skin: Skin): Promise<string> {
-  if (skin === 'default') {
-    await import('@videojs/html/audio/skin.tailwind');
-    const { AudioSkinTailwindElement } = await import('@videojs/html/audio');
-    const { getTailwindStyles } = await import('./tailwind-setup');
+  const { loadSandboxAudioTailwindSkin } = await import('./tailwind-skins');
 
-    AudioSkinTailwindElement.styles = getTailwindStyles();
-  } else {
-    await import('@videojs/html/audio/minimal-skin.tailwind');
-    const { MinimalAudioSkinTailwindElement } = await import('@videojs/html/audio');
-    const { getTailwindStyles } = await import('./tailwind-setup');
-
-    MinimalAudioSkinTailwindElement.styles = getTailwindStyles();
-  }
-
-  return TAILWIND_SKIN_TAGS[skin].audio;
+  return loadSandboxAudioTailwindSkin(skin);
 }
 
 async function loadLiveVideoCssSkin(skin: Skin): Promise<string> {
@@ -81,21 +52,9 @@ async function loadLiveVideoCssSkin(skin: Skin): Promise<string> {
 }
 
 async function loadLiveVideoTailwindSkin(skin: Skin): Promise<string> {
-  if (skin === 'default') {
-    await import('@videojs/html/live-video/skin.tailwind');
-    const { LiveVideoSkinTailwindElement } = await import('@videojs/html/live-video');
-    const { getTailwindStyles } = await import('./tailwind-setup');
+  const { loadSandboxLiveVideoTailwindSkin } = await import('./tailwind-skins');
 
-    LiveVideoSkinTailwindElement.styles = getTailwindStyles();
-  } else {
-    await import('@videojs/html/live-video/minimal-skin.tailwind');
-    const { MinimalLiveVideoSkinTailwindElement } = await import('@videojs/html/live-video');
-    const { getTailwindStyles } = await import('./tailwind-setup');
-
-    MinimalLiveVideoSkinTailwindElement.styles = getTailwindStyles();
-  }
-
-  return LIVE_VIDEO_TAILWIND_SKIN_TAGS[skin];
+  return loadSandboxLiveVideoTailwindSkin(skin);
 }
 
 type VideoSkinOptions = { live?: boolean };

--- a/apps/sandbox/app/shared/html/tailwind-skins.ts
+++ b/apps/sandbox/app/shared/html/tailwind-skins.ts
@@ -1,0 +1,76 @@
+import type { Skin } from '@app/types';
+import { createTemplate, type ShadowStyle } from '@videojs/utils/dom';
+
+import { LIVE_VIDEO_TAILWIND_SKIN_TAGS, TAILWIND_SKIN_TAGS } from './skin-tags';
+import { getTailwindStyles } from './tailwind-setup';
+
+// Tailwind HTML skins are no longer exported by @videojs/html. Wrap the ejected source here so it remains testable
+// in the sandbox until the compiler owns this compatibility path.
+type SkinElementConstructor = CustomElementConstructor & {
+  styles?: ShadowStyle;
+  template?: HTMLTemplateElement | null;
+};
+
+function defineTailwindSkin(
+  tagName: string,
+  BaseElement: SkinElementConstructor,
+  getTemplateHTML: () => string
+): string {
+  if (customElements.get(tagName)) return tagName;
+
+  class SandboxTailwindSkinElement extends BaseElement {}
+
+  SandboxTailwindSkinElement.styles = getTailwindStyles();
+  SandboxTailwindSkinElement.template = createTemplate(getTemplateHTML());
+  customElements.define(tagName, SandboxTailwindSkinElement);
+
+  return tagName;
+}
+
+export async function loadSandboxVideoTailwindSkin(skin: Skin): Promise<string> {
+  const tagName = TAILWIND_SKIN_TAGS[skin].video;
+  if (customElements.get(tagName)) return tagName;
+
+  const [{ MinimalVideoSkinElement, VideoSkinElement }, template] = await Promise.all([
+    import('@videojs/html/video'),
+    skin === 'default'
+      ? import('../../../../../site/scripts/ejected-skins/templates/html/video/skin.tailwind')
+      : import('../../../../../site/scripts/ejected-skins/templates/html/video/minimal-skin.tailwind'),
+    import('@videojs/html/video/ui'),
+  ]);
+  const BaseElement = skin === 'default' ? VideoSkinElement : MinimalVideoSkinElement;
+
+  return defineTailwindSkin(tagName, BaseElement, template.getTemplateHTML);
+}
+
+export async function loadSandboxAudioTailwindSkin(skin: Skin): Promise<string> {
+  const tagName = TAILWIND_SKIN_TAGS[skin].audio;
+  if (customElements.get(tagName)) return tagName;
+
+  const [{ AudioSkinElement, MinimalAudioSkinElement }, template] = await Promise.all([
+    import('@videojs/html/audio'),
+    skin === 'default'
+      ? import('../../../../../site/scripts/ejected-skins/templates/html/audio/skin.tailwind')
+      : import('../../../../../site/scripts/ejected-skins/templates/html/audio/minimal-skin.tailwind'),
+    import('@videojs/html/audio/ui'),
+  ]);
+  const BaseElement = skin === 'default' ? AudioSkinElement : MinimalAudioSkinElement;
+
+  return defineTailwindSkin(tagName, BaseElement, template.getTemplateHTML);
+}
+
+export async function loadSandboxLiveVideoTailwindSkin(skin: Skin): Promise<string> {
+  const tagName = LIVE_VIDEO_TAILWIND_SKIN_TAGS[skin];
+  if (customElements.get(tagName)) return tagName;
+
+  const [{ LiveVideoSkinElement, MinimalLiveVideoSkinElement }, template] = await Promise.all([
+    import('@videojs/html/live-video'),
+    skin === 'default'
+      ? import('../../../../../site/scripts/ejected-skins/templates/html/live-video/skin.tailwind')
+      : import('../../../../../site/scripts/ejected-skins/templates/html/live-video/minimal-skin.tailwind'),
+    import('@videojs/html/live-video/ui'),
+  ]);
+  const BaseElement = skin === 'default' ? LiveVideoSkinElement : MinimalLiveVideoSkinElement;
+
+  return defineTailwindSkin(tagName, BaseElement, template.getTemplateHTML);
+}

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@videojs/core": "workspace:*",
     "@videojs/html": "workspace:*",
+    "@videojs/icons": "workspace:*",
     "@videojs/media": "workspace:*",
     "@videojs/react": "workspace:*",
+    "@videojs/skins": "workspace:*",
     "@videojs/spf": "workspace:*",
     "@videojs/store": "workspace:*",
     "@videojs/utils": "workspace:*"

--- a/apps/sandbox/vite.config.ts
+++ b/apps/sandbox/vite.config.ts
@@ -188,7 +188,15 @@ export default defineConfig({
       ...(existsSync(cdnSandboxMainTemplate) ? { [cdnSandboxMainSrc]: cdnSandboxMainTemplate } : {}),
     },
     conditions: ['development', 'import', 'module', 'browser', 'default'],
-    dedupe: ['react', 'react-dom'],
+    dedupe: [
+      '@videojs/core',
+      '@videojs/html',
+      '@videojs/icons',
+      '@videojs/skins',
+      '@videojs/utils',
+      'react',
+      'react-dom',
+    ],
   },
   optimizeDeps: {
     include: ['@videojs/html > @videojs/element > @lit/context', 'react', 'react-dom'],

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -1,5 +1,0 @@
-import { MinimalAudioSkinTailwindElement } from '../../presets/audio/minimal-skin.tailwind';
-import { safeDefine } from '../../registration/safe-define';
-import './minimal-ui';
-
-safeDefine(MinimalAudioSkinTailwindElement);

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -1,5 +1,0 @@
-import { AudioSkinTailwindElement } from '../../presets/audio/skin.tailwind';
-import { safeDefine } from '../../registration/safe-define';
-import './ui';
-
-safeDefine(AudioSkinTailwindElement);

--- a/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
@@ -1,5 +1,0 @@
-import { MinimalLiveAudioSkinTailwindElement } from '../../presets/live-audio/minimal-skin.tailwind';
-import { safeDefine } from '../../registration/safe-define';
-import './minimal-ui';
-
-safeDefine(MinimalLiveAudioSkinTailwindElement);

--- a/packages/html/src/define/live-audio/skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/skin.tailwind.ts
@@ -1,5 +1,0 @@
-import { LiveAudioSkinTailwindElement } from '../../presets/live-audio/skin.tailwind';
-import { safeDefine } from '../../registration/safe-define';
-import './ui';
-
-safeDefine(LiveAudioSkinTailwindElement);

--- a/packages/html/src/define/live-video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-video/minimal-skin.tailwind.ts
@@ -1,5 +1,0 @@
-import { MinimalLiveVideoSkinTailwindElement } from '../../presets/live-video/minimal-skin.tailwind';
-import { safeDefine } from '../../registration/safe-define';
-import './minimal-ui';
-
-safeDefine(MinimalLiveVideoSkinTailwindElement);

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -1,5 +1,0 @@
-import { LiveVideoSkinTailwindElement } from '../../presets/live-video/skin.tailwind';
-import { safeDefine } from '../../registration/safe-define';
-import './ui';
-
-safeDefine(LiveVideoSkinTailwindElement);

--- a/packages/html/src/define/tests/preset-registration.test.ts
+++ b/packages/html/src/define/tests/preset-registration.test.ts
@@ -60,25 +60,9 @@ describe('preset registration boundaries', () => {
 
   it.each([
     ['video/minimal-skin', 'video-minimal-skin', () => import('../video/minimal-skin')],
-    ['video/skin.tailwind', 'video-skin-tailwind', () => import('../video/skin.tailwind')],
-    ['video/minimal-skin.tailwind', 'video-minimal-skin-tailwind', () => import('../video/minimal-skin.tailwind')],
     ['audio/minimal-skin', 'audio-minimal-skin', () => import('../audio/minimal-skin')],
-    ['audio/skin.tailwind', 'audio-skin-tailwind', () => import('../audio/skin.tailwind')],
-    ['audio/minimal-skin.tailwind', 'audio-minimal-skin-tailwind', () => import('../audio/minimal-skin.tailwind')],
     ['live-video/minimal-skin', 'live-video-minimal-skin', () => import('../live-video/minimal-skin')],
-    ['live-video/skin.tailwind', 'live-video-skin-tailwind', () => import('../live-video/skin.tailwind')],
-    [
-      'live-video/minimal-skin.tailwind',
-      'live-video-minimal-skin-tailwind',
-      () => import('../live-video/minimal-skin.tailwind'),
-    ],
     ['live-audio/minimal-skin', 'live-audio-minimal-skin', () => import('../live-audio/minimal-skin')],
-    ['live-audio/skin.tailwind', 'live-audio-skin-tailwind', () => import('../live-audio/skin.tailwind')],
-    [
-      'live-audio/minimal-skin.tailwind',
-      'live-audio-minimal-skin-tailwind',
-      () => import('../live-audio/minimal-skin.tailwind'),
-    ],
   ])('%s registers only its skin element', async (_, skinTag, load) => {
     const before = define.mock.calls.length;
 

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -1,5 +1,0 @@
-import { MinimalVideoSkinTailwindElement } from '../../presets/video/minimal-skin.tailwind';
-import { safeDefine } from '../../registration/safe-define';
-import './minimal-ui';
-
-safeDefine(MinimalVideoSkinTailwindElement);

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -1,5 +1,0 @@
-import { VideoSkinTailwindElement } from '../../presets/video/skin.tailwind';
-import { safeDefine } from '../../registration/safe-define';
-import './ui';
-
-safeDefine(VideoSkinTailwindElement);

--- a/packages/html/src/presets/audio/index.ts
+++ b/packages/html/src/presets/audio/index.ts
@@ -2,6 +2,4 @@
 export { audioFeatures } from '@videojs/core/dom';
 export { AudioPlayerElement, PlayerController } from './player';
 export { AudioSkinElement } from './skin';
-export { AudioSkinTailwindElement } from './skin.tailwind';
 export { MinimalAudioSkinElement } from './minimal-skin';
-export { MinimalAudioSkinTailwindElement } from './minimal-skin.tailwind';

--- a/packages/html/src/presets/live-audio/index.ts
+++ b/packages/html/src/presets/live-audio/index.ts
@@ -5,6 +5,4 @@
 export { liveAudioFeatures } from '@videojs/core/dom';
 export { LiveAudioPlayerElement, PlayerController } from './player';
 export { LiveAudioSkinElement } from './skin';
-export { LiveAudioSkinTailwindElement } from './skin.tailwind';
 export { MinimalLiveAudioSkinElement } from './minimal-skin';
-export { MinimalLiveAudioSkinTailwindElement } from './minimal-skin.tailwind';

--- a/packages/html/src/presets/live-video/index.ts
+++ b/packages/html/src/presets/live-video/index.ts
@@ -5,6 +5,4 @@
 export { liveVideoFeatures } from '@videojs/core/dom';
 export { LiveVideoPlayerElement, PlayerController } from './player';
 export { LiveVideoSkinElement } from './skin';
-export { LiveVideoSkinTailwindElement } from './skin.tailwind';
 export { MinimalLiveVideoSkinElement } from './minimal-skin';
-export { MinimalLiveVideoSkinTailwindElement } from './minimal-skin.tailwind';

--- a/packages/html/src/presets/tests/presets.test.ts
+++ b/packages/html/src/presets/tests/presets.test.ts
@@ -15,24 +15,16 @@ describe('HTML preset exports', () => {
     expect(define).not.toHaveBeenCalled();
     expect(video.VideoPlayerElement).toBeTypeOf('function');
     expect(video.VideoSkinElement).toBeTypeOf('function');
-    expect(video.VideoSkinTailwindElement).toBeTypeOf('function');
     expect(video.MinimalVideoSkinElement).toBeTypeOf('function');
-    expect(video.MinimalVideoSkinTailwindElement).toBeTypeOf('function');
     expect(audio.AudioPlayerElement).toBeTypeOf('function');
     expect(audio.AudioSkinElement).toBeTypeOf('function');
-    expect(audio.AudioSkinTailwindElement).toBeTypeOf('function');
     expect(audio.MinimalAudioSkinElement).toBeTypeOf('function');
-    expect(audio.MinimalAudioSkinTailwindElement).toBeTypeOf('function');
     expect(liveVideo.LiveVideoPlayerElement).toBeTypeOf('function');
     expect(liveVideo.LiveVideoSkinElement).toBeTypeOf('function');
-    expect(liveVideo.LiveVideoSkinTailwindElement).toBeTypeOf('function');
     expect(liveVideo.MinimalLiveVideoSkinElement).toBeTypeOf('function');
-    expect(liveVideo.MinimalLiveVideoSkinTailwindElement).toBeTypeOf('function');
     expect(liveAudio.LiveAudioPlayerElement).toBeTypeOf('function');
     expect(liveAudio.LiveAudioSkinElement).toBeTypeOf('function');
-    expect(liveAudio.LiveAudioSkinTailwindElement).toBeTypeOf('function');
     expect(liveAudio.MinimalLiveAudioSkinElement).toBeTypeOf('function');
-    expect(liveAudio.MinimalLiveAudioSkinTailwindElement).toBeTypeOf('function');
     expect(background.BackgroundVideoPlayerElement).toBeTypeOf('function');
     expect(background.BackgroundVideoSkinElement).toBeTypeOf('function');
 

--- a/packages/html/src/presets/video/index.ts
+++ b/packages/html/src/presets/video/index.ts
@@ -1,7 +1,5 @@
 /** General-purpose video player preset with full playback controls. */
 export { videoFeatures } from '@videojs/core/dom';
 export { MinimalVideoSkinElement } from './minimal-skin';
-export { MinimalVideoSkinTailwindElement } from './minimal-skin.tailwind';
 export { PlayerController, VideoPlayerElement } from './player';
 export { VideoSkinElement } from './skin';
-export { VideoSkinTailwindElement } from './skin.tailwind';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,12 +144,18 @@ importers:
       '@videojs/html':
         specifier: workspace:*
         version: link:../../packages/html
+      '@videojs/icons':
+        specifier: workspace:*
+        version: link:../../packages/icons
       '@videojs/media':
         specifier: workspace:*
         version: link:../../packages/media
       '@videojs/react':
         specifier: workspace:*
         version: link:../../packages/react
+      '@videojs/skins':
+        specifier: workspace:*
+        version: link:../../packages/skins
       '@videojs/spf':
         specifier: workspace:*
         version: link:../../packages/spf

--- a/site/scripts/ejected-skins/config.ts
+++ b/site/scripts/ejected-skins/config.ts
@@ -96,7 +96,10 @@ function getName(
 function createHtmlSkin(style: SkinStyle, variant: SkinVariant, mediaType: MediaType, live: boolean): HtmlSkinDef {
   const group = getGroup(mediaType, live);
   const file = variant === 'minimal' ? 'minimal-skin' : 'skin';
-  const styleSuffix = style === 'tailwind' ? '.tailwind' : '';
+  const template =
+    style === 'tailwind'
+      ? `site/scripts/ejected-skins/templates/html/${group}/${file}.tailwind.ts`
+      : `packages/html/src/presets/${group}/${file}.ts`;
 
   return {
     id: getId('html', style, variant, mediaType, live),
@@ -107,7 +110,7 @@ function createHtmlSkin(style: SkinStyle, variant: SkinVariant, mediaType: Media
     group,
     variant,
     live,
-    template: `packages/html/src/presets/${group}/${file}${styleSuffix}.ts`,
+    template,
     ...(style === 'css' && { css: `packages/html/src/define/${group}/${file}.css` }),
     iconSet: variant,
   };

--- a/site/scripts/ejected-skins/templates/html/audio/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/audio/minimal-skin.tailwind.ts
@@ -1,4 +1,4 @@
-import { renderIcon } from '@videojs/icons/render';
+import { renderIcon } from '@videojs/icons/render/minimal';
 import {
   button,
   buttonGroup,
@@ -16,15 +16,12 @@ import {
   seek,
   slider,
   time,
-} from '@videojs/skins/default/tailwind/audio.tailwind';
-import { createTemplate } from '@videojs/utils/dom';
+} from '@videojs/skins/minimal/tailwind/audio.tailwind';
 import { cn } from '@videojs/utils/style';
-
-import { SkinElement } from '../skin';
 
 const SEEK_TIME = 10;
 
-function getTemplateHTML() {
+export function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${container}">
       <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
@@ -63,7 +60,7 @@ function getTemplateHTML() {
               </media-tooltip>
             </span>
 
-            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon, button.seek)}">
+            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon)}">
               <span class="${iconContainer}">
                 ${renderIcon('seek', { class: cn(icon, iconFlipped) })}
                 <span class="${cn(seek.label, seek.labelBackward)}">${SEEK_TIME}</span>
@@ -74,7 +71,7 @@ function getTemplateHTML() {
               <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
             </media-tooltip>
 
-            <media-seek-button commandfor="seek-forward-tooltip" seconds="${SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon, button.seek)}">
+            <media-seek-button commandfor="seek-forward-tooltip" seconds="${SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon)}">
               <span class="${iconContainer}">
                 ${renderIcon('seek', { class: icon })}
                 <span class="${cn(seek.label, seek.labelForward)}">${SEEK_TIME}</span>
@@ -86,23 +83,47 @@ function getTemplateHTML() {
             </media-tooltip>
           </div>
 
-          <div class="${time.group}">
-            <media-time type="current" class="${time.current}"></media-time>
+          <div class="${time.controls}">
+            <media-time-group class="${time.group}">
+              <media-time toggle type="current" class="${time.current}"></media-time>
+              <media-time-separator class="${time.separator}"></media-time-separator>
+              <media-time type="duration" class="${time.duration}"></media-time>
+            </media-time-group>
+
             <media-time-slider class="${slider.root}">
               <media-slider-track class="${slider.track}">
                 <media-slider-buffer class="${cn(slider.fill.base, slider.fill.buffer)}"></media-slider-buffer>
                 <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
               </media-slider-track>
               <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.interactive)}"></media-slider-thumb>
-              <media-slider-preview overflow="visible" class="${slider.preview}">
+              <media-slider-preview class="${slider.preview}">
                 <media-slider-value type="pointer" class="${slider.value}"></media-slider-value>
               </media-slider-preview>
             </media-time-slider>
-            <media-time toggle type="remaining" class="${time.duration}"></media-time>
           </div>
 
           <div class="${buttonGroup}">
-            <media-playback-rate-button id="playback-rate-trigger" commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}"></media-playback-rate-button>
+            <media-mute-button id="audio-mute-trigger" commandfor="audio-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
+              ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}
+              ${renderIcon('volume-low', { class: cn(icon, iconState.mute.volumeLow) })}
+              ${renderIcon('volume-high', { class: cn(icon, iconState.mute.volumeHigh) })}
+            </media-mute-button>
+            <media-tooltip trigger="audio-mute-trigger" delay="0" sticky side="top" class="${cn(popup.tooltip)}">
+              <media-tooltip-label></media-tooltip-label>
+              <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
+            </media-tooltip>
+
+            <media-popover id="audio-volume-popover" open-on-hover delay="200" close-delay="100" side="left" boundary="viewport" class="${cn(popup.volume)}">
+              <media-volume-slider class="${slider.root}" orientation="horizontal" thumb-alignment="edge">
+                <media-slider-track class="${slider.track}">
+                  <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
+                </media-slider-track>
+                <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
+              </media-volume-slider>
+            </media-popover>
+
+            <media-playback-rate-button id="playback-rate-trigger" commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}">
+            </media-playback-rate-button>
             <media-menu id="playback-rate-menu" side="top" align="center" boundary="viewport" class="${cn(popup.popover, menu.root)}">
               <media-menu-content class="${menu.content}">
                 <media-playback-rate-radio-group class="${menu.group}">
@@ -122,20 +143,6 @@ function getTemplateHTML() {
               <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
             </media-tooltip>
 
-            <media-mute-button commandfor="audio-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
-              ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}
-              ${renderIcon('volume-low', { class: cn(icon, iconState.mute.volumeLow) })}
-              ${renderIcon('volume-high', { class: cn(icon, iconState.mute.volumeHigh) })}
-            </media-mute-button>
-
-            <media-popover id="audio-volume-popover" open-on-hover delay="200" close-delay="100" side="top" boundary="viewport" class="${cn(popup.popover, popup.volume)}">
-              <media-volume-slider class="${slider.root}" orientation="vertical" thumb-alignment="edge">
-                <media-slider-track class="${slider.track}">
-                  <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
-                </media-slider-track>
-                <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
-              </media-volume-slider>
-            </media-popover>
           </div>
         </media-tooltip-group>
       </div>
@@ -157,15 +164,4 @@ function getTemplateHTML() {
       <media-hotkey keys="<" action="speedDown"></media-hotkey>
     </media-container>
   `;
-}
-
-export class AudioSkinTailwindElement extends SkinElement {
-  static readonly tagName = 'audio-skin-tailwind';
-  static template = createTemplate(getTemplateHTML());
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    [AudioSkinTailwindElement.tagName]: AudioSkinTailwindElement;
-  }
 }

--- a/site/scripts/ejected-skins/templates/html/audio/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/audio/skin.tailwind.ts
@@ -1,4 +1,4 @@
-import { renderIcon } from '@videojs/icons/render/minimal';
+import { renderIcon } from '@videojs/icons/render';
 import {
   button,
   buttonGroup,
@@ -16,15 +16,12 @@ import {
   seek,
   slider,
   time,
-} from '@videojs/skins/minimal/tailwind/audio.tailwind';
-import { createTemplate } from '@videojs/utils/dom';
+} from '@videojs/skins/default/tailwind/audio.tailwind';
 import { cn } from '@videojs/utils/style';
-
-import { SkinElement } from '../skin';
 
 const SEEK_TIME = 10;
 
-function getTemplateHTML() {
+export function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${container}">
       <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
@@ -63,7 +60,7 @@ function getTemplateHTML() {
               </media-tooltip>
             </span>
 
-            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon)}">
+            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon, button.seek)}">
               <span class="${iconContainer}">
                 ${renderIcon('seek', { class: cn(icon, iconFlipped) })}
                 <span class="${cn(seek.label, seek.labelBackward)}">${SEEK_TIME}</span>
@@ -74,7 +71,7 @@ function getTemplateHTML() {
               <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
             </media-tooltip>
 
-            <media-seek-button commandfor="seek-forward-tooltip" seconds="${SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon)}">
+            <media-seek-button commandfor="seek-forward-tooltip" seconds="${SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon, button.seek)}">
               <span class="${iconContainer}">
                 ${renderIcon('seek', { class: icon })}
                 <span class="${cn(seek.label, seek.labelForward)}">${SEEK_TIME}</span>
@@ -86,47 +83,23 @@ function getTemplateHTML() {
             </media-tooltip>
           </div>
 
-          <div class="${time.controls}">
-            <media-time-group class="${time.group}">
-              <media-time toggle type="current" class="${time.current}"></media-time>
-              <media-time-separator class="${time.separator}"></media-time-separator>
-              <media-time type="duration" class="${time.duration}"></media-time>
-            </media-time-group>
-
+          <div class="${time.group}">
+            <media-time type="current" class="${time.current}"></media-time>
             <media-time-slider class="${slider.root}">
               <media-slider-track class="${slider.track}">
                 <media-slider-buffer class="${cn(slider.fill.base, slider.fill.buffer)}"></media-slider-buffer>
                 <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
               </media-slider-track>
               <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.interactive)}"></media-slider-thumb>
-              <media-slider-preview class="${slider.preview}">
+              <media-slider-preview overflow="visible" class="${slider.preview}">
                 <media-slider-value type="pointer" class="${slider.value}"></media-slider-value>
               </media-slider-preview>
             </media-time-slider>
+            <media-time toggle type="remaining" class="${time.duration}"></media-time>
           </div>
 
           <div class="${buttonGroup}">
-            <media-mute-button id="audio-mute-trigger" commandfor="audio-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
-              ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}
-              ${renderIcon('volume-low', { class: cn(icon, iconState.mute.volumeLow) })}
-              ${renderIcon('volume-high', { class: cn(icon, iconState.mute.volumeHigh) })}
-            </media-mute-button>
-            <media-tooltip trigger="audio-mute-trigger" delay="0" sticky side="top" class="${cn(popup.tooltip)}">
-              <media-tooltip-label></media-tooltip-label>
-              <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
-            </media-tooltip>
-
-            <media-popover id="audio-volume-popover" open-on-hover delay="200" close-delay="100" side="left" boundary="viewport" class="${cn(popup.volume)}">
-              <media-volume-slider class="${slider.root}" orientation="horizontal" thumb-alignment="edge">
-                <media-slider-track class="${slider.track}">
-                  <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
-                </media-slider-track>
-                <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
-              </media-volume-slider>
-            </media-popover>
-
-            <media-playback-rate-button id="playback-rate-trigger" commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}">
-            </media-playback-rate-button>
+            <media-playback-rate-button id="playback-rate-trigger" commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}"></media-playback-rate-button>
             <media-menu id="playback-rate-menu" side="top" align="center" boundary="viewport" class="${cn(popup.popover, menu.root)}">
               <media-menu-content class="${menu.content}">
                 <media-playback-rate-radio-group class="${menu.group}">
@@ -146,6 +119,20 @@ function getTemplateHTML() {
               <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
             </media-tooltip>
 
+            <media-mute-button commandfor="audio-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
+              ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}
+              ${renderIcon('volume-low', { class: cn(icon, iconState.mute.volumeLow) })}
+              ${renderIcon('volume-high', { class: cn(icon, iconState.mute.volumeHigh) })}
+            </media-mute-button>
+
+            <media-popover id="audio-volume-popover" open-on-hover delay="200" close-delay="100" side="top" boundary="viewport" class="${cn(popup.popover, popup.volume)}">
+              <media-volume-slider class="${slider.root}" orientation="vertical" thumb-alignment="edge">
+                <media-slider-track class="${slider.track}">
+                  <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
+                </media-slider-track>
+                <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
+              </media-volume-slider>
+            </media-popover>
           </div>
         </media-tooltip-group>
       </div>
@@ -167,15 +154,4 @@ function getTemplateHTML() {
       <media-hotkey keys="<" action="speedDown"></media-hotkey>
     </media-container>
   `;
-}
-
-export class MinimalAudioSkinTailwindElement extends SkinElement {
-  static readonly tagName = 'audio-minimal-skin-tailwind';
-  static template = createTemplate(getTemplateHTML());
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    [MinimalAudioSkinTailwindElement.tagName]: MinimalAudioSkinTailwindElement;
-  }
 }

--- a/site/scripts/ejected-skins/templates/html/live-audio/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-audio/minimal-skin.tailwind.ts
@@ -12,12 +12,9 @@ import {
   slider,
   spacer,
 } from '@videojs/skins/minimal/tailwind/audio.tailwind';
-import { createTemplate } from '@videojs/utils/dom';
 import { cn } from '@videojs/utils/style';
 
-import { SkinElement } from '../skin';
-
-function getTemplateHTML() {
+export function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${container}">
       <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
@@ -92,15 +89,4 @@ function getTemplateHTML() {
       <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
     </media-container>
   `;
-}
-
-export class MinimalLiveAudioSkinTailwindElement extends SkinElement {
-  static readonly tagName = 'live-audio-minimal-skin-tailwind';
-  static template = createTemplate(getTemplateHTML());
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    [MinimalLiveAudioSkinTailwindElement.tagName]: MinimalLiveAudioSkinTailwindElement;
-  }
 }

--- a/site/scripts/ejected-skins/templates/html/live-audio/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-audio/skin.tailwind.ts
@@ -12,12 +12,9 @@ import {
   slider,
   spacer,
 } from '@videojs/skins/default/tailwind/audio.tailwind';
-import { createTemplate } from '@videojs/utils/dom';
 import { cn } from '@videojs/utils/style';
 
-import { SkinElement } from '../skin';
-
-function getTemplateHTML() {
+export function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${container}">
       <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
@@ -88,15 +85,4 @@ function getTemplateHTML() {
       <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
     </media-container>
   `;
-}
-
-export class LiveAudioSkinTailwindElement extends SkinElement {
-  static readonly tagName = 'live-audio-skin-tailwind';
-  static template = createTemplate(getTemplateHTML());
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    [LiveAudioSkinTailwindElement.tagName]: LiveAudioSkinTailwindElement;
-  }
 }

--- a/site/scripts/ejected-skins/templates/html/live-video/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-video/minimal-skin.tailwind.ts
@@ -19,12 +19,9 @@ import {
   statusIndicator,
   volumeIndicator,
 } from '@videojs/skins/minimal/tailwind/video.tailwind';
-import { createTemplate } from '@videojs/utils/dom';
 import { cn } from '@videojs/utils/style';
 
-import { SkinElement } from '../skin';
-
-function getTemplateHTML() {
+export function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${container(true)}">
       <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
@@ -202,15 +199,4 @@ function getTemplateHTML() {
       </div>
     </media-container>
   `;
-}
-
-export class MinimalLiveVideoSkinTailwindElement extends SkinElement {
-  static readonly tagName = 'live-video-minimal-skin-tailwind';
-  static template = createTemplate(getTemplateHTML());
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    [MinimalLiveVideoSkinTailwindElement.tagName]: MinimalLiveVideoSkinTailwindElement;
-  }
 }

--- a/site/scripts/ejected-skins/templates/html/live-video/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-video/skin.tailwind.ts
@@ -20,12 +20,9 @@ import {
   statusIndicator,
   volumeIndicator,
 } from '@videojs/skins/default/tailwind/video.tailwind';
-import { createTemplate } from '@videojs/utils/dom';
 import { cn } from '@videojs/utils/style';
 
-import { SkinElement } from '../skin';
-
-function getTemplateHTML() {
+export function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${container(true)}">
       <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
@@ -203,15 +200,4 @@ function getTemplateHTML() {
       </div>
     </media-container>
   `;
-}
-
-export class LiveVideoSkinTailwindElement extends SkinElement {
-  static readonly tagName = 'live-video-skin-tailwind';
-  static template = createTemplate(getTemplateHTML());
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    [LiveVideoSkinTailwindElement.tagName]: LiveVideoSkinTailwindElement;
-  }
 }

--- a/site/scripts/ejected-skins/templates/html/video/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/video/minimal-skin.tailwind.ts
@@ -1,4 +1,5 @@
 import { audioText, captionsText, qualityText, settingsText, speedText } from '@videojs/core/i18n/text/menu';
+import { renderText } from '@videojs/html/i18n';
 import { renderIcon } from '@videojs/icons/render/minimal';
 import {
   badge,
@@ -24,13 +25,9 @@ import {
   time,
   volumeIndicator,
 } from '@videojs/skins/minimal/tailwind/video.tailwind';
-import { createTemplate } from '@videojs/utils/dom';
 import { cn } from '@videojs/utils/style';
 
-import { renderText } from '../../i18n/render-text';
-import { SkinElement } from '../skin';
-
-function getTemplateHTML() {
+export function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${container(true)}">
       <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
@@ -356,15 +353,4 @@ function getTemplateHTML() {
       </div>
     </media-container>
   `;
-}
-
-export class MinimalVideoSkinTailwindElement extends SkinElement {
-  static readonly tagName = 'video-minimal-skin-tailwind';
-  static template = createTemplate(getTemplateHTML());
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    [MinimalVideoSkinTailwindElement.tagName]: MinimalVideoSkinTailwindElement;
-  }
 }

--- a/site/scripts/ejected-skins/templates/html/video/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/video/skin.tailwind.ts
@@ -1,4 +1,5 @@
 import { audioText, captionsText, qualityText, settingsText, speedText } from '@videojs/core/i18n/text/menu';
+import { renderText } from '@videojs/html/i18n';
 import { renderIcon } from '@videojs/icons/render';
 import {
   badge,
@@ -26,13 +27,9 @@ import {
   time,
   volumeIndicator,
 } from '@videojs/skins/default/tailwind/video.tailwind';
-import { createTemplate } from '@videojs/utils/dom';
 import { cn } from '@videojs/utils/style';
 
-import { renderText } from '../../i18n/render-text';
-import { SkinElement } from '../skin';
-
-function getTemplateHTML() {
+export function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${container(true)}">
       <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
@@ -356,15 +353,4 @@ function getTemplateHTML() {
       </div>
     </media-container>
   `;
-}
-
-export class VideoSkinTailwindElement extends SkinElement {
-  static readonly tagName = 'video-skin-tailwind';
-  static template = createTemplate(getTemplateHTML());
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    [VideoSkinTailwindElement.tagName]: VideoSkinTailwindElement;
-  }
 }

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -11,5 +11,5 @@
     "strictNullChecks": true
   },
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "exclude": ["dist", "scripts/ejected-skins/templates"]
 }


### PR DESCRIPTION
Refs #2371

## Summary

Remove the packaged HTML Tailwind skin custom elements and keep Tailwind as an ejected-source workflow. This keeps the public HTML preset surface focused on the CSS skin elements while preserving full Tailwind customization through the site generator. Stacked on #2247.

Before:

```ts
import { VideoSkinTailwindElement } from '@videojs/html/video';
import '@videojs/html/video/skin.tailwind';
```

After:

```ts
import { VideoSkinElement } from '@videojs/html/video';
import '@videojs/html/video/skin';
// Tailwind remains available by ejecting the skin source from the docs.
```

## Changes

- Remove HTML Tailwind skin constructors and registration paths from presets.
- Move HTML Tailwind templates out of `@videojs/html` and into the site-owned ejected-skin source.
- Remove HTML Tailwind variants from the sandbox and its browser coverage.
- Treat the copied templates as source artifacts rather than compiled site modules.

React Tailwind skins are unchanged.

## Testing

- `pnpm -F @videojs/html test` — 441 tests
- `pnpm exec vp run @videojs/html#build`
- `pnpm exec vp run @videojs/sandbox#build`
- `pnpm -F @videojs/e2e exec playwright test tests/sandbox-skin-styling.spec.ts --project=sandbox-chromium` — 13 tests
- `pnpm -F site test scripts/api-docs-builder/src/tests/e2e.test.ts scripts/tests/ejected-skins.test.ts src/utils/installation/__tests__/codegen.test.ts` — 227 tests
- `pnpm -C site astro check --minimumSeverity warning` — 0 errors, 0 warnings
- `pnpm exec vp run site#build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:workspace`
- Built-package checks that all eight removed Tailwind registration paths no longer resolve

