### PR TITLE
fix(site): convert docs link cards to clean markdown list items

### DIFF
--- a/site/integrations/llms-markdown.ts
+++ b/site/integrations/llms-markdown.ts
@@ -61,6 +61,30 @@ export default function llmsMarkdown(): AstroIntegration {
           },
         });
 
+        // Flatten docs link cards, whose block markup nests inside the <a>, into list items.
+        // Emitting a single leading/trailing newline keeps a run of adjacent cards as one tight list.
+        turndown.addRule('docs-link-card', {
+          filter: (node) => node.nodeType === 1 && hasClass(node as Element, 'docs-link-card'),
+          replacement: (_content, node) => {
+            const link = (node as Element).querySelector('a[href]');
+            if (!link) return '';
+
+            // Card body is either <span>title</span> or <div><div>title</div><div>description</div></div>,
+            // followed by a chevron icon.
+            const body = Array.from(link.children).find((child) => child.tagName.toLowerCase() !== 'svg');
+            const blocks = body ? Array.from(body.children) : [];
+            const hasDescription = blocks.length > 1;
+
+            const title = collapseWhitespace((hasDescription ? blocks[0] : body)?.textContent);
+            if (!title) return '';
+
+            const description = hasDescription ? collapseWhitespace(blocks[1]?.textContent) : '';
+            const href = link.getAttribute('href') ?? '';
+
+            return description ? `\n- [${title}](${href}): ${description}\n` : `\n- [${title}](${href})\n`;
+          },
+        });
+
         // Track pages for their llms.txt indexes
         const docsPages: PageEntry[] = [];
         const blogPages: PageEntry[] = [];
@@ -229,6 +253,15 @@ export default function llmsMarkdown(): AstroIntegration {
       },
     },
   };
+}
+
+/** Element.classList is not implemented consistently across DOM shims, so read the attribute directly. */
+function hasClass(element: Element, className: string): boolean {
+  return (element.getAttribute('class') ?? '').split(/\s+/).includes(className);
+}
+
+function collapseWhitespace(text: string | null | undefined): string {
+  return (text ?? '').replace(/\s+/g, ' ').trim();
 }
 
 function capitalize(str: string): string {


### PR DESCRIPTION
`DocsLinkCard` renders block divs inside an anchor, which Turndown mangled into multi-paragraph links in the Copy Markdown / llms.txt output for every "See also" section. Adds a Turndown rule matching the stable `docs-link-card` class that emits `- [Title](url): description`, skipping the chevron icon and dropping the description cleanly when absent; consecutive cards join as a tight list. Verified against real turndown@7.2.2 + linkedom with both card markup branches.

Spotted while here (not fixed, pre-existing): `installation.mdx:202` passes an `anchor` prop that `DocsLinkCard` silently drops.

**Stack 10/13**. Base: `claude/docs-stack-09-skip-buttons`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47)_


---

> [!NOTE]
> **Low Risk**
> Build-time HTML-to-markdown conversion only; no runtime site behavior, auth, or data handling changes.
> 
> **Overview**
> **Copy Markdown** and **llms.txt** output no longer break "See also" sections into mangled multi-paragraph links when pages use `DocsLinkCard`.
> 
> The LLM markdown integration adds a Turndown rule for elements with the `docs-link-card` class. It pulls title, optional description, and `href` from the nested anchor markup (ignoring the chevron SVG) and emits standard list lines like `- [Title](url): description`, with spacing so adjacent cards stay one tight list. Small helpers `hasClass` and `collapseWhitespace` support DOM shims used during HTML→markdown conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939a7a3aae5288e1e6491a476b1bdd5b1410ed51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>