### PR TITLE
fix(packages): hide source-less poster images

### DIFF
--- a/apps/e2e/tests/skin-container.spec.ts
+++ b/apps/e2e/tests/skin-container.spec.ts
@@ -5,6 +5,13 @@ const SOURCE_SKINS = [
   { framework: 'React', path: '/pages/source-react-video-mp4.html' },
 ] as const;
 
+const POSTER_SKINS = [
+  { framework: 'packaged HTML', path: '/pages/html-video-mp4.html', selector: 'img[slot="poster"]' },
+  { framework: 'packaged React', path: '/pages/react-video-mp4.html', selector: '.media-default-skin > img' },
+  { framework: 'VJSC HTML', path: '/pages/source-html-video-mp4.html', selector: 'media-poster img' },
+  { framework: 'VJSC React', path: '/pages/source-react-video-mp4.html', selector: 'img.media-poster' },
+] as const;
+
 for (const { framework, path } of SOURCE_SKINS) {
   test.describe(`Canonical Skin container — ${framework}`, () => {
     test.beforeEach(async ({ page }) => {
@@ -40,5 +47,21 @@ for (const { framework, path } of SOURCE_SKINS) {
       await expect(poster).not.toHaveAttribute('data-visible');
       await expect(poster).toHaveCSS('opacity', '0');
     });
+  });
+}
+
+for (const { framework, path, selector } of POSTER_SKINS) {
+  test(`hides a source-less poster image — ${framework}`, async ({ page }) => {
+    await page.goto(path);
+
+    const posterImage = page.locator(selector).first();
+
+    await expect(posterImage).toBeAttached();
+    await posterImage.evaluate((image) => {
+      image.removeAttribute('src');
+      image.removeAttribute('srcset');
+    });
+
+    await expect(posterImage).toHaveCSS('visibility', 'hidden');
   });
 }

--- a/packages/skins/src/default/css/components/poster.css
+++ b/packages/skins/src/default/css/components/poster.css
@@ -11,6 +11,11 @@
 .media-default-skin > img:not([data-visible]) {
   opacity: 0;
 }
+.media-default-skin media-poster > slot > img:not([src]):not([srcset]),
+.media-default-skin media-poster ::slotted(img:not([src]):not([srcset])),
+.media-default-skin > img:not([src]):not([srcset]) {
+  visibility: hidden;
+}
 .media-default-skin media-poster ::slotted(img),
 .media-default-skin media-poster img {
   position: absolute;

--- a/packages/skins/src/default/tailwind/components/poster.ts
+++ b/packages/skins/src/default/tailwind/components/poster.ts
@@ -6,9 +6,12 @@ export const poster = (isShadowDOM: boolean) =>
     // Fade in/out with the `data-visible` attribute
     'transition-opacity duration-250',
     'not-data-visible:opacity-0',
+    '[&:is(img):not([src]):not([srcset])]:invisible',
     // In the shadow DOM, the class applies to the parent so we have to set styles on the slotted img.
     isShadowDOM
       ? [
+          '[&>slot>img:not([src]):not([srcset])]:invisible',
+          '[&_::slotted(img:not([src]):not([srcset]))]:invisible',
           '[&_::slotted(img)]:absolute',
           '[&_::slotted(img)]:inset-0',
           '[&_::slotted(img)]:w-full',

--- a/packages/skins/src/minimal/css/components/poster.css
+++ b/packages/skins/src/minimal/css/components/poster.css
@@ -11,6 +11,11 @@
 .media-minimal-skin > img:not([data-visible]) {
   opacity: 0;
 }
+.media-minimal-skin media-poster > slot > img:not([src]):not([srcset]),
+.media-minimal-skin media-poster ::slotted(img:not([src]):not([srcset])),
+.media-minimal-skin > img:not([src]):not([srcset]) {
+  visibility: hidden;
+}
 .media-minimal-skin media-poster ::slotted(img),
 .media-minimal-skin media-poster img {
   position: absolute;

--- a/packages/skins/src/minimal/tailwind/components/poster.ts
+++ b/packages/skins/src/minimal/tailwind/components/poster.ts
@@ -6,9 +6,12 @@ export const poster = (isShadowDOM: boolean) =>
     // Fade in/out with the `data-visible` attribute
     'transition-opacity duration-250',
     'not-data-visible:opacity-0',
+    '[&:is(img):not([src]):not([srcset])]:invisible',
     // In the shadow DOM, the class applies to the parent so we have to set styles on the slotted img.
     isShadowDOM
       ? [
+          '[&>slot>img:not([src]):not([srcset])]:invisible',
+          '[&_::slotted(img:not([src]):not([srcset]))]:invisible',
           '[&_::slotted(img)]:absolute',
           '[&_::slotted(img)]:inset-0',
           '[&_::slotted(img)]:w-full',

--- a/packages/skins/vjsc/styles/layout/poster.styles.ts
+++ b/packages/skins/vjsc/styles/layout/poster.styles.ts
@@ -10,12 +10,15 @@ export default styles({
         'pointer-events-none absolute inset-0 h-full w-full rounded-[inherit]',
         '[object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]',
         'transition-opacity duration-250 not-data-visible:opacity-0',
+        '[&:is(img):not([src]):not([srcset])]:invisible',
         '[&_img]:absolute [&_img]:inset-0 [&_img]:h-full [&_img]:w-full [&_img]:rounded-[inherit]',
         '[&_img]:[object-fit:var(--media-object-fit,contain)]',
         '[&_img]:[object-position:var(--media-object-position,center)]',
       ],
       variants: {
         'shadow-dom': [
+          '[&>slot>img:not([src]):not([srcset])]:invisible',
+          '[&_::slotted(img:not([src]):not([srcset]))]:invisible',
           '[&_::slotted(img)]:absolute [&_::slotted(img)]:inset-0',
           '[&_::slotted(img)]:h-full [&_::slotted(img)]:w-full [&_::slotted(img)]:rounded-[inherit]',
           '[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]',

--- a/packages/skins/vjsc/tests/__snapshots__/generated.tsx.snap
+++ b/packages/skins/vjsc/tests/__snapshots__/generated.tsx.snap
@@ -1845,7 +1845,7 @@ import { cn, resolveClassName } from "@videojs/utils/style";
 export interface PosterProps extends PosterPrimitive.Props {}
 export function Poster({ children, className, src, ...props }: PosterProps = {}) {
   return (
-    <PosterPrimitive render={children} className={state => cn("pointer-events-none absolute inset-0 h-full w-full rounded-[inherit]", "[object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]", "transition-opacity duration-250 not-data-visible:opacity-0", "[&_img]:absolute [&_img]:inset-0 [&_img]:h-full [&_img]:w-full [&_img]:rounded-[inherit]", "[&_img]:[object-fit:var(--media-object-fit,contain)]", "[&_img]:[object-position:var(--media-object-position,center)]", resolveClassName(className, state))} src={src} {...props} />
+    <PosterPrimitive render={children} className={state => cn("pointer-events-none absolute inset-0 h-full w-full rounded-[inherit]", "[object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]", "transition-opacity duration-250 not-data-visible:opacity-0", "[&:is(img):not([src]):not([srcset])]:invisible", "[&_img]:absolute [&_img]:inset-0 [&_img]:h-full [&_img]:w-full [&_img]:rounded-[inherit]", "[&_img]:[object-fit:var(--media-object-fit,contain)]", "[&_img]:[object-position:var(--media-object-position,center)]", resolveClassName(className, state))} src={src} {...props} />
   );
 }
 
@@ -4312,7 +4312,7 @@ import { cn, resolveClassName } from "@videojs/utils/style";
 export interface PosterProps extends PosterPrimitive.Props {}
 export function Poster({ children, className, src, ...props }: PosterProps = {}) {
   return (
-    <PosterPrimitive render={children} className={state => cn("pointer-events-none absolute inset-0 h-full w-full rounded-[inherit]", "[object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]", "transition-opacity duration-250 not-data-visible:opacity-0", "[&_img]:absolute [&_img]:inset-0 [&_img]:h-full [&_img]:w-full [&_img]:rounded-[inherit]", "[&_img]:[object-fit:var(--media-object-fit,contain)]", "[&_img]:[object-position:var(--media-object-position,center)]", resolveClassName(className, state))} src={src} {...props} />
+    <PosterPrimitive render={children} className={state => cn("pointer-events-none absolute inset-0 h-full w-full rounded-[inherit]", "[object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]", "transition-opacity duration-250 not-data-visible:opacity-0", "[&:is(img):not([src]):not([srcset])]:invisible", "[&_img]:absolute [&_img]:inset-0 [&_img]:h-full [&_img]:w-full [&_img]:rounded-[inherit]", "[&_img]:[object-fit:var(--media-object-fit,contain)]", "[&_img]:[object-position:var(--media-object-position,center)]", resolveClassName(className, state))} src={src} {...props} />
   );
 }
 
@@ -6605,7 +6605,7 @@ import "@videojs/html/ui/poster";
 
 export function Poster({ children, className, src, ...props }: PropsWithChildren<CoreProps> = {}) {
   return (
-    <media-poster class={["pointer-events-none absolute inset-0 h-full w-full rounded-[inherit]", "[object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]", "transition-opacity duration-250 not-data-visible:opacity-0", "[&_img]:absolute [&_img]:inset-0 [&_img]:h-full [&_img]:w-full [&_img]:rounded-[inherit]", "[&_img]:[object-fit:var(--media-object-fit,contain)]", "[&_img]:[object-position:var(--media-object-position,center)]", "[&_::slotted(img)]:absolute [&_::slotted(img)]:inset-0", "[&_::slotted(img)]:h-full [&_::slotted(img)]:w-full [&_::slotted(img)]:rounded-[inherit]", "[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]", "[&_::slotted(img)]:[object-position:var(--media-object-position,center)]", className]} src={src} {...props}><slot name="poster"><img alt="" decoding="async" /></slot></media-poster>
+    <media-poster class={["pointer-events-none absolute inset-0 h-full w-full rounded-[inherit]", "[object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]", "transition-opacity duration-250 not-data-visible:opacity-0", "[&:is(img):not([src]):not([srcset])]:invisible", "[&_img]:absolute [&_img]:inset-0 [&_img]:h-full [&_img]:w-full [&_img]:rounded-[inherit]", "[&_img]:[object-fit:var(--media-object-fit,contain)]", "[&_img]:[object-position:var(--media-object-position,center)]", "[&>slot>img:not([src]):not([srcset])]:invisible", "[&_::slotted(img:not([src]):not([srcset]))]:invisible", "[&_::slotted(img)]:absolute [&_::slotted(img)]:inset-0", "[&_::slotted(img)]:h-full [&_::slotted(img)]:w-full [&_::slotted(img)]:rounded-[inherit]", "[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]", "[&_::slotted(img)]:[object-position:var(--media-object-position,center)]", className]} src={src} {...props}><slot name="poster"><img alt="" decoding="async" /></slot></media-poster>
   );
 }
 
@@ -8840,7 +8840,7 @@ import "@videojs/html/ui/poster";
 
 export function Poster({ children, className, src, ...props }: PropsWithChildren<CoreProps> = {}) {
   return (
-    <media-poster class={["pointer-events-none absolute inset-0 h-full w-full rounded-[inherit]", "[object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]", "transition-opacity duration-250 not-data-visible:opacity-0", "[&_img]:absolute [&_img]:inset-0 [&_img]:h-full [&_img]:w-full [&_img]:rounded-[inherit]", "[&_img]:[object-fit:var(--media-object-fit,contain)]", "[&_img]:[object-position:var(--media-object-position,center)]", "[&_::slotted(img)]:absolute [&_::slotted(img)]:inset-0", "[&_::slotted(img)]:h-full [&_::slotted(img)]:w-full [&_::slotted(img)]:rounded-[inherit]", "[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]", "[&_::slotted(img)]:[object-position:var(--media-object-position,center)]", className]} src={src} {...props}><slot name="poster"><img alt="" decoding="async" /></slot></media-poster>
+    <media-poster class={["pointer-events-none absolute inset-0 h-full w-full rounded-[inherit]", "[object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]", "transition-opacity duration-250 not-data-visible:opacity-0", "[&:is(img):not([src]):not([srcset])]:invisible", "[&_img]:absolute [&_img]:inset-0 [&_img]:h-full [&_img]:w-full [&_img]:rounded-[inherit]", "[&_img]:[object-fit:var(--media-object-fit,contain)]", "[&_img]:[object-position:var(--media-object-position,center)]", "[&>slot>img:not([src]):not([srcset])]:invisible", "[&_::slotted(img:not([src]):not([srcset]))]:invisible", "[&_::slotted(img)]:absolute [&_::slotted(img)]:inset-0", "[&_::slotted(img)]:h-full [&_::slotted(img)]:w-full [&_::slotted(img)]:rounded-[inherit]", "[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]", "[&_::slotted(img)]:[object-position:var(--media-object-position,center)]", className]} src={src} {...props}><slot name="poster"><img alt="" decoding="async" /></slot></media-poster>
   );
 }
 

--- a/packages/skins/vjsc/tests/poster.test.ts
+++ b/packages/skins/vjsc/tests/poster.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { poster as defaultPoster } from '../../src/default/tailwind/components/poster';
+import { poster as minimalPoster } from '../../src/minimal/tailwind/components/poster';
+
+const posters = [
+  ['default', defaultPoster],
+  ['minimal', minimalPoster],
+] as const;
+
+describe.each(posters)('%s poster', (_, poster) => {
+  it('hides the rendered image while it has no source', () => {
+    expect(poster(false)).toContain('[&:is(img):not([src]):not([srcset])]:invisible');
+  });
+
+  it('hides source-less fallback and slotted images in the Shadow DOM', () => {
+    const className = poster(true);
+
+    expect(className).toContain('[&>slot>img:not([src]):not([srcset])]:invisible');
+    expect(className).toContain('[&_::slotted(img:not([src]):not([srcset]))]:invisible');
+  });
+});

--- a/packages/skins/vjsc/tests/vite.test.ts
+++ b/packages/skins/vjsc/tests/vite.test.ts
@@ -143,6 +143,24 @@ describe('Skins Vite workflow', () => {
     expect(react?.code).not.toContain('::slotted');
   }, 30_000);
 
+  it('hides source-less poster images for both targets', async () => {
+    server = await createServer({
+      configFile,
+      logLevel: 'silent',
+      optimizeDeps: { include: [], noDiscovery: true },
+      server: { middlewareMode: true },
+    });
+
+    const html = await server.transformRequest(htmlPosterUrl);
+    const react = await server.transformRequest(reactPosterUrl);
+
+    expect(html?.code).toContain('[&:is(img):not([src]):not([srcset])]:invisible');
+    expect(html?.code).toContain('[&>slot>img:not([src]):not([srcset])]:invisible');
+    expect(html?.code).toContain('[&_::slotted(img:not([src]):not([srcset]))]:invisible');
+    expect(react?.code).toContain('[&:is(img):not([src]):not([srcset])]:invisible');
+    expect(react?.code).not.toContain('&>slot>img');
+  }, 30_000);
+
   it('invalidates transformed owners for component, style, and design changes', async () => {
     server = await createServer({
       configFile,


### PR DESCRIPTION
## Summary

Hide poster images while neither src nor srcset is present, preventing browsers from painting missing-image borders or outlines before a poster resolves.

## Changes

- Scope the visibility rule to packaged Default and Minimal poster images in CSS and Tailwind skins
- Carry the same behavior through VJSC React roots, HTML fallback images, and directly slotted images
- Cover packaged and VJSC HTML/React output in Chromium and WebKit

## Testing

- pnpm -F @videojs/skins test
- pnpm exec vp run @videojs/skins#build
- pnpm --dir apps/e2e exec playwright test tests/skin-container.spec.ts --project=vite-chromium
- pnpm --dir apps/e2e exec playwright test tests/skin-container.spec.ts --project=vite-webkit
- pnpm lint
- pnpm check:workspace