### PR TITLE
fix(packages): scope error dialogs to player containers

### DIFF
--- a/apps/e2e/tests/error-dialog.spec.ts
+++ b/apps/e2e/tests/error-dialog.spec.ts
@@ -49,4 +49,31 @@ test.describe('Error Dialog', () => {
     // Dialog should close
     await expect(errorDialog).not.toHaveAttribute(DATA_ATTRS.open, { timeout: 5_000 });
   });
+
+  test('keeps page content outside the player interactive', async ({ page }) => {
+    await page.evaluate(() => {
+      const button = document.createElement('button');
+
+      button.id = 'outside-player';
+      button.textContent = 'Outside action';
+      button.addEventListener('click', () => button.setAttribute('data-clicked', ''));
+      document.body.prepend(button);
+    });
+
+    await triggerError(page);
+
+    const errorDialog = page.locator(SELECTORS.errorDialog).first();
+    const popup = errorDialog.locator('media-dialog-popup');
+    const outsideButton = page.locator('#outside-player');
+
+    await expect(errorDialog).toHaveAttribute(DATA_ATTRS.open, '', { timeout: 15_000 });
+    await expect(popup).not.toHaveAttribute('aria-modal');
+    await expect(outsideButton).not.toHaveAttribute('inert');
+
+    await outsideButton.click();
+    await outsideButton.focus();
+
+    await expect(outsideButton).toHaveAttribute('data-clicked', '');
+    await expect(outsideButton).toBeFocused();
+  });
 });

--- a/packages/core/src/core/ui/dialog/core.ts
+++ b/packages/core/src/core/ui/dialog/core.ts
@@ -38,6 +38,7 @@ export class DialogCore {
   #input: DialogInput | null = null;
   #titleId: string | undefined = undefined;
   #descriptionId: string | undefined = undefined;
+  #documentModal = true;
 
   constructor(role: DialogRole = 'dialog') {
     this.#role = role;
@@ -56,6 +57,10 @@ export class DialogCore {
 
   setDescriptionId(id: string | undefined): void {
     this.#descriptionId = id;
+  }
+
+  setDocumentModal(documentModal: boolean): void {
+    this.#documentModal = documentModal;
   }
 
   getState(): DialogState {
@@ -81,7 +86,7 @@ export class DialogCore {
   getPopupAttrs(state: DialogState) {
     return {
       role: this.#role,
-      'aria-modal': 'true' as const,
+      'aria-modal': this.#documentModal ? ('true' as const) : undefined,
       'aria-labelledby': state.titleId,
       'aria-describedby': state.descriptionId,
     };

--- a/packages/core/src/core/ui/dialog/tests/core.test.ts
+++ b/packages/core/src/core/ui/dialog/tests/core.test.ts
@@ -37,6 +37,15 @@ describe('DialogCore', () => {
     });
   });
 
+  it('omits aria-modal for a scoped dialog', () => {
+    const core = new DialogCore();
+
+    core.setInput(OPEN);
+    core.setDocumentModal(false);
+
+    expect(core.getPopupAttrs(core.getState())['aria-modal']).toBeUndefined();
+  });
+
   it('connects a trigger to the popup', () => {
     const core = new DialogCore();
 

--- a/packages/core/src/dom/gesture/coordinator.ts
+++ b/packages/core/src/dom/gesture/coordinator.ts
@@ -1,5 +1,6 @@
 import { isInteractiveTarget, listen } from '@videojs/utils/dom';
 
+import { isInteractionLocked } from '../ui/interaction-lock';
 import type {
   GestureActivateEvent,
   GestureBinding,
@@ -39,6 +40,8 @@ export class GestureCoordinator {
    * action, it doesn't hand the tap back to a fallback handler.
    */
   claimsTap(event: PointerEvent, action: string): boolean {
+    if (isInteractionLocked(this.#target)) return true;
+
     if (isInteractiveTarget(event)) return false;
 
     return this.#bindings.some(
@@ -107,6 +110,11 @@ export class GestureCoordinator {
       this.#target,
       'pointerdown',
       (event) => {
+        if (isInteractionLocked(this.#target)) {
+          pointerDownTime = 0;
+          return;
+        }
+
         if (event.button !== 0) return;
 
         pointerDownTime = Date.now();
@@ -118,6 +126,11 @@ export class GestureCoordinator {
       this.#target,
       'pointerup',
       (event) => {
+        if (isInteractionLocked(this.#target)) {
+          pointerDownTime = 0;
+          return;
+        }
+
         if (event.button !== 0) return;
 
         if (Date.now() - pointerDownTime > TAP_THRESHOLD) return;

--- a/packages/core/src/dom/gesture/tests/coordinator.test.ts
+++ b/packages/core/src/dom/gesture/tests/coordinator.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
+import { lockInteractions } from '../../ui/interaction-lock';
 import { getGestureCoordinator } from '../coordinator';
 import { createDoubleTapGesture, createTapGesture } from '../create-tap-gesture';
 
@@ -122,6 +123,23 @@ describe('GestureCoordinator.subscribe', () => {
 
     expect(subscriber).not.toHaveBeenCalled();
   });
+
+  it('does not fire while container interactions are locked', () => {
+    const container = setup();
+    const subscriber = vi.fn();
+    const release = lockInteractions(container);
+
+    getGestureCoordinator(container).subscribe(subscriber);
+    createTapGesture(container, vi.fn(), { action: 'togglePaused' });
+
+    pointerDown(container);
+    vi.advanceTimersByTime(50);
+    pointerUp(container, { pointerType: 'mouse', clientX: 150 });
+
+    expect(subscriber).not.toHaveBeenCalled();
+
+    release();
+  });
 });
 
 describe('GestureCoordinator.claimsTap', () => {
@@ -133,6 +151,16 @@ describe('GestureCoordinator.claimsTap', () => {
     const event = pointerUp(container, { pointerType: 'touch', clientX: 150 });
 
     expect(getGestureCoordinator(container).claimsTap(event, 'toggleControls')).toBe(true);
+  });
+
+  it('claims taps while container interactions are locked', () => {
+    const container = setup();
+    const release = lockInteractions(container);
+    const event = pointerUp(container, { pointerType: 'touch', clientX: 150 });
+
+    expect(getGestureCoordinator(container).claimsTap(event, 'toggleControls')).toBe(true);
+
+    release();
   });
 
   it('does not claim a tap on an interactive target', () => {

--- a/packages/core/src/dom/hotkey/coordinator.ts
+++ b/packages/core/src/dom/hotkey/coordinator.ts
@@ -1,6 +1,7 @@
 import { isEditableTarget, isInteractiveActivation, listen } from '@videojs/utils/dom';
 import { isUndefined } from '@videojs/utils/predicate';
 
+import { isInteractionLocked } from '../ui/interaction-lock';
 import { toAriaKeyShortcut, toDisplayKeyShortcut } from './aria';
 import type { HotkeyOptions, ParsedHotkeyBinding } from './hotkey';
 import { matchesHotkeyEvent, parseHotkeyPattern } from './hotkey';
@@ -154,6 +155,8 @@ export class HotkeyCoordinator {
   }
 
   #handleEvent = (event: KeyboardEvent): void => {
+    if (isInteractionLocked(this.#target)) return;
+
     // IME composition filtering.
     if (event.key === 'Unidentified') return;
 

--- a/packages/core/src/dom/hotkey/tests/coordinator.test.ts
+++ b/packages/core/src/dom/hotkey/tests/coordinator.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
+import { lockInteractions } from '../../ui/interaction-lock';
 import { HotkeyCoordinator } from '../coordinator';
 
 function keydown(target: EventTarget, key: string, mods?: Partial<KeyboardEventInit>): KeyboardEvent {
@@ -65,6 +66,22 @@ describe('HotkeyCoordinator', () => {
       keydown(container, 'j');
 
       expect(onActivate).not.toHaveBeenCalled();
+    });
+
+    it('does not fire while container interactions are locked', () => {
+      const c = setup();
+      const onActivate = vi.fn();
+      const release = lockInteractions(container);
+
+      c.add({ keys: 'k', onActivate });
+      keydown(container, 'k');
+
+      expect(onActivate).not.toHaveBeenCalled();
+
+      release();
+      keydown(container, 'k');
+
+      expect(onActivate).toHaveBeenCalledOnce();
     });
 
     it('removes binding on cleanup', () => {

--- a/packages/core/src/dom/ui/dialog.ts
+++ b/packages/core/src/dom/ui/dialog.ts
@@ -1,8 +1,9 @@
-import type { State } from '@videojs/store';
+import { createState, type State } from '@videojs/store';
 import { containsComposed, getDeepActiveElement, getTabbableElements, listen, walkAncestors } from '@videojs/utils/dom';
 
 import type { DialogInput } from '../../core/ui/dialog/core';
 import { createDismissLayer } from './dismiss-layer';
+import { lockInteractions } from './interaction-lock';
 import type { TransitionApi } from './transition';
 
 export interface DialogOptions {
@@ -23,6 +24,8 @@ export interface DialogTriggerProps {
 export interface DialogApi {
   /** Reactive transition state that platforms subscribe to for rendering. */
   input: State<DialogInput>;
+  /** Whether the active dialog currently prevents interaction with the entire document. */
+  modality: State<DialogModality>;
   /** Props for a trigger that opens the dialog. */
   triggerProps: DialogTriggerProps;
   /** Open the dialog and save the currently focused element for restoration. */
@@ -33,8 +36,14 @@ export interface DialogApi {
   setTriggerElement(el: HTMLElement | null): void;
   /** Register the popup for focus management and transitions. */
   setPopupElement(el: HTMLElement | null): void;
+  /** Limit modal interaction to this root. Pass `null` for document-wide modality. */
+  setInteractionRoot(el: HTMLElement | null): void;
   /** Tear down all listeners and subscriptions. */
   destroy(): void;
+}
+
+export interface DialogModality {
+  documentModal: boolean;
 }
 
 /** Manages modal dialog transitions, dismissal, initial focus, focus trapping, and focus restoration. */
@@ -42,13 +51,19 @@ export function createDialog(options: DialogOptions): DialogApi {
   let popupElement: HTMLElement | null = null;
   let triggerElement: HTMLElement | null = null;
   let previousFocus: HTMLElement | null = null;
+  let requestedInteractionRoot: HTMLElement | null = null;
+  let activeInteractionRoot: HTMLElement | null = null;
+  let releaseInteractionLock: (() => void) | null = null;
   let focusFrame = 0;
   const isolatedElements = new Map<HTMLElement, boolean>();
+  const modality = createState<DialogModality>({ documentModal: true });
 
   const layer = createDismissLayer({
     transition: options.transition,
     closeOnEscape: options.closeOnEscape,
     onEscapeDismiss(event) {
+      if (!shouldHandleScopedEvent(event)) return;
+
       event.preventDefault();
       event.stopPropagation();
       applyClose();
@@ -67,6 +82,7 @@ export function createDialog(options: DialogOptions): DialogApi {
     const opening = layer.open(() => popupElement);
     if (!opening) return;
 
+    resolveInteractionRoot();
     isolateBackground();
     options.onOpenChange(true);
     scheduleInitialFocus();
@@ -89,10 +105,14 @@ export function createDialog(options: DialogOptions): DialogApi {
     closing.then(() => {
       if (layer.signal.aborted || state.current.active) return;
 
+      const active = getDeepActiveElement();
+      const focusLeftScope =
+        activeInteractionRoot && active instanceof Element && !containsComposed(activeInteractionRoot, active);
+
       restoreBackground();
       const restoreTarget = triggerElement?.isConnected ? triggerElement : previousFocus;
 
-      if (restoreTarget?.isConnected) restoreTarget.focus();
+      if (!focusLeftScope && restoreTarget?.isConnected) restoreTarget.focus();
 
       previousFocus = null;
 
@@ -115,7 +135,7 @@ export function createDialog(options: DialogOptions): DialogApi {
   }
 
   function handleDocumentKeydown(event: KeyboardEvent): void {
-    if (event.key !== 'Tab' || !state.current.active || !popupElement) return;
+    if (event.key !== 'Tab' || !state.current.active || !popupElement || !modality.current.documentModal) return;
 
     const tabbable = getTabbableElements(popupElement);
 
@@ -143,6 +163,14 @@ export function createDialog(options: DialogOptions): DialogApi {
 
     if (event.target instanceof Element && containsComposed(popupElement, event.target)) return;
 
+    if (
+      activeInteractionRoot &&
+      event.target instanceof Element &&
+      !containsComposed(activeInteractionRoot, event.target)
+    ) {
+      return;
+    }
+
     const target = getTabbableElements(popupElement)[0] ?? popupElement;
 
     target.focus();
@@ -156,6 +184,7 @@ export function createDialog(options: DialogOptions): DialogApi {
     if (popupElement !== el) restoreBackground();
 
     popupElement = el;
+    resolveInteractionRoot();
 
     if (el && state.current.active) isolateBackground();
 
@@ -166,6 +195,16 @@ export function createDialog(options: DialogOptions): DialogApi {
     }
   }
 
+  function setInteractionRoot(el: HTMLElement | null): void {
+    if (requestedInteractionRoot === el) return;
+
+    restoreBackground();
+    requestedInteractionRoot = el;
+    resolveInteractionRoot();
+
+    if (popupElement && state.current.active) isolateBackground();
+  }
+
   layer.signal.addEventListener('abort', () => {
     cancelAnimationFrame(focusFrame);
     focusFrame = 0;
@@ -173,10 +212,13 @@ export function createDialog(options: DialogOptions): DialogApi {
     popupElement = null;
     triggerElement = null;
     previousFocus = null;
+    requestedInteractionRoot = null;
+    activeInteractionRoot = null;
   });
 
   return {
     input: state,
+    modality,
     triggerProps: {
       onClick() {
         applyOpen();
@@ -186,16 +228,19 @@ export function createDialog(options: DialogOptions): DialogApi {
     close: applyClose,
     setTriggerElement,
     setPopupElement,
+    setInteractionRoot,
     destroy: layer.destroy,
   };
 
   function isolateBackground(): void {
-    if (!popupElement?.isConnected || isolatedElements.size > 0) return;
+    if (!popupElement?.isConnected || isolatedElements.size > 0 || releaseInteractionLock) return;
+
+    resolveInteractionRoot();
 
     walkAncestors(
       popupElement,
       (current) => {
-        if (current === document.body) return true;
+        if (current === activeInteractionRoot || current === popupElement?.ownerDocument.body) return true;
 
         if (current.assignedSlot) {
           for (const sibling of current.assignedSlot.assignedElements({ flatten: true })) {
@@ -226,6 +271,8 @@ export function createDialog(options: DialogOptions): DialogApi {
       },
       { composed: true }
     );
+
+    if (activeInteractionRoot) releaseInteractionLock = lockInteractions(activeInteractionRoot);
   }
 
   function makeInert(element: HTMLElement): void {
@@ -239,5 +286,24 @@ export function createDialog(options: DialogOptions): DialogApi {
     }
 
     isolatedElements.clear();
+    releaseInteractionLock?.();
+    releaseInteractionLock = null;
+  }
+
+  function resolveInteractionRoot(): void {
+    activeInteractionRoot =
+      requestedInteractionRoot && popupElement && containsComposed(requestedInteractionRoot, popupElement)
+        ? requestedInteractionRoot
+        : null;
+
+    modality.patch({ documentModal: !activeInteractionRoot });
+  }
+
+  function shouldHandleScopedEvent(event: Event): boolean {
+    if (!activeInteractionRoot) return true;
+
+    const target = event.target instanceof Element ? event.target : getDeepActiveElement();
+
+    return target instanceof Element && containsComposed(activeInteractionRoot, target);
   }
 }

--- a/packages/core/src/dom/ui/interaction-lock.ts
+++ b/packages/core/src/dom/ui/interaction-lock.ts
@@ -1,0 +1,24 @@
+const locks = new WeakMap<HTMLElement, number>();
+
+/** Prevent container-level interactions while a scoped overlay owns the container. */
+export function lockInteractions(element: HTMLElement): () => void {
+  locks.set(element, (locks.get(element) ?? 0) + 1);
+
+  let released = false;
+
+  return () => {
+    if (released) return;
+
+    released = true;
+
+    const count = locks.get(element) ?? 0;
+
+    if (count <= 1) locks.delete(element);
+    else locks.set(element, count - 1);
+  };
+}
+
+/** Whether a scoped overlay currently prevents interactions on this container. */
+export function isInteractionLocked(element: HTMLElement): boolean {
+  return (locks.get(element) ?? 0) > 0;
+}

--- a/packages/core/src/dom/ui/tests/dialog.test.ts
+++ b/packages/core/src/dom/ui/tests/dialog.test.ts
@@ -2,6 +2,7 @@ import { flush } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { createDialog, type DialogOptions } from '../dialog';
+import { isInteractionLocked } from '../interaction-lock';
 import { createTransition } from '../transition';
 
 const dialogs = new Set<ReturnType<typeof createDialog>>();
@@ -181,6 +182,119 @@ describe('createDialog', () => {
     expect(background.hasAttribute('inert')).toBe(false);
   });
 
+  it('limits background isolation to an interaction root', async () => {
+    const outside = document.createElement('button');
+    const root = document.createElement('div');
+    const sibling = document.createElement('button');
+    const popup = document.createElement('div');
+
+    root.append(sibling, popup);
+    document.body.append(outside, root);
+
+    const { dialog } = createTestDialog();
+
+    dialog.setPopupElement(popup);
+    dialog.setInteractionRoot(root);
+    dialog.open();
+
+    expect(dialog.modality.current.documentModal).toBe(false);
+    expect(sibling.hasAttribute('inert')).toBe(true);
+    expect(outside.hasAttribute('inert')).toBe(false);
+    expect(isInteractionLocked(root)).toBe(true);
+
+    dialog.close();
+    await vi.waitFor(() => expect(dialog.input.current.active).toBe(false));
+
+    expect(sibling.hasAttribute('inert')).toBe(false);
+    expect(isInteractionLocked(root)).toBe(false);
+  });
+
+  it('falls back to document modality when the interaction root does not contain the popup', () => {
+    const outside = document.createElement('button');
+    const unrelatedRoot = document.createElement('div');
+    const popup = document.createElement('div');
+
+    document.body.append(outside, unrelatedRoot, popup);
+
+    const { dialog } = createTestDialog();
+
+    dialog.setPopupElement(popup);
+    dialog.setInteractionRoot(unrelatedRoot);
+    dialog.open();
+
+    expect(dialog.modality.current.documentModal).toBe(true);
+    expect(outside.hasAttribute('inert')).toBe(true);
+    expect(unrelatedRoot.hasAttribute('inert')).toBe(true);
+    expect(isInteractionLocked(unrelatedRoot)).toBe(false);
+  });
+
+  it('allows focus to move outside a scoped interaction root', () => {
+    const outside = document.createElement('button');
+    const root = document.createElement('div');
+    const popup = document.createElement('div');
+
+    root.append(popup);
+    document.body.append(outside, root);
+
+    const { dialog } = createTestDialog();
+
+    dialog.setPopupElement(popup);
+    dialog.setInteractionRoot(root);
+    dialog.open();
+    flush();
+    outside.focus();
+
+    expect(document.activeElement).toBe(outside);
+  });
+
+  it('does not restore focus into a scoped root after focus leaves it', async () => {
+    const outside = document.createElement('button');
+    const root = document.createElement('div');
+    const trigger = document.createElement('button');
+    const popup = document.createElement('div');
+
+    root.append(trigger, popup);
+    document.body.append(outside, root);
+
+    const { dialog } = createTestDialog();
+
+    dialog.setTriggerElement(trigger);
+    dialog.setPopupElement(popup);
+    dialog.setInteractionRoot(root);
+    trigger.focus();
+    dialog.open();
+    flush();
+    outside.focus();
+    dialog.close();
+
+    await vi.waitFor(() => expect(dialog.input.current.active).toBe(false));
+    expect(document.activeElement).toBe(outside);
+  });
+
+  it('does not trap Tab within a scoped dialog', () => {
+    const root = document.createElement('div');
+    const popup = document.createElement('div');
+    const button = document.createElement('button');
+
+    popup.append(button);
+    root.append(popup);
+    document.body.append(root);
+
+    const { dialog } = createTestDialog();
+
+    dialog.setPopupElement(popup);
+    dialog.setInteractionRoot(root);
+    dialog.open();
+    flush();
+    button.focus();
+
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+
+    button.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   it('closes on Escape', () => {
     const { dialog, onOpenChange } = createTestDialog();
 
@@ -190,6 +304,29 @@ describe('createDialog', () => {
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
 
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('only closes a scoped dialog on Escape from within its interaction root', () => {
+    const outside = document.createElement('button');
+    const root = document.createElement('div');
+    const popup = document.createElement('div');
+
+    root.append(popup);
+    document.body.append(outside, root);
+
+    const { dialog, onOpenChange } = createTestDialog();
+
+    dialog.setPopupElement(popup);
+    dialog.setInteractionRoot(root);
+    dialog.open();
+    onOpenChange.mockClear();
+    flush();
+
+    outside.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    popup.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 

--- a/packages/html/src/ui/error-dialog/error-dialog-element.ts
+++ b/packages/html/src/ui/error-dialog/error-dialog-element.ts
@@ -7,16 +7,23 @@ import {
   getErrorDialogUnexpectedText,
   resolveErrorDialogDescription,
 } from '@videojs/core';
-import { applyStateDataAttrs, createDialog, createTransition, type DialogApi, selectError } from '@videojs/core/dom';
+import {
+  applyStateDataAttrs,
+  createDialog,
+  createTransition,
+  type DialogApi,
+  type DialogModality,
+  selectError,
+} from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';
 import type { PropertyValues } from '@videojs/element';
-import { ContextProvider } from '@videojs/element/context';
+import { ContextConsumer, ContextProvider } from '@videojs/element/context';
 import type { ErrorLike } from '@videojs/media';
 import { SnapshotController } from '@videojs/store/html';
 
 import { i18nContext } from '../../i18n/context';
 import { I18nController } from '../../i18n/controller';
-import { playerContext } from '../../player/context';
+import { containerContext, playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { dialogContext } from '../dialog/context';
 import { UIElement } from '../ui-element';
@@ -37,9 +44,11 @@ export class ErrorDialogElement extends UIElement {
   readonly #descriptionId = `vjs-error-dialog-desc-${idCounter++}`;
   readonly #errorState = new PlayerController(this, playerContext, selectError);
   readonly #i18n = new I18nController(this, i18nContext);
+  readonly #container = new ContextConsumer(this, { context: containerContext, subscribe: true });
 
   #dialog: DialogApi | null = null;
   #snapshot: SnapshotController<DialogInput> | null = null;
+  #modalitySnapshot: SnapshotController<DialogModality> | null = null;
   #lastError: ErrorLike | null = null;
   #lastDescription: ReturnType<typeof resolveErrorDialogDescription> | null = null;
   #seenCopyParts = new WeakSet<HTMLElement>();
@@ -70,6 +79,12 @@ export class ErrorDialogElement extends UIElement {
     } else {
       this.#snapshot = new SnapshotController(this, this.#dialog.input);
     }
+
+    if (this.#modalitySnapshot) {
+      this.#modalitySnapshot.track(this.#dialog.modality);
+    } else {
+      this.#modalitySnapshot = new SnapshotController(this, this.#dialog.modality);
+    }
   }
 
   override disconnectedCallback(): void {
@@ -82,6 +97,8 @@ export class ErrorDialogElement extends UIElement {
     super.willUpdate(_changed);
 
     if (!this.#dialog) return;
+
+    this.#dialog.setInteractionRoot(this.#container.value?.container ?? null);
 
     const errorState = this.#errorState.value;
     const hasError = Boolean(errorState?.error);
@@ -115,6 +132,7 @@ export class ErrorDialogElement extends UIElement {
     const input = this.#dialog.input.current;
 
     this.#core.setInput(input);
+    this.#core.setDocumentModal(this.#dialog.modality.current.documentModal);
     const state = this.#core.getState();
 
     applyStateDataAttrs(this, state, ErrorDialogDataAttrs);

--- a/packages/html/src/ui/error-dialog/tests/error-dialog-element.test.ts
+++ b/packages/html/src/ui/error-dialog/tests/error-dialog-element.test.ts
@@ -1,11 +1,14 @@
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
+import { ContextProvider } from '@videojs/element/context';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
 
 import { MediaI18nProviderElement } from '../../../i18n';
+import { containerContext } from '../../../player/context';
 import { DialogCloseElement } from '../../dialog/dialog-close-element';
 import { DialogDescriptionElement } from '../../dialog/dialog-description-element';
 import { DialogPopupElement } from '../../dialog/dialog-popup-element';
 import { DialogTitleElement } from '../../dialog/dialog-title-element';
+import { UIElement } from '../../ui-element';
 import { ErrorDialogElement } from '../error-dialog-element';
 
 let tagCounter = 0;
@@ -25,6 +28,16 @@ function ensureDefined(tagName: string, Base: CustomElementConstructor): void {
   if (!customElements.get(tagName)) {
     customElements.define(tagName, Base);
   }
+}
+
+class TestContainerProviderElement extends UIElement {
+  readonly provider = new ContextProvider(this, {
+    context: containerContext,
+    initialValue: {
+      container: this,
+      registerContainer: () => () => {},
+    },
+  });
 }
 
 afterEach(() => {
@@ -60,6 +73,22 @@ describe('ErrorDialogElement', () => {
     expect(close.isConnected).toBe(true);
     expect(popup.getAttribute('aria-labelledby')).toBe(title.id);
     expect(popup.getAttribute('aria-describedby')).toBe(desc.id);
+  });
+
+  it('scopes dialog semantics to the provided container', async () => {
+    const container = createElement(TestContainerProviderElement);
+    const el = createElement(ErrorDialogElement);
+    const popup = createElement(DialogPopupElement);
+
+    el.append(popup);
+    container.append(el);
+    document.body.append(container);
+    await el.updateComplete;
+    await popup.updateComplete;
+    await el.updateComplete;
+
+    expect(popup.getAttribute('role')).toBe('alertdialog');
+    expect(popup.hasAttribute('aria-modal')).toBe(false);
   });
 
   it('handles missing child elements gracefully', async () => {

--- a/packages/react/src/ui/dialog/use-dialog-root.ts
+++ b/packages/react/src/ui/dialog/use-dialog-root.ts
@@ -1,7 +1,7 @@
 import { DialogCore, DialogDataAttrs, type DialogProps, type DialogState, type StateAttrMap } from '@videojs/core';
 import { createDialog, createTransition } from '@videojs/core/dom';
 import { useSnapshot } from '@videojs/store/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 import { useDestroy } from '../../utils/use-destroy';
 import { useLatestRef } from '../../utils/use-latest-ref';
@@ -14,6 +14,7 @@ export interface UseDialogRootOptions extends DialogProps {
   coreFactory?: () => DialogCore;
   stateAttrMap?: StateAttrMap<DialogState>;
   idPrefix?: string;
+  interactionRoot?: HTMLElement | null;
 }
 
 export function useDialogRoot({
@@ -25,6 +26,7 @@ export function useDialogRoot({
   coreFactory = createDialogCore,
   stateAttrMap = DialogDataAttrs,
   idPrefix = 'dialog',
+  interactionRoot,
 }: UseDialogRootOptions): DialogContextValue {
   const [core] = useState(coreFactory);
 
@@ -65,11 +67,17 @@ export function useDialogRoot({
     else dialog.close();
   }, [controlledOpen, dialog]);
 
+  useLayoutEffect(() => {
+    dialog.setInteractionRoot(interactionRoot ?? null);
+  }, [dialog, interactionRoot]);
+
   useDestroy(dialog);
 
   const input = useSnapshot(dialog.input);
+  const modality = useSnapshot(dialog.modality);
 
   core.setInput(input);
+  core.setDocumentModal(modality.documentModal);
 
   return {
     core,

--- a/packages/react/src/ui/error-dialog/error-dialog-root.tsx
+++ b/packages/react/src/ui/error-dialog/error-dialog-root.tsx
@@ -3,7 +3,7 @@ import { selectError } from '@videojs/core/dom';
 import type { ReactNode } from 'react';
 import { useRef } from 'react';
 
-import { usePlayer } from '../../player/context';
+import { useContainer, usePlayer } from '../../player/context';
 import { useLatestRef } from '../../utils/use-latest-ref';
 import { DialogContextProvider } from '../dialog/context';
 import { useDialogRoot } from '../dialog/use-dialog-root';
@@ -16,6 +16,7 @@ export interface ErrorDialogRootProps {
 /** Opens from player error state and provides it to the shared dialog parts. */
 export function ErrorDialogRoot({ children }: ErrorDialogRootProps): ReactNode {
   const errorState = usePlayer(selectError);
+  const container = useContainer();
   const lastError = useRef(errorState?.error ?? null);
 
   if (errorState?.error) lastError.current = errorState.error;
@@ -29,6 +30,7 @@ export function ErrorDialogRoot({ children }: ErrorDialogRootProps): ReactNode {
     coreFactory: createErrorDialogCore,
     stateAttrMap: ErrorDialogDataAttrs,
     idPrefix: 'error-dialog',
+    interactionRoot: container,
   });
 
   if (!errorState) return null;

--- a/packages/react/src/ui/error-dialog/tests/error-dialog.test.tsx
+++ b/packages/react/src/ui/error-dialog/tests/error-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
@@ -48,5 +48,31 @@ describe('ErrorDialog', () => {
     expect(screen.getByTestId('title').textContent).toBe('Algo salió mal.');
     expect(screen.getByTestId('description').textContent).toBe('Error de red.');
     expect(screen.getByTestId('close').textContent).toBe('Aceptar');
+  });
+
+  it('scopes dialog semantics to the player container', async () => {
+    const container = document.createElement('div');
+    const { Wrapper, value } = createPlayerWrapper({
+      error: { code: 4, message: 'The media could not be played.' },
+      dismissError: vi.fn(),
+    });
+
+    value.container = container;
+    document.body.append(container);
+
+    const { getByRole } = render(
+      <Wrapper>
+        <ErrorDialog.Root>
+          <ErrorDialog.Popup>
+            <ErrorDialog.Title />
+          </ErrorDialog.Popup>
+        </ErrorDialog.Root>
+      </Wrapper>,
+      { container }
+    );
+
+    const popup = await waitFor(() => getByRole('alertdialog'));
+
+    expect(popup.hasAttribute('aria-modal')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- use the registered player Container as the ErrorDialog interaction boundary in HTML and React
- stop background isolation at that Container, allow page focus and Escape outside it, and omit `aria-modal` for the scoped dialog
- suspend Container hotkeys and gestures while the fatal error owns the player
- preserve document-wide modality for generic Dialog/AlertDialog and as a fallback when the supplied root is not an ancestor

No Container state attribute or error-open marker is introduced.

## Context

Addresses [Error dialog blocks page interaction until dismissed](https://app.notion.com/p/mux/Error-dialog-blocks-page-interaction-until-dismissed-fbe1b61f6e3846e3900c78b4e8e58f68?source=copy_link).

## Verification

- `pnpm -F @videojs/core test src/core/ui/dialog/tests/core.test.ts src/dom/ui/tests/dialog.test.ts src/dom/hotkey/tests/coordinator.test.ts src/dom/gesture/tests/coordinator.test.ts`
- `pnpm -F @videojs/html test src/ui/error-dialog/tests/error-dialog-element.test.ts`
- `pnpm -F @videojs/react test src/ui/error-dialog/tests/error-dialog.test.tsx src/ui/dialog/tests/dialog.test.tsx`
- `pnpm -F @videojs/e2e e2e tests/error-dialog.spec.ts --project=vite-chromium`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`