### PR TITLE
docs(site): lead HLS and Mux flavor choices with the default

### DIFF
--- a/site/scripts/api-docs-builder/src/preset-handler.ts
+++ b/site/scripts/api-docs-builder/src/preset-handler.ts
@@ -22,6 +22,8 @@
  *   - *Skin → skin
  *   - Remaining → media element
  * - .tailwind in filename → excluded (both frameworks)
+ * - No HTML media element found → derived from the React media element when it wraps a native tag (Video → `video`, Audio
+ *   → `audio`), so every preset framework pair reports the same default media
  *
  * Feature resolution: packages/core/src/dom/store/features/presets.ts
  */
@@ -512,6 +514,16 @@ function scanReactDirectory(scanDir: string, barrelPath: string, presetName: str
 
 // ─── Preset Reference Building ──────────────────────────────────────
 
+/**
+ * React media components that render a native element rather than a custom element. The HTML directory scan can't see
+ * these — there is no class with a `static tagName` for a plain `<video>` — so the native tag is derived from the React
+ * barrel's media re-export instead.
+ */
+const NATIVE_MEDIA_TAGS: Record<string, string> = {
+  Audio: 'audio',
+  Video: 'video',
+};
+
 function buildPresetReference(
   preset: PresetInfo,
   featureBundleMap: Map<string, string[]>,
@@ -548,7 +560,9 @@ function buildPresetReference(
     react: { skins: reactSkins, mediaElement: reactMediaElement ?? '' },
   };
 
-  if (htmlResult.mediaElement) ref.html.mediaElement = htmlResult.mediaElement;
+  const htmlMediaElement = htmlResult.mediaElement ?? (reactMediaElement && NATIVE_MEDIA_TAGS[reactMediaElement]);
+
+  if (preset.html && htmlMediaElement) ref.html.mediaElement = htmlMediaElement;
 
   if (description) ref.description = description;
 

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -1214,7 +1214,9 @@ describe('Feature pipeline (end-to-end)', () => {
 //   - Discovery: reads package.json exports for ./X + ./X/* pairs
 //   - Feature bundle: *Features export from barrel → resolved to feature names
 //   - HTML skins: classes with static tagName whose name matches *Skin*Element
-//   - HTML media element: classes with static tagName that aren't skins or players
+//   - HTML media element: classes with static tagName that aren't skins or
+//     players; native tags derived from the React media element (Video →
+//     video, Audio → audio) when the scan finds none
 //   - React skins: exports matching *Skin naming
 //   - React media element: remaining exports that aren't bundles or skins
 //   - Tailwind exclusion: .tailwind files are filtered out
@@ -1307,10 +1309,10 @@ describe('Preset pipeline (end-to-end)', () => {
       expect(skinNames).not.toContain('VideoSkinTailwindElement');
     });
 
-    it('does not produce an HTML media element for native video', () => {
+    it('derives the native HTML media element from the React media component', () => {
       const ref = findPreset('video')!.reference;
 
-      expect(ref.html.mediaElement).toBeUndefined();
+      expect(ref.html.mediaElement).toBe('video');
     });
 
     it('detects React skins with CSS imports', () => {
@@ -1360,10 +1362,10 @@ describe('Preset pipeline (end-to-end)', () => {
       expect(skins).toEqual([{ name: 'AudioSkinElement', tagName: 'audio-skin' }]);
     });
 
-    it('does not produce an HTML media element for native audio', () => {
+    it('derives the native HTML media element from the React media component', () => {
       const ref = findPreset('audio')!.reference;
 
-      expect(ref.html.mediaElement).toBeUndefined();
+      expect(ref.html.mediaElement).toBe('audio');
     });
 
     it('detects single React skin with CSS import', () => {

--- a/site/src/components/docs/api-reference/PresetReference.astro
+++ b/site/src/components/docs/api-reference/PresetReference.astro
@@ -33,19 +33,6 @@ const presets: PresetReferenceType[] = entries
 const { framework } = Astro.params;
 const pkg = framework && isValidFramework(framework) ? `@videojs/${framework}` : '@videojs/html';
 
-/**
- * Native media elements used by presets that don't have a custom element.
- * The pipeline can't detect these since they're not classes with `static tagName`.
- */
-const NATIVE_MEDIA_ELEMENTS: Record<string, string> = {
-  video: 'video',
-  audio: 'audio',
-};
-
-function htmlMediaElement(preset: PresetReferenceType): string | undefined {
-  return preset.html.mediaElement ?? NATIVE_MEDIA_ELEMENTS[preset.name];
-}
-
 const listFormat = new Intl.ListFormat('en', { style: 'long', type: 'unit' });
 ---
 
@@ -62,7 +49,7 @@ const listFormat = new Intl.ListFormat('en', { style: 'long', type: 'unit' });
       {
         presets.map((preset) => {
           const id = `preset-${preset.name}`;
-          const htmlMedia = htmlMediaElement(preset);
+          const htmlMedia = preset.html.mediaElement;
           return (
             <>
               <Tr

--- a/site/src/content/docs/how-to/add-quality-selector.mdx
+++ b/site/src/content/docs/how-to/add-quality-selector.mdx
@@ -132,7 +132,7 @@ Access the player store through the <DocsLink slug="reference/player-controller"
 
 ### The quality menu doesn't render
 
-Quality availability is `'unavailable'`. The source is progressive (no renditions), the manifest hasn't loaded yet, or the media element doesn't support renditions. Use a streaming media element such as <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>.
+Quality availability is `'unavailable'`. The source is progressive (no renditions), the manifest hasn't loaded yet, or the media element doesn't support renditions. Use a streaming media element such as the default <DocsLink slug="reference/hls-video">HlsVideo</DocsLink> or <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>.
 
 ### The menu doesn't render for a single-rendition stream
 
@@ -151,6 +151,7 @@ The pinned rendition exceeds available bandwidth. Selecting "Auto" lets the engi
 
 - <DocsLink slug="reference/feature-quality">Quality feature</DocsLink>
 - <DocsLink slug="reference/use-quality-options">useQualityOptions</DocsLink>
+- <DocsLink slug="reference/hls-video">HlsVideo</DocsLink>
 - <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>
 - <DocsLink slug="reference/dash-video">DashVideo</DocsLink>
 

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -546,7 +546,7 @@ Control everything through the player: "the player's" entries are store actions,
 
 You can skip this section until you hit one of the two problems in it.
 
-`MuxVideo` comes in two flavors, backed by two different playback engines, and the import path chooses:
+`MuxVideo` comes in two flavors, backed by two different playback engines, and the import path chooses between them. Start with the default. The tradeoff: the `/spf` flavor is smaller and the `/hls-js` flavor is more compatible:
 
 | Import | Engine | When |
 |---|---|---|

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -315,7 +315,7 @@ import { HlsVideo } from '@videojs/react/media/hls-video';
 ```
 </FrameworkCase>
 
-Two things to know when you pick between the HLS options. The default HLS component runs on SPF, Video.js's own playback engine, and it's the reason v10 can be as small as it is. The hls.js one is a much larger download but supports more, including TS-packaged media and DRM. Start with the default and move to hls.js if you hit something it doesn't handle.
+Start with the default HLS component, and move to hls.js if you hit something it doesn't handle. The default runs on SPF, Video.js's own playback engine, and it's the reason v10 can be as small as it is. The hls.js one is a much larger download but more compatible, supporting TS-packaged media and DRM.
 
 Your VHS tuning options don't have direct equivalents. Rendition capping, bandwidth hints, and the rest are engine-specific, so they belong to whichever engine you chose rather than to a shared options object.
 

--- a/site/src/content/docs/how-to/play-live-streams.mdx
+++ b/site/src/content/docs/how-to/play-live-streams.mdx
@@ -53,6 +53,8 @@ export default function App() {
 
 </FrameworkCase>
 
+The examples use <DocsLink slug="reference/hlsjs-video">`HlsJsVideo`</DocsLink>, but any streaming media component works here, including the smaller default <DocsLink slug="reference/hls-video">`HlsVideo`</DocsLink>. Start with the default and switch engines only if your stream needs it.
+
 The `liveVideoFeatures` bundle mirrors <DocsLink slug="concepts/features">`videoFeatures`</DocsLink> but adds the live feature and drops playback rate (not meaningful for live), quality selection, and audio-track selection. The live presets also ship skins without a time slider, duration display, or current-time display.
 
 Both bundles are plain arrays, so extending one is a spread:

--- a/site/src/content/docs/how-to/self-host-the-player.mdx
+++ b/site/src/content/docs/how-to/self-host-the-player.mdx
@@ -32,7 +32,7 @@ You get one file (plus a sourcemap), no runtime requests to a CDN, and only the 
 
 ## Availability and constraints
 
-- HLS and other non-default media need their own module on top of the player, and your self-hosted build has to include it. When bundling, add the media import to your entry file (`import '@videojs/html/media/hlsjs-video';`) and use the matching `<hlsjs-video>` element with your `.m3u8` source. When mirroring the CDN files, serve the media file too and add its script tag (`<script type="module" src="/videojs/media/hlsjs-video.js"></script>`).
+- HLS and other non-default media need their own module on top of the player, and your self-hosted build has to include it. When bundling, add the media import to your entry file (`import '@videojs/html/media/hlsjs-video';`) and use the matching `<hlsjs-video>` element with your `.m3u8` source. When mirroring the CDN files, serve the media file too and add its script tag (`<script type="module" src="/videojs/media/hlsjs-video.js"></script>`). The same pattern applies to every media module, including the smaller default HLS element (`media/hls-video`).
 
 ## Common variations
 

--- a/site/src/content/docs/reference/hls-video.mdx
+++ b/site/src/content/docs/reference/hls-video.mdx
@@ -21,7 +21,7 @@ import basicUsageHtml from "@/components/docs/demos/hls-video/html/css/BasicUsag
 import basicUsageHtmlCss from "@/components/docs/demos/hls-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/hls-video/html/css/BasicUsage.ts?raw";
 
-Lightweight HLS video element optimized for minimal bundle size. For full hls.js feature support, use [HlsJsVideo](/docs/framework/html/reference/hlsjs-video/) instead.
+The default HLS video element, optimized for minimal bundle size. [HlsJsVideo](/docs/framework/html/reference/hlsjs-video/) is the larger, more compatible alternative.
 
 ## Examples
 

--- a/site/src/content/docs/reference/hlsjs-video.mdx
+++ b/site/src/content/docs/reference/hlsjs-video.mdx
@@ -22,7 +22,7 @@ import basicUsageHtml from "@/components/docs/demos/hlsjs-video/html/css/BasicUs
 import basicUsageHtmlCss from "@/components/docs/demos/hlsjs-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/hlsjs-video/html/css/BasicUsage.ts?raw";
 
-HLS video element powered by [hls.js](https://github.com/video-dev/hls.js/) for adaptive bitrate streaming. It's the recommended choice for HLS playback: full feature support across every browser. For alternatives, see [NativeHlsVideo](/docs/framework/html/reference/native-hls-video/) (browser-native HLS) or [HlsVideo](/docs/framework/html/reference/hls-video/) (lightweight HLS).
+HLS video element powered by [hls.js](https://github.com/video-dev/hls.js/) for adaptive bitrate streaming, with full feature support across every browser. It's more compatible than the default [HlsVideo](/docs/framework/html/reference/hls-video/), which is smaller and covers most HLS playback. For browser-native playback, see [NativeHlsVideo](/docs/framework/html/reference/native-hls-video/).
 
 ## Examples
 


### PR DESCRIPTION
The pages presenting the media flavor choice (hls-video and hlsjs-video references, the Video.js 8 guide, the Mux Player guide) now lead with the default and state the tradeoff plainly: `/spf` is smaller, `/hls.js` is more compatible. The hlsjs-video reference no longer calls itself "the recommended choice".

Also fixes the generated presets reference: live presets showed a React default component next to an empty HTML cell because the HTML scan can't see native `<video>`/`<audio>` tags. The generator now derives the native tag from the React barrel's media component, replacing the renderer's preset-name-keyed fallback map. Builder e2e suite updated and passing (189/189); regenerated output verified (`live-video → video`, `live-audio → audio`).

## Why the preset change is here

The live preset tables are part of the same reader-facing story: the mux and vjs8 guides send readers to the preset reference to pick a media component, and the live presets' HTML column rendered as empty (`–`) next to a populated React column — implying HTML live presets have no default media. The old workaround was a hardcoded preset-name→tag map inside `PresetReference.astro`, which silently goes stale when a preset is added; deriving the tag in the generator from the React barrel's media component keeps the two columns in agreement from one source.

## Netlify previews of affected pages

Generated preset tables (the generator fix — compare the live-video / live-audio rows' HTML default-component cells):
- [Presets concept (HTML)](https://deploy-preview-2464--vjs10-site.netlify.app/docs/framework/html/concepts/presets) · [same page on main](https://main.videojs.org/docs/framework/html/concepts/presets)
- [Skins concept (HTML)](https://deploy-preview-2464--vjs10-site.netlify.app/docs/framework/html/concepts/skins)

Prose changes:
- [hls-video reference](https://deploy-preview-2464--vjs10-site.netlify.app/docs/framework/html/reference/hls-video)
- [hlsjs-video reference](https://deploy-preview-2464--vjs10-site.netlify.app/docs/framework/html/reference/hlsjs-video)
- [Migrate from Mux Player](https://deploy-preview-2464--vjs10-site.netlify.app/docs/framework/react/how-to/migrate-from-mux-player)
- [Migrate from Video.js 8](https://deploy-preview-2464--vjs10-site.netlify.app/docs/framework/react/how-to/migrate-from-video-js-8)

**Stack 8/13**. Base: `claude/docs-stack-07-poster-hierarchy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47


---

> [!NOTE]
> **Low Risk**
> Documentation and docs-build output only; preset derivation is additive and covered by e2e tests.
> 
> **Overview**
> **Docs** now steer readers toward the default HLS path first: **`HlsVideo`** / SPF as the smaller default, **`HlsJsVideo`** as the larger, more compatible option. Reference pages (`hls-video`, `hlsjs-video`), migration guides (Video.js 8, Mux), and how-tos (live streams, quality selector, self-host) were updated so hls.js is no longer called "the recommended choice."
> 
> **Preset reference generation** fills in the HTML "default media element" when the HTML scan only sees native `<video>` / `<audio>` (no `static tagName` class). The api-docs builder maps React barrel media exports (`Video` → `video`, `Audio` → `audio`) so HTML and React preset columns stay aligned. **`PresetReference.astro`** drops the hardcoded preset-name → tag fallback in favor of generated `preset.html.mediaElement`. E2E preset tests expect `video` / `audio` for those presets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 858a5b37b39f375ed0fe3e619754d845efdb751a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>