### PR TITLE
test(e2e): cover handled arrow key scrolling

### DIFF
--- a/apps/e2e/tests/keyboard.spec.ts
+++ b/apps/e2e/tests/keyboard.spec.ts
@@ -163,6 +163,18 @@ for (const entry of PAGES as readonly PageEntry[]) {
       }
     });
 
+    test('keeps handled arrow keys inside the player', async ({ page }) => {
+      await page.evaluate(() => {
+        document.body.style.height = '200vh';
+        window.scrollTo(0, 100);
+      });
+      await player.playerRoot.focus();
+      const scrollBefore = await page.evaluate(() => window.scrollY);
+
+      await page.keyboard.press('ArrowDown');
+      await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(scrollBefore);
+    });
+
     if (isAudio) {
       test('navigates the playback rate menu and restores focus', async ({ page }) => {
         const trigger = player.playbackRateButton;


### PR DESCRIPTION
## Summary

Add regression coverage ensuring handled arrow shortcuts stay inside the focused player instead of scrolling the page.

## Changes

- Focus the player on an already-scrolled page
- Verify a handled Arrow Down shortcut leaves the page position unchanged

## Related

- [Arrow keys escape player and scroll page](https://app.notion.com/p/mux/Arrow-keys-escape-player-and-scroll-page-c8202b33259747b59df54e2fd1feaecb?v=3bc97a7f89d08023a21d000c69cb1285&source=copy_link)

## Testing

- Keyboard Playwright suite passed on the byte-identical combined branch: 40 tests across Chromium and Firefox
- `pnpm lint`
- `pnpm typecheck`
