### PR TITLE
docs(agents): encode Diátaxis boundaries in the writing skills

### DIFF
--- a/.agents/skills/review-docs/SKILL.md
+++ b/.agents/skills/review-docs/SKILL.md
@@ -10,7 +10,8 @@ Treat implementation, types, tests, schemas, and generated output as factual sou
 1. Identify the audience, intended outcome, artifact type, and owning source files.
 2. For site guides and concepts, read `site/src/content/docs/how-to/write-guides.mdx`. For generated reference pages, read `site/src/content/docs/reference/write-references.mdx`. Use neighboring docs for other artifact types.
 3. Verify claims and examples against current code before reviewing voice, structure, examples, MDX conventions, and reader outcomes against the owning guide.
-4. Render affected MDX and run examples where practical.
+4. When content seems to mix document types — steps in a concept, teaching or opinion in a reference — check it against `.agents/skills/write-docs/references/diataxis.md`.
+5. Render affected MDX and run examples where practical.
 
 Report broken or misleading content first. For each finding, give the location, reader impact, evidence, and concise fix. Keep stylistic preferences separate from correctness issues.
 

--- a/.agents/skills/write-api-reference/SKILL.md
+++ b/.agents/skills/write-api-reference/SKILL.md
@@ -25,6 +25,7 @@ Treat TypeScript source and the builder E2E test as the specification. Generated
 
 - Derive props, state, data attributes, parts, tag names, and behavior from source.
 - Add prose only for non-obvious behavior, styling contracts, accessibility, or platform constraints.
+- Keep reference prose neutral and descriptive: state facts, let examples illustrate without teaching, and link how-to guides for tasks and concept pages for rationale (see `.agents/skills/write-docs/references/diataxis.md`).
 - Include basic HTML and React demos when both platforms expose the component; follow existing neighboring demos when the reference guide leaves room for judgment.
 
 ## Utility pages

--- a/.agents/skills/write-docs/SKILL.md
+++ b/.agents/skills/write-docs/SKILL.md
@@ -21,6 +21,7 @@ Treat implementation, types, tests, and content schemas as factual sources. Read
 2. Read neighboring docs for current voice and MDX patterns.
 3. Load only what applies:
    - Voice and structure: `references/writing-style.md`
+   - Content drifting between document types, or per-type tone and sentence forms: `references/diataxis.md`
    - SEO-sensitive site content: `references/seo.md`
    - State/tooling concepts: `references/state-tooling.md`
    - Component-library comparisons: `references/component-libraries.md`

--- a/.agents/skills/write-docs/references/diataxis.md
+++ b/.agents/skills/write-docs/references/diataxis.md
@@ -1,0 +1,27 @@
+# Diátaxis boundaries and language
+
+Distilled from [Diátaxis](https://diataxis.fr/). The document-type map and the compass for picking a mode live in `site/src/content/docs/how-to/write-guides.mdx`. Read this file when content drifts between modes or a passage's tone feels wrong for its page type.
+
+## Apply the compass to passages, not only pages
+
+The compass (action vs. cognition, study vs. work) also works at the sentence and paragraph level. When a passage feels off, ask which quadrant it serves and move it to the page type that owns that quadrant, leaving a link behind when readers need the trail.
+
+## What does not belong in each type
+
+- How-to guide: no teaching and no digression. Background beyond what the reader needs to adapt the code links to a concept page. Exhaustive options, defaults, and surfaces link to reference.
+- Concept page: no step-by-step instruction and no close-up API detail. Steps that creep in belong in a how-to; exact surfaces belong in reference.
+- Reference page: no instruction, persuasion, or opinion. Describe the machinery; do not walk the reader through tasks or argue for approaches. Link how-to guides for tasks and concept pages for rationale.
+- Getting started guides (our stand-in for tutorials): no alternatives and minimal explanation. The writer carries the lesson: every step must work, produce a visible result quickly, and lead to the next. Link deeper material instead of pausing to teach it.
+
+## The language of each type
+
+Each mode has characteristic sentence forms. When your sentences read like a different mode, the content is probably in the wrong place.
+
+- How-to guide: imperatives and conditional imperatives aimed at the reader's goal. "To loop playback, set…" "If you self-host, configure…"
+- Concept page: discussion of why and how things relate. "Features are split this way because…" "Compared with the native element…" Alternatives, trade-offs, and opinions are welcome here, and only here.
+- Reference page: neutral statements of fact in one consistent shape per kind of entry. "`preload` accepts…" "Defaults to…" Examples illustrate usage without teaching or advocating.
+- Getting started guide: guided steps with confirmations. "First, create…" "You should see…"
+
+## Reference tone
+
+Reference is austere by design: neutral, consistent, and example-rich. Its value is accuracy, completeness, and predictable structure. The api-docs-builder provides the structure; hold hand-written prose on reference pages to the same standard, and spend warmth and persuasion in how-tos and concepts instead.

--- a/.agents/skills/write-docs/references/diataxis.md
+++ b/.agents/skills/write-docs/references/diataxis.md
@@ -11,7 +11,7 @@ The compass (action vs. cognition, study vs. work) also works at the sentence an
 - How-to guide: no teaching and no digression. Background beyond what the reader needs to adapt the code links to a concept page. Exhaustive options, defaults, and surfaces link to reference.
 - Concept page: no step-by-step instruction and no close-up API detail. Steps that creep in belong in a how-to; exact surfaces belong in reference.
 - Reference page: no instruction, persuasion, or opinion. Describe the machinery; do not walk the reader through tasks or argue for approaches. Link how-to guides for tasks and concept pages for rationale.
-- Tutorial: we deliberately publish none yet. The Getting started sidebar category is not one — it mixes essential concept and how-to pages, each following its own type's rules above. If we add true tutorials later: no alternatives and minimal explanation, and the writer carries the lesson — every step must work, produce a visible result quickly, and lead to the next.
+- Tutorial: we deliberately publish none yet. If we add true tutorials later: no alternatives and minimal explanation, and the writer carries the lesson — every step must work, produce a visible result quickly, and lead to the next.
 
 ## The language of each type
 

--- a/.agents/skills/write-docs/references/diataxis.md
+++ b/.agents/skills/write-docs/references/diataxis.md
@@ -11,7 +11,7 @@ The compass (action vs. cognition, study vs. work) also works at the sentence an
 - How-to guide: no teaching and no digression. Background beyond what the reader needs to adapt the code links to a concept page. Exhaustive options, defaults, and surfaces link to reference.
 - Concept page: no step-by-step instruction and no close-up API detail. Steps that creep in belong in a how-to; exact surfaces belong in reference.
 - Reference page: no instruction, persuasion, or opinion. Describe the machinery; do not walk the reader through tasks or argue for approaches. Link how-to guides for tasks and concept pages for rationale.
-- Getting started guides (our stand-in for tutorials): no alternatives and minimal explanation. The writer carries the lesson: every step must work, produce a visible result quickly, and lead to the next. Link deeper material instead of pausing to teach it.
+- Tutorial: we deliberately publish none yet. The Getting started sidebar category is not one — it mixes essential concept and how-to pages, each following its own type's rules above. If we add true tutorials later: no alternatives and minimal explanation, and the writer carries the lesson — every step must work, produce a visible result quickly, and lead to the next.
 
 ## The language of each type
 
@@ -20,7 +20,7 @@ Each mode has characteristic sentence forms. When your sentences read like a dif
 - How-to guide: imperatives and conditional imperatives aimed at the reader's goal. "To loop playback, set…" "If you self-host, configure…"
 - Concept page: discussion of why and how things relate. "Features are split this way because…" "Compared with the native element…" Alternatives, trade-offs, and opinions are welcome here, and only here.
 - Reference page: neutral statements of fact in one consistent shape per kind of entry. "`preload` accepts…" "Defaults to…" Examples illustrate usage without teaching or advocating.
-- Getting started guide: guided steps with confirmations. "First, create…" "You should see…"
+- Tutorial (if we add them): guided steps with confirmations. "First, create…" "You should see…"
 
 ## Reference tone
 

--- a/.agents/skills/write-docs/templates/concept.md
+++ b/.agents/skills/write-docs/templates/concept.md
@@ -33,7 +33,6 @@ description: 'Brief description'
 ---
 
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
-import Aside from '@/components/Aside.astro';
 import DocsLink from '@/components/docs/DocsLink.astro';
 
 One-sentence description of the concept. Show code immediately:
@@ -57,23 +56,6 @@ HTML-specific explanation or code example.
 
 </FrameworkCase>
 
-## Common patterns
-
-### Pattern name
-
-When to use this pattern.
-
-{/* Code example */}
-
-<Aside type="tip">
-Helpful optimization or best practice.
-</Aside>
-
-## Common pitfalls
-
-{/* ❌ Don't — explain why */}
-{/* ✅ Do — explain the fix */}
-
 ## See also
 
 - <DocsLink slug="concepts/related-concept">Related concept</DocsLink>
@@ -86,5 +68,4 @@ Helpful optimization or best practice.
 - [ ] Code example in first 5 lines after description
 - [ ] Brief explanation (2-3 paragraphs max)
 - [ ] Framework-specific content uses `<FrameworkCase>`
-- [ ] Common pitfalls as do/don't
 - [ ] Scannable in under 2 minutes

--- a/site/src/content/docs/how-to/write-guides.mdx
+++ b/site/src/content/docs/how-to/write-guides.mdx
@@ -34,7 +34,7 @@ First, read and understand [Diátaxis](https://diataxis.fr/). We organize docume
 3. **Reference pages** (`src/content/docs/reference/`): Describe the exact machinery — components, features, hooks, utilities, options, state, and behavior. These are scaffolded using `write-api-reference` and the api-docs-builder. Again, see <DocsLink slug="reference/write-references">Write reference pages</DocsLink> for details.
 
 <Aside type="note">
-Diátaxis has a fourth mode — learning-oriented **tutorials**. We don't have a tutorials section yet — something we've intentionally chosen to omit, for now. Learning-oriented content lives in the Getting started how-to guides instead. Those pages carry the tutorial's obligations: you, the writer, own the lesson — every step must work, show a visible result quickly, and avoid alternatives and explanation beyond a link.
+Diátaxis has a fourth mode — learning-oriented **tutorials**. We don't have a tutorials section yet — something we've intentionally chosen to omit, for now.
 </Aside>
 
 To pick a mode, use the Diátaxis [compass](https://diataxis.fr/compass/). Ask two questions: does the content inform **action** (practical steps) or **cognition** (understanding)? And does it serve the reader's **study** (acquiring skills) or their **work** (applying them)?

--- a/site/src/content/docs/how-to/write-guides.mdx
+++ b/site/src/content/docs/how-to/write-guides.mdx
@@ -34,7 +34,7 @@ First, read and understand [Diátaxis](https://diataxis.fr/). We organize docume
 3. **Reference pages** (`src/content/docs/reference/`): Describe the exact machinery — components, features, hooks, utilities, options, state, and behavior. These are scaffolded using `write-api-reference` and the api-docs-builder. Again, see <DocsLink slug="reference/write-references">Write reference pages</DocsLink> for details.
 
 <Aside type="note">
-Diátaxis has a fourth mode — learning-oriented **tutorials**. We don't have a tutorials section yet — something we've intentionally chosen to omit, for now. Learning-oriented content lives in the Getting started how-to guides instead.
+Diátaxis has a fourth mode — learning-oriented **tutorials**. We don't have a tutorials section yet — something we've intentionally chosen to omit, for now. Learning-oriented content lives in the Getting started how-to guides instead. Those pages carry the tutorial's obligations: you, the writer, own the lesson — every step must work, show a visible result quickly, and avoid alternatives and explanation beyond a link.
 </Aside>
 
 To pick a mode, use the Diátaxis [compass](https://diataxis.fr/compass/). Ask two questions: does the content inform **action** (practical steps) or **cognition** (understanding)? And does it serve the reader's **study** (acquiring skills) or their **work** (applying them)?


### PR DESCRIPTION
Gap analysis of diataxis.fr against the repo's writing artifacts (write-docs, review-docs, write-api-reference skills; write-guides.mdx; write-references.mdx; writing-style.md). Most of Diátaxis is already encoded — the map, the compass, goal-oriented how-tos, one-concept pages, builder-enforced reference structure. Three principles were implicit or absent, now distilled into `.agents/skills/write-docs/references/diataxis.md` (~30 lines, conditionally loaded):

- **The compass applies to passages, not only pages** — when a paragraph feels off, ask which quadrant it serves and move it.
- **Per-type exclusion lists** — no teaching in how-tos, no steps or API close-ups in concepts, no instruction/persuasion/opinion in reference; and, should we ever add true tutorials (we deliberately publish none yet), no alternatives and minimal explanation.
- **The language of each type** — characteristic sentence forms per mode, as a drift detector.

Pointer lines added to write-docs (conditional-load list), review-docs (mode-mixing findings), and write-api-reference (reference prose stays neutral). The write-guides.mdx tutorials aside now simply states that we intentionally publish no tutorials for now — its earlier claim that tutorial-style learning lives in Getting started was never true and is removed; the obligations true tutorials would carry live in diataxis.md for if we add them.

Also removes the concept template's "Common patterns" and "Common pitfalls" sections (and their checklist item and now-unused Aside import): pattern walkthroughs and do/don't fixes are how-to material, and the new boundary rules would flag them as drift.

Deliberately skipped as already covered: quality-ordering theory (review-docs already puts accuracy first), reference structure/consistency (api-docs-builder enforces it), how-to goal orientation (write-guides.mdx owns it).

`pnpm check:workspace` passes (10/10, including agent-context token budgets).

**Stack 13/13**. Base: `claude/docs-stack-12-roadmap-blog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGK1DZagw6XWLAX6L3LH47


---

> [!NOTE]
> **Low Risk**
> Agent-skill and internal docs-template changes only; no runtime, API, or published user-facing guide content beyond a single aside trim.
> 
> **Overview**
> Adds **`.agents/skills/write-docs/references/diataxis.md`** as a short, conditionally loaded reference for agents: applying the Diátaxis compass to **passages** (not just whole pages), per-type **exclusion rules** (what must not appear in how-tos, concepts, reference, or future tutorials), and **characteristic sentence forms** as a tone/drift check, plus explicit **reference** neutrality.
> 
> **`write-docs`**, **`review-docs`**, and **`write-api-reference`** skills now point reviewers and authors at that file when content mixes modes or reference prose gets instructional. **`write-api-reference`** also states that component reference prose should stay factual and link out for tasks and rationale.
> 
> The **concept page template** drops **Common patterns**, **Common pitfalls**, the related checklist item, and the unused **`Aside`** import so new concepts stay explanation-focused rather than how-to walkthroughs.
> 
> **`write-guides.mdx`** shortens the tutorials aside by removing the line that sent learning-oriented readers to Getting started how-tos (tutorial obligations remain documented in `diataxis.md` for when tutorials exist).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936f640a18e8ddc9fbe86bfb1fcd58e292f6c0d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>