### PR TITLE
docs(site): make the React Player provider model explicit

### DIFF
--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -523,6 +523,8 @@ function Elapsed() {
 
 Every feature has a selector (`selectPlayback`, `selectTime`, `selectVolume`, `selectQuality`, `selectLive`, `selectTextTrack`, and so on) for when you want a whole slice rather than one value.
 
+`usePlayer` reads through context, so it only works inside `Player`. If a component that needs player state renders outside `Player`, lift `Player` above it: it's a context provider that renders no DOM, so wrapping a page or layout in it changes nothing visually and puts the store in reach of everything inside.
+
 Use a ref for imperative browser media APIs or for custom events that do not have React event props, such as `sourcechange`. The ref value is the rendered `HTMLVideoElement`.
 
 </FrameworkCase>

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -523,7 +523,7 @@ function Elapsed() {
 
 Every feature has a selector (`selectPlayback`, `selectTime`, `selectVolume`, `selectQuality`, `selectLive`, `selectTextTrack`, and so on) for when you want a whole slice rather than one value.
 
-`usePlayer` reads through context, so it only works inside `Player`. If a component that needs player state renders outside `Player`, lift `Player` above it: it's a context provider that renders no DOM, so wrapping a page or layout in it changes nothing visually and puts the store in reach of everything inside.
+The pair works exactly like React Context: `Player` is the Provider, and `usePlayer` is its `useContext`-style consumer, so it only works inside `Player`. If a component that needs player state renders outside `Player`, lift `Player` above it the way you'd lift any Provider. It renders no DOM, so wrapping a page or layout in it changes nothing visually and puts the store in reach of everything inside.
 
 Use a ref for imperative browser media APIs or for custom events that do not have React event props, such as `sourcechange`. The ref value is the rendered `HTMLVideoElement`.
 

--- a/site/src/content/docs/reference/player.mdx
+++ b/site/src/content/docs/reference/player.mdx
@@ -126,6 +126,8 @@ Everything that needs player state goes inside `Player`: skins, containers, UI c
 
 <FrameworkCase frameworks={["react"]}>
 `Player` renders no DOM element of its own — it's purely a state wrapper. Put sizing, positioning, borders, backgrounds, and DOM measurements on the <DocsLink slug="reference/player-container">`Container`</DocsLink>, not `Player`.
+
+Because it renders nothing, `Player` behaves like any React context provider: if a component needs player state, lift `Player` above it. Wrapping a page section, a route, or even your whole app in `Player` costs nothing visually and keeps <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> available wherever you need it.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
 Packaged skins make `<video-player>` boxless with `display: contents`. Width, height, positioning, transforms, and `getBoundingClientRect()` do not describe a visible player box there. Put layout and measurements on the <DocsLink slug="reference/player-container">`<media-container>`</DocsLink> instead.

--- a/site/src/content/docs/reference/player.mdx
+++ b/site/src/content/docs/reference/player.mdx
@@ -127,7 +127,7 @@ Everything that needs player state goes inside `Player`: skins, containers, UI c
 <FrameworkCase frameworks={["react"]}>
 `Player` renders no DOM element of its own — it's purely a state wrapper. Put sizing, positioning, borders, backgrounds, and DOM measurements on the <DocsLink slug="reference/player-container">`Container`</DocsLink>, not `Player`.
 
-Because it renders nothing, `Player` behaves like any React context provider: if a component needs player state, lift `Player` above it. Wrapping a page section, a route, or even your whole app in `Player` costs nothing visually and keeps <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> available wherever you need it.
+`Player` is the Provider half of a React Context pair, with <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> as its consumer, and it renders nothing. If a component needs player state, lift `Player` above it the way you'd lift any Provider: wrapping a page section, a route, or even your whole app in `Player` costs nothing visually and keeps `usePlayer` available wherever you need it.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
 Packaged skins make `<video-player>` boxless with `display: contents`. Width, height, positioning, transforms, and `getBoundingClientRect()` do not describe a visible player box there. Put layout and measurements on the <DocsLink slug="reference/player-container">`<media-container>`</DocsLink> instead.

--- a/site/src/content/docs/reference/use-player.mdx
+++ b/site/src/content/docs/reference/use-player.mdx
@@ -21,6 +21,8 @@ The `usePlayer` hook returned by <DocsLink slug="reference/create-player">`creat
 const { Player, usePlayer } = createPlayer({ features: videoFeatures });
 ```
 
+`usePlayer` reads the store through context, so the calling component must render inside `Player`. You can still read state anywhere: <DocsLink slug="reference/player">`Player`</DocsLink> works like any React context provider and renders no DOM of its own, so lift it above every component that needs player state.
+
 `usePlayer` is also available as a standalone import (`import { usePlayer } from '@videojs/react'`), but the standalone version returns an untyped `UnknownStore`. Pass a premade selector to recover typing:
 
 ```tsx

--- a/site/src/content/docs/reference/use-player.mdx
+++ b/site/src/content/docs/reference/use-player.mdx
@@ -21,7 +21,7 @@ The `usePlayer` hook returned by <DocsLink slug="reference/create-player">`creat
 const { Player, usePlayer } = createPlayer({ features: videoFeatures });
 ```
 
-`usePlayer` reads the store through context, so the calling component must render inside `Player`. You can still read state anywhere: <DocsLink slug="reference/player">`Player`</DocsLink> works like any React context provider and renders no DOM of its own, so lift it above every component that needs player state.
+The pair works exactly like React Context: <DocsLink slug="reference/player">`Player`</DocsLink> is the Provider, and `usePlayer` is its `useContext`-style consumer, so the calling component must render inside `Player`. You can still read state anywhere: `Player` renders no DOM of its own, so lift it above every component that needs player state, the way you'd lift any Provider.
 
 `usePlayer` is also available as a standalone import (`import { usePlayer } from '@videojs/react'`), but the standalone version returns an untyped `UnknownStore`. Pass a premade selector to recover typing:
 


### PR DESCRIPTION
Readers asked how to reach player state outside the player subtree. States the mental model where they look for it, in explicitly React terms: the pair works exactly like React Context — `Player` is the Provider, `usePlayer` is its `useContext`-style consumer — and `Player` renders no DOM, so lift it above every component that needs state. Added to the `usePlayer` reference, the `Player` reference's React branch, and the Mux Player guide's "Read player state" section. Deliberately does not recommend external-store bridge patterns.

**Stack 6/13**. Base: `claude/docs-stack-05-imperative-control`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47)_


---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no code, config, or behavioral changes.
> 
> **Overview**
> Adds parallel guidance in three docs so readers know how to reach player state outside the immediate player UI tree.
> 
> **`usePlayer` reference**, **`Player` reference** (React "No visual presence"), and the **Mux migration** "Read player state" section now state that **`Player` / `usePlayer` behave like a React Context provider and consumer**, that hooks only work under **`Player`**, and that **`Player` renders no DOM**—so you can wrap a page, route, or app and lift the provider without changing layout.
> 
> No API or runtime changes; prose only, aligned with the PR goal of avoiding external-store bridge patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 051b17b86fa93d9c9ba9b946d7fa5131b6c4e55e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>