### PR TITLE
fix(packages): reject invalid gesture types

### DIFF
--- a/packages/html/src/ui/gesture/gesture-element.ts
+++ b/packages/html/src/ui/gesture/gesture-element.ts
@@ -79,7 +79,7 @@ export class GestureElement extends UIElement {
 
     if (this.type === 'doubletap') {
       this.#cleanup = createDoubleTapGesture(container, onActivate, options);
-    } else {
+    } else if (this.type === 'tap') {
       this.#cleanup = createTapGesture(container, onActivate, options);
     }
   }

--- a/packages/html/src/ui/gesture/tests/gesture-element.test.ts
+++ b/packages/html/src/ui/gesture/tests/gesture-element.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { type AnyPlayerStore, getGestureCoordinator } from '@videojs/core/dom';
+import { ContextProvider } from '@videojs/element/context';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
 
+import { containerContext, playerContext } from '../../../player/context';
+import { UIElement } from '../../ui-element';
 import { GestureElement } from '../gesture-element';
 
 beforeAll(() => {
@@ -9,6 +13,20 @@ beforeAll(() => {
 afterEach(() => {
   document.body.innerHTML = '';
 });
+
+class TestGestureProvider extends UIElement {
+  readonly #store = {
+    state: { togglePaused: vi.fn() },
+    subscribe: () => () => {},
+  } as unknown as AnyPlayerStore;
+  readonly containerProvider = new ContextProvider(this, {
+    context: containerContext,
+    initialValue: { container: this, registerContainer: () => () => {} },
+  });
+  readonly playerProvider = new ContextProvider(this, { context: playerContext, initialValue: this.#store });
+}
+
+customElements.define('test-gesture-provider', TestGestureProvider);
 
 describe('GestureElement', () => {
   it('has the correct tag name', () => {
@@ -42,5 +60,17 @@ describe('GestureElement', () => {
 
     document.body.appendChild(el);
     expect(el.style.display).toBe('none');
+  });
+
+  it('does not treat an invalid gesture type as a tap', () => {
+    const provider = document.createElement('test-gesture-provider');
+    const el = document.createElement('media-gesture') as GestureElement;
+
+    el.type = 'double-tap' as GestureElement['type'];
+    el.action = 'togglePaused';
+    provider.append(el);
+    document.body.append(provider);
+
+    expect(getGestureCoordinator(provider).bindings).toHaveLength(0);
   });
 });

--- a/packages/react/src/ui/gesture/gesture.tsx
+++ b/packages/react/src/ui/gesture/gesture.tsx
@@ -28,7 +28,9 @@ export function Gesture({ type, action, value, pointer, region, disabled }: Gest
       return createDoubleTapGesture(container, onActivate, options);
     }
 
-    return createTapGesture(container, onActivate, options);
+    if (type === 'tap') return createTapGesture(container, onActivate, options);
+
+    return;
   }, [container, store, type, action, value, pointer, region, disabled]);
 
   return null;


### PR DESCRIPTION
## Summary

Prevent unsupported gesture type values from silently falling back to a tap gesture.

## Changes

- Only create tap handling for the explicit `tap` type
- Keep `doubletap` handling unchanged
- Apply the same guard in HTML and React

## Related

- [Tap gesture is misread as double-tap seek](https://app.notion.com/p/mux/Tap-gesture-is-misread-as-double-tap-seek-fca19ba68aa449db950d8e7dcacb6dc6?v=3bc97a7f89d08023a21d000c69cb1285&source=copy_link)

## Testing

- HTML gesture element: 5 tests
- `pnpm lint`
- `pnpm typecheck`
