### PR TITLE
feat(site): show the documented Video.js version in the docs navbar

### DIFF
--- a/site/src/assets/logos/vjs.svg
+++ b/site/src/assets/logos/vjs.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="100%" height="100%" viewBox="0 0 103 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <path d="M28.614,0L28.614,30.65L12.305,0L0,0L20.743,38.975L38.908,38.975L38.908,0L28.614,0Z" style="fill-rule:nonzero;"/>
+    <path d="M28.614,0L28.614,30.65L12.305,0L0,0L20.743,38.975L38.908,38.975L38.908,0L28.614,0Z" fill="currentColor" style="fill-rule:nonzero;"/>
     <g transform="matrix(1,0,0,1,-121.115,0)">
         <path d="M210.515,14.782L204.24,14.782C202.522,14.782 201.141,13.956 201.141,12.257C201.141,10.559 202.476,9.885 204.148,9.855L221.286,9.855L221.286,0L203.765,0C197.167,0 190.34,4.682 190.34,12.181C190.34,19.679 197.167,24.086 203.765,24.086L210.04,24.086C211.789,24.086 213.2,24.881 213.2,26.626C213.2,28.37 211.773,29.135 210.04,29.135L190.555,29.135L190.555,38.975L210.531,38.975C217.158,38.975 224.017,34.751 224.017,26.626C224.017,19.067 217.158,14.767 210.531,14.767L210.515,14.782Z" style="fill:rgb(255,98,0);fill-rule:nonzero;"/>
     </g>

--- a/site/src/assets/logos/vjs.svg
+++ b/site/src/assets/logos/vjs.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 103 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <path d="M28.614,0L28.614,30.65L12.305,0L0,0L20.743,38.975L38.908,38.975L38.908,0L28.614,0Z" style="fill-rule:nonzero;"/>
+    <g transform="matrix(1,0,0,1,-121.115,0)">
+        <path d="M210.515,14.782L204.24,14.782C202.522,14.782 201.141,13.956 201.141,12.257C201.141,10.559 202.476,9.885 204.148,9.855L221.286,9.855L221.286,0L203.765,0C197.167,0 190.34,4.682 190.34,12.181C190.34,19.679 197.167,24.086 203.765,24.086L210.04,24.086C211.789,24.086 213.2,24.881 213.2,26.626C213.2,28.37 211.773,29.135 210.04,29.135L190.555,29.135L190.555,38.975L210.531,38.975C217.158,38.975 224.017,34.751 224.017,26.626C224.017,19.067 217.158,14.767 210.531,14.767L210.515,14.782Z" style="fill:rgb(255,98,0);fill-rule:nonzero;"/>
+    </g>
+    <g transform="matrix(1,0,0,1,-121.115,0)">
+        <path d="M176.792,21.515C176.792,23.565 175.703,29.12 169.643,29.135L163,29.135L163,38.99L170.932,39.067L172.895,39.067C181.963,39.051 187.363,33.221 187.363,22.877L187.363,0L176.792,0L176.792,21.515Z" style="fill:rgb(255,98,0);fill-rule:nonzero;"/>
+    </g>
+</svg>

--- a/site/src/components/BetaPill.tsx
+++ b/site/src/components/BetaPill.tsx
@@ -4,9 +4,11 @@ interface BetaPillProps {
   className?: string;
   style?: React.CSSProperties;
   compact?: boolean;
+  /** Replaces the default "v10 beta" text, e.g. with the documented package version. */
+  label?: string;
 }
 
-export default function BetaPill({ className, style, compact }: BetaPillProps) {
+export default function BetaPill({ className, style, compact, label }: BetaPillProps) {
   return (
     <span
       className={twMerge(
@@ -18,7 +20,9 @@ export default function BetaPill({ className, style, compact }: BetaPillProps) {
       )}
       style={{ '--text': '0.75rem', ...style } as React.CSSProperties}
     >
-      {compact ? (
+      {label ? (
+        label
+      ) : compact ? (
         <>
           <span>v10</span>
           <span className="hidden whitespace-pre uppercase sm:inline"> beta</span>

--- a/site/src/components/BetaPill.tsx
+++ b/site/src/components/BetaPill.tsx
@@ -21,7 +21,7 @@ export default function BetaPill({ className, style, compact, label }: BetaPillP
       style={{ '--text': '0.75rem', ...style } as React.CSSProperties}
     >
       {label ? (
-        label
+        <span className="whitespace-nowrap">{label}</span>
       ) : compact ? (
         <>
           <span>v10</span>

--- a/site/src/components/NavBar/MobileNav.tsx
+++ b/site/src/components/NavBar/MobileNav.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { ArrowUpRight } from 'lucide-react';
 
 import Logo from '@/assets/logos/videojs.svg?react';
+import CompactLogo from '@/assets/logos/vjs.svg?react';
 import BetaPill from '@/components/BetaPill';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '@/consts';
 
@@ -19,9 +20,11 @@ export interface MobileNavProps {
   navLinks: NavLink[];
   currentPath: string;
   children?: React.ReactNode;
+  compact?: boolean;
+  pill?: React.ReactNode;
 }
 
-export default function MobileNav({ navLinks, currentPath, children }: MobileNavProps) {
+export default function MobileNav({ navLinks, currentPath, children, compact, pill }: MobileNavProps) {
   return (
     <Dialog.Root modal>
       {/* Trigger button - hamburger menu */}
@@ -33,8 +36,11 @@ export default function MobileNav({ navLinks, currentPath, children }: MobileNav
         aria-label="Open navigation menu"
       >
         <span
-          className="font-display text-manila-light bg-faded-black dark:bg-manila-light dark:text-faded-black px-4 py-2.5 leading-none font-bold tracking-normal uppercase"
-          style={{ fontSize: '0.75rem' }}
+          className={clsx(
+            'font-display text-manila-light bg-faded-black dark:bg-manila-light dark:text-faded-black leading-none font-bold tracking-normal uppercase',
+            compact ? 'p-2' : 'p-2.5 sm:px-4 sm:py-2.5'
+          )}
+          style={{ fontSize: compact ? '0.625rem' : '0.75rem' }}
         >
           Menu
         </span>
@@ -50,12 +56,25 @@ export default function MobileNav({ navLinks, currentPath, children }: MobileNav
           )}
         >
           {/* Header with close button */}
-          <div className={clsx('flex justify-between items-center px-5 py-7')}>
+          <div className={clsx('flex justify-between items-center px-5', compact ? 'py-2' : 'py-7')}>
             <Dialog.Title className="sr-only">Navigation</Dialog.Title>
-            <a href="/" className="flex h-7 items-center gap-3 lg:h-10 lg:gap-4">
-              <Logo height="100%" />
+            <a
+              href="/"
+              className={clsx(
+                'flex items-center',
+                compact ? 'h-5 gap-2 sm:h-6 sm:gap-3' : 'h-7 gap-3 lg:h-10 lg:gap-4'
+              )}
+            >
+              {compact ? (
+                <>
+                  <CompactLogo height="100%" className="xs:hidden w-auto" />
+                  <Logo height="100%" className="xs:inline hidden w-auto" />
+                </>
+              ) : (
+                <Logo height="100%" className="w-auto" />
+              )}
               <span className="sr-only">Video.js video player</span>
-              <BetaPill className="hidden sm:inline-flex" />
+              {pill ? pill : <BetaPill className="hidden sm:inline-flex" />}
             </a>
             <Dialog.Close
               className={clsx(
@@ -64,8 +83,11 @@ export default function MobileNav({ navLinks, currentPath, children }: MobileNav
               aria-label="Close navigation menu"
             >
               <span
-                className="font-display text-manila-light bg-faded-black dark:bg-manila-light dark:text-faded-black px-4 py-2.5 leading-none font-bold tracking-normal uppercase"
-                style={{ fontSize: '0.75rem' }}
+                className={clsx(
+                  'font-display text-manila-light bg-faded-black dark:bg-manila-light dark:text-faded-black leading-none font-bold tracking-normal uppercase',
+                  compact ? 'p-2' : 'p-2.5 sm:px-4 sm:py-2.5'
+                )}
+                style={{ fontSize: compact ? '0.625rem' : '0.75rem' }}
               >
                 Close
               </span>

--- a/site/src/components/NavBar/NavBarDocs.astro
+++ b/site/src/components/NavBar/NavBarDocs.astro
@@ -6,7 +6,7 @@ import GitHub from '@/assets/logos/github.svg?react';
 import Logo from '@/assets/logos/videojs.svg?react';
 import BetaPill from '@/components/BetaPill';
 import Search from '@/components/Search';
-import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '@/consts';
+import { DISCORD_INVITE_URL, GITHUB_REPO_URL, VJS10_VERSION } from '@/consts';
 import GetStartedLink from './GetStartedLink';
 import MobileNav from './MobileNav';
 
@@ -42,7 +42,7 @@ const { class: className } = Astro.props;
   <a href="/" class="flex h-5 items-center gap-2 sm:h-6 sm:gap-3">
     <Logo height="100%" />
     <span class="sr-only">Video.js video player</span>
-    <BetaPill compact />
+    <BetaPill compact label={`v${VJS10_VERSION}`} />
   </a>
   <Search client:load className="mr-4 ml-auto sm:self-center" />
   {/* Desktop nav links */}

--- a/site/src/components/NavBar/NavBarDocs.astro
+++ b/site/src/components/NavBar/NavBarDocs.astro
@@ -4,6 +4,7 @@ import { ArrowUpRight } from 'lucide-react';
 import Discord from '@/assets/logos/discord.svg?react';
 import GitHub from '@/assets/logos/github.svg?react';
 import Logo from '@/assets/logos/videojs.svg?react';
+import CompactLogo from '@/assets/logos/vjs.svg?react';
 import BetaPill from '@/components/BetaPill';
 import Search from '@/components/Search';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL, VJS10_VERSION } from '@/consts';
@@ -40,11 +41,12 @@ const { class: className } = Astro.props;
   style="height:var(--nav-h)"
 >
   <a href="/" class="flex h-5 items-center gap-2 sm:h-6 sm:gap-3">
-    <Logo height="100%" />
+    <CompactLogo height="100%" className="xs:hidden w-auto" />
+    <Logo height="100%" className="hidden xs:inline w-auto" />
     <span class="sr-only">Video.js video player</span>
     <BetaPill compact label={`v${VJS10_VERSION}`} />
   </a>
-  <Search client:load className="mr-4 ml-auto sm:self-center" />
+  <Search client:load className="mr-2 xs:mr-4 ml-auto sm:self-center" />
   {/* Desktop nav links */}
   <div class="hidden h-full md:flex">
     <GetStartedLink
@@ -100,7 +102,8 @@ const { class: className } = Astro.props;
     </a>
   </div>
 
-  <MobileNav client:idle navLinks={navLinks} currentPath={currentPath}>
+  <MobileNav client:idle navLinks={navLinks} currentPath={currentPath} compact>
+    <BetaPill compact label={`v${VJS10_VERSION}`} slot="pill" />
     <slot name="mobile-nav" />
   </MobileNav>
 </nav>

--- a/site/src/styles/globals.css
+++ b/site/src/styles/globals.css
@@ -83,6 +83,8 @@
 
 /* Tailwind theme namespace resets are order-sensitive. */
 @theme {
+  --breakpoint-xs: 30rem;
+
   --color-*: initial;
 
   --color-white: white;


### PR DESCRIPTION
The docs never said which version they document. The docs navbar pill now shows the full documented release — `v{VJS10_VERSION}`, e.g. `v10.0.0-beta.33` — at every width, through a new optional `label` prop on `BetaPill`, rendered with `whitespace-nowrap` so it can never wrap onto two lines.

To make room at narrow widths the docs navbar goes properly compact: a new `xs` breakpoint (30rem) in the site theme, a compact "VJS" logo mark below it (drawn with `currentColor` so it follows dark mode) swapping to the full wordmark above, a tighter search margin, and new `compact` / `pill` props on `MobileNav` for smaller menu/close controls, reduced header padding, and the same logo swap inside the mobile menu. Docs pages only — the main-site navbar keeps its existing markup and breakpoints.

**Stack 11/13**. Base: `claude/docs-stack-10-copy-markdown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47)_


---

> [!NOTE]
> **Low Risk**
> Docs-only navbar and presentational component tweaks with no auth, data, or API changes.
> 
> **Overview**
> The **docs navbar** now surfaces the documented release as **`v{VJS10_VERSION}`** in the compact **beta pill** (desktop and mobile) instead of the generic **v10 beta** copy, wired through a new optional **`label`** on `BetaPill`.
> 
> To fit the tighter docs chrome, **`NavBarDocs`** switches to a **compact "VJS" logo** below the new **`xs` (30rem)** breakpoint and the full wordmark above it, trims search margin, and passes **`compact`** plus a custom pill into **`MobileNav`**. **`MobileNav`** gains **`compact`** / **`pill`** props for smaller menu/close controls, reduced header padding, and the same responsive logo swap when compact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bac4d5bb7767721c596daad15bbb1ba45160b59a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>