### PR TITLE
fix(site): repair broken docs anchors and add built-page anchor checker

### DIFF
--- a/.github/workflows/website-tests.yml
+++ b/.github/workflows/website-tests.yml
@@ -76,3 +76,11 @@ jobs:
 
       - name: Astro check
         run: cd site && pnpm astro check --minimumSeverity warning
+
+      # No other PR workflow builds the site (only cd.yml on release and Netlify
+      # on deploy), so this job owns the build and the checks that need dist/.
+      - name: Build site
+        run: pnpm build:site
+
+      - name: Check anchors
+        run: pnpm -F site check:anchors

--- a/site/package.json
+++ b/site/package.json
@@ -6,6 +6,7 @@
     "api-docs": "vp run site#api-docs:generate",
     "clean": "rimraf --glob dist .netlify 'src/content/generated-*-reference' src/content/cdn-media.json src/content/ejected-skins.json",
     "astro": "astro",
+    "check:anchors": "tsx scripts/check-anchors.ts",
     "test": "vp test run",
     "test:watch": "vp test",
     "test:ui": "vp test --ui",

--- a/site/scripts/check-anchors.ts
+++ b/site/scripts/check-anchors.ts
@@ -1,0 +1,154 @@
+/** Verify fragment links in the built site resolve to an element id on the target page. */
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, posix, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(import.meta.url);
+const siteDirectory = resolve(scriptPath, '..', '..');
+
+export interface BrokenAnchor {
+  /** Dist-relative path of the page containing the link. */
+  page: string;
+  /** The raw href as written in the built HTML. */
+  href: string;
+  /** Why the link cannot resolve. */
+  reason: 'missing-anchor' | 'missing-page';
+}
+
+const ID_PATTERN = /\bid=(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
+const HREF_PATTERN = /<a\s[^>]*?\bhref=(?:"([^"]*)"|'([^']*)')/gis;
+const EXTERNAL_PATTERN = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
+function walkHtml(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const path = join(directory, entry.name);
+
+      if (entry.isDirectory()) return walkHtml(path);
+
+      return entry.isFile() && entry.name.endsWith('.html') ? [path] : [];
+    })
+    .sort();
+}
+
+export function collectIds(html: string): Set<string> {
+  const ids = new Set<string>();
+
+  for (const match of html.matchAll(ID_PATTERN)) {
+    ids.add(match[1] ?? match[2] ?? match[3] ?? '');
+  }
+
+  return ids;
+}
+
+function collectFragmentHrefs(html: string): string[] {
+  const hrefs: string[] = [];
+
+  for (const match of html.matchAll(HREF_PATTERN)) {
+    const href = match[1] ?? match[2] ?? '';
+
+    if (href.includes('#') && !EXTERNAL_PATTERN.test(href)) hrefs.push(href);
+  }
+
+  return hrefs;
+}
+
+/** Resolve a link path to the dist-relative HTML file that serves it, or undefined. */
+function resolveTargetPage(distDirectory: string, pagePath: string): string | undefined {
+  const normalized = posix.normalize(pagePath).replace(/^\/+/, '').replace(/\/+$/, '');
+  const candidates =
+    normalized === '' ? ['index.html'] : [normalized, `${normalized}/index.html`, `${normalized}.html`];
+
+  for (const candidate of candidates) {
+    if (!candidate.endsWith('.html')) continue;
+
+    const absolute = join(distDirectory, candidate);
+    if (existsSync(absolute) && statSync(absolute).isFile()) return candidate;
+  }
+
+  return undefined;
+}
+
+export function checkAnchors(distDirectory: string): BrokenAnchor[] {
+  const root = resolve(distDirectory);
+  const pages = walkHtml(root).map((path) =>
+    posix.join(
+      ...resolve(path)
+        .slice(root.length + 1)
+        .split(/[\\/]/)
+    )
+  );
+  const idsByPage = new Map(pages.map((page) => [page, collectIds(readFileSync(join(distDirectory, page), 'utf-8'))]));
+
+  const broken: BrokenAnchor[] = [];
+
+  for (const page of pages) {
+    const html = readFileSync(join(distDirectory, page), 'utf-8');
+
+    // Relative hrefs resolve against the served URL, not the dist layout:
+    // `a/b/index.html` is served at `/a/b` (`trailingSlash: 'never'`), so `../`
+    // climbs from `/a`, one level above the index.html's own directory.
+    const urlPath = page.replace(/\/?index\.html$/, '').replace(/\.html$/, '');
+    const urlDirectory = posix.dirname(urlPath);
+
+    for (const href of collectFragmentHrefs(html)) {
+      const hashIndex = href.indexOf('#');
+      const rawPath = href.slice(0, hashIndex).split('?')[0] ?? '';
+      const fragment = decodeURIComponent(href.slice(hashIndex + 1));
+      if (fragment === '' || fragment.startsWith(':~:')) continue;
+
+      let targetPage: string | undefined;
+
+      if (rawPath === '') {
+        targetPage = page;
+      } else if (rawPath.startsWith('/')) {
+        targetPage = resolveTargetPage(distDirectory, decodeURIComponent(rawPath));
+      } else {
+        targetPage = resolveTargetPage(
+          distDirectory,
+          posix.join(urlDirectory === '.' ? '' : urlDirectory, decodeURIComponent(rawPath))
+        );
+      }
+
+      if (!targetPage) {
+        broken.push({ page, href, reason: 'missing-page' });
+        continue;
+      }
+
+      if (!idsByPage.get(targetPage)?.has(fragment)) {
+        broken.push({ page, href, reason: 'missing-anchor' });
+      }
+    }
+  }
+
+  return broken;
+}
+
+function main(): void {
+  const distDirectory = resolve(siteDirectory, process.argv[2] ?? 'dist');
+
+  if (!existsSync(distDirectory)) {
+    console.error(`✗ ${distDirectory} not found — run \`pnpm build:site\` first.`);
+    process.exit(1);
+  }
+
+  const broken = checkAnchors(distDirectory);
+
+  if (broken.length === 0) {
+    console.log('✓ All fragment links resolve to an element id.');
+    return;
+  }
+
+  for (const { page, href, reason } of broken) {
+    const label = reason === 'missing-page' ? 'target page not found' : 'missing anchor';
+
+    console.error(`✗ ${page}: ${href} (${label})`);
+  }
+
+  console.error(`\n✗ ${broken.length} broken fragment link${broken.length === 1 ? '' : 's'}.`);
+  process.exit(1);
+}
+
+const isEntrypoint = process.argv[1] && resolve(process.argv[1]) === resolve(scriptPath);
+
+if (isEntrypoint) main();

--- a/site/src/content/docs/concepts/skins.mdx
+++ b/site/src/content/docs/concepts/skins.mdx
@@ -108,7 +108,7 @@ Either way the styles travel inside the skin's JavaScript and apply when the ele
 
 </FrameworkCase>
 
-To use Tailwind or change the underlying CSS, [eject the skin](../how-to/customize-skins#ejecting) and edit its styles in your app.
+To use Tailwind or change the underlying CSS, [eject the skin](../how-to/customize-skins#eject-a-skin) and edit its styles in your app.
 
 ### Shared limitations
 

--- a/site/src/content/docs/how-to/build-your-own-component.mdx
+++ b/site/src/content/docs/how-to/build-your-own-component.mdx
@@ -402,7 +402,7 @@ if (playback?.paused) {
 }
 ```
 
-Each selector returns both state and actions for that feature. Use separate controllers when you need multiple features (the [example above](#recommended-approach) demonstrates this).
+Each selector returns both state and actions for that feature. Use separate controllers when you need multiple features (the [full example](#full-example) demonstrates this).
 
 Without a selector, `PlayerController` returns the full store without subscribing to changes. Create the controller with the typed context that <DocsLink slug="reference/html-create-player">`createPlayer`</DocsLink> returns — the shared `playerContext` types the store's members as `unknown` — and guard the value, which stays `undefined` until a player provides the store:
 

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -16,7 +16,7 @@ Start with the Minimal skin, move media settings into markup, and replace calls 
 - **The player becomes three pieces.** Player state, the media component, and the skin are separate, so you can replace one without wrapping or forking the others.
 - **Streaming behavior becomes player state.** HLS, DASH, and Mux integrations expose renditions, tracks, and live state to the UI instead of leaving that wiring to application code.
 - **React uses native components and hooks.** `@videojs/react` owns its lifecycle instead of wrapping an imperative constructor around framework-owned DOM.
-- **The UI is composable.** Buttons, sliders, menus, gestures, and hotkeys are individual accessible components. Start with the Minimal or Default skin, then [eject it](#ejecting) when you need to change the structure.
+- **The UI is composable.** Buttons, sliders, menus, gestures, and hotkeys are individual accessible components. Start with the Minimal or Default skin, then [eject it](#eject-a-skin) when you need to change the structure.
 - **Remote playback is built in.** The video skins include AirPlay and Cast controls. Follow <DocsLink slug="how-to/cast-to-airplay-and-chromecast">Cast to AirPlay and Chromecast</DocsLink> to add the Google Cast integration.
 
 <Aside type="note">
@@ -347,15 +347,15 @@ Here's a matrix for configuration options in Plyr and how each maps to Video.js 
 
 | Plyr option | Video.js v10 |
 |---|---|
-| `controls` | The <DocsLink slug="concepts/skins">skins</DocsLink> include all the common controls, laid out in a familiar way that users would expect. If you want to customize the skin beyond basic colors, you can [eject the skin](#ejecting) and change layout, styles, or icons. |
+| `controls` | The <DocsLink slug="concepts/skins">skins</DocsLink> include all the common controls, laid out in a familiar way that users would expect. If you want to customize the skin beyond basic colors, you can [eject the skin](#eject-a-skin) and change layout, styles, or icons. |
 | `settings` | Included automatically in the skins when quality, speed, audio tracks, or captions are available. |
 | `autoplay`, `muted`, `loop`, `playsinline`, `preload` | These are attributes on your media (e.g. `<video>`) component. |
 | `poster` / `data-poster` | In HTML, slot an image into the skin. In React, set `poster` on `VideoPlayer`. See [Basic migration](#basic-migration). |
 | `ratio` | Set `aspect-ratio` in CSS on the skin component. |
 | `hideControls` | Preset skins auto-hide controls based on activity. The delay is currently not configurable. |
-| `clickToPlay` | Preset video skins include click and tap gestures. [Eject the skin](#ejecting) to remove or change them. |
-| `keyboard` | Preset video skins include common hotkeys. [Eject the skin](#ejecting) to remove or change them. |
-| `tooltips` | Preset skins include tooltips for common controls. [Eject the skin](#ejecting) to customize them. |
+| `clickToPlay` | Preset video skins include click and tap gestures. [Eject the skin](#eject-a-skin) to remove or change them. |
+| `keyboard` | Preset video skins include common hotkeys. [Eject the skin](#eject-a-skin) to remove or change them. |
+| `tooltips` | Preset skins include tooltips for common controls. [Eject the skin](#eject-a-skin) to customize them. |
 | `captions` | Add `<track kind="captions">` or `<track kind="subtitles">`; preset skins show captions controls when tracks are available. |
 | `previewThumbnails` | Add `<track kind="metadata" label="thumbnails">`; preset video skins show slider thumbnails when thumbnail cues are available. |
 | `quality` | Works when the media provider exposes renditions. Plain MP4 source arrays do not currently become a quality menu automatically. |
@@ -369,7 +369,7 @@ Here's a matrix for configuration options in Plyr and how each maps to Video.js 
 
 ## Customize the controls
 
-Plyr's `controls` option chooses which controls appear. Video.js skins come with their own control set and layout. Keep the skin when that UI fits your player. To remove, reorder, or restyle its controls, [eject the skin](#ejecting) and edit the copied implementation. Adding a child to a skin does not place it inside the control bar.
+Plyr's `controls` option chooses which controls appear. Video.js skins come with their own control set and layout. Keep the skin when that UI fits your player. To remove, reorder, or restyle its controls, [eject the skin](#eject-a-skin) and edit the copied implementation. Adding a child to a skin does not place it inside the control bar.
 
 If your app already has a custom control bar, build it from individual <DocsLink slug="concepts/ui-components">UI components</DocsLink>. Video.js handles the media action, accessible name, and state. You add the visible contents, layout, and CSS.
 
@@ -439,7 +439,7 @@ class MyElapsed extends ReactiveElement {
 
 ## Rewrite styles
 
-Video.js v10 skins offer similar color customization via CSS custom properties. [Eject the skin](#ejecting) when you need deeper control over layout, control structure, icons, or interaction styling.
+Video.js v10 skins offer similar color customization via CSS custom properties. [Eject the skin](#eject-a-skin) when you need deeper control over layout, control structure, icons, or interaction styling.
 
 ```css
 /* Plyr */


### PR DESCRIPTION
Seven links pointed at `#ejecting` on pages where the heading renders as `#eject-to-your-codebase` or `#eject-and-customize`, and build-your-own-component linked a stale `#recommended-approach` slug (now `#full-example` — a catch by the new checker itself).

Adds `site/scripts/check-anchors.ts`, which walks the built dist HTML and fails on any same-site fragment link that matches no `id` on the target page, wired into the website-tests workflow after the build step (`pnpm -F site check:anchors`).

**Stack 1/13** (docs-feedback triage). Base: `main`. Next: → `claude/docs-stack-02-live-preset-jsdoc`.

Verified: `astro check`, `build:site`, and the checker green at the stack head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47)_


---

> [!NOTE]
> **Low Risk**
> Docs link fixes plus CI-only validation; no runtime or auth/data-path changes.
> 
> **Overview**
> Fixes stale in-doc fragment links (`#ejecting` → `#eject-a-skin`, `#recommended-approach` → `#full-example`) in skins, migrate-from-plyr, and build-your-own-component so they match rendered heading ids.
> 
> Adds **`check-anchors.ts`**, which scans built `dist/` HTML for same-site `href` fragments and fails when the target page or element `id` is missing, exposed as `pnpm -F site check:anchors`. The **website-tests** `astro-check` job now runs **`pnpm build:site`** and the anchor check after content generation, since PR CI otherwise never produced `dist/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 080388063ad1d295ac7a451762ddb2f1e6cdd52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>