### PR TITLE
docs(site): structure poster guidance as a decision hierarchy

### DIFF
--- a/site/src/content/docs/how-to/add-a-poster-and-loading-placeholder.mdx
+++ b/site/src/content/docs/how-to/add-a-poster-and-loading-placeholder.mdx
@@ -6,11 +6,64 @@ description: Set the image shown before playback, then add a lightweight placeho
 import DocsLink from '@/components/docs/DocsLink.astro';
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
 
-A poster is the image shown before your video plays. Set one on the player. If it loads slowly, add a small placeholder so the player does not start as empty space.
+A poster is the image shown before your video plays. There are several places to set one, so work down this list and stop at the first step that fits:
 
-## Set a poster
+1. **Let the media provide it.** Some media components create a poster from the source, so there is nothing extra to host or keep in sync.
+2. **Set `poster` on the player.** With a packaged skin, that is all a static image needs.
+3. **Take control of the image** when you need a framework image component, a `<picture>` element, or a loading placeholder. The skin renders your image instead of its own.
+4. **Keep it working in an <DocsLink slug="how-to/customize-skins">ejected skin</DocsLink>.** The player's `poster` still reaches the Poster component your skin renders, or you can set the image's source yourself.
 
-Set the player's `poster` to an image URL:
+## Let the media provide a poster
+
+Some media components choose a poster for you. For example, `MuxVideo` creates one from its playback ID:
+
+<FrameworkCase frameworks={["react"]}>
+
+```tsx
+import '@videojs/react/video/skin.css';
+import { MuxVideo } from '@videojs/react/media/mux-video';
+import { VideoPlayer, VideoSkin } from '@videojs/react/video';
+
+export function MyPlayer() {
+  return (
+    <VideoPlayer>
+      <VideoSkin>
+        <MuxVideo
+          source={{
+            playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
+            poster: { time: 2 },
+          }}
+          playsInline
+        />
+      </VideoSkin>
+    </VideoPlayer>
+  );
+}
+```
+
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+
+```html
+<video-player>
+  <video-skin>
+    <mux-video
+      src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"
+      poster-time="2"
+      playsinline
+    ></mux-video>
+  </video-skin>
+</video-player>
+```
+
+</FrameworkCase>
+
+When the player and media component both choose a poster, the player's `poster` wins. See <DocsLink slug="reference/feature-metadata">Metadata</DocsLink> for how the player combines those values.
+
+## Set a poster on the player
+
+When the media has no poster of its own, set the player's `poster` to an image URL:
 
 <FrameworkCase frameworks={["react"]}>
 
@@ -47,15 +100,63 @@ If you use a ready-made skin, it includes <DocsLink slug="reference/poster">Post
 
 Posters are decorative by default, with an empty `alt`. If the image communicates something that is not available elsewhere, add `alt` text when you customize the poster image.
 
+## Take control of the poster image
+
+The packaged skins also accept an image of your own, for when a plain `<img>` is not enough:
+
+<FrameworkCase frameworks={["react"]}>
+
+Pass `renderPoster` to the skin. Video.js passes the poster URL as `src` alongside the rest of the image props; `src` stays `undefined` until a poster URL resolves. That fits a framework image component:
+
+```tsx
+import '@videojs/react/video/skin.css';
+import { Video, VideoPlayer, VideoSkin } from '@videojs/react/video';
+import NextImage from 'next/image';
+
+export function MyPlayer() {
+  return (
+    <VideoPlayer poster="/poster.jpg">
+      <VideoSkin
+        renderPoster={({ src, ...props }) =>
+          src ? <NextImage {...props} src={src} alt="" fill /> : null
+        }
+      >
+        <Video src="/video.mp4" playsInline />
+      </VideoSkin>
+    </VideoPlayer>
+  );
+}
+```
+
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+
+Add your image to the skin's `poster` slot. Leave off `src` and Video.js fills in the player's poster. Provide a `src`, a `srcset`, or `<picture>` sources and Video.js leaves the image alone:
+
+```html
+<video-player>
+  <video-skin>
+    <video src="/video.mp4" playsinline></video>
+    <picture slot="poster">
+      <source media="(min-width: 1200px)" srcset="/poster-1080.jpg" />
+      <img src="/poster-480.jpg" alt="" />
+    </picture>
+  </video-skin>
+</video-player>
+```
+
+</FrameworkCase>
+
 ## Add a loading placeholder
 
-A placeholder is a tiny preview that appears while the poster downloads. Keep it small enough to include with the page, such as a short data URL.
+A placeholder is a tiny preview that appears while the poster downloads, so a slow poster does not leave the player as empty space. Keep it small enough to include with the page, such as a short data URL. Add it to the customized image from the previous section.
 
 <FrameworkCase frameworks={["react"]}>
 
 ### Use your framework's image component
 
-If you use `VideoSkin`, pass your framework's image component to `renderPoster`. Video.js passes the poster URL as `src`.
+If your image component supports placeholders, pass yours through `renderPoster`:
 
 ```tsx
 import '@videojs/react/video/skin.css';
@@ -124,7 +225,7 @@ export function MyPlayer() {
 
 ### Add an image to the poster slot
 
-If you use `<video-skin>`, add an image to its `poster` slot. Leave off `src`: Video.js adds the poster URL, while the background appears immediately.
+Add an image to the skin's `poster` slot with the placeholder as its background. Leave off `src`: Video.js adds the poster URL, while the background appears immediately.
 
 ```html
 <video-player poster="/poster.jpg">
@@ -143,59 +244,15 @@ If you use `<video-skin>`, add an image to its `poster` slot. Leave off `src`: V
 
 The examples use `contain` for both images. Use `cover` for both when the poster should fill the player. Keeping the same size and position prevents the image from jumping when the poster appears.
 
-## Let the media choose a poster
+## Set the poster in an ejected skin
 
-Some media components choose a poster for you. For example, `MuxVideo` creates one from its playback ID:
-
-<FrameworkCase frameworks={["react"]}>
-
-```tsx
-import '@videojs/react/video/skin.css';
-import { MuxVideo } from '@videojs/react/media/mux-video';
-import { VideoPlayer, VideoSkin } from '@videojs/react/video';
-
-export function MyPlayer() {
-  return (
-    <VideoPlayer>
-      <VideoSkin>
-        <MuxVideo
-          source={{
-            playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
-            poster: { time: 2 },
-          }}
-          playsInline
-        />
-      </VideoSkin>
-    </VideoPlayer>
-  );
-}
-```
-
-</FrameworkCase>
-
-<FrameworkCase frameworks={["html"]}>
-
-```html
-<video-player>
-  <video-skin>
-    <mux-video
-      src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"
-      poster-time="2"
-      playsinline
-    ></mux-video>
-  </video-skin>
-</video-player>
-```
-
-</FrameworkCase>
-
-When the player and media component both choose a poster, the player's `poster` wins. See <DocsLink slug="reference/feature-metadata">Metadata</DocsLink> for how the player combines those values.
-
-## Add a poster to your own UI
+Ejecting a skin changes nothing about the first two approaches: the player's `poster`, or the poster the media provides, still reaches the <DocsLink slug="reference/poster">Poster</DocsLink> component your skin renders.
 
 <FrameworkCase frameworks={["react"]}>
 
-When your UI already includes Poster, apply the same placeholder directly:
+Poster renders an `<img>` and fills its `src` from the player, so `srcSet`, `sizes`, `loading`, and the rest of the image attributes are yours. Provide your own `src` or `srcSet` and Video.js leaves the image alone.
+
+When your UI already includes Poster, apply a placeholder through its `render` prop:
 
 ```tsx
 <Poster
@@ -216,7 +273,9 @@ When your UI already includes Poster, apply the same placeholder directly:
 
 <FrameworkCase frameworks={["html"]}>
 
-In an ejected skin, put the image inside `<media-poster>`:
+`<media-poster>` fills the `src` of the image inside it. Give that image a `src`, a `srcset`, or `<picture>` sources instead and Video.js leaves it untouched — set the source at this level when the poster should bypass player state entirely.
+
+For a placeholder, put the background on the image inside `<media-poster>`:
 
 ```html
 <media-poster>

--- a/site/src/content/docs/how-to/add-a-poster-and-loading-placeholder.mdx
+++ b/site/src/content/docs/how-to/add-a-poster-and-loading-placeholder.mdx
@@ -59,8 +59,6 @@ export function MyPlayer() {
 
 </FrameworkCase>
 
-When the player and media component both choose a poster, the player's `poster` wins. See <DocsLink slug="reference/feature-metadata">Metadata</DocsLink> for how the player combines those values.
-
 ## Set a poster on the player
 
 When the media has no poster of its own, set the player's `poster` to an image URL:
@@ -97,6 +95,8 @@ export function MyPlayer() {
 </FrameworkCase>
 
 If you use a ready-made skin, it includes <DocsLink slug="reference/poster">Poster</DocsLink> and shows the image automatically. If you build your own UI, add Poster yourself. It hides after the user plays or seeks.
+
+When the player and the media component both choose a poster, the player's `poster` wins. See <DocsLink slug="reference/feature-metadata">Metadata</DocsLink> for how the player combines those values.
 
 Posters are decorative by default, with an empty `alt`. If the image communicates something that is not available elsewhere, add `alt` text when you customize the poster image.
 

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -55,14 +55,12 @@ The easiest path is the CDN:
 ```html
 <script type="module" src="{{VJS10_HTML_CDN_BASE}}/video-minimal.js"></script>
 
-<video-player>
+<video-player poster="/path/to/poster.jpg">
   <video-minimal-skin>
     <video src="/path/to/video.mp4" playsinline>
       <track kind="captions" label="English" src="/path/to/captions/en.vtt" srclang="en" default />
       <track kind="metadata" label="thumbnails" src="/path/to/storyboard.vtt" default />
     </video>
-
-    <img slot="poster" src="/path/to/poster.jpg" alt="" />
   </video-minimal-skin>
 </video-player>
 ```
@@ -77,7 +75,7 @@ import '@videojs/html/video/minimal-skin';
 ### Notes
 
 - The skin attaches its styles automatically to its shadow root.
-- The poster is a slotted `img` rather than a `poster` attribute, which gives the skin control over how it appears. That's much like Plyr's `data-poster`.
+- The poster moves from `data-poster` on the media to `poster` on `<video-player>`. The skin reads that value and controls how the poster appears. To supply your own image element, see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink>.
 - There's also a default skin with a modern, frosted appearance that some may prefer. Try it by removing the `-minimal` suffix from the script `src` if you're using the CDN, or the `minimal-` prefix from the imports.
 
 </FrameworkCase>
@@ -119,7 +117,7 @@ export function AppVideoPlayer({ origin }: AppVideoPlayerProps) {
 ### Notes
 
 - `@videojs/react/video` is a <DocsLink slug="concepts/presets">preset</DocsLink>: a player, a skin, and a media element that already fit together. `VideoPlayer` is the piece that owns the state, built from the standard set of <DocsLink slug="concepts/features">features</DocsLink> for video.
-- The poster URL is metadata on `VideoPlayer`. The skin reads that metadata and controls how the poster appears. To replace the rendered image, pass `renderPoster` to the skin.
+- The poster URL is metadata on `VideoPlayer`. The skin reads that metadata and controls how the poster appears. To replace the rendered image, pass `renderPoster` to the skin — see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink>.
 - This example assumes all your files for a given asset live in the same path, using consistent filenames. This will almost certainly need adjusting for your implementation.
 - If `origin` points somewhere other than your page's origin, add `crossOrigin="anonymous"` to `<Video>` and serve those files with CORS headers. A cross-origin thumbnail track only loads when the media element is CORS-enabled. See <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink>.
 - There's also a default skin with a modern, frosted appearance that some may prefer. Try it by switching the CSS import filename to `skin.css` and the `MinimalVideoSkin` import and usage to `VideoSkin`.
@@ -350,7 +348,7 @@ Here's a matrix for configuration options in Plyr and how each maps to Video.js 
 | `controls` | The <DocsLink slug="concepts/skins">skins</DocsLink> include all the common controls, laid out in a familiar way that users would expect. If you want to customize the skin beyond basic colors, you can [eject the skin](#eject-a-skin) and change layout, styles, or icons. |
 | `settings` | Included automatically in the skins when quality, speed, audio tracks, or captions are available. |
 | `autoplay`, `muted`, `loop`, `playsinline`, `preload` | These are attributes on your media (e.g. `<video>`) component. |
-| `poster` / `data-poster` | In HTML, slot an image into the skin. In React, set `poster` on `VideoPlayer`. See [Basic migration](#basic-migration). |
+| `poster` / `data-poster` | Set `poster` on `<video-player>` or `VideoPlayer`. See [Basic migration](#basic-migration). |
 | `ratio` | Set `aspect-ratio` in CSS on the skin component. |
 | `hideControls` | Preset skins auto-hide controls based on activity. The delay is currently not configurable. |
 | `clickToPlay` | Preset video skins include click and tap gestures. [Eject the skin](#eject-a-skin) to remove or change them. |

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -75,7 +75,7 @@ import '@videojs/html/video/minimal-skin';
 ### Notes
 
 - The skin attaches its styles automatically to its shadow root.
-- The poster moves from `data-poster` on the media to `poster` on `<video-player>`. The skin reads that value and controls how the poster appears. To supply your own image element, see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink>.
+- The poster moves from `data-poster` on the media to `poster` on `<video-player>`. The skin reads that value and controls how the poster appears. For more advanced control (like supplying your own image element), see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink>.
 - There's also a default skin with a modern, frosted appearance that some may prefer. Try it by removing the `-minimal` suffix from the script `src` if you're using the CDN, or the `minimal-` prefix from the imports.
 
 </FrameworkCase>

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -82,14 +82,12 @@ v10 ships web components, so the migration keeps its declarative feel. One scrip
 ```html
 <script type="module" src="{{VJS10_HTML_CDN_BASE}}/video.js"></script>
 
-<video-player>
+<video-player poster="/poster.jpg">
   <video-skin class="aspect-video">
     <video src="/video.mp4" preload="auto" playsinline>
       <track kind="captions" src="/captions/en.vtt" srclang="en" label="English" default />
       <track kind="metadata" src="/storyboard.vtt" label="thumbnails" default />
     </video>
-
-    <img slot="poster" src="/poster.jpg" alt="" />
   </video-skin>
 </video-player>
 ```
@@ -105,7 +103,7 @@ Four differences worth understanding, because each one is a pattern you'll see a
 
 - **No `class="video-js"`, no `data-setup`, no `videojs()` call.** The custom elements register themselves and wire up when the browser upgrades them. Nothing scans the page looking for players.
 - **No `controls` attribute.** The skin *is* the controls. Including a skin is how you ask for them, which is also how you opt out: leave it out and you get a player with no UI.
-- **The poster is a slotted image, not an attribute.** That's what lets the skin control how it appears, rather than the browser.
+- **The poster is player metadata, not a media attribute.** Set `poster` on `<video-player>`, and the skin, not the browser, controls how it appears. To supply your own image element, see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink>.
 - **Your `<track>` elements don't change.** Captions, subtitles, chapters, and thumbnails are all still tracks, and the skin shows the matching controls when it finds them.
 
 There's also a minimal skin, closer to v8's control bar if the default's frosted look is too much of a change. Swap `cdn/video.js` for `cdn/video-minimal.js`.
@@ -232,7 +230,7 @@ The poster belongs to player state rather than the media, which lets the skin co
 ```
 </FrameworkCase>
 
-The packaged skins do not place the title in their default layouts. Add the <DocsLink slug="reference/title">Title</DocsLink> component as a child of the skin, or place it in an ejected or custom layout. See the <DocsLink slug="reference/poster">Poster</DocsLink> reference for poster rendering options.
+The packaged skins do not place the title in their default layouts. Add the <DocsLink slug="reference/title">Title</DocsLink> component as a child of the skin, or place it in an ejected or custom layout. For poster rendering options — including placeholders and custom image elements — see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink> and the <DocsLink slug="reference/poster">Poster</DocsLink> reference.
 
 ### Your CSS
 

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -103,7 +103,7 @@ Four differences worth understanding, because each one is a pattern you'll see a
 
 - **No `class="video-js"`, no `data-setup`, no `videojs()` call.** The custom elements register themselves and wire up when the browser upgrades them. Nothing scans the page looking for players.
 - **No `controls` attribute.** The skin *is* the controls. Including a skin is how you ask for them, which is also how you opt out: leave it out and you get a player with no UI.
-- **The poster is player metadata, not a media attribute.** Set `poster` on `<video-player>`, and the skin, not the browser, controls how it appears. To supply your own image element, see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink>.
+- **The poster is player metadata, not a media attribute.** Set `poster` on `<video-player>`, and the skin, not the browser, controls how it appears. For more advanced control (like supplying your own image element), see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink>.
 - **Your `<track>` elements don't change.** Captions, subtitles, chapters, and thumbnails are all still tracks, and the skin shows the matching controls when it finds them.
 
 There's also a minimal skin, closer to v8's control bar if the default's frosted look is too much of a change. Swap `cdn/video.js` for `cdn/video-minimal.js`.


### PR DESCRIPTION
The poster how-to now leads with a stop-at-the-first-fit hierarchy: (1) let the media provide a poster, (2) set `poster` on the player for packaged skins, (3) use `renderPoster` / the `poster` slot for more control (framework image components, `<picture>`), (4) in an ejected skin the player's `poster` still works, or set the image source directly. The player-wins precedence rule now closes the "set a poster on the player" section, where the reader has just seen both mechanisms.

Also fixes the Video.js 8 and Plyr guides, whose prose claimed the HTML poster is a slotted image rather than an attribute — contradicting their own mapping tables. Prose and examples now agree with the tables and link to the how-to. All API claims verified against `packages/react/src/ui/poster/poster.tsx`, `packages/html/src/ui/poster/poster-element.ts`, and the preset skins.

**Stack 7/13**. Base: `claude/docs-stack-06-react-provider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47)_


---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to site MDX; no runtime or API code modified.
> 
> **Overview**
> **Poster how-to** is reorganized around a four-step "stop when it fits" flow: media-generated poster → `poster` on the player → `renderPoster` / `poster` slot for custom images and placeholders → ejected-skin behavior. Content that was scattered (Mux examples, precedence rules, Next.js/`picture` customization) is split into matching sections, and the loading-placeholder guidance explicitly builds on the custom-image step.
> 
> **Plyr and Video.js 8 migration guides** no longer tell readers to use a slotted `<img>` as the default HTML pattern. Examples and bullets now set **`poster` on `<video-skin>`** (aligned with the option tables), with pointers to the poster how-to for `renderPoster`, slots, and placeholders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdccd4a53dfe08d3fad0d8bb06bc7654f13285ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>