### PR TITLE
docs(site): document imperative control in the migration guides

### DIFF
--- a/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
+++ b/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
@@ -300,10 +300,10 @@ React skins do not use Shadow DOM. Use `render` props when you build individual 
 
 ## Control the player imperatively
 
-Media Chrome taught you to script the slotted media element directly, and that habit carries over unchanged. The media is a plain child of the player, and Video.js derives player state from the native media events, so `video.play()` or `video.currentTime = 30` never leaves the controls out of sync. What changes is where everything else lives: Media Chrome had no player object, while Video.js puts the state the browser doesn't own — fullscreen, captions, quality — on the player.
+Control everything through the player's store. Media Chrome had no player object; Video.js gives you one, with an action for every operation — `play`, `togglePaused`, `seek`, `setVolume`, `toggleFullscreen` — so one mental model covers playback and the state the browser doesn't own, such as fullscreen, captions, and quality.
 
 <FrameworkCase frameworks={["html"]}>
-Query the media element and drive it as before. Player-owned actions live on the player element's store:
+Hold a reference to the player element and call actions on its store:
 
 ```js
 const player = document.querySelector('video-player');
@@ -313,7 +313,7 @@ player.store.state.toggleFullscreen();
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
-Put a `ref` on the media component; its value is the rendered `HTMLVideoElement`, so there's no `media` slot to reach through. Player-owned actions come from the same <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> hook you read state with:
+Select an action with the same <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> hook you read state with:
 
 ```tsx
 import { usePlayer } from '@videojs/react/video';
@@ -324,8 +324,12 @@ function FullscreenShortcut() {
   return null;
 }
 ```
+</FrameworkCase>
 
-For the Video.js media object, call <DocsLink slug="reference/use-media">`useMedia`</DocsLink> from a component inside the player; media that wrap a playback engine expose it there through the `engine` escape hatch.
+The Media Chrome habit of scripting the media element directly still works, unchanged. The media is a plain child of the player, and Video.js derives player state from the native media events, so `video.play()` or `video.currentTime = 30` never leaves the controls out of sync. The media element also stays the way to swap `src`, replace the media component, and listen for native events.
+
+<FrameworkCase frameworks={["react"]}>
+Put a `ref` on the media component to reach the rendered `HTMLVideoElement`; there's no `media` slot to reach through. For the Video.js media object, call <DocsLink slug="reference/use-media">`useMedia`</DocsLink> from a component inside the player; media that wrap a playback engine expose it there through the `engine` escape hatch.
 </FrameworkCase>
 
 ## Known gaps

--- a/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
+++ b/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
@@ -298,6 +298,36 @@ Keep the skin when its CSS variables and content slots cover your changes. Build
 React skins do not use Shadow DOM. Use `render` props when you build individual controls. Eject a ready-made skin when you need to change its control set or layout.
 </FrameworkCase>
 
+## Control the player imperatively
+
+Media Chrome taught you to script the slotted media element directly, and that habit carries over unchanged. The media is a plain child of the player, and Video.js derives player state from the native media events, so `video.play()` or `video.currentTime = 30` never leaves the controls out of sync. What changes is where everything else lives: Media Chrome had no player object, while Video.js puts the state the browser doesn't own — fullscreen, captions, quality — on the player.
+
+<FrameworkCase frameworks={["html"]}>
+Query the media element and drive it as before. Player-owned actions live on the player element's store:
+
+```js
+const player = document.querySelector('video-player');
+
+player.store.state.toggleFullscreen();
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+Put a `ref` on the media component; its value is the rendered `HTMLVideoElement`, so there's no `media` slot to reach through. Player-owned actions come from the same <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> hook you read state with:
+
+```tsx
+import { usePlayer } from '@videojs/react/video';
+
+function FullscreenShortcut() {
+  const toggleFullscreen = usePlayer((state) => state.toggleFullscreen);
+  // Call toggleFullscreen() from your own UI.
+  return null;
+}
+```
+
+For the Video.js media object, call <DocsLink slug="reference/use-media">`useMedia`</DocsLink> from a component inside the player; media that wrap a playback engine expose it there through the `engine` escape hatch.
+</FrameworkCase>
+
 ## Known gaps
 
 These Media Chrome features have no direct equivalent yet. Several can be approximated; see [Workarounds](#workarounds).

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -531,14 +531,14 @@ Use a ref for imperative browser media APIs or for custom events that do not hav
 
 | Mux Player | Video.js v10 |
 |---|---|
-| `player.play()`, `player.pause()` | `media.play()`, `media.pause()`, or the player's `togglePaused` |
-| `player.currentTime = 10` | `media.currentTime = 10` |
-| `player.volume`, `player.muted` | `media.volume`, `media.muted` |
-| `player.playbackRate` | `media.playbackRate`, or the player's `setPlaybackRate` |
+| `player.play()`, `player.pause()` | the player's `play`, `pause`, `togglePaused`, or `media.play()`, `media.pause()` |
+| `player.currentTime = 10` | the player's `seek(10)`, or `media.currentTime = 10` |
+| `player.volume`, `player.muted` | the player's `setVolume`, `toggleMuted`, or `media.volume`, `media.muted` |
+| `player.playbackRate` | the player's `setPlaybackRate`, or `media.playbackRate` |
 | `player.requestFullscreen()` | the player's `requestFullscreen`, `exitFullscreen`, `toggleFullscreen` |
 | `player.addChapters([…])` | a `<track kind="chapters">`, covered below |
 
-Anything that's a standard media property you set on the media. Anything the browser doesn't own — fullscreen, captions, quality — goes through the player, because the player is what tracks it.
+Control everything through the player: "the player's" entries are store actions, reached the same way you read state above. Setting a standard media property directly works too — player state derives from the native media events, so the UI stays in sync either way.
 
 ## Which Mux media should you use?
 

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -383,24 +383,19 @@ Individual React buttons do not include visible content. Use their `render` prop
 
 ## Use the imperative API
 
-Use the media element for standard playback operations:
+Control everything through the player's store. Every Plyr call has a matching store action, so one mental model covers playback, volume, fullscreen, and captions alike:
 
-| Plyr | Video.js v10 |
+| Plyr | Video.js v10 store action |
 |---|---|
-| `player.play()` | `video.play()` or player action |
-| `player.pause()` | `video.pause()` or player action |
-| `player.currentTime = 10` | `video.currentTime = 10` |
-| `player.volume = 0.5` | `video.volume = 0.5` |
-| `player.muted = true` | `video.muted = true` |
-| `player.speed = 1.5` | `video.playbackRate = 1.5` |
-| `player.fullscreen.enter()` | Fullscreen feature or fullscreen control |
-| `player.toggleCaptions()` | Text-track feature or captions control |
+| `player.play()`, `player.pause()` | `play()`, `pause()`, or `togglePaused()` |
+| `player.currentTime = 10` | `seek(10)` |
+| `player.volume = 0.5` | `setVolume(0.5)` |
+| `player.muted = true` | `toggleMuted()` |
+| `player.speed = 1.5` | `setPlaybackRate(1.5)` |
+| `player.fullscreen.enter()` | `requestFullscreen()` |
+| `player.toggleCaptions()` | `toggleSubtitles()` |
 
-Plyr routed those calls through its wrapper because the wrapper had to know about every change. Video.js works the other way around: player state derives from the native media events, so scripting the media element directly — `video.play()`, `video.currentTime = 10` — keeps every control in sync. There is no wrapper to notify. Anything the browser doesn't own — fullscreen, captions, quality — goes through the player instead, because the player is what tracks it.
-
-To change content without changing media type, set `src` on the media component. Replace the component when the media type changes, such as moving from `Video` to `HlsVideo`. The player UI follows the attached media.
-
-For custom UI, read and write through the Video.js player store.
+You can still script the media element directly when you want to. Plyr routed calls through its wrapper because the wrapper had to know about every change; Video.js derives player state from the native media events, so `video.play()` or `video.currentTime = 10` keeps every control in sync. The media element is also the way to change content: set `src` on the media component to swap sources, and replace the component when the media type changes, such as moving from `Video` to `HlsVideo`. The player UI follows the attached media.
 
 <FrameworkCase frameworks={["react"]}>
 Import the preset's <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> hook and call it from a descendant of `VideoPlayer`. The component that creates `VideoPlayer` cannot also consume its context, so put store access in a child component:
@@ -426,11 +421,13 @@ export function AppVideoPlayer() {
 }
 ```
 
-For the element itself, put a `ref` on the media component; its value is the rendered `HTMLVideoElement`, so `ref.current.play()` works the way Plyr's underlying element did. For the Video.js media object, call <DocsLink slug="reference/use-media">`useMedia`</DocsLink> from a component inside the player; media that wrap a playback engine expose it there through the `engine` escape hatch.
+The same hook selects actions: `usePlayer((state) => state.togglePaused)` returns a function you can call from your own UI.
+
+When you need the element itself, put a `ref` on the media component; its value is the rendered `HTMLVideoElement`, so `ref.current.play()` works the way Plyr's underlying element did. For the Video.js media object, call <DocsLink slug="reference/use-media">`useMedia`</DocsLink> from a component inside the player; media that wrap a playback engine expose it there through the `engine` escape hatch.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-Your media element is a plain child in your markup, so query it and drive it directly. Player-owned actions such as `toggleFullscreen` live on the player element's `store.state`. To keep a custom element in sync with player state, use <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink>:
+The store's actions live on the player element's `store.state`: query `<video-player>` and call `player.store.state.togglePaused()`. Your media element is also a plain child in your markup, so you can query and drive it directly. To keep a custom element in sync with player state, use <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink>:
 
 ```js
 import { PlayerController, playerContext, ReactiveElement, selectTime } from '@videojs/html';

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -396,6 +396,8 @@ Use the media element for standard playback operations:
 | `player.fullscreen.enter()` | Fullscreen feature or fullscreen control |
 | `player.toggleCaptions()` | Text-track feature or captions control |
 
+Plyr routed those calls through its wrapper because the wrapper had to know about every change. Video.js works the other way around: player state derives from the native media events, so scripting the media element directly — `video.play()`, `video.currentTime = 10` — keeps every control in sync. There is no wrapper to notify. Anything the browser doesn't own — fullscreen, captions, quality — goes through the player instead, because the player is what tracks it.
+
 To change content without changing media type, set `src` on the media component. Replace the component when the media type changes, such as moving from `Video` to `HlsVideo`. The player UI follows the attached media.
 
 For custom UI, read and write through the Video.js player store.
@@ -423,10 +425,12 @@ export function AppVideoPlayer() {
   );
 }
 ```
+
+For the element itself, put a `ref` on the media component; its value is the rendered `HTMLVideoElement`, so `ref.current.play()` works the way Plyr's underlying element did. For the Video.js media object, call <DocsLink slug="reference/use-media">`useMedia`</DocsLink> from a component inside the player; media that wrap a playback engine expose it there through the `engine` escape hatch.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-Use <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink> inside a custom element:
+Your media element is a plain child in your markup, so query it and drive it directly. Player-owned actions such as `toggleFullscreen` live on the player element's `store.state`. To keep a custom element in sync with player state, use <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink>:
 
 ```js
 import { PlayerController, playerContext, ReactiveElement, selectTime } from '@videojs/html';

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -519,6 +519,8 @@ Every feature has a selector (`selectPlayback`, `selectTime`, `selectVolume`, `s
 
 v8 used accessor methods for everything: `player.currentTime()` to read, `player.currentTime(10)` to write. v10 splits the difference by owner. Anything the browser owns you set on the media, as a plain property. Anything it doesn't — fullscreen, captions, quality — goes through the player, because the player is what tracks it.
 
+Writing to the media directly is safe because player state derives from the native media events: set `media.currentTime` and the time slider follows. There is no wrapper to fall out of sync.
+
 | Video.js 8 | Video.js v10 |
 |---|---|
 | `player.play()`, `player.pause()` | `media.play()`, `media.pause()`, or the player's `togglePaused` |
@@ -527,13 +529,27 @@ v8 used accessor methods for everything: `player.currentTime()` to read, `player
 | `player.volume()`, `player.muted()` | `media.volume`, `media.muted` |
 | `player.playbackRate()` | `media.playbackRate`, or the player's `setPlaybackRate` |
 | `player.src({ src, type })` | set `src` on the media |
-| `player.requestFullscreen()`, `exitFullscreen()` | the player's `enterFullscreen`, `exitFullscreen`, `toggleFullscreen` |
+| `player.requestFullscreen()`, `exitFullscreen()` | the player's `requestFullscreen`, `exitFullscreen`, `toggleFullscreen` |
 | `player.textTracks()`, `addRemoteTextTrack()` | `<track>` elements, and `textTrackList` in player state |
 | `player.audioTracks()` | `audioTracks` in player state |
 | `player.error()` | `error` in player state |
 | `player.dispose()` | remove the element, or unmount the component |
 | `player.tech()` | the media component's public `engine` escape hatch, where one exists; in React, reach it through `useMedia()` |
 | `videojs.getPlayer(id)` | hold a reference to the element |
+
+<FrameworkCase frameworks={["html"]}>
+Everything the table describes as "the player's" lives on the player element's store. Hold a reference to `<video-player>` the way you held a v8 player instance, and call actions on its `store.state`:
+
+```js
+const player = document.querySelector('video-player');
+
+player.store.state.toggleFullscreen();
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+Where v8 had you keep the `videojs()` return value in a ref, put the ref on the media component instead; its value is the rendered `HTMLVideoElement`, ready for every `media.*` entry in the table. The player's actions come from the same `usePlayer` hook you read state with — select `togglePaused`, `setPlaybackRate`, or `toggleFullscreen` from state and call it. Where `player.tech()` habits linger, <DocsLink slug="reference/use-media">`useMedia`</DocsLink> returns the Video.js media object.
+</FrameworkCase>
 
 Swapping sources is the change most likely to surprise you. There's no `player.src()`; you set `src` on the media element, or replace the media element entirely, and the UI follows. Changing formats is changing tags.
 

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -517,17 +517,17 @@ Every feature has a selector (`selectPlayback`, `selectTime`, `selectVolume`, `s
 
 ### Drive playback
 
-v8 used accessor methods for everything: `player.currentTime()` to read, `player.currentTime(10)` to write. v10 splits the difference by owner. Anything the browser owns you set on the media, as a plain property. Anything it doesn't — fullscreen, captions, quality — goes through the player, because the player is what tracks it.
+v8 used accessor methods for everything: `player.currentTime()` to read, `player.currentTime(10)` to write. v10 keeps that single-object habit: control everything through the player. Its store holds the state each feature tracks and an action for each of these calls — playback, seeking, volume, rate, fullscreen, captions, and quality alike.
 
-Writing to the media directly is safe because player state derives from the native media events: set `media.currentTime` and the time slider follows. There is no wrapper to fall out of sync.
+You can also write to the media element directly. That is safe because player state derives from the native media events: set `media.currentTime` and the time slider follows. There is no wrapper to fall out of sync.
 
 | Video.js 8 | Video.js v10 |
 |---|---|
-| `player.play()`, `player.pause()` | `media.play()`, `media.pause()`, or the player's `togglePaused` |
-| `player.currentTime()` / `player.currentTime(10)` | `media.currentTime` |
-| `player.duration()` | `media.duration`, or `duration` in player state |
-| `player.volume()`, `player.muted()` | `media.volume`, `media.muted` |
-| `player.playbackRate()` | `media.playbackRate`, or the player's `setPlaybackRate` |
+| `player.play()`, `player.pause()` | the player's `play`, `pause`, `togglePaused`, or `media.play()`, `media.pause()` |
+| `player.currentTime()` / `player.currentTime(10)` | `currentTime` in player state, the player's `seek(10)`, or `media.currentTime` |
+| `player.duration()` | `duration` in player state, or `media.duration` |
+| `player.volume()`, `player.muted()` | the player's `setVolume`, `toggleMuted`, or `media.volume`, `media.muted` |
+| `player.playbackRate()` | the player's `setPlaybackRate`, or `media.playbackRate` |
 | `player.src({ src, type })` | set `src` on the media |
 | `player.requestFullscreen()`, `exitFullscreen()` | the player's `requestFullscreen`, `exitFullscreen`, `toggleFullscreen` |
 | `player.textTracks()`, `addRemoteTextTrack()` | `<track>` elements, and `textTrackList` in player state |


### PR DESCRIPTION
The Mux Player guide explains how to script the player directly; the Plyr, Media Chrome, and Video.js 8 guides did not. Completes the Plyr guide's imperative section, adds a "Control the player imperatively" section to the Media Chrome guide, and augments the Video.js 8 guide's "Drive playback" section with framework cases mapping old ref-to-`videojs()` habits.

After review, all four guides lead with the same story: control everything through the player's store — actions like `play()`, `seek()`, `setPlaybackRate()` — with direct `media.*` calls as the escape hatch, not the default. All four state the architectural point: player state derives from native media events, so scripting the media element never desyncs the UI. Every referenced API verified against `packages/` source; also corrects `enterFullscreen` → `requestFullscreen` in the Video.js 8 table.

**Stack 5/13**. Base: `claude/docs-stack-04-mux-guide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47)_


---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to site migration MDX; no runtime or API behavior changes.
> 
> **Overview**
> Aligns **Plyr**, **Media Chrome**, **Video.js 8**, and **Mux Player** migration guides on how to drive playback imperatively in v10.
> 
> Each guide now treats the **player store** as the primary model: store actions such as `play`, `seek`, `setVolume`, `toggleFullscreen`, and `toggleSubtitles`, reached via `player.store.state` in HTML or `usePlayer` in React. **Drive playback** / imperative API tables list those actions first and still document direct `media.*` calls, with shared wording that player state follows native media events so the UI stays in sync.
> 
> **Media Chrome** gains a full **Control the player imperatively** section (new for that guide). **Plyr** and **v8** gain expanded framework notes on refs, `useMedia`, and `PlayerController`. The **v8** table fixes fullscreen naming (`requestFullscreen` instead of `enterFullscreen`). **Mux** only tightens the existing drive-playback table and intro paragraph to match the same story.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce16716b0174424b4b69ad6e4611b00c6dc28ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>