### PR TITLE
docs(site): surface seek buttons for skin customizers and Plyr migrators

### DIFF
--- a/site/src/content/docs/how-to/customize-skins.mdx
+++ b/site/src/content/docs/how-to/customize-skins.mdx
@@ -91,7 +91,7 @@ Packaged video skins also let you replace the poster through the `renderPoster` 
 
 See <DocsLink slug="reference/poster">Poster</DocsLink>.
 
-For anything deeper, eject instead of reaching into the packaged skin. There are no packaged-skin options for adding, removing, or rearranging controls, or replacing its built-in feedback and interactions.
+For anything deeper, eject instead of reaching into the packaged skin. There are no packaged-skin options for adding, removing, or rearranging controls, or replacing its built-in feedback and interactions. Seek buttons are a common example: the audio skins include 10-second skip-back and skip-forward buttons, but the video skins ship without them. To add rewind and fast-forward controls to a video skin, eject it and place a <DocsLink slug="reference/seek-button">SeekButton</DocsLink> in the control bar.
 
 ## Eject a skin
 

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -345,7 +345,8 @@ Here's a matrix for configuration options in Plyr and how each maps to Video.js 
 
 | Plyr option | Video.js v10 |
 |---|---|
-| `controls` | The <DocsLink slug="concepts/skins">skins</DocsLink> include all the common controls, laid out in a familiar way that users would expect. If you want to customize the skin beyond basic colors, you can [eject the skin](#eject-a-skin) and change layout, styles, or icons. |
+| `controls` | The <DocsLink slug="concepts/skins">skins</DocsLink> include the common controls, laid out in a familiar way that users would expect. Not every Plyr control ships in every skin—the video skins do not include `rewind` and `fast-forward` buttons, for example. To change which controls appear, or to customize the skin beyond basic colors, [eject the skin](#eject-a-skin) and change controls, layout, styles, or icons. |
+| `rewind`, `fast-forward`, `seekTime` | The audio skins include 10-second skip buttons; the video skins do not. [Eject the skin](#eject-a-skin) and add a <DocsLink slug="reference/seek-button">SeekButton</DocsLink>, which skips by its `seconds` value (default `30`; negative values seek backward). |
 | `settings` | Included automatically in the skins when quality, speed, audio tracks, or captions are available. |
 | `autoplay`, `muted`, `loop`, `playsinline`, `preload` | These are attributes on your media (e.g. `<video>`) component. |
 | `poster` / `data-poster` | Set `poster` on `<video-player>` or `VideoPlayer`. See [Basic migration](#basic-migration). |


### PR DESCRIPTION
Plyr migrators couldn't find rewind and fast-forward. Maps Plyr's `rewind`, `fast-forward`, and `seekTime` onto `SeekButton` and its `seconds` config (default 30, negative = backward) in the Plyr guide's matrix, tempers its claim that packaged skins include *all* the common controls, and uses seek buttons as the concrete example in customize-skins' "Where packaged customization stops": audio skins ship 10-second skips, video skins ship none. Facts verified: `packages/core/src/core/ui/seek-button/core.ts:31`, `packages/html/src/presets/audio/skin.ts:8`, and zero SeekButton usage in the video presets.

**Stack 9/13**. Base: `claude/docs-stack-08-hls-messaging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47)_


---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to two how-to pages; no runtime or API changes.
> 
> **Overview**
> Clarifies that **packaged skins do not include every Plyr-style control**: audio presets ship 10-second skip buttons, while **video presets omit rewind/fast-forward**.
> 
> In **Customize skins**, the "where packaged customization stops" section now uses seek buttons as the concrete example—eject the skin and add a **SeekButton** in the control bar for video.
> 
> In **Migrate from Plyr**, the configuration matrix softens the `controls` row (not *all* common controls in every skin) and adds a row mapping **`rewind`**, **`fast-forward`**, and **`seekTime`** to **SeekButton** (`seconds`, default 30, negative for backward).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f291c2ac0d13e9a52ef54efbba2adf95d814a4d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>