### PR TITLE
docs(site): link the roadmap and beta announcement to shipped guides

### DIFF
--- a/site/src/content/blog/2026-03-10-videojs-v10-beta-hello-world-again.mdx
+++ b/site/src/content/blog/2026-03-10-videojs-v10-beta-hello-world-again.mdx
@@ -5,6 +5,8 @@ authors: [steve-heffernan]
 ogImage: '../../assets/blog/2026-03-10-videojs-v10-beta-hello-world-again/og.png'
 ---
 
+import Aside from '@/components/Aside.astro';
+
 Today we're excited to release the Video.js v10.0.0 beta. It's the result of a rather large ground-up rewrite, not just of Video.js ([discussion](https://github.com/videojs/video.js/discussions/9035)) but also of [Plyr](https://github.com/sampotts/plyr/discussions/2871), [Vidstack](https://github.com/vidstack/player/discussions/1747), and [Media Chrome](https://www.mux.com/blog/from-media-chrome-to-video-js-v10-the-evolution-of-html-first-video-players), through a rare teaming-up of open source projects and people who care a lot about web video, with a combined 75,000 github stars and tens of billions of video plays monthly.
 
 I built Video.js 16 years ago to help the transition from Flash to HTML5 video. It's grown a lot since then with the help of [many people](https://github.com/videojs/video.js/graphs/contributors), but the codebase and APIs have continued to reflect a different era of web development. This rebuild modernizes the player both for how developers build today and sets up the foundation for the next significant transition to AI-augmented features and development.
@@ -358,6 +360,10 @@ A few things to know:
 If you're starting something new, this is a good time to try v10. Go to [videojs.org](http://videojs.org) and check out the [installation guide](https://videojs.org/docs/).
 
 If you're running a previous version in production, sit tight. We'll have migration guides before we ask you to move.
+
+<Aside type="note" title="Update, August 2026">
+The migration guides mentioned here (and under "What's coming" below) are now available: [Video.js 8](/docs/framework/html/how-to/migrate-from-video-js-8), [Mux Player](/docs/framework/html/how-to/migrate-from-mux-player), [Plyr](/docs/framework/html/how-to/migrate-from-plyr), and [Media Chrome](/docs/framework/html/how-to/migrate-from-media-chrome).
+</Aside>
 
 ## What's coming
 

--- a/site/src/content/docs/concepts/v10-roadmap.mdx
+++ b/site/src/content/docs/concepts/v10-roadmap.mdx
@@ -3,6 +3,8 @@ title: v10 Roadmap
 description: Timeline and milestones for Video.js v10 rebuild and the future of v8
 ---
 
+import DocsLink from '@/components/docs/DocsLink.astro';
+
 Video.js v10 is a complete rebuild from the ground up, designed to be more modular, framework-flexible, and aligned with modern web development practices.
 
 ## Current versions
@@ -32,7 +34,7 @@ Wider testing release to the community.
 
 - Close to stable, but API changes are still possible
 - Intended for experimental adoption in real-world projects
-- Developers encouraged to try it out and report issues
+- Developers encouraged to follow the <DocsLink slug="how-to/installation">installation guide</DocsLink>, try it out, and report issues
 
 ## Mid-2026: v10 GA Release
 
@@ -42,7 +44,7 @@ Wider testing release to the community.
 
 - Core feature parity with v8 in terms of fundamentals
 - Feature parity with Media Chrome, Vidstack, Plyr, and Mux Player
-- Community encouraged to begin full reintegration projects
+- Community encouraged to begin full reintegration projects, following the migration guides for <DocsLink slug="how-to/migrate-from-video-js-8">Video.js 8</DocsLink>, <DocsLink slug="how-to/migrate-from-mux-player">Mux Player</DocsLink>, <DocsLink slug="how-to/migrate-from-plyr">Plyr</DocsLink>, and <DocsLink slug="how-to/migrate-from-media-chrome">Media Chrome</DocsLink>
 - Plugin ecosystem migration begins in earnest
 
 ### Engine development focus


### PR DESCRIPTION
The roadmap mentioned the installation flow and migration guides without linking them; its bullets now link the installation guide and the four migration guides. The beta announcement still said migration guides were coming; adds a dated update aside (matching the blog's existing `Aside type="note"` convention) pointing at the shipped guides, without altering any original post text.

**Stack 12/13**. Base: `claude/docs-stack-11-site-version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47)_


---

> [!NOTE]
> **Low Risk**
> Docs-only MDX edits (imports, aside, internal doc links) with no runtime or API impact.
> 
> **Overview**
> **Documentation cross-links** so readers can reach shipped install and migration content from the v10 beta announcement and roadmap.
> 
> The **v10 beta blog post** adds an August 2026 `Aside` note that migration guides are now live, with links to the Video.js 8, Mux Player, Plyr, and Media Chrome how-to pages. Original wording (including "migration guides coming") is left unchanged.
> 
> The **v10 roadmap** now uses `DocsLink` on the beta bullet for the installation guide and on the GA bullet for all four migration guides, replacing plain text that previously named those docs without links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5754d444bf50b466aad3e3d7507b20527f05fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>