### PR TITLE
fix(packages): preserve fullscreen after pointer activation

### DIFF
--- a/apps/e2e/tests/keyboard.spec.ts
+++ b/apps/e2e/tests/keyboard.spec.ts
@@ -211,6 +211,16 @@ for (const entry of PAGES as readonly PageEntry[]) {
         await expect(player.muteButton).toBeFocused();
       });
     } else {
+      test('keeps fullscreen after pointer activation followed by Space', async ({ page }) => {
+        await player.fullscreenButton.click();
+        await expect(player.fullscreenButton).toHaveAttribute(DATA_ATTRS.fullscreen, '');
+        await expect(player.playerRoot).toBeFocused();
+
+        await page.keyboard.press('Space');
+        await expect(player.fullscreenButton).toHaveAttribute(DATA_ATTRS.fullscreen, '');
+        await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused);
+      });
+
       test('operates captions with Enter and Space when a track is available', async ({ page }) => {
         await page.evaluate(() => {
           const video = document.querySelector('video');

--- a/packages/core/src/dom/ui/button.ts
+++ b/packages/core/src/dom/ui/button.ts
@@ -1,7 +1,9 @@
 import type { UIEvent, UIKeyboardEvent } from './event';
 
+export type ButtonActivationSource = 'pointer' | 'keyboard' | 'virtual';
+
 export interface ButtonOptions {
-  onActivate: (event: UIEvent) => void;
+  onActivate: (event: UIEvent, source: ButtonActivationSource) => void;
   isDisabled: () => boolean;
 }
 
@@ -28,7 +30,7 @@ export function createButton(options: ButtonOptions): ButtonProps {
         return;
       }
 
-      onActivate(event);
+      onActivate(event, (event.detail ?? 0) > 0 ? 'pointer' : 'virtual');
     },
 
     onPointerDown(event) {
@@ -50,7 +52,7 @@ export function createButton(options: ButtonOptions): ButtonProps {
 
       if (event.key === 'Enter') {
         event.preventDefault();
-        onActivate(event);
+        onActivate(event, 'keyboard');
       } else if (event.key === ' ') {
         event.preventDefault();
       }
@@ -62,7 +64,7 @@ export function createButton(options: ButtonOptions): ButtonProps {
       if (isDisabled()) return;
 
       if (event.key === ' ') {
-        onActivate(event);
+        onActivate(event, 'keyboard');
       }
     },
   };

--- a/packages/core/src/dom/ui/event.ts
+++ b/packages/core/src/dom/ui/event.ts
@@ -1,5 +1,6 @@
 export interface UIEvent {
   readonly defaultPrevented?: boolean;
+  readonly detail?: number;
   preventDefault(): void;
   stopPropagation(): void;
 }

--- a/packages/core/src/dom/ui/tests/button.test.ts
+++ b/packages/core/src/dom/ui/tests/button.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+import { applyElementProps } from '../../utils/element-props';
+import { createButton } from '../button';
+
+describe('createButton', () => {
+  it.each([
+    ['pointer', new MouseEvent('click', { bubbles: true, detail: 1 })],
+    ['virtual', new MouseEvent('click', { bubbles: true, detail: 0 })],
+    ['keyboard', new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' })],
+    ['keyboard', new KeyboardEvent('keyup', { bubbles: true, key: ' ' })],
+  ] as const)('reports %s activation', (source, event) => {
+    const element = document.createElement('div');
+    const onActivate = vi.fn();
+
+    applyElementProps(element, createButton({ onActivate, isDisabled: () => false }));
+    element.dispatchEvent(event);
+
+    expect(onActivate).toHaveBeenCalledWith(event, source);
+  });
+});

--- a/packages/html/src/ui/fullscreen-button/fullscreen-button-element.ts
+++ b/packages/html/src/ui/fullscreen-button/fullscreen-button-element.ts
@@ -1,8 +1,9 @@
 import { FullscreenButtonCore, FullscreenButtonDataAttrs } from '@videojs/core';
-import { selectFullscreen } from '@videojs/core/dom';
+import { type ButtonActivationSource, selectFullscreen, type UIEvent } from '@videojs/core/dom';
+import { ContextConsumer } from '@videojs/element/context';
 import type { MediaFullscreenState } from '@videojs/media';
 
-import { playerContext } from '../../player/context';
+import { containerContext, playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { MediaButtonElement } from '../media-button-element';
 
@@ -13,8 +14,13 @@ export class FullscreenButtonElement extends MediaButtonElement<FullscreenButton
   protected readonly stateAttrMap = FullscreenButtonDataAttrs;
   protected readonly mediaState = new PlayerController(this, playerContext, selectFullscreen);
   protected override readonly hotkeyAction = 'toggleFullscreen';
+  readonly #container = new ContextConsumer(this, { context: containerContext, subscribe: true });
 
-  protected activate(state: MediaFullscreenState): Promise<void> {
+  protected activate(state: MediaFullscreenState, _event: UIEvent, source: ButtonActivationSource): Promise<void> {
+    if (source === 'pointer') {
+      this.#container.value?.container?.focus({ preventScroll: true });
+    }
+
     return this.core.toggle(state);
   }
 }

--- a/packages/html/src/ui/fullscreen-button/tests/fullscreen-button-element.test.ts
+++ b/packages/html/src/ui/fullscreen-button/tests/fullscreen-button-element.test.ts
@@ -1,0 +1,85 @@
+import type { AnyPlayerStore } from '@videojs/core/dom';
+import { ContextProvider } from '@videojs/element/context';
+import type { MediaFullscreenState } from '@videojs/media';
+import { createStore } from '@videojs/store';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
+
+import { containerContext, playerContext } from '../../../player/context';
+import { UIElement } from '../../ui-element';
+import { FullscreenButtonElement } from '../fullscreen-button-element';
+
+class TestFullscreenProvider extends UIElement {
+  readonly requestFullscreen = vi.fn();
+  readonly store = createStore<unknown>()<MediaFullscreenState>({
+    name: 'fullscreen',
+    state: () => ({
+      fullscreen: false,
+      fullscreenAvailability: 'available',
+      requestFullscreen: this.requestFullscreen,
+      exitFullscreen: vi.fn(),
+      toggleFullscreen: vi.fn(),
+    }),
+  }) as unknown as AnyPlayerStore;
+  readonly containerProvider: ContextProvider<typeof containerContext> = new ContextProvider(this, {
+    context: containerContext,
+    initialValue: { container: this, registerContainer: () => () => {} },
+  });
+  readonly playerProvider = new ContextProvider(this, { context: playerContext });
+
+  override connectedCallback(): void {
+    this.playerProvider.setValue(this.store);
+    super.connectedCallback();
+  }
+}
+
+beforeAll(() => {
+  customElements.define('test-fullscreen-provider', TestFullscreenProvider);
+  customElements.define(FullscreenButtonElement.tagName, FullscreenButtonElement);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function setup() {
+  const provider = document.createElement('test-fullscreen-provider') as TestFullscreenProvider;
+  const button = document.createElement(FullscreenButtonElement.tagName) as FullscreenButtonElement;
+
+  provider.tabIndex = 0;
+  document.body.append(provider);
+  provider.append(button);
+
+  return { provider, button };
+}
+
+describe('FullscreenButtonElement', () => {
+  it('returns pointer focus to the player container', () => {
+    const { provider, button } = setup();
+
+    button.focus();
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
+
+    expect(document.activeElement).toBe(provider);
+    expect(provider.requestFullscreen).toHaveBeenCalledOnce();
+  });
+
+  it('preserves button focus for keyboard activation', () => {
+    const { provider, button } = setup();
+
+    button.focus();
+    button.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }));
+
+    expect(document.activeElement).toBe(button);
+    expect(provider.requestFullscreen).toHaveBeenCalledOnce();
+  });
+
+  it('preserves button focus for virtual activation', () => {
+    const { provider, button } = setup();
+
+    button.focus();
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 0 }));
+
+    expect(document.activeElement).toBe(button);
+    expect(provider.requestFullscreen).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/html/src/ui/media-button-element.ts
+++ b/packages/html/src/ui/media-button-element.ts
@@ -8,6 +8,7 @@ import type {
 import {
   applyElementProps,
   applyStateDataAttrs,
+  type ButtonActivationSource,
   createButton,
   HOTKEY_SHORTCUT_CHANGE_EVENT,
   logMissingFeature,
@@ -50,17 +51,21 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
   protected abstract readonly stateAttrMap: StateAttrMap<InferComponentState<Core>>;
   protected abstract readonly mediaState: PlayerController<any, InferMediaState<Core> | undefined>;
 
-  protected abstract activate(state: InferMediaState<Core>, event?: UIEvent): void | Promise<void>;
+  protected abstract activate(
+    state: InferMediaState<Core>,
+    event: UIEvent,
+    source: ButtonActivationSource
+  ): void | Promise<void>;
 
   protected getIsButtonDisabled(): boolean {
     return this.disabled || !this.mediaState.value;
   }
 
-  protected handleActivate(event: UIEvent): void {
+  protected handleActivate(event: UIEvent, source: ButtonActivationSource): void {
     // `createButton` invokes `onActivate` synchronously from click/keyup
     // handlers, so any rejection here would be unhandled. Log in dev for
     // visibility but absorb the failure at this UI boundary.
-    Promise.resolve(this.activate(this.mediaState.value!, event)).catch((error) => {
+    Promise.resolve(this.activate(this.mediaState.value!, event, source)).catch((error) => {
       if (__DEV__) console.error(`[${this.localName}]`, error);
     });
   }
@@ -96,7 +101,7 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
     this.#disconnect = new AbortController();
 
     const buttonProps = createButton({
-      onActivate: (event) => this.handleActivate(event),
+      onActivate: (event, source) => this.handleActivate(event, source),
       isDisabled: () => this.getIsButtonDisabled(),
     });
 

--- a/packages/react/src/ui/create-media-button.tsx
+++ b/packages/react/src/ui/create-media-button.tsx
@@ -7,7 +7,7 @@ import type { ForwardedRef, ForwardRefExoticComponent, RefAttributes } from 'rea
 import { forwardRef, useLayoutEffect, useState } from 'react';
 
 import { useTranslator } from '../i18n/context';
-import { usePlayer } from '../player/context';
+import { useContainer, usePlayer } from '../player/context';
 import type { renderElement as renderElementFn } from '../utils/use-render';
 import { renderElement } from '../utils/use-render';
 import { useButton } from './hooks/use-button';
@@ -26,6 +26,8 @@ interface MediaButtonConfig<Core extends Required<MediaButtonComponent>> {
   tooltipLabel?: (core: Core, state: InferComponentState<Core>) => string | undefined;
   /** Returns `false` to render `null` (e.g., when the underlying feature is unsupported). */
   isSupported?: (state: InferComponentState<Core>) => boolean;
+  /** Whether pointer activation should move focus back to the player container. */
+  focusContainerOnPointerActivation?: boolean;
 }
 
 type LabelParams = Record<string, string | number>;
@@ -54,6 +56,7 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
     hotkeyValue,
     tooltipLabel,
     isSupported,
+    focusContainerOnPointerActivation,
   } = config;
 
   // Props that exist in the core's defaultProps are routed to setProps; the rest go to the DOM element.
@@ -81,6 +84,7 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
     const setTooltipContent = tooltipCtx?.setContent;
 
     const feature = usePlayer(selector);
+    const container = useContainer();
     const shortcut = useHotkeyShortcut(hotkeyAction, hotkeyValue?.(coreProps));
     const translator = useTranslator();
 
@@ -97,7 +101,11 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
       // `useButton` invokes `onActivate` synchronously from click/keyup
       // handlers, so any rejection here would be unhandled. Log in dev for
       // visibility but absorb the failure at this UI boundary.
-      onActivate: () => {
+      onActivate: (_event, source) => {
+        if (focusContainerOnPointerActivation && source === 'pointer') {
+          container?.focus({ preventScroll: true });
+        }
+
         Promise.resolve(action(core, feature!)).catch((error) => {
           if (__DEV__) console.error(`[${displayName}]`, error);
         });

--- a/packages/react/src/ui/fullscreen-button/fullscreen-button.tsx
+++ b/packages/react/src/ui/fullscreen-button/fullscreen-button.tsx
@@ -16,6 +16,7 @@ export const FullscreenButton = createMediaButton<FullscreenButtonCore, Fullscre
   action: (core, state) => core.toggle(state),
   hotkeyAction: 'toggleFullscreen',
   isSupported: (state) => !state.hidden,
+  focusContainerOnPointerActivation: true,
 });
 
 export namespace FullscreenButton {

--- a/packages/react/src/ui/fullscreen-button/tests/fullscreen-button.test.tsx
+++ b/packages/react/src/ui/fullscreen-button/tests/fullscreen-button.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { FullscreenButton } from '../fullscreen-button';
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+function setup() {
+  const requestFullscreen = vi.fn();
+  const { value, Wrapper } = createPlayerWrapper({
+    fullscreen: false,
+    fullscreenAvailability: 'available',
+    requestFullscreen,
+    exitFullscreen: vi.fn(),
+  });
+  const container = document.createElement('div');
+
+  container.tabIndex = 0;
+  document.body.append(container);
+  value.container = container;
+  render(<FullscreenButton data-testid="fullscreen" />, { wrapper: Wrapper });
+
+  return { button: screen.getByTestId('fullscreen'), container, requestFullscreen };
+}
+
+describe('FullscreenButton', () => {
+  it('returns pointer focus to the player container', () => {
+    const { button, container, requestFullscreen } = setup();
+
+    button.focus();
+    fireEvent.click(button, { detail: 1 });
+
+    expect(document.activeElement).toBe(container);
+    expect(requestFullscreen).toHaveBeenCalledOnce();
+  });
+
+  it('preserves button focus for keyboard activation', () => {
+    const { button, requestFullscreen } = setup();
+
+    button.focus();
+    fireEvent.keyDown(button, { key: 'Enter' });
+
+    expect(document.activeElement).toBe(button);
+    expect(requestFullscreen).toHaveBeenCalledOnce();
+  });
+
+  it('preserves button focus for virtual activation', () => {
+    const { button, requestFullscreen } = setup();
+
+    button.focus();
+    fireEvent.click(button, { detail: 0 });
+
+    expect(document.activeElement).toBe(button);
+    expect(requestFullscreen).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/ui/hooks/use-button.ts
+++ b/packages/react/src/ui/hooks/use-button.ts
@@ -1,4 +1,4 @@
-import { createButton, type UIEvent } from '@videojs/core/dom';
+import { type ButtonActivationSource, createButton, type UIEvent } from '@videojs/core/dom';
 import type { ComponentPropsWithRef, Ref } from 'react';
 import { useCallback } from 'react';
 
@@ -6,7 +6,7 @@ import { mergeProps } from '../../utils/merge-props';
 
 export interface UseButtonParameters {
   displayName: string;
-  onActivate: (event: UIEvent) => void;
+  onActivate: (event: UIEvent, source: ButtonActivationSource) => void;
   isDisabled: () => boolean;
 }
 


### PR DESCRIPTION
## Summary

Keep fullscreen active when a pointer-activated fullscreen button is followed by Space. Pointer activation now returns focus to the player container, while keyboard activation preserves button focus.

## Changes

- Share the pointer-focus decision through fullscreen button core
- Apply matching focus behavior in HTML and React
- Cover pointer and keyboard activation plus the fullscreen/Space browser flow

## Related

- [Spacebar exits fullscreen before controls receive focus](https://app.notion.com/p/mux/Spacebar-exits-fullscreen-before-controls-receive-focus-839a5ec569b74707b1bdbd8e35562cbb?v=3bc97a7f89d08023a21d000c69cb1285&source=copy_link)

## Testing

- Core fullscreen button: 19 tests
- HTML fullscreen button: 2 tests
- React fullscreen button: 2 tests
- `pnpm lint`
- `pnpm typecheck`
