### PR TITLE
fix(ci): publish matching html release archives

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,6 +40,10 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
+          # release-please creates the tags while this job is running, so the
+          # triggering SHA is still the commit before the release PR. Build the
+          # exact commit tagged for @videojs/html instead.
+          ref: ${{ steps.release.outputs['packages/html--sha'] }}
 
       - name: Setup pnpm
         if: ${{ steps.release.outputs.releases_created == 'true' }}
@@ -54,6 +58,12 @@ jobs:
       - name: Install
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm i --frozen-lockfile
+
+      - name: Verify release checkout
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: node -e "process.exit(require('./packages/html/package.json').version === process.env.VERSION ? 0 : 1)"
+        env:
+          VERSION: ${{ steps.release.outputs['packages/html--version'] }}
 
       - name: Restore Vite Task cache
         if: ${{ steps.release.outputs.releases_created == 'true' }}
@@ -105,19 +115,25 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Attach the archive to the @videojs/html release so installers outside npm
-      # (Composer, Drupal) have a stable, versioned download. The version comes from
-      # the manifest release-please just bumped, matching release-pr.yml.
+      # (Composer, Drupal) have a stable, versioned download. Use the outputs from
+      # the release that this run created, matching the SHA checked out above.
       - name: Upload distribution archive to the release
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: |
-          VERSION=$(jq -r '."packages/html"' .github/release-please/.release-please-manifest.json)
-          gh release upload "@videojs/html@${VERSION}" \
+          gh release upload "$RELEASE_TAG" \
             "packages/html/archive/videojs-html-${VERSION}.zip" \
             "packages/html/archive/videojs-html-${VERSION}.tar.gz" \
             packages/html/archive/SHA256SUMS \
             --clobber
+
+          ASSETS=$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name')
+          grep -Fx "videojs-html-${VERSION}.zip" <<< "$ASSETS"
+          grep -Fx "videojs-html-${VERSION}.tar.gz" <<< "$ASSETS"
+          grep -Fx "SHA256SUMS" <<< "$ASSETS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs['packages/html--tag_name'] }}
+          VERSION: ${{ steps.release.outputs['packages/html--version'] }}
 
       - name: Update site/v10 branch
         if: ${{ steps.release.outputs.releases_created == 'true' }}

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -20,6 +20,13 @@ export const BLOG_PAGE_SIZE = 10;
 export const VJS10_VERSION = htmlPackage.version;
 export const VJS10_HTML_CDN_BASE = `https://cdn.jsdelivr.net/npm/@videojs/html@${VJS10_VERSION}/cdn`;
 
+// The beta.32 release job checked out the commit before its version bump, so its
+// archive upload rebuilt beta.31 instead. Future releases use the current package
+// version; keep the latest available archive in docs until beta.32 is backfilled.
+const VJS10_HTML_ARCHIVE_VERSION_OVERRIDES = new Map([['10.0.0-beta.32', '10.0.0-beta.31']]);
+
+export const VJS10_HTML_ARCHIVE_VERSION = VJS10_HTML_ARCHIVE_VERSION_OVERRIDES.get(VJS10_VERSION) ?? VJS10_VERSION;
+
 export function isPrereleaseSite(siteUrl: URL | undefined): boolean {
   return siteUrl?.origin === PRERELEASE_URL.origin;
 }

--- a/site/src/content/docs/how-to/self-host-the-player.mdx
+++ b/site/src/content/docs/how-to/self-host-the-player.mdx
@@ -40,12 +40,12 @@ Bundle a single file when you already build your front end. Download the release
 
 ### Download the release archive
 
-Every [release](https://github.com/videojs/v10/releases) ships a `videojs-html-<version>.zip` (and a `.tar.gz`) holding the prebuilt player. Use it when your deployment installs dependencies outside npm, or when you want a versioned artifact to vendor into your own repository.
+[Video.js releases](https://github.com/videojs/v10/releases) provide a `videojs-html-<version>.zip` (and a `.tar.gz`) holding the prebuilt player. Use it when your deployment installs dependencies outside npm, or when you want a versioned artifact to vendor into your own repository.
 
 Unpack it into whatever your server treats as static files:
 
 ```bash
-VIDEOJS_VERSION=10.0.0-beta.31
+VIDEOJS_VERSION={{VJS10_HTML_ARCHIVE_VERSION}}
 curl -fLO "https://github.com/videojs/v10/releases/download/@videojs/html@${VIDEOJS_VERSION}/videojs-html-${VIDEOJS_VERSION}.zip"
 unzip "videojs-html-${VIDEOJS_VERSION}.zip" -d public/
 ```
@@ -53,7 +53,7 @@ unzip "videojs-html-${VIDEOJS_VERSION}.zip" -d public/
 Then point a script tag at the player you want:
 
 ```html
-<script type="module" src="/videojs-html-10.0.0-beta.31/video.js"></script>
+<script type="module" src="/videojs-html-{{VJS10_HTML_ARCHIVE_VERSION}}/video.js"></script>
 ```
 
 The archive holds the same production bundles the CDN serves, minus sourcemaps and development builds. Every path inside it is relative, so it runs from any origin with no outbound requests. `SHA256SUMS` on the release verifies the download.
@@ -67,17 +67,17 @@ For Composer-based projects such as Drupal, declare the archive as a package:
       "type": "package",
       "package": {
         "name": "videojs/html",
-        "version": "10.0.0-beta.31",
+        "version": "{{VJS10_HTML_ARCHIVE_VERSION}}",
         "type": "drupal-library",
         "dist": {
           "type": "zip",
-          "url": "https://github.com/videojs/v10/releases/download/@videojs/html@10.0.0-beta.31/videojs-html-10.0.0-beta.31.zip"
+          "url": "https://github.com/videojs/v10/releases/download/@videojs/html@{{VJS10_HTML_ARCHIVE_VERSION}}/videojs-html-{{VJS10_HTML_ARCHIVE_VERSION}}.zip"
         }
       }
     }
   ],
   "require": {
-    "videojs/html": "10.0.0-beta.31"
+    "videojs/html": "{{VJS10_HTML_ARCHIVE_VERSION}}"
   }
 }
 ```

--- a/site/src/content/docs/how-to/self-host-the-player.mdx
+++ b/site/src/content/docs/how-to/self-host-the-player.mdx
@@ -45,14 +45,15 @@ Every [release](https://github.com/videojs/v10/releases) ships a `videojs-html-<
 Unpack it into whatever your server treats as static files:
 
 ```bash
-curl -LO https://github.com/videojs/v10/releases/download/@videojs/html@10.0.0-beta.26/videojs-html-10.0.0-beta.26.zip
-unzip videojs-html-10.0.0-beta.26.zip -d public/
+VIDEOJS_VERSION=10.0.0-beta.31
+curl -fLO "https://github.com/videojs/v10/releases/download/@videojs/html@${VIDEOJS_VERSION}/videojs-html-${VIDEOJS_VERSION}.zip"
+unzip "videojs-html-${VIDEOJS_VERSION}.zip" -d public/
 ```
 
 Then point a script tag at the player you want:
 
 ```html
-<script type="module" src="/videojs-html-10.0.0-beta.26/video.js"></script>
+<script type="module" src="/videojs-html-10.0.0-beta.31/video.js"></script>
 ```
 
 The archive holds the same production bundles the CDN serves, minus sourcemaps and development builds. Every path inside it is relative, so it runs from any origin with no outbound requests. `SHA256SUMS` on the release verifies the download.
@@ -66,17 +67,17 @@ For Composer-based projects such as Drupal, declare the archive as a package:
       "type": "package",
       "package": {
         "name": "videojs/html",
-        "version": "10.0.0-beta.26",
+        "version": "10.0.0-beta.31",
         "type": "drupal-library",
         "dist": {
           "type": "zip",
-          "url": "https://github.com/videojs/v10/releases/download/@videojs/html@10.0.0-beta.26/videojs-html-10.0.0-beta.26.zip"
+          "url": "https://github.com/videojs/v10/releases/download/@videojs/html@10.0.0-beta.31/videojs-html-10.0.0-beta.31.zip"
         }
       }
     }
   ],
   "require": {
-    "videojs/html": "10.0.0-beta.26"
+    "videojs/html": "10.0.0-beta.31"
   }
 }
 ```

--- a/site/src/utils/satteriCdnVersion.ts
+++ b/site/src/utils/satteriCdnVersion.ts
@@ -1,27 +1,45 @@
 import { defineMdastPlugin } from 'satteri';
 
-import { VJS10_HTML_CDN_BASE } from '../consts';
+import { VJS10_HTML_ARCHIVE_VERSION, VJS10_HTML_CDN_BASE } from '../consts';
 
 export const VJS10_HTML_CDN_PLACEHOLDER = '{{VJS10_HTML_CDN_BASE}}';
+export const VJS10_HTML_ARCHIVE_VERSION_PLACEHOLDER = '{{VJS10_HTML_ARCHIVE_VERSION}}';
 
-/** Replace CDN placeholders in documentation code with the current package version. */
+const replacements = new Map([
+  [VJS10_HTML_CDN_PLACEHOLDER, VJS10_HTML_CDN_BASE],
+  [VJS10_HTML_ARCHIVE_VERSION_PLACEHOLDER, VJS10_HTML_ARCHIVE_VERSION],
+]);
+
+function replaceVersionPlaceholders(value: string): string {
+  let result = value;
+
+  for (const [placeholder, replacement] of replacements) {
+    result = result.replaceAll(placeholder, replacement);
+  }
+
+  return result;
+}
+
+/** Replace Video.js placeholders in documentation code with package-derived versions. */
 export function satteriCdnVersion() {
   return defineMdastPlugin({
     name: 'videojs-cdn-version',
     code: (node, ctx) => {
-      if (!node.value.includes(VJS10_HTML_CDN_PLACEHOLDER)) return;
+      const value = replaceVersionPlaceholders(node.value);
+      if (value === node.value) return;
 
       ctx.replaceNode(node, {
         ...node,
-        value: node.value.replaceAll(VJS10_HTML_CDN_PLACEHOLDER, VJS10_HTML_CDN_BASE),
+        value,
       });
     },
     inlineCode: (node, ctx) => {
-      if (!node.value.includes(VJS10_HTML_CDN_PLACEHOLDER)) return;
+      const value = replaceVersionPlaceholders(node.value);
+      if (value === node.value) return;
 
       ctx.replaceNode(node, {
         ...node,
-        value: node.value.replaceAll(VJS10_HTML_CDN_PLACEHOLDER, VJS10_HTML_CDN_BASE),
+        value,
       });
     },
   });

--- a/site/src/utils/tests/satteriCdnVersion.test.ts
+++ b/site/src/utils/tests/satteriCdnVersion.test.ts
@@ -4,9 +4,13 @@
 import { mdxToJs } from 'satteri';
 import { describe, expect, it } from 'vite-plus/test';
 
-import { VJS10_HTML_CDN_BASE } from '@/consts';
+import { VJS10_HTML_ARCHIVE_VERSION, VJS10_HTML_CDN_BASE } from '@/consts';
 
-import { satteriCdnVersion, VJS10_HTML_CDN_PLACEHOLDER } from '../satteriCdnVersion';
+import {
+  satteriCdnVersion,
+  VJS10_HTML_ARCHIVE_VERSION_PLACEHOLDER,
+  VJS10_HTML_CDN_PLACEHOLDER,
+} from '../satteriCdnVersion';
 
 function compile(source: string): string {
   const data = {
@@ -37,5 +41,17 @@ describe('satteriCdnVersion', () => {
 
     expect(code).toContain(`${VJS10_HTML_CDN_BASE}/video.js`);
     expect(code).not.toContain(VJS10_HTML_CDN_PLACEHOLDER);
+  });
+
+  it('replaces archive version placeholders', () => {
+    const code = compile(`\`@videojs/html@${VJS10_HTML_ARCHIVE_VERSION_PLACEHOLDER}\`
+
+\`\`\`bash
+VIDEOJS_VERSION=${VJS10_HTML_ARCHIVE_VERSION_PLACEHOLDER}
+\`\`\``);
+
+    expect(code).toContain(`@videojs/html@${VJS10_HTML_ARCHIVE_VERSION}`);
+    expect(code).toContain(`VIDEOJS_VERSION=${VJS10_HTML_ARCHIVE_VERSION}`);
+    expect(code).not.toContain(VJS10_HTML_ARCHIVE_VERSION_PLACEHOLDER);
   });
 });


### PR DESCRIPTION
## Summary

Make self-hosting archive examples version-aware and ensure release CI builds and uploads artifacts from the commit that release-please tagged.

The beta.32 release job checked out the triggering beta.31 commit, so it rebuilt and uploaded beta.31 while beta.32 remained without archive assets. The docs use the verified beta.31 archive for that known gap and will follow the package version automatically for future releases.

## Changes

- Check out the `@videojs/html` release SHA before building, publishing, and updating `site/v10`
- Fail release CI if the checked-out package version does not match release-please output
- Upload to the exact release tag and verify the ZIP, tarball, and checksum assets exist
- Render archive examples from one package-derived placeholder instead of repeated beta literals
- Preserve a beta.32 to beta.31 fallback until the missing beta.32 assets are backfilled
- Make `curl` fail on HTTP errors

## Testing

- `pnpm -F site test src/utils/tests/satteriCdnVersion.test.ts`
- `pnpm check:workspace`
- `pnpm build:site`
- Parsed `.github/workflows/cd.yml` as YAML
- Verified the rendered self-hosting page contains beta.31 URLs and no unresolved placeholders
- Verified the beta.31 archive URL returns a successful HTTP response