### PR TITLE
fix(site): split changelog from root llms index

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -192,6 +192,6 @@ Search is powered by [Algolia DocSearch v4](https://docsearch.algolia.com). Conf
 
 One custom Astro integration in `integrations/`:
 
-- **llms-markdown** — Generates LLM-optimized `.md` files and `llms.txt` index from `[data-llms-content]` elements
+- **llms-markdown** — Generates LLM-optimized `.md` files and `llms.txt` indexes from `[data-llms-content]` elements
 
 Read [`integrations/llms-markdown.ts`](integrations/llms-markdown.ts) for implementation details.

--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -98,11 +98,12 @@ export default defineConfig({
       : []),
     mdx({ extendMarkdownConfig: true }),
     sitemap({
-      // llms-markdown.ts auto-generates per-framework sub-indexes, but sitemap
-      // entries are hardcoded here. Add a new line when adding a framework.
+      // llms-markdown.ts auto-generates sub-indexes, but sitemap entries are
+      // hardcoded here. Add a new line when adding an index.
       customPages: [
         `${SITE_URL}/llms.txt`,
         `${SITE_URL}/blog/llms.txt`,
+        `${SITE_URL}/changelog/llms.txt`,
         `${SITE_URL}/docs/framework/html/llms.txt`,
         `${SITE_URL}/docs/framework/react/llms.txt`,
       ],

--- a/site/integrations/llms-markdown.ts
+++ b/site/integrations/llms-markdown.ts
@@ -61,9 +61,10 @@ export default function llmsMarkdown(): AstroIntegration {
           },
         });
 
-        // Track all docs and blog pages for llms.txt index
+        // Track pages for their llms.txt indexes
         const docsPages: PageEntry[] = [];
         const blogPages: PageEntry[] = [];
+        const changelogPages: PageEntry[] = [];
         const otherPages: PageEntry[] = [];
 
         logger.info('Generating LLM-optimized markdown files...');
@@ -138,6 +139,8 @@ export default function llmsMarkdown(): AstroIntegration {
               docsPages.push({ pathname: `/${pathname}`, title, description, sort, framework });
             } else if (pathname.startsWith('blog/')) {
               blogPages.push({ pathname: `/${pathname}`, title, description, sort });
+            } else if (pathname.startsWith('changelog/')) {
+              changelogPages.push({ pathname: `/${pathname}`, title, description, sort });
             } else {
               otherPages.push({ pathname: `/${pathname}`, title, description, sort });
             }
@@ -197,16 +200,31 @@ export default function llmsMarkdown(): AstroIntegration {
           await writeFile(blogIndexPath, blogIndex, 'utf-8');
         }
 
+        // Write changelog sub-index
+        if (changelogPages.length > 0) {
+          const changelogIndex = generateChangelogIndex(changelogPages, siteUrl);
+          const changelogIndexPath = join(siteDir, 'changelog', 'llms.txt');
+
+          await mkdir(dirname(changelogIndexPath), { recursive: true });
+          await writeFile(changelogIndexPath, changelogIndex, 'utf-8');
+        }
+
         // Write root llms.txt index
-        const rootIndex = generateRootIndex(frameworks, blogPages.length > 0, otherPages, siteUrl);
+        const rootIndex = generateRootIndex(
+          frameworks,
+          blogPages.length > 0,
+          changelogPages.length > 0,
+          otherPages,
+          siteUrl
+        );
         const rootIndexPath = join(siteDir, 'llms.txt');
 
         await writeFile(rootIndexPath, rootIndex, 'utf-8');
 
-        const subIndexCount = frameworks.length + (blogPages.length > 0 ? 1 : 0);
+        const subIndexCount = frameworks.length + (blogPages.length > 0 ? 1 : 0) + (changelogPages.length > 0 ? 1 : 0);
 
         logger.info(
-          `Generated ${docsPages.length + blogPages.length + otherPages.length} markdown files, llms.txt root index, and ${subIndexCount} sub-indexes`
+          `Generated ${docsPages.length + blogPages.length + changelogPages.length + otherPages.length} markdown files, llms.txt root index, and ${subIndexCount} sub-indexes`
         );
       },
     },
@@ -225,6 +243,8 @@ function generatePageFooter(pathname: string, framework: string | undefined, sit
     lines.push(`${capitalize(framework)} documentation: ${siteUrl}/docs/framework/${framework}/llms.txt`);
   } else if (pathname.startsWith('blog/')) {
     lines.push(`All blog posts: ${siteUrl}/blog/llms.txt`);
+  } else if (pathname.startsWith('changelog/')) {
+    lines.push(`Full changelog: ${siteUrl}/changelog/llms.txt`);
   }
 
   lines.push(`All documentation: ${siteUrl}/llms.txt`);
@@ -236,7 +256,13 @@ function generateIndexFooter(siteUrl: string): string {
   return `\n---\n\nAll documentation: ${siteUrl}/llms.txt\n`;
 }
 
-function generateRootIndex(frameworks: string[], hasBlog: boolean, otherPages: PageEntry[], siteUrl: string): string {
+function generateRootIndex(
+  frameworks: string[],
+  hasBlog: boolean,
+  hasChangelog: boolean,
+  otherPages: PageEntry[],
+  siteUrl: string
+): string {
   let content = `# Video.js v10\n\n`;
 
   content += `> Modern video player framework with multi-platform support\n\n`;
@@ -252,6 +278,11 @@ function generateRootIndex(frameworks: string[], hasBlog: boolean, otherPages: P
   if (hasBlog) {
     content += `## Blog\n\n`;
     content += `- [Blog Posts](${siteUrl}/blog/llms.txt)\n\n`;
+  }
+
+  if (hasChangelog) {
+    content += `## Changelog\n\n`;
+    content += `- [Changelog](${siteUrl}/changelog/llms.txt)\n\n`;
   }
 
   if (otherPages.length > 0) {
@@ -355,7 +386,15 @@ function filterSidebarForLlms(items: Sidebar, framework: SupportedFramework): Si
 }
 
 function generateBlogIndex(pages: PageEntry[], siteUrl: string): string {
-  let content = `# Video.js v10 — Blog\n\n`;
+  return generateChronologicalIndex('Blog', pages, siteUrl);
+}
+
+function generateChangelogIndex(pages: PageEntry[], siteUrl: string): string {
+  return generateChronologicalIndex('Changelog', pages, siteUrl);
+}
+
+function generateChronologicalIndex(title: string, pages: PageEntry[], siteUrl: string): string {
+  let content = `# Video.js v10 — ${title}\n\n`;
   // Newest first
   const sorted = [...pages].sort((a, b) => {
     if (a.sort && b.sort) {


### PR DESCRIPTION
## Summary

Keep the root `llms.txt` focused on top-level navigation by moving individual release entries into a dedicated changelog index.

## Changes

- Generate `/changelog/llms.txt` with changelog entries ordered newest first
- Replace the root index's release list with one link to the changelog index
- Link release Markdown pages back to the changelog index and include the new index in the sitemap

## Testing

- `env -u SENTRY_AUTH_TOKEN pnpm build:site`
- `pnpm -F site test` (33 files, 577 tests)
- Verified the generated changelog index contains all 32 releases, including beta.32
- Verified the generated root index contains no individual changelog entry links
