### PR TITLE
fix(packages): isolate focused slider hotkeys

### DIFF
--- a/apps/e2e/tests/keyboard.spec.ts
+++ b/apps/e2e/tests/keyboard.spec.ts
@@ -131,10 +131,14 @@ for (const entry of PAGES as readonly PageEntry[]) {
 
       await expect(player.volumeSlider).toBeVisible();
       await player.volumeSliderThumb.focus();
-      await page.keyboard.press('End');
-      await expect.poll(() => getMediaValue(page, 'volume')).toBe(1);
-      await page.keyboard.press('ArrowDown');
-      await expect.poll(() => getMediaValue(page, 'volume')).toBeLessThan(1);
+      await page.keyboard.press('Home');
+      await expect.poll(() => getMediaValue(page, 'volume')).toBe(0);
+      await expect(player.volumeSliderThumb).toHaveAttribute('aria-valuenow', '0');
+      const timeBeforeVolume = await getMediaValue(page, 'currentTime');
+
+      await page.keyboard.press('ArrowRight');
+      await expect.poll(() => getMediaValue(page, 'currentTime')).toBeCloseTo(timeBeforeVolume);
+      await expect.poll(() => getMediaValue(page, 'volume')).toBeCloseTo(0.05);
 
       if (isAudio) {
         await player.seekTo(50);

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -59,7 +59,7 @@ export interface SliderRootStyle extends Record<string, string> {
 }
 
 export interface SliderThumbProps {
-  onKeyDown: (event: UIKeyboardEvent) => void;
+  onKeyDownCapture: (event: UIKeyboardEvent) => void;
   onFocus: () => void;
   onBlur: () => void;
 }
@@ -270,7 +270,7 @@ export function createSlider(options: SliderOptions): SliderApi {
 
   // --- Thumb props ---
   const thumbProps: SliderThumbProps = {
-    onKeyDown(event) {
+    onKeyDownCapture(event) {
       if (options.isDisabled()) {
         if (event.key !== 'Tab') event.preventDefault();
 

--- a/packages/core/src/dom/ui/tests/slider.test.ts
+++ b/packages/core/src/dom/ui/tests/slider.test.ts
@@ -110,7 +110,7 @@ describe('createSlider', () => {
       expect(slider.rootProps.onPointerDown).toBeTypeOf('function');
       expect(slider.rootProps.onPointerMove).toBeTypeOf('function');
       expect(slider.rootProps.onPointerLeave).toBeTypeOf('function');
-      expect(slider.thumbProps.onKeyDown).toBeTypeOf('function');
+      expect(slider.thumbProps.onKeyDownCapture).toBeTypeOf('function');
       expect(slider.thumbProps.onFocus).toBeTypeOf('function');
       expect(slider.thumbProps.onBlur).toBeTypeOf('function');
       expect(slider.destroy).toBeTypeOf('function');
@@ -518,7 +518,7 @@ describe('createSlider', () => {
 
       const event = keyboardEvent('ArrowRight');
 
-      slider.thumbProps.onKeyDown(event);
+      slider.thumbProps.onKeyDownCapture(event);
 
       expect(onValueChange).toHaveBeenCalledWith(51);
       expect(onValueCommit).toHaveBeenCalledWith(51);
@@ -531,7 +531,7 @@ describe('createSlider', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 1, onValueChange }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowLeft'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowLeft'));
 
       expect(onValueChange).toHaveBeenCalledWith(49);
 
@@ -542,7 +542,7 @@ describe('createSlider', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 5, onValueChange }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowUp'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowUp'));
 
       expect(onValueChange).toHaveBeenCalledWith(55);
 
@@ -553,7 +553,7 @@ describe('createSlider', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 5, onValueChange }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowDown'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowDown'));
 
       expect(onValueChange).toHaveBeenCalledWith(45);
 
@@ -571,7 +571,7 @@ describe('createSlider', () => {
         })
       );
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowRight', { shiftKey: true }));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight', { shiftKey: true }));
 
       expect(onValueChange).toHaveBeenCalledWith(60);
 
@@ -584,7 +584,7 @@ describe('createSlider', () => {
         createOptions({ getPercent: () => 50, getLargeStepPercent: () => 10, onValueChange })
       );
 
-      slider.thumbProps.onKeyDown(keyboardEvent('PageUp'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('PageUp'));
 
       expect(onValueChange).toHaveBeenCalledWith(60);
 
@@ -597,7 +597,7 @@ describe('createSlider', () => {
         createOptions({ getPercent: () => 50, getLargeStepPercent: () => 10, onValueChange })
       );
 
-      slider.thumbProps.onKeyDown(keyboardEvent('PageDown'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('PageDown'));
 
       expect(onValueChange).toHaveBeenCalledWith(40);
 
@@ -608,7 +608,7 @@ describe('createSlider', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(createOptions({ onValueChange }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('Home'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('Home'));
 
       expect(onValueChange).toHaveBeenCalledWith(0);
 
@@ -619,7 +619,7 @@ describe('createSlider', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(createOptions({ onValueChange }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('End'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('End'));
 
       expect(onValueChange).toHaveBeenCalledWith(100);
 
@@ -630,7 +630,7 @@ describe('createSlider', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(createOptions({ getPercent: () => 99, getStepPercent: () => 5, onValueChange }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowRight'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
 
       expect(onValueChange).toHaveBeenCalledWith(100);
 
@@ -642,7 +642,7 @@ describe('createSlider', () => {
       const onValueCommit = vi.fn();
       const slider = createSlider(createOptions({ getPercent: () => 50, onValueChange, onValueCommit }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowRight'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
 
       expect(onValueChange).toHaveBeenCalledOnce();
       expect(onValueCommit).toHaveBeenCalledOnce();
@@ -655,7 +655,7 @@ describe('createSlider', () => {
 
       const event = keyboardEvent('ArrowRight');
 
-      slider.thumbProps.onKeyDown(event);
+      slider.thumbProps.onKeyDownCapture(event);
 
       expect(event.preventDefault).toHaveBeenCalled();
 
@@ -668,7 +668,7 @@ describe('createSlider', () => {
 
       const event = keyboardEvent('Tab');
 
-      slider.thumbProps.onKeyDown(event);
+      slider.thumbProps.onKeyDownCapture(event);
 
       expect(event.preventDefault).not.toHaveBeenCalled();
       expect(onValueChange).not.toHaveBeenCalled();
@@ -686,7 +686,7 @@ describe('createSlider', () => {
       flush();
       expect(slider.input.current.pointing).toBe(true);
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowRight'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
       flush();
 
       expect(slider.input.current.pointing).toBe(false);
@@ -699,7 +699,7 @@ describe('createSlider', () => {
       // Simulate a value between steps (e.g., from a drag that landed at 47.3)
       const slider = createSlider(createOptions({ getPercent: () => 47.3, getStepPercent: () => 5, onValueChange }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowRight'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
 
       // 47.3 rounds to 45 (nearest step of 5 from 0), then +5 = 50
       expect(onValueChange).toHaveBeenCalledWith(50);
@@ -715,7 +715,7 @@ describe('createSlider', () => {
       document.documentElement.dir = 'rtl';
       const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 1, onValueChange }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowRight'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
 
       expect(onValueChange).toHaveBeenCalledWith(51);
 
@@ -728,7 +728,7 @@ describe('createSlider', () => {
       document.documentElement.dir = 'rtl';
       const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 1, onValueChange }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowLeft'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowLeft'));
 
       expect(onValueChange).toHaveBeenCalledWith(49);
 
@@ -747,11 +747,11 @@ describe('createSlider', () => {
         })
       );
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowUp'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowUp'));
       expect(onValueChange).toHaveBeenCalledWith(51);
 
       onValueChange.mockClear();
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowDown'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowDown'));
       expect(onValueChange).toHaveBeenCalledWith(49);
 
       slider.destroy();
@@ -765,7 +765,7 @@ describe('createSlider', () => {
 
       const arrowEvent = keyboardEvent('ArrowRight');
 
-      slider.thumbProps.onKeyDown(arrowEvent);
+      slider.thumbProps.onKeyDownCapture(arrowEvent);
 
       expect(onValueChange).not.toHaveBeenCalled();
       expect(arrowEvent.preventDefault).toHaveBeenCalled();
@@ -778,7 +778,7 @@ describe('createSlider', () => {
 
       const tabEvent = keyboardEvent('Tab');
 
-      slider.thumbProps.onKeyDown(tabEvent);
+      slider.thumbProps.onKeyDownCapture(tabEvent);
 
       expect(tabEvent.preventDefault).not.toHaveBeenCalled();
 
@@ -1129,7 +1129,7 @@ describe('createSlider', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(createOptions({ getPercent: () => 50, onValueChange, changeThrottle: 100 }));
 
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowRight'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
 
       expect(onValueChange).toHaveBeenCalledOnce();
       expect(onValueChange).toHaveBeenCalledWith(51);

--- a/packages/core/src/dom/utils/element-props.ts
+++ b/packages/core/src/dom/utils/element-props.ts
@@ -5,17 +5,18 @@ import { isFunction, isUndefined } from '@videojs/utils/predicate';
  * Apply props to a DOM element.
  *
  * Handles both attributes and event listeners: - Event props (onClick, onKeyDown, etc.) are attached as listeners -
- * Boolean props: `true` sets empty attribute, `false` removes - `undefined` removes the attribute - Other props are set
- * as string attributes
+ * Event props ending in `Capture` use capture phase, except pointer capture events - Boolean props: `true` sets empty
+ * attribute, `false` removes - `undefined` removes the attribute - Other props are set as string attributes
  */
 export function applyElementProps(element: HTMLElement, props: object, options?: { signal?: AbortSignal }): void {
   const signal = options?.signal;
 
   for (const [key, value] of Object.entries(props)) {
     if (isFunction(value) && key.startsWith('on')) {
-      const event = key.slice(2).toLowerCase();
+      const capture = key.endsWith('Capture') && !key.endsWith('PointerCapture');
+      const event = key.slice(2, capture ? -7 : undefined).toLowerCase();
 
-      listen(element, event, value as EventListener, signal ? { signal } : undefined);
+      listen(element, event, value as EventListener, signal ? { capture, signal } : { capture });
     } else if (isUndefined(value) || value === false) {
       element.removeAttribute(key);
     } else if (value === true) {

--- a/packages/core/src/dom/utils/tests/element-props.test.ts
+++ b/packages/core/src/dom/utils/tests/element-props.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { applyElementProps } from '../element-props';
+
+describe('applyElementProps', () => {
+  it('applies capture event handlers', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('div');
+    const order: string[] = [];
+
+    parent.append(child);
+    applyElementProps(parent, { onKeyDownCapture: () => order.push('parent') });
+    child.addEventListener('keydown', () => order.push('child'));
+    child.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true }));
+
+    expect(order).toEqual(['parent', 'child']);
+  });
+
+  it('applies pointer capture event handlers', () => {
+    const element = document.createElement('div');
+    let called = false;
+
+    applyElementProps(element, { onLostPointerCapture: () => (called = true) });
+    element.dispatchEvent(new PointerEvent('lostpointercapture'));
+
+    expect(called).toBe(true);
+  });
+});

--- a/packages/html/src/presets/audio/minimal-skin.ts
+++ b/packages/html/src/presets/audio/minimal-skin.ts
@@ -5,6 +5,7 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/audio/minimal-skin.css?inline';
 
+const VOLUME_STEP = 5;
 const SEEK_TIME = 10;
 
 function getTemplateHTML() {
@@ -100,7 +101,7 @@ function getTemplateHTML() {
             </media-tooltip>
 
             <media-popover id="audio-volume-popover" open-on-hover delay="200" close-delay="100" side="left" boundary="viewport" class="media-popover media-popover--volume">
-              <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">
+              <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="horizontal" thumb-alignment="edge">
                 <media-slider-track class="media-slider__track">
                   <media-slider-fill class="media-slider__fill"></media-slider-fill>
                 </media-slider-track>
@@ -140,8 +141,8 @@ function getTemplateHTML() {
       <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
       <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
       <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>

--- a/packages/html/src/presets/audio/skin.ts
+++ b/packages/html/src/presets/audio/skin.ts
@@ -5,6 +5,7 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/audio/skin.css?inline';
 
+const VOLUME_STEP = 5;
 const SEEK_TIME = 10;
 
 function getTemplateHTML() {
@@ -112,7 +113,7 @@ function getTemplateHTML() {
             </media-mute-button>
 
             <media-popover id="audio-volume-popover" open-on-hover delay="200" close-delay="100" side="top" boundary="viewport" class="media-surface media-popover media-popover--volume">
-              <media-volume-slider class="media-slider" orientation="vertical" thumb-alignment="edge">
+              <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="vertical" thumb-alignment="edge">
                 <media-slider-track class="media-slider__track">
                   <media-slider-fill class="media-slider__fill"></media-slider-fill>
                 </media-slider-track>
@@ -131,8 +132,8 @@ function getTemplateHTML() {
       <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
       <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
       <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>

--- a/packages/html/src/presets/live-audio/minimal-skin.ts
+++ b/packages/html/src/presets/live-audio/minimal-skin.ts
@@ -5,6 +5,8 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/live-audio/minimal-skin.css?inline';
 
+const VOLUME_STEP = 5;
+
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-minimal-skin media-minimal-skin--audio">
@@ -61,7 +63,7 @@ function getTemplateHTML() {
             </media-tooltip>
 
             <media-popover id="live-audio-volume-popover" open-on-hover delay="200" close-delay="100" side="left" boundary="viewport" class="media-popover media-popover--volume">
-              <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">
+              <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="horizontal" thumb-alignment="edge">
                 <media-slider-track class="media-slider__track">
                   <media-slider-fill class="media-slider__fill"></media-slider-fill>
                 </media-slider-track>
@@ -76,8 +78,8 @@ function getTemplateHTML() {
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
     </media-container>
   `;
 }

--- a/packages/html/src/presets/live-audio/skin.ts
+++ b/packages/html/src/presets/live-audio/skin.ts
@@ -5,6 +5,8 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/live-audio/skin.css?inline';
 
+const VOLUME_STEP = 5;
+
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-default-skin media-default-skin--audio">
@@ -57,7 +59,7 @@ function getTemplateHTML() {
             </media-mute-button>
 
             <media-popover id="live-audio-volume-popover" open-on-hover delay="200" close-delay="100" side="top" boundary="viewport" class="media-surface media-popover media-popover--volume">
-              <media-volume-slider class="media-slider" orientation="vertical" thumb-alignment="edge">
+              <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="vertical" thumb-alignment="edge">
                 <media-slider-track class="media-slider__track">
                   <media-slider-fill class="media-slider__fill"></media-slider-fill>
                 </media-slider-track>
@@ -72,8 +74,8 @@ function getTemplateHTML() {
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
     </media-container>
   `;
 }

--- a/packages/html/src/presets/live-video/minimal-skin.ts
+++ b/packages/html/src/presets/live-video/minimal-skin.ts
@@ -5,6 +5,8 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/live-video/minimal-skin.css?inline';
 
+const VOLUME_STEP = 5;
+
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-minimal-skin media-minimal-skin--video">
@@ -63,7 +65,7 @@ function getTemplateHTML() {
               </media-tooltip>
 
               <media-popover id="live-video-volume-popover" open-on-hover delay="200" close-delay="100" side="right" class="media-popover media-popover--volume">
-                <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">
+                <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="horizontal" thumb-alignment="edge">
                   <media-slider-track class="media-slider__track">
                     <media-slider-fill class="media-slider__fill"></media-slider-fill>
                   </media-slider-track>
@@ -145,8 +147,8 @@ function getTemplateHTML() {
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
       <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
 
       <!-- Gestures -->
       <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>

--- a/packages/html/src/presets/live-video/skin.ts
+++ b/packages/html/src/presets/live-video/skin.ts
@@ -5,6 +5,8 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/live-video/skin.css?inline';
 
+const VOLUME_STEP = 5;
+
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-default-skin media-default-skin--video">
@@ -64,7 +66,7 @@ function getTemplateHTML() {
                 </media-mute-button>
 
                 <media-popover id="live-video-volume-popover" open-on-hover delay="200" close-delay="100" side="top" class="media-surface media-popover media-popover--volume">
-                  <media-volume-slider class="media-slider" orientation="vertical" thumb-alignment="edge">
+                  <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="vertical" thumb-alignment="edge">
                     <media-slider-track class="media-slider__track">
                       <media-slider-fill class="media-slider__fill"></media-slider-fill>
                     </media-slider-track>
@@ -144,8 +146,8 @@ function getTemplateHTML() {
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
       <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
 
       <!-- Gestures -->
       <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>

--- a/packages/html/src/presets/video/minimal-skin.ts
+++ b/packages/html/src/presets/video/minimal-skin.ts
@@ -7,6 +7,8 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/video/minimal-skin.css?inline';
 
+const VOLUME_STEP = 5;
+
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-minimal-skin media-minimal-skin--video">
@@ -63,7 +65,7 @@ function getTemplateHTML() {
               </media-tooltip>
 
               <media-popover id="video-volume-popover" open-on-hover delay="200" close-delay="100" side="right" class="media-popover media-popover--volume">
-                <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">
+                <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="horizontal" thumb-alignment="edge">
                   <media-slider-track class="media-slider__track">
                     <media-slider-fill class="media-slider__fill"></media-slider-fill>
                   </media-slider-track>
@@ -282,8 +284,8 @@ function getTemplateHTML() {
       <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
       <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
       <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>

--- a/packages/html/src/presets/video/skin.ts
+++ b/packages/html/src/presets/video/skin.ts
@@ -7,6 +7,8 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/video/skin.css?inline';
 
+const VOLUME_STEP = 5;
+
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-default-skin media-default-skin--video">
@@ -60,7 +62,7 @@ function getTemplateHTML() {
                 </media-mute-button>
 
                 <media-popover id="video-volume-popover" open-on-hover delay="200" close-delay="100" side="top" class="media-surface media-popover media-popover--volume">
-                  <media-volume-slider class="media-slider" orientation="vertical" thumb-alignment="edge">
+                  <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="vertical" thumb-alignment="edge">
                     <media-slider-track class="media-slider__track">
                       <media-slider-fill class="media-slider__fill"></media-slider-fill>
                     </media-slider-track>
@@ -280,8 +282,8 @@ function getTemplateHTML() {
       <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
       <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
       <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>

--- a/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
+++ b/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
@@ -47,7 +47,7 @@ function createSliderContext(state: Partial<SliderState> = {}, pointerValue = 0)
     stateAttrMap: SliderDataAttrs,
     pointerValue,
     thumbAttrs: {},
-    thumbProps: { onKeyDown: () => {}, onFocus: () => {}, onBlur: () => {} },
+    thumbProps: { onKeyDownCapture: () => {}, onFocus: () => {}, onBlur: () => {} },
   };
 }
 

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -55,6 +55,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { MinimalAudioSkinProps } from './minimal-skin';
 
+const VOLUME_STEP = 5;
 const SEEK_TIME = 10;
 
 /* --------------------------------------- Components ---------------------------------------- */
@@ -139,7 +140,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className={cn(popup.volume)}>
-        <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root step={VOLUME_STEP} orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -319,8 +320,8 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
       <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
       <Hotkey keys="l" action="seekStep" value={10} />
       <Hotkey keys="j" action="seekStep" value={-10} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -39,6 +39,7 @@ import type { BaseSkinProps } from '../types';
 
 export type MinimalAudioSkinProps = BaseSkinProps;
 
+const VOLUME_STEP = 5;
 const SEEK_TIME = 10;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
@@ -85,7 +86,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
-        <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
+        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -263,8 +264,8 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
       <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
       <Hotkey keys="l" action="seekStep" value={10} />
       <Hotkey keys="j" action="seekStep" value={-10} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -55,6 +55,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { AudioSkinProps } from './skin';
 
+const VOLUME_STEP = 5;
 const SEEK_TIME = 10;
 
 /* --------------------------------------- Components ---------------------------------------- */
@@ -123,7 +124,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className={cn(popup.popover, popup.volume)}>
-        <VolumeSlider.Root orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root step={VOLUME_STEP} orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -299,8 +300,8 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
       <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
       <Hotkey keys="l" action="seekStep" value={10} />
       <Hotkey keys="j" action="seekStep" value={-10} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -37,6 +37,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseSkinProps } from '../types';
 
+const VOLUME_STEP = 5;
 const SEEK_TIME = 10;
 
 export type AudioSkinProps = BaseSkinProps;
@@ -69,7 +70,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className="media-surface media-popover media-popover--volume">
-        <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
+        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="vertical" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -246,8 +247,8 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
       <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
       <Hotkey keys="l" action="seekStep" value={10} />
       <Hotkey keys="j" action="seekStep" value={-10} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -40,6 +40,8 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { MinimalLiveAudioSkinProps } from './minimal-skin';
 
+const VOLUME_STEP = 5;
+
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return (
     <button ref={ref} type="button" className={cn(button.base, button.subtle, button.icon, className)} {...props} />
@@ -116,7 +118,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className={cn(popup.volume)}>
-        <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root step={VOLUME_STEP} orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -191,8 +193,8 @@ export function MinimalLiveAudioSkinTailwind(props: MinimalLiveAudioSkinProps): 
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
 
       {/* Input Feedback */}
       <StatusAnnouncer className="sr-only" />

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -27,6 +27,8 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseSkinProps } from '../types';
 
+const VOLUME_STEP = 5;
+
 export type MinimalLiveAudioSkinProps = BaseSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
@@ -73,7 +75,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
-        <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
+        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -153,8 +155,8 @@ export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNod
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
 
       {/* Input Feedback */}
       <StatusAnnouncer className="media-sr-only" />

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -32,6 +32,8 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { LiveAudioSkinProps } from './skin';
 
+const VOLUME_STEP = 5;
+
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return (
     <button ref={ref} type="button" className={cn(button.base, button.subtle, button.icon, className)} {...props} />
@@ -92,7 +94,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className={cn(popup.popover, popup.volume)}>
-        <VolumeSlider.Root orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root step={VOLUME_STEP} orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -167,8 +169,8 @@ export function LiveAudioSkinTailwind(props: LiveAudioSkinProps): ReactNode {
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
 
       {/* Input Feedback */}
       <StatusAnnouncer className="sr-only" />

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -19,6 +19,8 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseSkinProps } from '../types';
 
+const VOLUME_STEP = 5;
+
 export type LiveAudioSkinProps = BaseSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
@@ -49,7 +51,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className="media-surface media-popover media-popover--volume">
-        <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
+        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="vertical" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -135,8 +137,8 @@ export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
 
       {/* Input Feedback */}
       <StatusAnnouncer className="media-sr-only" />

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -72,6 +72,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { MinimalLiveVideoSkinProps } from './minimal-skin';
 
+const VOLUME_STEP = 5;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -151,7 +152,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className={cn(popup.volume)}>
-        <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root step={VOLUME_STEP} orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -354,8 +355,8 @@ export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): 
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
 
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -52,6 +52,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseVideoSkinProps } from '../types';
 
+const VOLUME_STEP = 5;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -101,7 +102,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
-        <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
+        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -318,8 +319,8 @@ export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNod
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
 
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -73,6 +73,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { LiveVideoSkinProps } from './skin';
 
+const VOLUME_STEP = 5;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -136,7 +137,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className={cn(popup.popover, popup.volume)}>
-        <VolumeSlider.Root orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root step={VOLUME_STEP} orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -341,8 +342,8 @@ export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
 
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -52,6 +52,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseVideoSkinProps } from '../types';
 
+const VOLUME_STEP = 5;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -85,7 +86,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className="media-surface media-popover media-popover--volume">
-        <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
+        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="vertical" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -302,8 +303,8 @@ export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
 
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -97,6 +97,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { MinimalVideoSkinProps } from './minimal-skin';
 
+const VOLUME_STEP = 5;
 const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
@@ -179,7 +180,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className={popup.volume}>
-        <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root step={VOLUME_STEP} orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -576,8 +577,8 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
       <Hotkey keys="ArrowLeft" action="seekStep" value={-(SEEK_TIME / 2)} />
       <Hotkey keys="l" action="seekStep" value={SEEK_TIME} />
       <Hotkey keys="j" action="seekStep" value={-SEEK_TIME} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -73,6 +73,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseVideoSkinProps } from '../types';
 
+const VOLUME_STEP = 5;
 const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
@@ -124,7 +125,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
-        <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
+        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -521,8 +522,8 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
       <Hotkey keys="ArrowLeft" action="seekStep" value={-(SEEK_TIME / 2)} />
       <Hotkey keys="l" action="seekStep" value={SEEK_TIME} />
       <Hotkey keys="j" action="seekStep" value={-SEEK_TIME} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -99,6 +99,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { VideoSkinProps } from './skin';
 
+const VOLUME_STEP = 5;
 const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
@@ -165,7 +166,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className={cn(popup.popover, popup.volume)}>
-        <VolumeSlider.Root orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root step={VOLUME_STEP} orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -564,8 +565,8 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
       <Hotkey keys="ArrowLeft" action="seekStep" value={-(SEEK_TIME / 2)} />
       <Hotkey keys="l" action="seekStep" value={SEEK_TIME} />
       <Hotkey keys="j" action="seekStep" value={-SEEK_TIME} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -73,6 +73,7 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseVideoSkinProps } from '../types';
 
+const VOLUME_STEP = 5;
 const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
@@ -108,7 +109,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className="media-surface media-popover media-popover--volume">
-        <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
+        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="vertical" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -526,8 +527,8 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
       <Hotkey keys="ArrowLeft" action="seekStep" value={-(SEEK_TIME / 2)} />
       <Hotkey keys="l" action="seekStep" value={SEEK_TIME} />
       <Hotkey keys="j" action="seekStep" value={-SEEK_TIME} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/ui/slider/tests/slider-preview.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider-preview.test.tsx
@@ -32,7 +32,7 @@ const { mockSliderApi } = vi.hoisted(() => ({
       onPointerLeave: vi.fn(),
     },
     thumbProps: {
-      onKeyDown: vi.fn(),
+      onKeyDownCapture: vi.fn(),
       onFocus: vi.fn(),
       onBlur: vi.fn(),
     },

--- a/packages/react/src/ui/slider/tests/slider-thumbnail.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider-thumbnail.test.tsx
@@ -23,7 +23,7 @@ const { mockSliderApi, mockThumbnailApi } = vi.hoisted(() => ({
       onPointerLeave: vi.fn(),
     },
     thumbProps: {
-      onKeyDown: vi.fn(),
+      onKeyDownCapture: vi.fn(),
       onFocus: vi.fn(),
       onBlur: vi.fn(),
     },

--- a/packages/react/src/ui/slider/tests/slider.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { createRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
@@ -48,7 +48,7 @@ const { mockSliderApi, sliderOptionsRef } = vi.hoisted(() => {
           onPointerLeave: vi.fn(),
         },
         thumbProps: {
-          onKeyDown: vi.fn(),
+          onKeyDownCapture: (event: { preventDefault(): void }) => event.preventDefault(),
           onFocus: vi.fn(),
           onBlur: vi.fn(),
         },
@@ -249,6 +249,22 @@ describe('SliderThumb', () => {
     const thumb = container.querySelector('[data-testid="thumb"]');
 
     expect(thumb?.getAttribute('role')).toBe('slider');
+  });
+
+  it('handles keydown before native ancestor listeners', () => {
+    const { container } = render(
+      <SliderRoot>
+        <SliderThumb data-testid="thumb" />
+      </SliderRoot>
+    );
+    const root = container.firstElementChild!;
+    const thumb = container.querySelector('[data-testid="thumb"]')!;
+    const onKeyDown = vi.fn((event: Event) => event.defaultPrevented);
+
+    root.addEventListener('keydown', onKeyDown);
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+
+    expect(onKeyDown).toHaveReturnedWith(true);
   });
 });
 

--- a/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
+++ b/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
@@ -51,7 +51,7 @@ const {
           onPointerLeave: vi.fn(),
         },
         thumbProps: {
-          onKeyDown: vi.fn(),
+          onKeyDownCapture: vi.fn(),
           onFocus: vi.fn(),
           onBlur: vi.fn(),
         },

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -38,7 +38,7 @@ const { mockSliderApi, mockVolumeState, mutableVolume } = vi.hoisted(() => {
         onPointerLeave: vi.fn(),
       },
       thumbProps: {
-        onKeyDown: vi.fn(),
+        onKeyDownCapture: vi.fn(),
         onFocus: vi.fn(),
         onBlur: vi.fn(),
       },

--- a/site/scripts/ejected-skins/html.ts
+++ b/site/scripts/ejected-skins/html.ts
@@ -146,7 +146,7 @@ export async function processHtmlSkin(skin: HtmlSkinDef): Promise<string> {
 
   validatePackageImports(source, skin.template);
   const templateBody = extractTemplateLiteral(source);
-  const context: Record<string, unknown> = { SEEK_TIME: 10 };
+  const context: Record<string, unknown> = { SEEK_TIME: 10, VOLUME_STEP: 5 };
 
   await loadImportedNames(source, templateBody, skin.template, context);
   context.renderIcon = createRenderMediaIcon(skin.iconSet);


### PR DESCRIPTION
## Summary

Let focused sliders own their keyboard input before player hotkeys run, and make focused volume movement use the same 5% step as volume hotkeys.

## Changes

- Handle slider keydown during capture in HTML and React
- Preserve native pointer-capture event names in the shared element prop adapter
- Define the 5% volume step in every HTML and React skin
- Keep time-slider stepping unchanged

## Related

- [Focused sliders also trigger player hotkeys](https://app.notion.com/p/mux/Focused-sliders-also-trigger-player-hotkeys-c9f0f2b16a57427eb9671cc563a56f23?v=3bc97a7f89d08023a21d000c69cb1285&source=copy_link)

## Testing

- Core slider and element props: 66 tests
- HTML slider and time slider: 42 tests
- React slider, time slider, and volume slider: 80 tests
- Ejected-skin generator: 32 variants
- Site ejected-skin tests: 16 tests
- `pnpm lint`
- `pnpm typecheck`
