### PR TITLE
fix(ci): restore codex agent workflows

### DIFF
--- a/.github/actions/configure-codex/action.yml
+++ b/.github/actions/configure-codex/action.yml
@@ -1,0 +1,99 @@
+name: Configure Codex permissions
+description: Define trusted, least-privilege permission profiles for Codex jobs.
+
+outputs:
+  codex_home:
+    description: Trusted Codex home containing the permission profiles.
+    value: ${{ steps.configure.outputs.codex_home }}
+
+runs:
+  using: composite
+  steps:
+    - name: Write permission profiles
+      id: configure
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        codex_home_path="$RUNNER_TEMP/codex-home"
+        mkdir -p "$codex_home_path"
+
+        cat > "$codex_home_path/config.toml" <<'EOF'
+        [features]
+        network_proxy = true
+
+        [permissions.github-read]
+        description = "Read-only repository access plus GitHub command access."
+        extends = ":read-only"
+
+        [permissions.github-read.network]
+        enabled = true
+
+        [permissions.github-read.network.domains]
+        "**.github.com" = "allow"
+        "**.githubusercontent.com" = "allow"
+        "**.actions.githubusercontent.com" = "allow"
+
+        [permissions.github-web]
+        description = "Read-only repository access plus GitHub and Video.js documentation."
+        extends = ":read-only"
+
+        [permissions.github-web.network]
+        enabled = true
+
+        [permissions.github-web.network.domains]
+        "**.github.com" = "allow"
+        "**.githubusercontent.com" = "allow"
+        "**.actions.githubusercontent.com" = "allow"
+        "**.videojs.org" = "allow"
+
+        [permissions.github-write]
+        description = "Workspace writes plus GitHub command access."
+        extends = ":workspace"
+
+        [permissions.github-write.network]
+        enabled = true
+
+        [permissions.github-write.network.domains]
+        "**.github.com" = "allow"
+        "**.githubusercontent.com" = "allow"
+        "**.actions.githubusercontent.com" = "allow"
+
+        [permissions.github-artifacts]
+        description = "Workspace writes plus GitHub run and artifact access."
+        extends = ":workspace"
+
+        [permissions.github-artifacts.network]
+        enabled = true
+
+        [permissions.github-artifacts.network.domains]
+        "**.github.com" = "allow"
+        "**.githubusercontent.com" = "allow"
+        "**.actions.githubusercontent.com" = "allow"
+        "**.blob.core.windows.net" = "allow"
+
+        [permissions.github-build]
+        description = "Workspace writes plus GitHub, package, documentation, and test access."
+        extends = ":workspace"
+
+        [permissions.github-build.network]
+        enabled = true
+        allow_local_binding = true
+
+        [permissions.github-build.network.domains]
+        "**.github.com" = "allow"
+        "**.githubusercontent.com" = "allow"
+        "**.actions.githubusercontent.com" = "allow"
+        "**.blob.core.windows.net" = "allow"
+        "**.npmjs.org" = "allow"
+        "**.sentry-cdn.com" = "allow"
+        "**.videojs.org" = "allow"
+        "**.mux.com" = "allow"
+        "dash.akamaized.net" = "allow"
+        "cdn.playwright.dev" = "allow"
+        "playwright.download.prss.microsoft.com" = "allow"
+        "localhost" = "allow"
+        "127.0.0.1" = "allow"
+        EOF
+
+        echo "codex_home=$codex_home_path" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/api-reference-sync.yml
+++ b/.github/workflows/api-reference-sync.yml
@@ -251,7 +251,7 @@ jobs:
             done < /tmp/api-sync/new-utils.txt
           fi
 
-  # ─── Job 2: Detect stale docs (GPT-5.6 Sol) ───────────────────
+  # ─── Job 2: Detect stale docs (GPT-5.6 Terra) ─────────────────
   stale-docs:
     needs: analyze
     if: needs.analyze.outputs.has_diff == 'true'
@@ -272,17 +272,23 @@ jobs:
           name: api-diff
           path: /tmp/api-sync
 
+      - name: Configure Codex permissions
+        id: codex_permissions
+        uses: ./.github/actions/configure-codex
+
       - name: Detect stale docs
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1
         env:
           GH_TOKEN: ${{ github.token }}
         with:
+          allow-bot-users: 'github-actions[bot]'
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: 0.149.1
           model: gpt-5.6-terra
           effort: high
-          sandbox: workspace-write
           safety-strategy: drop-sudo
-          codex-args: '["--config", "sandbox_workspace_write.network_access=true"]'
+          codex-home: ${{ steps.codex_permissions.outputs.codex_home }}
+          permission-profile: github-read
           prompt: |
             You are the stale-docs detection agent. Your job: given a pre-computed API diff,
             find documentation that may need updating and open ONE GitHub issue summarizing all findings.

--- a/.github/workflows/changelog-prose.yml
+++ b/.github/workflows/changelog-prose.yml
@@ -81,25 +81,14 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # codex-action rejects sandbox_workspace_write overrides under a
-      # protected safety strategy; a named permission profile is the
-      # supported way to grant workspace writes plus network access.
-      - name: Define Codex permission profile
+      - name: Configure Codex permissions
+        id: codex_permissions
         if: steps.guard.outputs.skip != 'true'
-        run: |
-          mkdir -p "$RUNNER_TEMP/codex-home"
-          cat > "$RUNNER_TEMP/codex-home/config.toml" <<'EOF'
-          [permissions.changelog-prose]
-          description = "Workspace writes plus network access for gh and git."
-          extends = ":workspace"
-
-          [permissions.changelog-prose.network]
-          enabled = true
-          EOF
+        uses: ./.github/actions/configure-codex
 
       - name: Generate changelog prose
         if: steps.guard.outputs.skip != 'true'
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1
         env:
           GH_TOKEN: ${{ github.token }}
         with:
@@ -107,11 +96,12 @@ jobs:
           # workflow_dispatch actor is the Actions bot.
           allow-bot-users: 'github-actions[bot]'
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: 0.149.1
           model: gpt-5.6-terra
           effort: high
           safety-strategy: drop-sudo
-          codex-home: ${{ runner.temp }}/codex-home
-          permission-profile: changelog-prose
+          codex-home: ${{ steps.codex_permissions.outputs.codex_home }}
+          permission-profile: github-write
           prompt: |
             You are the changelog prose writer for Video.js 10.
 

--- a/.github/workflows/changelog-prose.yml
+++ b/.github/workflows/changelog-prose.yml
@@ -81,6 +81,22 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # codex-action rejects sandbox_workspace_write overrides under a
+      # protected safety strategy; a named permission profile is the
+      # supported way to grant workspace writes plus network access.
+      - name: Define Codex permission profile
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          mkdir -p "$RUNNER_TEMP/codex-home"
+          cat > "$RUNNER_TEMP/codex-home/config.toml" <<'EOF'
+          [permissions.changelog-prose]
+          description = "Workspace writes plus network access for gh and git."
+          extends = ":workspace"
+
+          [permissions.changelog-prose.network]
+          enabled = true
+          EOF
+
       - name: Generate changelog prose
         if: steps.guard.outputs.skip != 'true'
         uses: openai/codex-action@v1
@@ -93,9 +109,9 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.6-terra
           effort: high
-          sandbox: workspace-write
           safety-strategy: drop-sudo
-          codex-args: '["--config", "sandbox_workspace_write.network_access=true"]'
+          codex-home: ${{ runner.temp }}/codex-home
+          permission-profile: changelog-prose
           prompt: |
             You are the changelog prose writer for Video.js 10.
 

--- a/.github/workflows/e2e-failure-triage.yml
+++ b/.github/workflows/e2e-failure-triage.yml
@@ -25,18 +25,24 @@ jobs:
       - name: Checkout trusted code
         uses: actions/checkout@v5
 
+      - name: Configure Codex permissions
+        id: codex_permissions
+        uses: ./.github/actions/configure-codex
+
       - name: Diagnose E2E failure
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1
         env:
           GH_TOKEN: ${{ github.token }}
         with:
           allow-users: '*'
+          allow-bot-users: 'github-actions[bot]'
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: 0.149.1
           model: gpt-5.6-terra
           effort: medium
-          sandbox: workspace-write
           safety-strategy: drop-sudo
-          codex-args: '["--config", "sandbox_workspace_write.network_access=true"]'
+          codex-home: ${{ steps.codex_permissions.outputs.codex_home }}
+          permission-profile: github-artifacts
           prompt: |
             You are diagnosing a failed Video.js E2E workflow for a pull request.
 
@@ -107,17 +113,23 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - name: Configure Codex permissions
+        id: codex_permissions
+        uses: ./.github/actions/configure-codex
+
       - name: Diagnose E2E failure
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1
         env:
           GH_TOKEN: ${{ github.token }}
         with:
+          allow-bot-users: 'github-actions[bot]'
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: 0.149.1
           model: gpt-5.6-sol
           effort: high
-          sandbox: workspace-write
           safety-strategy: drop-sudo
-          codex-args: '["--config", "sandbox_workspace_write.network_access=true"]'
+          codex-home: ${{ steps.codex_permissions.outputs.codex_home }}
+          permission-profile: github-build
           prompt: |
             You are diagnosing a failed Video.js E2E workflow on main.
 

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -26,17 +26,23 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Configure Codex permissions
+        id: codex_permissions
+        uses: ./.github/actions/configure-codex
+
       - name: Run Codex issue follow-up
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1
         env:
           GH_TOKEN: ${{ github.token }}
         with:
+          allow-bot-users: 'github-actions[bot]'
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: 0.149.1
           model: gpt-5.6-terra
           effort: medium
-          sandbox: workspace-write
           safety-strategy: drop-sudo
-          codex-args: '["--config", "sandbox_workspace_write.network_access=true"]'
+          codex-home: ${{ steps.codex_permissions.outputs.codex_home }}
+          permission-profile: github-read
           prompt: |
             A pull request was merged and you are the issue follow-up agent.
 

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -26,17 +26,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure Codex permissions
+        id: codex_permissions
+        uses: ./.github/actions/configure-codex
+
       - name: Run Codex issue implementer
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1
         env:
           GH_TOKEN: ${{ github.token }}
         with:
+          allow-bot-users: 'github-actions[bot]'
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: 0.149.1
           model: gpt-5.6-sol
           effort: high
-          sandbox: workspace-write
           safety-strategy: drop-sudo
-          codex-args: '["--config", "sandbox_workspace_write.network_access=true"]'
+          codex-home: ${{ steps.codex_permissions.outputs.codex_home }}
+          permission-profile: github-build
           prompt: |
             You are the issue-to-PR implementation agent for this repository.
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -22,17 +22,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Configure Codex permissions
+        id: codex_permissions
+        uses: ./.github/actions/configure-codex
+
       - name: Run Codex issue triager
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1
         env:
           GH_TOKEN: ${{ github.token }}
         with:
+          allow-users: '*'
+          allow-bot-users: 'github-actions[bot]'
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: 0.149.1
           model: gpt-5.6-terra
           effort: medium
-          sandbox: workspace-write
           safety-strategy: drop-sudo
-          codex-args: '["--config", "sandbox_workspace_write.network_access=true"]'
+          codex-home: ${{ steps.codex_permissions.outputs.codex_home }}
+          permission-profile: github-web
           prompt: |
             You are the issue triage agent for this repository.
 


### PR DESCRIPTION
## Summary

Restore all seven Codex-powered GitHub Actions jobs after the current action began rejecting legacy `sandbox_workspace_write` overrides under protected safety strategies. The beta.32 changelog run and the other migrated agent jobs were failing before Codex started.

## Changes

- Replace every legacy sandbox/network override with a named [Codex permission profile](https://developers.openai.com/codex/permissions).
- Share trusted profiles across the six workflows while keeping read-only, repository-writing, artifact, web, and build/test access separate.
- Enable the command network proxy and allow only the destinations each workflow needs.
- Let Issue Triage run for external reporters and allow trusted `github-actions[bot]` triggers where repository automation can initiate a job.
- Pin `openai/codex-action` and Codex CLI/proxy `0.149.1` so mutable releases cannot silently change the workflow contract again.

## Testing

- `pnpm check:workspace` — 10 passed, 0 failed
- YAML parsing for the composite action and all six workflows
- TOML parsing and permission-profile assertions
- ShellCheck for the composite action
- `actionlint` for all six workflows, excluding two pre-existing SC2086 notices in API Reference Sync
- Verified seven pinned action invocations, seven selected profiles, and no remaining legacy Codex sandbox overrides

After merge, re-dispatch Changelog Prose for `@videojs/core@10.0.0-beta.32`; the raw changelog is already on `main` from #2442.