### PR TITLE
feat(html): expose store state on player elements

### DIFF
--- a/packages/core/src/dom/store/features/metadata.ts
+++ b/packages/core/src/dom/store/features/metadata.ts
@@ -44,7 +44,7 @@ export const metadataFeature = definePlayerFeature({
       action: SET_USER_POSTER,
       state: USER_POSTER,
     },
-  } satisfies PlayerFeatureConfig<MetadataSourceState>,
+  } as const satisfies PlayerFeatureConfig<MetadataSourceState>,
   state: ({ set }): MetadataSourceState => ({
     [MEDIA_TITLE]: undefined,
     [USER_TITLE]: undefined,

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -68,8 +68,8 @@ export { i18nContext } from './i18n/context';
 export * from './player/context';
 export * from './player/create-player';
 export { PlayerController, type PlayerControllerHost } from './player/player-controller';
+export * from './player/types';
 export * from './store/media-attach-mixin';
-export * from './store/types';
 export { AirPlayButtonElement } from './ui/airplay-button/airplay-button-element';
 export { AlertDialogElement } from './ui/alert-dialog/alert-dialog-element';
 // UI Components

--- a/packages/html/src/player/create-player.ts
+++ b/packages/html/src/player/create-player.ts
@@ -10,10 +10,10 @@ import {
 } from '@videojs/core/dom';
 import { combine, createStore } from '@videojs/store';
 
-import type { PlayerElementConstructor } from '../store/types';
 import { containerContext, mediaContext, type PlayerContext, playerContext } from './context';
 import { createPlayerController, type PlayerController } from './player-controller';
 import { createPlayerElement } from './player-element';
+import type { PlayerElementConstructor } from './types';
 
 export interface CreatePlayerConfig<Features extends AnyPlayerFeature[]> {
   features: Features;

--- a/packages/html/src/player/player-element.ts
+++ b/packages/html/src/player/player-element.ts
@@ -8,12 +8,13 @@ import {
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextProvider } from '@videojs/element/context';
 import type { Media } from '@videojs/media/dom';
+import type { StateChange, SubscribeOptions } from '@videojs/store';
 import { isNull } from '@videojs/utils/predicate';
 import { camelCase, kebabCase } from '@videojs/utils/string';
 
-import type { PlayerElementConstructor } from '../store/types';
 import { UIElement } from '../ui/ui-element';
 import type { ContainerContext, MediaContext, PlayerContext } from './context';
+import type { PlayerElementConstructor } from './types';
 
 export interface CreatePlayerElementOptions<Store extends PlayerStore> {
   playerContext: PlayerContext<Store>;
@@ -32,6 +33,15 @@ interface ConfigInput {
   attribute: string;
   entry: PlayerFeatureConfig[string];
 }
+
+const reservedStoreAccessorKeys = new Set([
+  'enableUpdating',
+  'hasUpdated',
+  'isUpdatePending',
+  'requestFullscreen',
+  'title',
+]);
+const hasOwnProp = Object.prototype.hasOwnProperty;
 
 function resolveInputs(config: PlayerFeatureConfig): ConfigInput[] {
   return Object.entries(config).map(([key, entry]) => {
@@ -54,6 +64,8 @@ export function createPlayerElement<Store extends PlayerStore>(
   options: CreatePlayerElementOptions<Store>
 ): typeof UIElement {
   const inputs = resolveInputs(options.config);
+  const storeAccessorKeys = new Set<string>();
+  const inputProperties = new Set(inputs.map(({ property }) => property));
 
   class ConfiguredPlayerElement extends UIElement {
     static properties = {
@@ -71,6 +83,11 @@ export function createPlayerElement<Store extends PlayerStore>(
     #mediaRegistrations: Registration<Media>[] = [];
     #containerRegistrations: Registration<MediaContainer>[] = [];
     #observer = new MutationObserver(() => this.#syncNativeMedia());
+
+    constructor() {
+      super();
+      this.#installStoreAccessors();
+    }
 
     #registerMedia = (media: Media): (() => void) => {
       const registration = { value: media };
@@ -129,8 +146,13 @@ export function createPlayerElement<Store extends PlayerStore>(
       return this.#store;
     }
 
+    subscribe(callback: StateChange, options?: SubscribeOptions): () => void {
+      return this.store.subscribe(callback, options);
+    }
+
     override connectedCallback(): void {
       this.#connected = true;
+      this.#installStoreAccessors();
       super.connectedCallback();
       this.#syncInitialConfig();
       this.#playerProvider.setValue(this.store);
@@ -249,6 +271,27 @@ export function createPlayerElement<Store extends PlayerStore>(
       }
 
       this.#configuredStore = store;
+    }
+
+    #installStoreAccessors(): void {
+      for (const key of Object.keys(this.store.state)) {
+        if (inputProperties.has(key) || reservedStoreAccessorKeys.has(key)) continue;
+
+        if (!storeAccessorKeys.has(key)) {
+          if (key in ConfiguredPlayerElement.prototype) continue;
+
+          Object.defineProperty(ConfiguredPlayerElement.prototype, key, {
+            get(this: ConfiguredPlayerElement) {
+              return this.store[key];
+            },
+            configurable: true,
+          });
+          storeAccessorKeys.add(key);
+        }
+
+        // Direct state is read-only, so an assignment made before upgrade or connection must not shadow its accessor.
+        if (hasOwnProp.call(this, key)) Reflect.deleteProperty(this, key);
+      }
     }
   }
 

--- a/packages/html/src/player/tests/create-player.test-d.ts
+++ b/packages/html/src/player/tests/create-player.test-d.ts
@@ -37,11 +37,12 @@ describe('createPlayer', () => {
 
     assertType<CreatePlayerResult<AudioPlayerStore>>(result);
 
-    const store = new result.PlayerElement().store;
+    const player = new result.PlayerElement();
 
-    assertType<number | undefined>(store.error?.code);
-    assertType<string | undefined>(store.error?.message);
-    assertType<() => void>(store.dismissError);
+    assertType<number | undefined>(player.error?.code);
+    assertType<string | undefined>(player.error?.message);
+    assertType<() => void>(player.dismissError);
+    assertType<() => void>(player.subscribe(() => {}));
   });
 
   it('resolves spread video features to VideoPlayerStore', () => {
@@ -60,8 +61,10 @@ describe('createPlayer', () => {
     });
 
     const result = createPlayer({ features: [customFeature] });
+    const player = new result.PlayerElement();
 
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
+    assertType<boolean>(player.custom);
   });
 
   it('infers config properties from selected features', () => {
@@ -72,6 +75,10 @@ describe('createPlayer', () => {
 
     // The store calls this `title`; on an element that name is the tooltip.
     assertType<string | null | undefined>(metadataPlayer.contentTitle);
+    assertType<string>(metadataPlayer.title);
+    assertType<string | null | undefined>(metadataPlayer.poster);
+    assertType<string>(metadataPlayer.store.title);
+    assertType<string>(metadataPlayer.store.poster);
 
     // @ts-expect-error metadata properties are absent when the feature is absent.
     plainPlayer.contentTitle;
@@ -116,18 +123,26 @@ describe('createPlayer', () => {
     // Extended features fall through to the generic overload
     assertType<CreatePlayerResult<PlayerStore<[...typeof videoFeatures, typeof analyticsFeature]>>>(result);
 
-    // The store has both video and analytics state
-    const store = new result.PlayerElement().store;
+    // The player has both video and analytics state
+    const player = new result.PlayerElement();
 
-    assertType<boolean>(store.paused);
-    assertType<number>(store.volume);
-    assertType<string[]>(store.events);
+    assertType<boolean>(player.paused);
+    assertType<number>(player.volume);
+    assertType<string[]>(player.events);
+    assertType<Promise<void>>(player.play());
+
+    // @ts-expect-error Direct state is read-only; use the feature action.
+    player.paused = false;
   });
 
   it('resolves background features to generic PlayerStore', () => {
     const result = createPlayer({ features: backgroundFeatures });
+    const player = new result.PlayerElement();
 
     assertType<CreatePlayerResult<PlayerStore<[]>>>(result);
+
+    // @ts-expect-error Playback state is absent without the playback feature.
+    void player.paused;
   });
 
   it('resolves extended audio features to generic PlayerStore', () => {
@@ -143,10 +158,10 @@ describe('createPlayer', () => {
       features: [...audioFeatures, analyticsFeature],
     });
 
-    const store = new result.PlayerElement().store;
+    const player = new result.PlayerElement();
 
-    assertType<boolean>(store.paused);
-    assertType<number>(store.volume);
-    assertType<string[]>(store.events);
+    assertType<boolean>(player.paused);
+    assertType<number>(player.volume);
+    assertType<string[]>(player.events);
   });
 });

--- a/packages/html/src/player/tests/create-player.test.ts
+++ b/packages/html/src/player/tests/create-player.test.ts
@@ -1,6 +1,7 @@
 import {
   audioFeatures,
   backgroundFeatures,
+  definePlayerFeature,
   features,
   metadataFeature,
   type PopupGroup,
@@ -49,6 +50,57 @@ describe('createPlayer', () => {
     expect(player.store.attach).toBeInstanceOf(Function);
     expect(player.store.subscribe).toBeInstanceOf(Function);
     expect(player.store.destroy).toBeInstanceOf(Function);
+  });
+
+  it('exposes store state, actions, and subscriptions directly', async () => {
+    interface CounterState {
+      count: number;
+      increment(): void;
+    }
+
+    const counterFeature = definePlayerFeature({
+      state: ({ set }): CounterState => ({
+        count: 0,
+        increment() {
+          set({ count: 1 });
+        },
+      }),
+    });
+    const { PlayerElement } = createPlayer({ features: [counterFeature] });
+
+    // SAFETY: The tag is registered with this configured PlayerElement immediately before creation.
+    const player = document.createElement(defineTestElement(PlayerElement)) as InstanceType<typeof PlayerElement>;
+    const callback = vi.fn();
+
+    const unsubscribe = player.subscribe(callback);
+
+    expect(player.count).toBe(0);
+
+    player.increment();
+    await vi.waitFor(() => expect(player.count).toBe(1));
+    expect(callback).toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  it('removes direct state assignments made before connection', () => {
+    const counterFeature = definePlayerFeature({
+      state: () => ({ count: 0 }),
+    });
+    const { PlayerElement } = createPlayer({ features: [counterFeature] });
+
+    // SAFETY: The tag is registered with this configured PlayerElement immediately before creation.
+    const player = document.createElement(defineTestElement(PlayerElement)) as InstanceType<typeof PlayerElement>;
+
+    Object.defineProperty(player, 'count', {
+      value: 42,
+      writable: true,
+      configurable: true,
+    });
+
+    document.body.append(player);
+
+    expect(player.count).toBe(0);
   });
 
   it('PlayerElement is a valid custom element class', () => {
@@ -230,6 +282,7 @@ describe('createPlayer', () => {
 
     expect(player.contentTitle).toBe('Attribute title');
     expect(player.store.title).toBe('Attribute title');
+    expect(player.poster).toBeUndefined();
     expect(PlayerElement.observedAttributes).toContain('content-title');
 
     player.contentTitle = 'Property title';
@@ -269,6 +322,17 @@ describe('createPlayer', () => {
 
     expect(player.getAttribute('title')).toBe('Tooltip');
     expect(player.store.title).toBe('');
+  });
+
+  it('keeps native element members ahead of direct store members', () => {
+    const { PlayerElement } = createPlayer({ features: [features.fullscreen, metadataFeature] });
+
+    // SAFETY: The tag is registered with this configured PlayerElement immediately before creation.
+    const player = document.createElement(defineTestElement(PlayerElement)) as InstanceType<typeof PlayerElement>;
+
+    expect(Object.getOwnPropertyDescriptor(PlayerElement.prototype, 'requestFullscreen')).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(PlayerElement.prototype, 'title')).toBeUndefined();
+    expect(player.requestFullscreen).not.toBe(player.store.requestFullscreen);
   });
 
   it('applies orientation lock configuration through attributes and properties', async () => {

--- a/packages/html/src/player/types.ts
+++ b/packages/html/src/player/types.ts
@@ -1,19 +1,16 @@
 import type { InferPlayerHtmlConfig, PlayerStore } from '@videojs/core/dom';
+import type { StoreHost } from '@videojs/store';
 import type { Constructor } from '@videojs/utils/types';
 
 import type { UIElement } from '@/ui/ui-element';
-
-// ----------------------------------------
-// PlayerElement
-// ----------------------------------------
 
 type PlayerProperties<Store extends PlayerStore> = {
   -readonly [Key in keyof InferPlayerHtmlConfig<Store>]?: InferPlayerHtmlConfig<Store>[Key] | undefined;
 };
 
-export type PlayerElement<Store extends PlayerStore> = UIElement &
-  PlayerProperties<Store> & {
-    readonly store: Store;
-  };
+type PlayerHost<Store extends PlayerStore> = UIElement & PlayerProperties<Store>;
+
+/** A player element with direct, typed access to its configured store state and actions. */
+export type PlayerElement<Store extends PlayerStore> = StoreHost<Store, PlayerHost<Store>>;
 
 export type PlayerElementConstructor<Store extends PlayerStore> = typeof UIElement & Constructor<PlayerElement<Store>>;

--- a/packages/store/src/core/store.ts
+++ b/packages/store/src/core/store.ts
@@ -291,3 +291,13 @@ export type InferStoreTarget<S extends AnyStore> = S extends { readonly target: 
   : never;
 
 export type InferStoreState<S extends AnyStore> = S extends { readonly state: infer State } ? State : never;
+
+/**
+ * An object that owns a store and exposes its state and actions as direct, read-only properties.
+ *
+ * Members already defined by the host keep their host meaning. Access the store directly when a state member collides.
+ */
+export type StoreHost<Store extends AnyStore, Host extends object = object> = Host & {
+  readonly store: Store;
+  subscribe(callback: StateChange, options?: SubscribeOptions): () => void;
+} & Readonly<Omit<InferStoreState<Store>, keyof Host | 'store' | 'subscribe'>>;

--- a/packages/store/src/core/tests/store-host.test-d.ts
+++ b/packages/store/src/core/tests/store-host.test-d.ts
@@ -1,0 +1,23 @@
+import { assertType } from 'vite-plus/test';
+
+import type { Store, StoreHost } from '../store';
+
+interface TestState {
+  count: number;
+  title: number;
+  increment(): void;
+}
+
+type TestStore = Store<unknown, TestState>;
+type TestHost = StoreHost<TestStore, { title: string }>;
+
+declare const host: TestHost;
+
+assertType<number>(host.count);
+assertType<string>(host.title);
+assertType<() => void>(host.increment);
+assertType<TestStore>(host.store);
+assertType<() => void>(host.subscribe(() => {}));
+
+// @ts-expect-error Direct store state is read-only.
+host.count = 1;

--- a/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
+++ b/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
@@ -20,9 +20,9 @@ If your component needs to react to player state or call a player action, wait u
   let paused = true;
 
   onMount(() => {
-    const sync = () => (paused = player.store.paused);
+    const sync = () => (paused = player.paused);
     sync();
-    return player.store.subscribe(sync);
+    return player.subscribe(sync);
   });
 </script>
 
@@ -30,7 +30,7 @@ If your component needs to react to player state or call a player action, wait u
 <p>{paused ? 'Paused' : 'Playing'}</p>
 ```
 
-Return the store's unsubscribe function from `onMount` so Svelte cleans up the subscription. Use the store for player state and actions.
+Return the unsubscribe function from `onMount` so Svelte cleans up the subscription. The player element exposes its configured state and actions directly.
 
 When you need the native event itself, attach a listener to the `<video>`, `<audio>`, or media custom element:
 

--- a/site/src/content/docs/reference/html-create-player.mdx
+++ b/site/src/content/docs/reference/html-create-player.mdx
@@ -32,6 +32,19 @@ class PlayButton extends UIElement {
 
 `PlayerElement` and `PlayerController` are scoped to the created player's feature set. The element owns its store and attachment lifecycle; the configured controller does not need a context argument. `ContainerElement` consumes the shared player context, so the same class works with any created player.
 
+Read state, call actions, and subscribe directly through a player element reference:
+
+```ts
+player.paused;
+await player.play();
+
+const unsubscribe = player.subscribe(() => {
+  console.log(player.currentTime);
+});
+```
+
+Element and configuration properties keep their existing meaning when a state name conflicts. Use `player.store` to access a conflicting store member, such as the resolved content `title`.
+
 Use split elements (recommended for reusable skins/layouts):
 
 ```ts title="player.ts"


### PR DESCRIPTION
## Summary

Expose configured player store state and actions directly on typed player element references. HTML consumers can now use `player.paused`, `player.play()`, and `player.subscribe()` while retaining `player.store` as an escape hatch for collisions.

## Changes

- Add a generic `StoreHost` type that preserves host members and exposes non-conflicting store state as read-only properties
- Install direct store accessors and subscription delegation on configured player elements
- Preserve native element and HTML configuration semantics when store names collide
- Cover custom feature inference, actions, subscriptions, pre-upgrade assignments, and collisions
- Update the HTML and Svelte documentation with direct-access examples

## Testing

- `pnpm -F @videojs/store test`
- `pnpm -F @videojs/html test src/player/tests/create-player.test.ts`
- `pnpm exec vp run @videojs/store#build`
- `pnpm exec vp run @videojs/html#build`
- `pnpm typecheck`