### PR TITLE
docs: correct live preset feature and skin descriptions

### DIFF
--- a/packages/core/src/dom/store/features/presets.ts
+++ b/packages/core/src/dom/store/features/presets.ts
@@ -56,7 +56,8 @@ export const backgroundFeatures: BackgroundFeatures = [];
 
 /**
  * Features for a live video player. Mirrors {@link videoFeatures} but drops {@link playbackRateFeature} (not meaningful
- * for live) and adds {@link liveFeature} so store consumers can read `liveEdgeStart` and `targetLiveWindow`.
+ * for live) along with {@link qualityFeature} and {@link audioTrackFeature}, and adds {@link liveFeature} so store
+ * consumers can read `liveEdgeStart` and `targetLiveWindow`.
  */
 export const liveVideoFeatures: LiveVideoFeatures = [
   playbackFeature,

--- a/packages/html/src/presets/live-audio/index.ts
+++ b/packages/html/src/presets/live-audio/index.ts
@@ -1,6 +1,6 @@
 /**
- * Live audio player preset — `liveAudioFeatures` (adds `liveFeature`, drops `playbackRateFeature`) with a skin that
- * includes a Live button.
+ * Live audio player preset — `liveAudioFeatures` (adds `liveFeature`; drops `playbackRateFeature`) with a skin that
+ * swaps the time slider and time displays for a Live button.
  */
 export { liveAudioFeatures } from '@videojs/core/dom';
 export { LiveAudioPlayerElement, PlayerController } from './player';

--- a/packages/html/src/presets/live-video/index.ts
+++ b/packages/html/src/presets/live-video/index.ts
@@ -1,6 +1,6 @@
 /**
- * Live video player preset — `liveVideoFeatures` (adds `liveFeature`, drops `playbackRateFeature`) with a skin that
- * includes a Live button.
+ * Live video player preset — `liveVideoFeatures` (adds `liveFeature`; drops `playbackRateFeature`, `qualityFeature`,
+ * and `audioTrackFeature`) with a skin that swaps the time slider and time displays for a Live button.
  */
 export { liveVideoFeatures } from '@videojs/core/dom';
 export { LiveVideoPlayerElement, PlayerController } from './player';

--- a/packages/react/src/presets/live-audio/index.ts
+++ b/packages/react/src/presets/live-audio/index.ts
@@ -1,4 +1,7 @@
-/** Live audio player preset — same features as `audio` with a skin that omits duration / current-time displays. */
+/**
+ * Live audio player preset — `audio` minus playback rate, plus the live feature, with a skin that swaps the time slider
+ * and time displays for a Live button.
+ */
 'use client';
 
 export { liveAudioFeatures } from '@videojs/core/dom';

--- a/packages/react/src/presets/live-video/index.ts
+++ b/packages/react/src/presets/live-video/index.ts
@@ -1,4 +1,7 @@
-/** Live video player preset — same features as `video` with a skin that omits duration / current-time displays. */
+/**
+ * Live video player preset — `video` minus playback rate, quality selection, and audio-track selection, plus the live
+ * feature, with a skin that swaps the time slider and time displays for a Live button.
+ */
 'use client';
 
 export { liveVideoFeatures } from '@videojs/core/dom';

--- a/site/src/content/docs/how-to/play-live-streams.mdx
+++ b/site/src/content/docs/how-to/play-live-streams.mdx
@@ -53,7 +53,7 @@ export default function App() {
 
 </FrameworkCase>
 
-The `liveVideoFeatures` bundle mirrors <DocsLink slug="concepts/features">`videoFeatures`</DocsLink> but adds the live feature and drops playback rate (not meaningful for live), quality selection, and audio-track selection. The live presets also ship skins without duration and current-time displays.
+The `liveVideoFeatures` bundle mirrors <DocsLink slug="concepts/features">`videoFeatures`</DocsLink> but adds the live feature and drops playback rate (not meaningful for live), quality selection, and audio-track selection. The live presets also ship skins without a time slider, duration display, or current-time display.
 
 Both bundles are plain arrays, so extending one is a spread:
 
@@ -102,7 +102,7 @@ LiveButton reads this state: it renders as an active "go to live" control while 
 
 ### DVR: let users scrub back
 
-For streams with a DVR window, keep a <DocsLink slug="reference/time-slider">TimeSlider</DocsLink> in the UI. The slider tracks the sliding window automatically because `duration` follows the live edge.
+For streams with a DVR window, give users a <DocsLink slug="reference/time-slider">TimeSlider</DocsLink>. The live preset skins don't include one, so add it to your own UI or <DocsLink slug="how-to/customize-skins">eject the skin</DocsLink>. The slider tracks the sliding window automatically because `duration` follows the live edge.
 
 ### Switch UI by stream type
 


### PR DESCRIPTION
The live-video and live-audio preset JSDoc claimed the same features as video/audio. They actually ship video/audio minus playback rate, quality selection, and (for video) audio-track selection, plus the live feature, with skins that swap the time slider and time displays for a Live button. Aligns the preset barrels (React + HTML), the presets feature-table source, and the play-live-streams guide.

Follow-up to #1768, which closed with the JSDoc still inaccurate.

**Stack 2/13**. Base: `claude/docs-stack-01-anchors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47)_


---

> [!NOTE]
> **Low Risk**
> Comment and MDX-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> **Documentation-only** alignment so live preset docs match what `liveVideoFeatures` / `liveAudioFeatures` and the bundled skins actually do.
> 
> JSDoc on the core `liveVideoFeatures` preset now explicitly notes dropped **`qualityFeature`** and **`audioTrackFeature`** (in addition to playback rate). React and HTML preset barrel comments describe live video as video minus playback rate, quality, and audio-track selection, plus live; live audio as audio minus playback rate, plus live. All preset docs now say the default skins **swap the time slider and time displays for a Live button**, not merely "include" a Live control.
> 
> The **play-live-streams** guide is updated to state preset skins omit the time slider as well as duration/current-time, and the DVR section clarifies that **TimeSlider is not in the preset skin**—integrators must add it or eject/customize the skin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d0eba66b182e45849f11dec359b4ee2a415f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>