### PR TITLE
fix(core): suppress repeated volume boundary feedback

### DIFF
--- a/packages/core/src/core/ui/input-action/input-action.ts
+++ b/packages/core/src/core/ui/input-action/input-action.ts
@@ -19,6 +19,7 @@ export interface InputActionEvent {
   value?: number | undefined;
   source?: InputActionSource | undefined;
   key?: string | undefined;
+  repeat?: boolean | undefined;
 }
 
 export interface MediaSnapshot {

--- a/packages/core/src/core/ui/volume-indicator/core.ts
+++ b/packages/core/src/core/ui/volume-indicator/core.ts
@@ -52,7 +52,6 @@ export class VolumeIndicatorCore {
 
   #props: VolumeIndicatorProps = {};
   #boundaryTimer: ReturnType<typeof setTimeout> | null = null;
-  #boundaryRestartTimer: ReturnType<typeof setTimeout> | null = null;
   #close = new IndicatorCloseController(
     () => this.state.patch({ open: false, level: null, value: null, fill: null, min: false, max: false }),
     () => getIndicatorCloseDelay(this.#props)
@@ -84,7 +83,7 @@ export class VolumeIndicatorCore {
       prediction
     );
     const boundary = getVolumeBoundary(event, prediction.snapshotVolume, prediction.nextVolume);
-    const repeatedBoundary = boundary !== null && current[boundary] === true;
+    const showBoundary = boundary !== null && !event.repeat;
 
     if (!boundary) this.#clearBoundaryTimers();
 
@@ -94,17 +93,11 @@ export class VolumeIndicatorCore {
       level: details.volumeLevel,
       value: details.value,
       fill: details.value,
-      min: boundary === 'min' && !repeatedBoundary,
-      max: boundary === 'max' && !repeatedBoundary,
+      min: boundary && event.repeat ? current.min : showBoundary && boundary === 'min',
+      max: boundary && event.repeat ? current.max : showBoundary && boundary === 'max',
     });
 
-    if (boundary) {
-      if (repeatedBoundary) {
-        this.#restartBoundary(boundary);
-      } else {
-        this.#scheduleBoundaryClear();
-      }
-    }
+    if (showBoundary) this.#scheduleBoundaryClear();
 
     this.#close.arm();
     return true;
@@ -118,16 +111,6 @@ export class VolumeIndicatorCore {
     }, BOUNDARY_CLEAR_DELAY);
   }
 
-  #restartBoundary(boundary: 'min' | 'max'): void {
-    this.#clearBoundaryTimers();
-    this.state.patch({ min: false, max: false });
-    this.#boundaryRestartTimer = setTimeout(() => {
-      this.#boundaryRestartTimer = null;
-      this.state.patch({ [boundary]: true });
-      this.#scheduleBoundaryClear();
-    }, 0);
-  }
-
   #clearBoundaryTimer(): void {
     if (this.#boundaryTimer === null) return;
 
@@ -135,16 +118,8 @@ export class VolumeIndicatorCore {
     this.#boundaryTimer = null;
   }
 
-  #clearBoundaryRestartTimer(): void {
-    if (this.#boundaryRestartTimer === null) return;
-
-    clearTimeout(this.#boundaryRestartTimer);
-    this.#boundaryRestartTimer = null;
-  }
-
   #clearBoundaryTimers(): void {
     this.#clearBoundaryTimer();
-    this.#clearBoundaryRestartTimer();
   }
 }
 

--- a/packages/core/src/core/ui/volume-indicator/tests/core.test.ts
+++ b/packages/core/src/core/ui/volume-indicator/tests/core.test.ts
@@ -48,20 +48,23 @@ describe('VolumeIndicatorCore', () => {
     expect(core.state.current.min).toBe(false);
   });
 
-  it('restarts the boundary flag when the same edge is hit repeatedly', () => {
+  it('does not restart boundary feedback for held keys', () => {
     const core = new VolumeIndicatorCore();
 
     core.processEvent({ action: 'volumeStep', value: 0.05 }, { volume: 1, muted: false });
     expect(core.state.current.max).toBe(true);
 
-    core.processEvent({ action: 'volumeStep', value: 0.05 }, { volume: 1, muted: false });
-    expect(core.state.current.max).toBe(false);
-
-    vi.advanceTimersByTime(0);
+    core.processEvent({ action: 'volumeStep', value: 0.05, repeat: true }, { volume: 1, muted: false });
     expect(core.state.current.max).toBe(true);
 
     vi.advanceTimersByTime(300);
     expect(core.state.current.max).toBe(false);
+
+    core.processEvent({ action: 'volumeStep', value: 0.05, repeat: true }, { volume: 1, muted: false });
+    expect(core.state.current.max).toBe(false);
+
+    core.processEvent({ action: 'volumeStep', value: 0.05, repeat: false }, { volume: 1, muted: false });
+    expect(core.state.current.max).toBe(true);
   });
 
   it('closes after the configured delay', () => {

--- a/packages/core/src/dom/ui/input-action.ts
+++ b/packages/core/src/dom/ui/input-action.ts
@@ -28,6 +28,7 @@ export function toInputActionEvent(event: CoordinatorEvent): InputActionEvent {
     value: event.value,
     source: event.source,
     key: 'key' in event.event ? event.event.key : undefined,
+    repeat: 'repeat' in event.event ? event.event.repeat : undefined,
   };
 }
 

--- a/packages/core/src/dom/ui/tests/input-action.test.ts
+++ b/packages/core/src/dom/ui/tests/input-action.test.ts
@@ -19,13 +19,14 @@ describe('input-action', () => {
         source: 'hotkey',
         action: 'togglePaused',
         value: 1,
-        event: new KeyboardEvent('keydown', { key: 'k' }),
+        event: new KeyboardEvent('keydown', { key: 'k', repeat: true }),
       })
     ).toEqual({
       source: 'hotkey',
       action: 'togglePaused',
       value: 1,
       key: 'k',
+      repeat: true,
     });
   });
 


### PR DESCRIPTION
## Summary

Suppress repeated volume-boundary feedback while a volume key remains held, then allow a fresh transition after keyup.

## Changes

- Carry the keyboard repeat flag into input actions
- Preserve existing boundary state during repeated keydown events
- Allow the next non-repeated keydown to start fresh feedback

## Related

- [Volume bound shake loops while key is held](https://app.notion.com/p/mux/Volume-bound-shake-loops-while-key-is-held-12289ce259cf4fb0bfb46c8ae1f7899a?v=3bc97a7f89d08023a21d000c69cb1285&source=copy_link)

## Testing

- Core volume indicator and input action: 11 tests
- `pnpm lint`
- `pnpm typecheck`
