### PR TITLE
fix(packages): make overflowing error content keyboard accessible

### DIFF
--- a/apps/e2e/tests/error-dialog.spec.ts
+++ b/apps/e2e/tests/error-dialog.spec.ts
@@ -36,6 +36,12 @@ test.describe('Error Dialog', () => {
 
     // Error dialog should appear with data-open
     await expect(errorDialog).toHaveAttribute(DATA_ATTRS.open, '', { timeout: 15_000 });
+
+    const content = errorDialog.locator('media-error-dialog-content');
+    const close = errorDialog.locator('media-dialog-close');
+
+    await expect(content).toHaveAttribute('tabindex', '-1');
+    await expect(close).toBeFocused();
   });
 
   test('error dialog can be dismissed', async ({ page }) => {
@@ -81,21 +87,32 @@ test.describe('Error Dialog', () => {
     await expect(outsideButton).toBeFocused();
   });
 
-  test('keeps long error content and the dismiss action inside a narrow player', async ({ page }) => {
+  test('keeps long error content keyboard-accessible inside a narrow player', async ({ page }) => {
     await player.playerRoot.evaluate((element) => {
       if (element instanceof HTMLElement) element.style.width = '320px';
     });
     await triggerError(page, 'A long authored playback error message. '.repeat(120));
 
     const popup = page.getByRole('alertdialog');
-    const content = popup.locator('.media-dialog__content');
+    const content = popup.locator('media-error-dialog-content');
+    const close = popup.locator('media-dialog-close');
 
     await expect(popup).toBeVisible({ timeout: 15_000 });
     await expect(player.controls).toBeHidden();
+    await expect(content).toHaveAttribute('tabindex', '0');
+    await expect(content).toBeFocused();
 
     const scrollRange = await content.evaluate((element) => element.scrollHeight - element.clientHeight);
 
     expect(scrollRange).toBeGreaterThan(0);
+
+    await page.keyboard.press('PageDown');
+
+    await expect.poll(() => content.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+
+    await page.keyboard.press('Tab');
+
+    await expect(close).toBeFocused();
 
     const contract = await player.playerRoot.evaluate((root) => {
       const popup = root.querySelector<HTMLElement>('[role="alertdialog"]');

--- a/apps/e2e/tests/sandbox-skin-styling.spec.ts
+++ b/apps/e2e/tests/sandbox-skin-styling.spec.ts
@@ -120,14 +120,16 @@ for (const { media, skin } of HTML_TAILWIND_ERROR_CASES) {
 
     const contract = await root.evaluate((element, mediaType) => {
       const popup = element.querySelector<HTMLElement>('[role="alertdialog"]');
+      const content = popup?.querySelector<HTMLElement>('media-error-dialog-content');
       const controls = element.querySelector<HTMLElement>('.media-controls');
-      if (!popup || !controls) throw new Error('Expected an error dialog and controls.');
+      if (!popup || !content || !controls) throw new Error('Expected an error dialog, content, and controls.');
 
       const rootRect = element.getBoundingClientRect();
       const popupRect = popup.getBoundingClientRect();
       const controlsStyle = getComputedStyle(controls);
 
       return {
+        contentTabIndex: content.tabIndex,
         controlsSuppressed:
           mediaType === 'video'
             ? controlsStyle.display === 'none'
@@ -137,6 +139,7 @@ for (const { media, skin } of HTML_TAILWIND_ERROR_CASES) {
       };
     }, media);
 
+    expect(contract.contentTabIndex).toBe(-1);
     expect(contract.controlsSuppressed).toBe(true);
     expect(contract.popupInside).toBe(true);
     expect(Math.abs(contract.rootHeight - initialRootBox.height)).toBeLessThanOrEqual(1);

--- a/packages/core/src/core/ui/error-dialog/error-dialog-component.ts
+++ b/packages/core/src/core/ui/error-dialog/error-dialog-component.ts
@@ -9,6 +9,7 @@ export default defineComponent({
     Root: defineComponent(),
     Backdrop: defineComponent(),
     Popup: defineComponent(),
+    Content: defineComponent(),
     Title: defineComponent(),
     Description: defineComponent(),
     Close: defineComponent(),

--- a/packages/core/src/dom/index.ts
+++ b/packages/core/src/dom/index.ts
@@ -23,6 +23,7 @@ export * from './ui/popover/popover';
 export type { PositioningCSSVars, PositioningOptions } from './ui/popover/popover-positioning';
 export * from './ui/popover/popup-group';
 export * from './ui/popover/popup-positioner';
+export * from './ui/scroll-region';
 export * from './ui/slider';
 export * from './ui/slider-css-vars';
 export * from './ui/slider-focus';

--- a/packages/core/src/dom/ui/scroll-region.ts
+++ b/packages/core/src/dom/ui/scroll-region.ts
@@ -1,0 +1,42 @@
+import { observeElements } from '@videojs/utils/dom';
+
+/**
+ * Whether an element's content extends beyond its visible box on either axis.
+ *
+ * @param element - Element whose scroll and client dimensions are compared.
+ */
+export function hasScrollOverflow(element: HTMLElement): boolean {
+  return element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth;
+}
+
+/**
+ * Observe whether an element's content extends beyond its visible box.
+ *
+ * The callback runs immediately with the current state, then only when that state changes after a resize or content
+ * mutation.
+ *
+ * @param element - Element whose overflow state is observed.
+ * @param onChange - Called with whether the element overflows on either axis.
+ */
+export function observeScrollOverflow(element: HTMLElement, onChange: (overflowing: boolean) => void): () => void {
+  let overflowing: boolean | undefined;
+
+  const sync = () => {
+    const nextOverflowing = hasScrollOverflow(element);
+    if (nextOverflowing === overflowing) return;
+
+    overflowing = nextOverflowing;
+    onChange(nextOverflowing);
+  };
+
+  const stopObserving = observeElements({
+    root: element,
+    getElements: () => [element, ...element.querySelectorAll('*')],
+    mutations: { childList: true, characterData: true, subtree: true },
+    onChange: sync,
+  });
+
+  sync();
+
+  return stopObserving;
+}

--- a/packages/core/src/dom/ui/tests/scroll-region.test.ts
+++ b/packages/core/src/dom/ui/tests/scroll-region.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { hasScrollOverflow, observeScrollOverflow } from '../scroll-region';
+
+class ResizeObserverStub implements ResizeObserver {
+  static instances: ResizeObserverStub[] = [];
+  readonly observe = vi.fn();
+  readonly unobserve = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+}
+
+class MutationObserverStub implements MutationObserver {
+  static instances: MutationObserverStub[] = [];
+  readonly observe = vi.fn();
+  readonly disconnect = vi.fn();
+  readonly takeRecords = vi.fn(() => []);
+
+  constructor(readonly callback: MutationCallback) {
+    MutationObserverStub.instances.push(this);
+  }
+}
+
+function setScrollMetrics(element: HTMLElement, clientHeight: number, scrollHeight: number): void {
+  Object.defineProperties(element, {
+    clientHeight: { configurable: true, value: clientHeight },
+    scrollHeight: { configurable: true, value: scrollHeight },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  ResizeObserverStub.instances.length = 0;
+  MutationObserverStub.instances.length = 0;
+});
+
+describe('hasScrollOverflow', () => {
+  it('detects content beyond the visible box', () => {
+    const element = document.createElement('div');
+
+    setScrollMetrics(element, 100, 101);
+    expect(hasScrollOverflow(element)).toBe(true);
+
+    setScrollMetrics(element, 100, 100);
+    expect(hasScrollOverflow(element)).toBe(false);
+  });
+});
+
+describe('observeScrollOverflow', () => {
+  it('reports overflow changes from resize and content mutations', () => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('MutationObserver', MutationObserverStub);
+
+    const element = document.createElement('div');
+    const child = document.createElement('p');
+
+    element.append(child);
+    setScrollMetrics(element, 100, 100);
+
+    const onChange = vi.fn();
+    const cleanup = observeScrollOverflow(element, onChange);
+
+    expect(onChange).toHaveBeenLastCalledWith(false);
+    expect(ResizeObserverStub.instances[0]!.observe).toHaveBeenCalledWith(element);
+    expect(ResizeObserverStub.instances[0]!.observe).toHaveBeenCalledWith(child);
+
+    setScrollMetrics(element, 100, 200);
+    ResizeObserverStub.instances[0]!.callback([], ResizeObserverStub.instances[0]!);
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    setScrollMetrics(element, 100, 100);
+    MutationObserverStub.instances[0]!.callback([], MutationObserverStub.instances[0]!);
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    cleanup();
+    expect(MutationObserverStub.instances[0]!.disconnect).toHaveBeenCalledOnce();
+    expect(ResizeObserverStub.instances.at(-1)!.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('does not notify when the overflow state is unchanged', () => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('MutationObserver', MutationObserverStub);
+
+    const element = document.createElement('div');
+
+    setScrollMetrics(element, 100, 100);
+
+    const onChange = vi.fn();
+
+    observeScrollOverflow(element, onChange);
+    ResizeObserverStub.instances[0]!.callback([], ResizeObserverStub.instances[0]!);
+
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/html/src/define/ui/error-dialog-content.ts
+++ b/packages/html/src/define/ui/error-dialog-content.ts
@@ -1,0 +1,10 @@
+import { safeDefine } from '../../registration/safe-define';
+import { ErrorDialogContentElement } from '../../ui/error-dialog/error-dialog-content-element';
+
+safeDefine(ErrorDialogContentElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [ErrorDialogContentElement.tagName]: ErrorDialogContentElement;
+  }
+}

--- a/packages/html/src/define/ui/error-dialog.ts
+++ b/packages/html/src/define/ui/error-dialog.ts
@@ -4,6 +4,7 @@ import { DialogCloseElement } from '../../ui/dialog/dialog-close-element';
 import { DialogDescriptionElement } from '../../ui/dialog/dialog-description-element';
 import { DialogPopupElement } from '../../ui/dialog/dialog-popup-element';
 import { DialogTitleElement } from '../../ui/dialog/dialog-title-element';
+import { ErrorDialogContentElement } from '../../ui/error-dialog/error-dialog-content-element';
 import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
 
 defineErrorDialog();
@@ -16,5 +17,6 @@ declare global {
     [DialogDescriptionElement.tagName]: DialogDescriptionElement;
     [DialogPopupElement.tagName]: DialogPopupElement;
     [DialogTitleElement.tagName]: DialogTitleElement;
+    [ErrorDialogContentElement.tagName]: ErrorDialogContentElement;
   }
 }

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -91,6 +91,7 @@ export { DialogDescriptionElement } from './ui/dialog/dialog-description-element
 export { DialogElement } from './ui/dialog/dialog-element';
 export { DialogPopupElement } from './ui/dialog/dialog-popup-element';
 export { DialogTitleElement } from './ui/dialog/dialog-title-element';
+export { ErrorDialogContentElement } from './ui/error-dialog/error-dialog-content-element';
 export { ErrorDialogElement } from './ui/error-dialog/error-dialog-element';
 export { FullscreenButtonElement } from './ui/fullscreen-button/fullscreen-button-element';
 export { GestureElement } from './ui/gesture/gesture-element';

--- a/packages/html/src/presets/audio/minimal-skin.ts
+++ b/packages/html/src/presets/audio/minimal-skin.ts
@@ -17,10 +17,10 @@ function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-popup class="media-dialog__popup">
           <div class="media-dialog__dialog">
-          <div class="media-dialog__content">
+          <media-error-dialog-content class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="media-dialog__actions">
             <media-dialog-close class="media-button media-button--subtle"></media-dialog-close>
           </div>

--- a/packages/html/src/presets/audio/skin.ts
+++ b/packages/html/src/presets/audio/skin.ts
@@ -17,10 +17,10 @@ function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-popup class="media-dialog__popup">
           <div class="media-dialog__dialog">
-          <div class="media-dialog__content">
+          <media-error-dialog-content class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="media-dialog__actions">
             <media-dialog-close class="media-button media-button--subtle"></media-dialog-close>
           </div>

--- a/packages/html/src/presets/live-audio/minimal-skin.ts
+++ b/packages/html/src/presets/live-audio/minimal-skin.ts
@@ -15,10 +15,10 @@ function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-popup class="media-dialog__popup">
           <div class="media-dialog__dialog">
-          <div class="media-dialog__content">
+          <media-error-dialog-content class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="media-dialog__actions">
             <media-dialog-close class="media-button media-button--subtle"></media-dialog-close>
           </div>

--- a/packages/html/src/presets/live-audio/skin.ts
+++ b/packages/html/src/presets/live-audio/skin.ts
@@ -15,10 +15,10 @@ function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-popup class="media-dialog__popup">
           <div class="media-dialog__dialog">
-          <div class="media-dialog__content">
+          <media-error-dialog-content class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="media-dialog__actions">
             <media-dialog-close class="media-button media-button--subtle"></media-dialog-close>
           </div>

--- a/packages/html/src/presets/live-video/minimal-skin.ts
+++ b/packages/html/src/presets/live-video/minimal-skin.ts
@@ -25,10 +25,10 @@ function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-backdrop class="media-dialog__backdrop"></media-dialog-backdrop>
         <media-dialog-popup class="media-dialog__popup media-surface">
-          <div class="media-dialog__content">
+          <media-error-dialog-content class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="media-dialog__actions">
             <media-dialog-close class="media-button media-button--primary"></media-dialog-close>
           </div>

--- a/packages/html/src/presets/live-video/skin.ts
+++ b/packages/html/src/presets/live-video/skin.ts
@@ -25,10 +25,10 @@ function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-backdrop class="media-dialog__backdrop"></media-dialog-backdrop>
         <media-dialog-popup class="media-dialog__popup media-surface">
-          <div class="media-dialog__content">
+          <media-error-dialog-content class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="media-dialog__actions">
             <media-dialog-close class="media-button media-button--primary"></media-dialog-close>
           </div>

--- a/packages/html/src/presets/video/minimal-skin.ts
+++ b/packages/html/src/presets/video/minimal-skin.ts
@@ -27,10 +27,10 @@ function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-backdrop class="media-dialog__backdrop"></media-dialog-backdrop>
         <media-dialog-popup class="media-dialog__popup media-surface">
-          <div class="media-dialog__content">
+          <media-error-dialog-content class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="media-dialog__actions">
             <media-dialog-close class="media-button media-button--primary"></media-dialog-close>
           </div>

--- a/packages/html/src/presets/video/skin.ts
+++ b/packages/html/src/presets/video/skin.ts
@@ -27,10 +27,10 @@ function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-backdrop class="media-dialog__backdrop"></media-dialog-backdrop>
         <media-dialog-popup class="media-dialog__popup media-surface">
-          <div class="media-dialog__content">
+          <media-error-dialog-content class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="media-dialog__actions">
             <media-dialog-close class="media-button media-button--primary"></media-dialog-close>
           </div>

--- a/packages/html/src/registration/ui-compounds.ts
+++ b/packages/html/src/registration/ui-compounds.ts
@@ -8,6 +8,7 @@ import { DialogCloseElement } from '../ui/dialog/dialog-close-element';
 import { DialogDescriptionElement } from '../ui/dialog/dialog-description-element';
 import { DialogPopupElement } from '../ui/dialog/dialog-popup-element';
 import { DialogTitleElement } from '../ui/dialog/dialog-title-element';
+import { ErrorDialogContentElement } from '../ui/error-dialog/error-dialog-content-element';
 import { ErrorDialogElement } from '../ui/error-dialog/error-dialog-element';
 import { MenuCheckboxItemElement } from '../ui/menu/menu-checkbox-item-element';
 import { MenuContentElement } from '../ui/menu/menu-content-element';
@@ -87,6 +88,7 @@ export function defineErrorDialog(): void {
   // Parent first — child elements consume its context.
   safeDefine(ErrorDialogElement);
   defineDialogParts();
+  safeDefine(ErrorDialogContentElement);
 }
 
 export function defineInputIndicators(): void {

--- a/packages/html/src/ui/error-dialog/error-dialog-content-element.ts
+++ b/packages/html/src/ui/error-dialog/error-dialog-content-element.ts
@@ -1,0 +1,29 @@
+import type { DialogState } from '@videojs/core';
+import { observeScrollOverflow } from '@videojs/core/dom';
+import { ContextConsumer } from '@videojs/element/context';
+
+import { ContextPartElement } from '../context-part-element';
+import { dialogContext } from '../dialog/context';
+
+/** Groups scrollable error copy and enters the tab order only when the content overflows. */
+export class ErrorDialogContentElement extends ContextPartElement<DialogState> {
+  static readonly tagName = 'media-error-dialog-content';
+
+  protected readonly consumer = new ContextConsumer(this, { context: dialogContext, subscribe: true });
+
+  #stopObservingOverflow: (() => void) | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    this.#stopObservingOverflow = observeScrollOverflow(this, (overflowing) => {
+      this.tabIndex = overflowing ? 0 : -1;
+    });
+  }
+
+  override disconnectedCallback(): void {
+    this.#stopObservingOverflow?.();
+    this.#stopObservingOverflow = null;
+    super.disconnectedCallback();
+  }
+}

--- a/packages/html/src/ui/error-dialog/tests/error-dialog-content-element.test.ts
+++ b/packages/html/src/ui/error-dialog/tests/error-dialog-content-element.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { ErrorDialogContentElement } from '../error-dialog-content-element';
+
+let tagCounter = 0;
+
+class ResizeObserverStub implements ResizeObserver {
+  static instances: ResizeObserverStub[] = [];
+  readonly observe = vi.fn();
+  readonly unobserve = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+}
+
+class MutationObserverStub implements MutationObserver {
+  static instances: MutationObserverStub[] = [];
+  readonly observe = vi.fn();
+  readonly disconnect = vi.fn();
+  readonly takeRecords = vi.fn(() => []);
+
+  constructor(readonly callback: MutationCallback) {
+    MutationObserverStub.instances.push(this);
+  }
+}
+
+function createContent(clientHeight: number, scrollHeight: number): ErrorDialogContentElement {
+  const tagName = `test-error-dialog-content-${tagCounter++}`;
+
+  customElements.define(tagName, class extends ErrorDialogContentElement {});
+
+  const element = document.createElement(tagName);
+  if (!(element instanceof ErrorDialogContentElement)) throw new Error('Expected error dialog content element.');
+
+  Object.defineProperties(element, {
+    clientHeight: { configurable: true, value: clientHeight },
+    scrollHeight: { configurable: true, value: scrollHeight },
+  });
+
+  return element;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+  ResizeObserverStub.instances.length = 0;
+  MutationObserverStub.instances.length = 0;
+});
+
+describe('ErrorDialogContentElement', () => {
+  it('stays out of the tab order when its content fits', () => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('MutationObserver', MutationObserverStub);
+
+    const content = createContent(100, 100);
+
+    document.body.append(content);
+
+    expect(content.tabIndex).toBe(-1);
+  });
+
+  it('enters the tab order when its content overflows', () => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('MutationObserver', MutationObserverStub);
+
+    const content = createContent(100, 200);
+
+    document.body.append(content);
+
+    expect(content.tabIndex).toBe(0);
+  });
+
+  it('updates focusability and stops observing on disconnect', () => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('MutationObserver', MutationObserverStub);
+
+    const content = createContent(100, 100);
+
+    document.body.append(content);
+
+    Object.defineProperty(content, 'scrollHeight', { configurable: true, value: 200 });
+    ResizeObserverStub.instances[0]!.callback([], ResizeObserverStub.instances[0]!);
+
+    expect(content.tabIndex).toBe(0);
+
+    content.remove();
+
+    expect(ResizeObserverStub.instances[0]!.disconnect).toHaveBeenCalledOnce();
+    expect(MutationObserverStub.instances[0]!.disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -203,10 +203,10 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
       <ErrorDialog.Root>
         <ErrorDialog.Popup className={dialog.popup}>
           <div className={dialog.dialog}>
-            <div className={dialog.content}>
+            <ErrorDialog.Content className={dialog.content}>
               <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
               <ErrorDialog.Description className={dialog.description} />
-            </div>
+            </ErrorDialog.Content>
             <div className={dialog.actions}>
               <ErrorDialog.Close className={cn(button.base, button.subtle)}></ErrorDialog.Close>
             </div>

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -147,10 +147,10 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
       <ErrorDialog.Root>
         <ErrorDialog.Popup className="media-dialog__popup">
           <div className="media-dialog__dialog">
-            <div className="media-dialog__content">
+            <ErrorDialog.Content className="media-dialog__content">
               <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
               <ErrorDialog.Description className="media-dialog__description" />
-            </div>
+            </ErrorDialog.Content>
             <div className="media-dialog__actions">
               <ErrorDialog.Close className="media-button media-button--subtle"></ErrorDialog.Close>
             </div>

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -187,10 +187,10 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
       <ErrorDialog.Root>
         <ErrorDialog.Popup className={dialog.popup}>
           <div className={dialog.dialog}>
-            <div className={dialog.content}>
+            <ErrorDialog.Content className={dialog.content}>
               <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
               <ErrorDialog.Description className={dialog.description} />
-            </div>
+            </ErrorDialog.Content>
             <div className={dialog.actions}>
               <ErrorDialog.Close className={cn(button.base, button.subtle)}></ErrorDialog.Close>
             </div>

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -131,10 +131,10 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
       <ErrorDialog.Root>
         <ErrorDialog.Popup className="media-dialog__popup">
           <div className="media-dialog__dialog">
-            <div className="media-dialog__content">
+            <ErrorDialog.Content className="media-dialog__content">
               <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
               <ErrorDialog.Description className="media-dialog__description" />
-            </div>
+            </ErrorDialog.Content>
             <div className="media-dialog__actions">
               <ErrorDialog.Close className="media-button media-button--subtle"></ErrorDialog.Close>
             </div>

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -137,10 +137,10 @@ export function MinimalLiveAudioSkinTailwind(props: MinimalLiveAudioSkinProps): 
       <ErrorDialog.Root>
         <ErrorDialog.Popup className={dialog.popup}>
           <div className={dialog.dialog}>
-            <div className={dialog.content}>
+            <ErrorDialog.Content className={dialog.content}>
               <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
               <ErrorDialog.Description className={dialog.description} />
-            </div>
+            </ErrorDialog.Content>
             <div className={dialog.actions}>
               <ErrorDialog.Close className={cn(button.base, button.subtle)}></ErrorDialog.Close>
             </div>

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -99,10 +99,10 @@ export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNod
       <ErrorDialog.Root>
         <ErrorDialog.Popup className="media-dialog__popup">
           <div className="media-dialog__dialog">
-            <div className="media-dialog__content">
+            <ErrorDialog.Content className="media-dialog__content">
               <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
               <ErrorDialog.Description className="media-dialog__description" />
-            </div>
+            </ErrorDialog.Content>
             <div className="media-dialog__actions">
               <ErrorDialog.Close className="media-button media-button--subtle"></ErrorDialog.Close>
             </div>

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -113,10 +113,10 @@ export function LiveAudioSkinTailwind(props: LiveAudioSkinProps): ReactNode {
       <ErrorDialog.Root>
         <ErrorDialog.Popup className={dialog.popup}>
           <div className={dialog.dialog}>
-            <div className={dialog.content}>
+            <ErrorDialog.Content className={dialog.content}>
               <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
               <ErrorDialog.Description className={dialog.description} />
-            </div>
+            </ErrorDialog.Content>
             <div className={dialog.actions}>
               <ErrorDialog.Close className={cn(button.base, button.subtle)}></ErrorDialog.Close>
             </div>

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -84,10 +84,10 @@ export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {
       <ErrorDialog.Root>
         <ErrorDialog.Popup className="media-dialog__popup">
           <div className="media-dialog__dialog">
-            <div className="media-dialog__content">
+            <ErrorDialog.Content className="media-dialog__content">
               <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
               <ErrorDialog.Description className="media-dialog__description" />
-            </div>
+            </ErrorDialog.Content>
             <div className="media-dialog__actions">
               <ErrorDialog.Close className="media-button media-button--subtle"></ErrorDialog.Close>
             </div>

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -242,10 +242,10 @@ export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): 
       <ErrorDialog.Root>
         <ErrorDialog.Backdrop className={dialog.backdrop} />
         <ErrorDialog.Popup className={dialog.popup}>
-          <div className={dialog.content}>
+          <ErrorDialog.Content className={dialog.content}>
             <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
             <ErrorDialog.Description className={dialog.description} />
-          </div>
+          </ErrorDialog.Content>
           <div className={dialog.actions}>
             <ErrorDialog.Close className={cn(button.base, button.primary)}></ErrorDialog.Close>
           </div>

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -206,10 +206,10 @@ export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNod
       <ErrorDialog.Root>
         <ErrorDialog.Backdrop className="media-dialog__backdrop" />
         <ErrorDialog.Popup className="media-dialog__popup media-surface">
-          <div className="media-dialog__content">
+          <ErrorDialog.Content className="media-dialog__content">
             <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
             <ErrorDialog.Description className="media-dialog__description" />
-          </div>
+          </ErrorDialog.Content>
           <div className="media-dialog__actions">
             <ErrorDialog.Close className="media-button media-button--primary"></ErrorDialog.Close>
           </div>

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -227,10 +227,10 @@ export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
       <ErrorDialog.Root>
         <ErrorDialog.Backdrop className={dialog.backdrop} />
         <ErrorDialog.Popup className={dialog.popup}>
-          <div className={dialog.content}>
+          <ErrorDialog.Content className={dialog.content}>
             <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
             <ErrorDialog.Description className={dialog.description} />
-          </div>
+          </ErrorDialog.Content>
           <div className={dialog.actions}>
             <ErrorDialog.Close className={cn(button.base, button.primary)}></ErrorDialog.Close>
           </div>

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -188,10 +188,10 @@ export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
       <ErrorDialog.Root>
         <ErrorDialog.Backdrop className="media-dialog__backdrop" />
         <ErrorDialog.Popup className="media-dialog__popup media-surface">
-          <div className="media-dialog__content">
+          <ErrorDialog.Content className="media-dialog__content">
             <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
             <ErrorDialog.Description className="media-dialog__description" />
-          </div>
+          </ErrorDialog.Content>
           <div className="media-dialog__actions">
             <ErrorDialog.Close className="media-button media-button--primary"></ErrorDialog.Close>
           </div>

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -416,10 +416,10 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
       <ErrorDialog.Root>
         <ErrorDialog.Backdrop className={dialog.backdrop} />
         <ErrorDialog.Popup className={dialog.popup}>
-          <div className={dialog.content}>
+          <ErrorDialog.Content className={dialog.content}>
             <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
             <ErrorDialog.Description className={dialog.description} />
-          </div>
+          </ErrorDialog.Content>
           <div className={dialog.actions}>
             <ErrorDialog.Close className={cn(button.base, button.primary)}></ErrorDialog.Close>
           </div>

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -360,10 +360,10 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
       <ErrorDialog.Root>
         <ErrorDialog.Backdrop className="media-dialog__backdrop" />
         <ErrorDialog.Popup className="media-dialog__popup media-surface">
-          <div className="media-dialog__content">
+          <ErrorDialog.Content className="media-dialog__content">
             <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
             <ErrorDialog.Description className="media-dialog__description" />
-          </div>
+          </ErrorDialog.Content>
           <div className="media-dialog__actions">
             <ErrorDialog.Close className="media-button media-button--primary"></ErrorDialog.Close>
           </div>

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -402,10 +402,10 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
       <ErrorDialog.Root>
         <ErrorDialog.Backdrop className={dialog.backdrop} />
         <ErrorDialog.Popup className={dialog.popup}>
-          <div className={dialog.content}>
+          <ErrorDialog.Content className={dialog.content}>
             <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
             <ErrorDialog.Description className={dialog.description} />
-          </div>
+          </ErrorDialog.Content>
           <div className={dialog.actions}>
             <ErrorDialog.Close className={cn(button.base, button.primary)}></ErrorDialog.Close>
           </div>

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -418,10 +418,10 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
       <ErrorDialog.Root>
         <ErrorDialog.Backdrop className="media-dialog__backdrop" />
         <ErrorDialog.Popup className="media-dialog__popup media-surface">
-          <div className="media-dialog__content">
+          <ErrorDialog.Content className="media-dialog__content">
             <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
             <ErrorDialog.Description className="media-dialog__description" />
-          </div>
+          </ErrorDialog.Content>
           <div className="media-dialog__actions">
             <ErrorDialog.Close className="media-button media-button--primary"></ErrorDialog.Close>
           </div>

--- a/packages/react/src/ui/error-dialog/error-dialog-content.tsx
+++ b/packages/react/src/ui/error-dialog/error-dialog-content.tsx
@@ -1,0 +1,44 @@
+import type { DialogCore } from '@videojs/core';
+import { observeScrollOverflow } from '@videojs/core/dom';
+import { forwardRef, useLayoutEffect, useRef, useState } from 'react';
+
+import type { UIComponentProps } from '../../utils/types';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { renderElement } from '../../utils/use-render';
+import { useDialogContext } from '../dialog/context';
+
+export interface ErrorDialogContentProps extends UIComponentProps<'div', DialogCore.State> {}
+
+/** Groups scrollable error copy and enters the tab order only when the content overflows. */
+export const ErrorDialogContent = forwardRef<HTMLDivElement, ErrorDialogContentProps>(function ErrorDialogContent(
+  { render, className, style, ...elementProps },
+  forwardedRef
+) {
+  const { state, stateAttrMap } = useDialogContext();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  const composedRef = useComposedRefs(forwardedRef, contentRef);
+
+  useLayoutEffect(() => {
+    const element = contentRef.current;
+    if (!element) return;
+
+    return observeScrollOverflow(element, setOverflowing);
+  }, []);
+
+  return renderElement(
+    'div',
+    { render, className, style },
+    {
+      state,
+      stateAttrMap,
+      ref: composedRef,
+      props: [{ tabIndex: overflowing ? 0 : -1 }, elementProps],
+    }
+  );
+});
+
+export namespace ErrorDialogContent {
+  export type Props = ErrorDialogContentProps;
+  export type State = DialogCore.State;
+}

--- a/packages/react/src/ui/error-dialog/index.parts.ts
+++ b/packages/react/src/ui/error-dialog/index.parts.ts
@@ -1,5 +1,6 @@
 export { Backdrop, type BackdropProps, Popup, type PopupProps } from '../dialog/index.parts';
 export { ErrorDialogClose as Close, type ErrorDialogCloseProps as CloseProps } from './error-dialog-close';
+export { ErrorDialogContent as Content, type ErrorDialogContentProps as ContentProps } from './error-dialog-content';
 export {
   ErrorDialogDescription as Description,
   type ErrorDialogDescriptionProps as DescriptionProps,

--- a/packages/react/src/ui/error-dialog/tests/error-dialog.test.tsx
+++ b/packages/react/src/ui/error-dialog/tests/error-dialog.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
+import { type RefCallback } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { ErrorDialog } from '..';
@@ -12,6 +13,42 @@ afterEach(() => {
 });
 
 describe('ErrorDialog', () => {
+  it.each([
+    { clientHeight: 100, expectedTabIndex: -1, scrollHeight: 100 },
+    { clientHeight: 100, expectedTabIndex: 0, scrollHeight: 200 },
+  ])(
+    'sets content tabIndex to $expectedTabIndex when its visible and scroll heights are $clientHeight and $scrollHeight',
+    ({ clientHeight, expectedTabIndex, scrollHeight }) => {
+      const { Wrapper } = createPlayerWrapper({
+        error: { code: 4, message: 'The media could not be played.' },
+        dismissError: vi.fn(),
+      });
+      const setMetrics: RefCallback<HTMLDivElement> = (element) => {
+        if (!element) return;
+
+        Object.defineProperties(element, {
+          clientHeight: { configurable: true, value: clientHeight },
+          scrollHeight: { configurable: true, value: scrollHeight },
+        });
+      };
+
+      render(
+        <Wrapper>
+          <ErrorDialog.Root>
+            <ErrorDialog.Popup>
+              <ErrorDialog.Content data-testid="content" ref={setMetrics}>
+                <ErrorDialog.Description />
+              </ErrorDialog.Content>
+              <ErrorDialog.Close />
+            </ErrorDialog.Popup>
+          </ErrorDialog.Root>
+        </Wrapper>
+      );
+
+      expect(screen.getByTestId('content').tabIndex).toBe(expectedTabIndex);
+    }
+  );
+
   it('shows translated title, description, and dismiss label when locale is es', () => {
     registerI18n('es', {
       'errors.title': 'Algo salió mal.',

--- a/packages/skins/vjsc/components/feedback/error-dialog.tsx
+++ b/packages/skins/vjsc/components/feedback/error-dialog.tsx
@@ -11,10 +11,10 @@ export function ErrorDialog({ className, ...props }: Props = {}) {
     <$.ErrorDialog.Root className={styles.root}>
       <$.ErrorDialog.Backdrop className={styles.backdrop} />
       <$.ErrorDialog.Popup className={[surfaceStyles.feedback, styles.popup, className]} {...props}>
-        <Box className={styles.content}>
+        <$.ErrorDialog.Content className={styles.content}>
           <$.ErrorDialog.Title className={styles.title} />
           <$.ErrorDialog.Description className={styles.description} />
-        </Box>
+        </$.ErrorDialog.Content>
         <Box className={styles.actions}>
           <$.ErrorDialog.Close className={[buttonStyles.root, styles.close]} />
         </Box>

--- a/packages/skins/vjsc/target/html.tsx
+++ b/packages/skins/vjsc/target/html.tsx
@@ -23,6 +23,7 @@ const componentParts: Readonly<Record<string, Readonly<Record<string, string>>>>
     Root: 'ErrorDialog',
     Backdrop: 'DialogBackdrop',
     Popup: 'DialogPopup',
+    Content: 'ErrorDialogContent',
     Title: 'DialogTitle',
     Description: 'DialogDescription',
     Close: 'DialogClose',

--- a/packages/skins/vjsc/tests/__snapshots__/generated.tsx.snap
+++ b/packages/skins/vjsc/tests/__snapshots__/generated.tsx.snap
@@ -390,10 +390,10 @@ export function ErrorDialog({ className, ...props }: ErrorDialogProps = {}) {
     <ErrorDialogPrimitive.Root>
       <ErrorDialogPrimitive.Backdrop className={"media-dialog-backdrop"} />
       <ErrorDialogPrimitive.Popup className={state => cn("media-feedback-surface", "media-dialog-popup", resolveClassName(className, state))} {...props}>
-        <div className={"media-dialog-content"}>
+        <ErrorDialogPrimitive.Content className={"media-dialog-content"}>
           <ErrorDialogPrimitive.Title className={"media-dialog-title"} />
           <ErrorDialogPrimitive.Description className={"media-dialog-description"} />
-        </div>
+        </ErrorDialogPrimitive.Content>
         <div className={"media-dialog-actions"}>
           <ErrorDialogPrimitive.Close className={cn("media-button", "media-dialog-close")} />
         </div>
@@ -1633,10 +1633,10 @@ export function ErrorDialog({ className, ...props }: ErrorDialogProps = {}) {
     <ErrorDialogPrimitive.Root>
       <ErrorDialogPrimitive.Backdrop className={"absolute inset-0 z-40 bg-black/20 backdrop-blur-lg opacity-100 backdrop-saturate-150 not-data-open:hidden transition-[opacity,backdrop-filter] delay-100 ease-out motion-reduce:duration-50 data-starting-style:opacity-0 data-ending-style:opacity-0 data-ending-style:delay-0 motion-reduce:delay-0 duration-350"} />
       <ErrorDialogPrimitive.Popup className={state => cn("text-white backdrop-blur-lg backdrop-saturate-150", "after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]", "after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.1),inset_0_0_0_1px_rgb(255_255_255/0.05)]", "[@media(prefers-reduced-transparency:reduce)]:bg-black [@media(prefers-reduced-transparency:reduce)]:ring-1 [@media(prefers-reduced-transparency:reduce)]:ring-transparent", "[@media(prefers-reduced-transparency:reduce)]:backdrop-filter-none", "[@media(prefers-reduced-transparency:reduce)]:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "contrast-more:bg-black contrast-more:ring-1 contrast-more:ring-transparent contrast-more:backdrop-filter-none", "contrast-more:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "forced-colors:bg-[Canvas] forced-colors:ring-1 forced-colors:ring-[CanvasText]", "forced-colors:after:shadow-[inset_0_1px_0_0_CanvasText,inset_0_0_0_1px_CanvasText]", "shadow-sm shadow-black/15 ring-1 ring-black/10", "[@media(prefers-reduced-transparency:reduce)]:shadow-sm [@media(prefers-reduced-transparency:reduce)]:shadow-black/15", "contrast-more:shadow-sm contrast-more:shadow-black/15", "forced-colors:shadow-sm forced-colors:shadow-black/15", "bg-white/10", "absolute top-1/2 left-1/2 z-50 flex max-h-[calc(100%-0.5rem)] -translate-x-1/2 -translate-y-1/2 flex-col gap-3 outline-none not-data-open:hidden", "transition-[opacity,scale] delay-100 ease-out motion-reduce:duration-50", "data-starting-style:scale-95 data-starting-style:opacity-0", "data-ending-style:scale-95 data-ending-style:opacity-0 data-ending-style:delay-0", "motion-reduce:delay-0", "w-[calc(100%-1.5rem)] max-w-72 rounded-[1.75rem] p-3 text-white", "text-shadow-[0_1px_0_rgb(0_0_0/0.25)] duration-350", resolveClassName(className, state))} {...props}>
-        <div className={"flex min-h-0 flex-col gap-2 overflow-y-auto px-2 pt-2 pb-1.5"}>
+        <ErrorDialogPrimitive.Content className={"flex min-h-0 flex-col gap-2 overflow-y-auto px-2 pt-2 pb-1.5"}>
           <ErrorDialogPrimitive.Title className={"m-0 text-media-lg font-semibold leading-tight"} />
           <ErrorDialogPrimitive.Description className={"m-0 opacity-70 wrap-anywhere"} />
-        </div>
+        </ErrorDialogPrimitive.Content>
         <div className={"flex shrink-0 gap-2"}>
           <ErrorDialogPrimitive.Close className={cn("grid min-h-0 shrink-0 touch-manipulation select-none place-items-center rounded-media-control border-0 bg-transparent p-0 text-center text-inherit", "cursor-pointer outline-2 outline-transparent -outline-offset-2", "will-change-[scale] transition-[background-color,color,outline-offset,scale] duration-150 ease-out", "not-aria-disabled:hover:bg-media-control-hover not-aria-disabled:hover:text-media-accent-text", "not-aria-disabled:focus-visible:bg-media-control-hover not-aria-disabled:focus-visible:text-media-accent-text", "not-aria-disabled:aria-expanded:bg-media-control-hover not-aria-disabled:aria-expanded:text-media-accent-text", "focus-visible:outline-white focus-visible:outline-offset-2", "not-aria-disabled:active:scale-[0.97]", "motion-reduce:scale-100 motion-reduce:transition-[background-color,color] motion-reduce:will-change-auto", "aria-disabled:cursor-not-allowed aria-disabled:opacity-50", "size-9", "w-full flex-1 bg-media-accent! px-4 py-2 font-medium text-media-accent-text!", "h-9")} />
         </div>
@@ -2851,10 +2851,10 @@ export function ErrorDialog({ className, ...props }: ErrorDialogProps = {}) {
     <ErrorDialogPrimitive.Root>
       <ErrorDialogPrimitive.Backdrop className={"media-dialog-backdrop"} />
       <ErrorDialogPrimitive.Popup className={state => cn("media-feedback-surface", "media-dialog-popup", resolveClassName(className, state))} {...props}>
-        <div className={"media-dialog-content"}>
+        <ErrorDialogPrimitive.Content className={"media-dialog-content"}>
           <ErrorDialogPrimitive.Title className={"media-dialog-title"} />
           <ErrorDialogPrimitive.Description className={"media-dialog-description"} />
-        </div>
+        </ErrorDialogPrimitive.Content>
         <div className={"media-dialog-actions"}>
           <ErrorDialogPrimitive.Close className={cn("media-button", "media-dialog-close")} />
         </div>
@@ -4094,10 +4094,10 @@ export function ErrorDialog({ className, ...props }: ErrorDialogProps = {}) {
     <ErrorDialogPrimitive.Root>
       <ErrorDialogPrimitive.Backdrop className={"absolute inset-0 z-40 bg-black/20 backdrop-blur-lg opacity-100 not-data-open:hidden transition-[opacity,backdrop-filter] delay-100 ease-out motion-reduce:duration-50 data-starting-style:opacity-0 data-ending-style:opacity-0 data-ending-style:delay-0 motion-reduce:delay-0 backdrop-saturate-120 duration-150"} />
       <ErrorDialogPrimitive.Popup className={state => cn("", "absolute top-1/2 left-1/2 z-50 flex max-h-[calc(100%-0.5rem)] -translate-x-1/2 -translate-y-1/2 flex-col gap-3 outline-none not-data-open:hidden", "transition-[opacity,scale] delay-100 ease-out motion-reduce:duration-50", "data-starting-style:scale-95 data-starting-style:opacity-0", "data-ending-style:scale-95 data-ending-style:opacity-0 data-ending-style:delay-0", "motion-reduce:delay-0", "w-full max-w-64 p-4 text-white", "text-shadow-[0_1px_0_rgb(0_0_0/0.5)] duration-150", resolveClassName(className, state))} {...props}>
-        <div className={"flex min-h-0 flex-col gap-2 overflow-y-auto py-1.5"}>
+        <ErrorDialogPrimitive.Content className={"flex min-h-0 flex-col gap-2 overflow-y-auto py-1.5"}>
           <ErrorDialogPrimitive.Title className={"m-0 text-media-lg font-semibold leading-tight"} />
           <ErrorDialogPrimitive.Description className={"m-0 opacity-70 wrap-anywhere"} />
-        </div>
+        </ErrorDialogPrimitive.Content>
         <div className={"flex shrink-0 gap-2"}>
           <ErrorDialogPrimitive.Close className={cn("grid min-h-0 shrink-0 touch-manipulation select-none place-items-center rounded-media-control border-0 bg-transparent p-0 text-center text-inherit", "cursor-pointer outline-2 outline-transparent -outline-offset-2", "will-change-[scale] transition-[background-color,color,outline-offset,scale] duration-150 ease-out", "not-aria-disabled:hover:bg-media-control-hover not-aria-disabled:hover:text-media-accent-text", "not-aria-disabled:focus-visible:bg-media-control-hover not-aria-disabled:focus-visible:text-media-accent-text", "not-aria-disabled:aria-expanded:bg-media-control-hover not-aria-disabled:aria-expanded:text-media-accent-text", "focus-visible:outline-white focus-visible:outline-offset-2", "not-aria-disabled:active:scale-[0.97]", "motion-reduce:scale-100 motion-reduce:transition-[background-color,color] motion-reduce:will-change-auto", "aria-disabled:cursor-not-allowed aria-disabled:opacity-50", "size-9.5", "supports-[corner-shape:squircle]:rounded-[--spacing(4)]", "supports-[corner-shape:squircle]:[corner-shape:squircle]", "w-full flex-1 bg-media-accent! px-4 py-2 font-medium text-media-accent-text!", "h-9.5")} />
         </div>
@@ -5267,6 +5267,7 @@ import "virtual:vjsc/css/<hash>/dialog.css";
 import "@videojs/html/ui/dialog-backdrop";
 import "@videojs/html/ui/dialog-title";
 import "@videojs/html/ui/dialog-description";
+import "@videojs/html/ui/error-dialog-content";
 import "@videojs/html/ui/dialog-close";
 import "@videojs/html/ui/dialog-popup";
 import "@videojs/html/ui/error-dialog";
@@ -5278,10 +5279,10 @@ export function ErrorDialog({ className, ...props }: Props = {}) {
     <media-error-dialog className={"media-dialog-root"}>
       <media-dialog-backdrop className={"media-dialog-backdrop"} />
       <media-dialog-popup className={["media-feedback-surface", "media-dialog-popup", className]} {...props}>
-        <div className={"media-dialog-content"}>
+        <media-error-dialog-content className={"media-dialog-content"}>
           <media-dialog-title className={"media-dialog-title"} />
           <media-dialog-description className={"media-dialog-description"} />
-        </div>
+        </media-error-dialog-content>
         <div className={"media-dialog-actions"}>
           <media-dialog-close className={["media-button", "media-dialog-close"]} />
         </div>
@@ -6391,6 +6392,7 @@ import { type Props } from "vjsc/components";
 import "@videojs/html/ui/dialog-backdrop";
 import "@videojs/html/ui/dialog-title";
 import "@videojs/html/ui/dialog-description";
+import "@videojs/html/ui/error-dialog-content";
 import "@videojs/html/ui/dialog-close";
 import "@videojs/html/ui/dialog-popup";
 import "@videojs/html/ui/error-dialog";
@@ -6404,10 +6406,10 @@ export function ErrorDialog({ className, ...props }: Props = {}) {
     <media-error-dialog className={""}>
       <media-dialog-backdrop className={"absolute inset-0 z-40 bg-black/20 backdrop-blur-lg opacity-100 backdrop-saturate-150 not-data-open:hidden transition-[opacity,backdrop-filter] delay-100 ease-out motion-reduce:duration-50 data-starting-style:opacity-0 data-ending-style:opacity-0 data-ending-style:delay-0 motion-reduce:delay-0 duration-350"} />
       <media-dialog-popup className={["text-white backdrop-blur-lg backdrop-saturate-150", "after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]", "after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.1),inset_0_0_0_1px_rgb(255_255_255/0.05)]", "[@media(prefers-reduced-transparency:reduce)]:bg-black [@media(prefers-reduced-transparency:reduce)]:ring-1 [@media(prefers-reduced-transparency:reduce)]:ring-transparent", "[@media(prefers-reduced-transparency:reduce)]:backdrop-filter-none", "[@media(prefers-reduced-transparency:reduce)]:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "contrast-more:bg-black contrast-more:ring-1 contrast-more:ring-transparent contrast-more:backdrop-filter-none", "contrast-more:after:shadow-[inset_0_1px_0_0_rgb(255_255_255/0.25),inset_0_0_0_1px_rgb(255_255_255/0.125)]", "forced-colors:bg-[Canvas] forced-colors:ring-1 forced-colors:ring-[CanvasText]", "forced-colors:after:shadow-[inset_0_1px_0_0_CanvasText,inset_0_0_0_1px_CanvasText]", "shadow-sm shadow-black/15 ring-1 ring-black/10", "[@media(prefers-reduced-transparency:reduce)]:shadow-sm [@media(prefers-reduced-transparency:reduce)]:shadow-black/15", "contrast-more:shadow-sm contrast-more:shadow-black/15", "forced-colors:shadow-sm forced-colors:shadow-black/15", "bg-white/10", "absolute top-1/2 left-1/2 z-50 flex max-h-[calc(100%-0.5rem)] -translate-x-1/2 -translate-y-1/2 flex-col gap-3 outline-none not-data-open:hidden", "transition-[opacity,scale] delay-100 ease-out motion-reduce:duration-50", "data-starting-style:scale-95 data-starting-style:opacity-0", "data-ending-style:scale-95 data-ending-style:opacity-0 data-ending-style:delay-0", "motion-reduce:delay-0", "w-[calc(100%-1.5rem)] max-w-72 rounded-[1.75rem] p-3 text-white", "text-shadow-[0_1px_0_rgb(0_0_0/0.25)] duration-350", className]} {...props}>
-        <div className={"flex min-h-0 flex-col gap-2 overflow-y-auto px-2 pt-2 pb-1.5"}>
+        <media-error-dialog-content className={"flex min-h-0 flex-col gap-2 overflow-y-auto px-2 pt-2 pb-1.5"}>
           <media-dialog-title className={"m-0 text-media-lg font-semibold leading-tight"} />
           <media-dialog-description className={"m-0 opacity-70 wrap-anywhere"} />
-        </div>
+        </media-error-dialog-content>
         <div className={"flex shrink-0 gap-2"}>
           <media-dialog-close className={["grid min-h-0 shrink-0 touch-manipulation select-none place-items-center rounded-media-control border-0 bg-transparent p-0 text-center text-inherit", "cursor-pointer outline-2 outline-transparent -outline-offset-2", "will-change-[scale] transition-[background-color,color,outline-offset,scale] duration-150 ease-out", "not-aria-disabled:hover:bg-media-control-hover not-aria-disabled:hover:text-media-accent-text", "not-aria-disabled:focus-visible:bg-media-control-hover not-aria-disabled:focus-visible:text-media-accent-text", "not-aria-disabled:aria-expanded:bg-media-control-hover not-aria-disabled:aria-expanded:text-media-accent-text", "focus-visible:outline-white focus-visible:outline-offset-2", "not-aria-disabled:active:scale-[0.97]", "motion-reduce:scale-100 motion-reduce:transition-[background-color,color] motion-reduce:will-change-auto", "aria-disabled:cursor-not-allowed aria-disabled:opacity-50", "size-9", "w-full flex-1 bg-media-accent! px-4 py-2 font-medium text-media-accent-text!", "h-9"]} />
         </div>
@@ -7494,6 +7496,7 @@ import "virtual:vjsc/css/<hash>/dialog.css";
 import "@videojs/html/ui/dialog-backdrop";
 import "@videojs/html/ui/dialog-title";
 import "@videojs/html/ui/dialog-description";
+import "@videojs/html/ui/error-dialog-content";
 import "@videojs/html/ui/dialog-close";
 import "@videojs/html/ui/dialog-popup";
 import "@videojs/html/ui/error-dialog";
@@ -7505,10 +7508,10 @@ export function ErrorDialog({ className, ...props }: Props = {}) {
     <media-error-dialog className={"media-dialog-root"}>
       <media-dialog-backdrop className={"media-dialog-backdrop"} />
       <media-dialog-popup className={["media-feedback-surface", "media-dialog-popup", className]} {...props}>
-        <div className={"media-dialog-content"}>
+        <media-error-dialog-content className={"media-dialog-content"}>
           <media-dialog-title className={"media-dialog-title"} />
           <media-dialog-description className={"media-dialog-description"} />
-        </div>
+        </media-error-dialog-content>
         <div className={"media-dialog-actions"}>
           <media-dialog-close className={["media-button", "media-dialog-close"]} />
         </div>
@@ -8620,6 +8623,7 @@ import { type Props } from "vjsc/components";
 import "@videojs/html/ui/dialog-backdrop";
 import "@videojs/html/ui/dialog-title";
 import "@videojs/html/ui/dialog-description";
+import "@videojs/html/ui/error-dialog-content";
 import "@videojs/html/ui/dialog-close";
 import "@videojs/html/ui/dialog-popup";
 import "@videojs/html/ui/error-dialog";
@@ -8633,10 +8637,10 @@ export function ErrorDialog({ className, ...props }: Props = {}) {
     <media-error-dialog className={""}>
       <media-dialog-backdrop className={"absolute inset-0 z-40 bg-black/20 backdrop-blur-lg opacity-100 not-data-open:hidden transition-[opacity,backdrop-filter] delay-100 ease-out motion-reduce:duration-50 data-starting-style:opacity-0 data-ending-style:opacity-0 data-ending-style:delay-0 motion-reduce:delay-0 backdrop-saturate-120 duration-150"} />
       <media-dialog-popup className={["", "absolute top-1/2 left-1/2 z-50 flex max-h-[calc(100%-0.5rem)] -translate-x-1/2 -translate-y-1/2 flex-col gap-3 outline-none not-data-open:hidden", "transition-[opacity,scale] delay-100 ease-out motion-reduce:duration-50", "data-starting-style:scale-95 data-starting-style:opacity-0", "data-ending-style:scale-95 data-ending-style:opacity-0 data-ending-style:delay-0", "motion-reduce:delay-0", "w-full max-w-64 p-4 text-white", "text-shadow-[0_1px_0_rgb(0_0_0/0.5)] duration-150", className]} {...props}>
-        <div className={"flex min-h-0 flex-col gap-2 overflow-y-auto py-1.5"}>
+        <media-error-dialog-content className={"flex min-h-0 flex-col gap-2 overflow-y-auto py-1.5"}>
           <media-dialog-title className={"m-0 text-media-lg font-semibold leading-tight"} />
           <media-dialog-description className={"m-0 opacity-70 wrap-anywhere"} />
-        </div>
+        </media-error-dialog-content>
         <div className={"flex shrink-0 gap-2"}>
           <media-dialog-close className={["grid min-h-0 shrink-0 touch-manipulation select-none place-items-center rounded-media-control border-0 bg-transparent p-0 text-center text-inherit", "cursor-pointer outline-2 outline-transparent -outline-offset-2", "will-change-[scale] transition-[background-color,color,outline-offset,scale] duration-150 ease-out", "not-aria-disabled:hover:bg-media-control-hover not-aria-disabled:hover:text-media-accent-text", "not-aria-disabled:focus-visible:bg-media-control-hover not-aria-disabled:focus-visible:text-media-accent-text", "not-aria-disabled:aria-expanded:bg-media-control-hover not-aria-disabled:aria-expanded:text-media-accent-text", "focus-visible:outline-white focus-visible:outline-offset-2", "not-aria-disabled:active:scale-[0.97]", "motion-reduce:scale-100 motion-reduce:transition-[background-color,color] motion-reduce:will-change-auto", "aria-disabled:cursor-not-allowed aria-disabled:opacity-50", "size-9.5", "supports-[corner-shape:squircle]:rounded-[--spacing(4)]", "supports-[corner-shape:squircle]:[corner-shape:squircle]", "w-full flex-1 bg-media-accent! px-4 py-2 font-medium text-media-accent-text!", "h-9.5"]} />
         </div>

--- a/site/scripts/ejected-skins/templates/html/audio/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/audio/minimal-skin.tailwind.ts
@@ -31,10 +31,10 @@ export function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-popup class="${dialog.popup}">
         <div class="${dialog.dialog}">
-          <div class="${dialog.content}">
+          <media-error-dialog-content class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="${dialog.actions}">
             <media-dialog-close class="${cn(button.base, button.subtle)}"></media-dialog-close>
           </div>

--- a/site/scripts/ejected-skins/templates/html/audio/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/audio/skin.tailwind.ts
@@ -31,10 +31,10 @@ export function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-popup class="${dialog.popup}">
         <div class="${dialog.dialog}">
-          <div class="${dialog.content}">
+          <media-error-dialog-content class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="${dialog.actions}">
             <media-dialog-close class="${cn(button.base, button.subtle)}"></media-dialog-close>
           </div>

--- a/site/scripts/ejected-skins/templates/html/live-audio/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-audio/minimal-skin.tailwind.ts
@@ -24,10 +24,10 @@ export function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-popup class="${dialog.popup}">
         <div class="${dialog.dialog}">
-          <div class="${dialog.content}">
+          <media-error-dialog-content class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="${dialog.actions}">
             <media-dialog-close class="${cn(button.base, button.subtle)}"></media-dialog-close>
           </div>

--- a/site/scripts/ejected-skins/templates/html/live-audio/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-audio/skin.tailwind.ts
@@ -24,10 +24,10 @@ export function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-popup class="${dialog.popup}">
         <div class="${dialog.dialog}">
-          <div class="${dialog.content}">
+          <media-error-dialog-content class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="${dialog.actions}">
             <media-dialog-close class="${cn(button.base, button.subtle)}"></media-dialog-close>
           </div>

--- a/site/scripts/ejected-skins/templates/html/live-video/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-video/minimal-skin.tailwind.ts
@@ -41,10 +41,10 @@ export function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-backdrop class="${dialog.backdrop}"></media-dialog-backdrop>
         <media-dialog-popup class="${dialog.popup}">
-          <div class="${dialog.content}">
+          <media-error-dialog-content class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="${dialog.actions}">
             <media-dialog-close class="${cn(button.base, button.primary)}"></media-dialog-close>
           </div>

--- a/site/scripts/ejected-skins/templates/html/live-video/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-video/skin.tailwind.ts
@@ -42,10 +42,10 @@ export function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-backdrop class="${dialog.backdrop}"></media-dialog-backdrop>
         <media-dialog-popup class="${dialog.popup}">
-          <div class="${dialog.content}">
+          <media-error-dialog-content class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="${dialog.actions}">
             <media-dialog-close class="${cn(button.base, button.primary)}"></media-dialog-close>
           </div>

--- a/site/scripts/ejected-skins/templates/html/video/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/video/minimal-skin.tailwind.ts
@@ -47,10 +47,10 @@ export function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-backdrop class="${dialog.backdrop}"></media-dialog-backdrop>
         <media-dialog-popup class="${dialog.popup}">
-          <div class="${dialog.content}">
+          <media-error-dialog-content class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="${dialog.actions}">
             <media-dialog-close class="${cn(button.base, button.primary)}"></media-dialog-close>
           </div>

--- a/site/scripts/ejected-skins/templates/html/video/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/video/skin.tailwind.ts
@@ -49,10 +49,10 @@ export function getTemplateHTML() {
       <media-error-dialog>
         <media-dialog-backdrop class="${dialog.backdrop}"></media-dialog-backdrop>
         <media-dialog-popup class="${dialog.popup}">
-          <div class="${dialog.content}">
+          <media-error-dialog-content class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
-          </div>
+          </media-error-dialog-content>
           <div class="${dialog.actions}">
             <media-dialog-close class="${cn(button.base, button.primary)}"></media-dialog-close>
           </div>

--- a/site/src/content/docs/reference/error-dialog.mdx
+++ b/site/src/content/docs/reference/error-dialog.mdx
@@ -34,8 +34,10 @@ import basicUsageHtmlTs from "@/components/docs/demos/error-dialog/html/css/Basi
 <ErrorDialog.Root>
   <ErrorDialog.Backdrop />
   <ErrorDialog.Popup>
-    <ErrorDialog.Title />
-    <ErrorDialog.Description />
+    <ErrorDialog.Content>
+      <ErrorDialog.Title />
+      <ErrorDialog.Description />
+    </ErrorDialog.Content>
     <ErrorDialog.Close />
   </ErrorDialog.Popup>
 </ErrorDialog.Root>
@@ -47,8 +49,10 @@ import basicUsageHtmlTs from "@/components/docs/demos/error-dialog/html/css/Basi
 <media-error-dialog>
   <media-dialog-backdrop></media-dialog-backdrop>
   <media-dialog-popup>
-    <media-dialog-title></media-dialog-title>
-    <media-dialog-description></media-dialog-description>
+    <media-error-dialog-content>
+      <media-dialog-title></media-dialog-title>
+      <media-dialog-description></media-dialog-description>
+    </media-error-dialog-content>
     <media-dialog-close></media-dialog-close>
   </media-dialog-popup>
 </media-error-dialog>
@@ -60,6 +64,8 @@ import basicUsageHtmlTs from "@/components/docs/demos/error-dialog/html/css/Basi
 `ErrorDialog` is a specialized root driven by the player's <DocsLink slug="reference/feature-error">error feature</DocsLink>. It uses alert semantics and reuses the backdrop, popup, title, description, and close parts from <DocsLink slug="reference/dialog">`Dialog`</DocsLink>; it is not nested inside `AlertDialog`. It opens when the attached media reports an error and stays hidden otherwise. Closing it dismisses the current error in the player store.
 
 The title, description, and close label use localized default text. Provide children to any of those parts to replace its default content. Known media error codes use the matching translated message, while custom error messages are shown as written.
+
+Wrap the title and description in `Content`. The part stays out of the tab order when all copy is visible and becomes keyboard-focusable when its content overflows, allowing keyboard users to scroll the complete message.
 
 The included player skins already render an error dialog. Compose this component directly when building a custom skin.
 


### PR DESCRIPTION
## Summary

- adds a dedicated `ErrorDialog.Content` part for HTML and React, with VJSC and preset parity
- keeps fitting error copy out of the tab order and makes only overflowing copy keyboard-scrollable
- observes resize and content mutations so focusability follows the rendered overflow state
- updates the error-dialog reference and ejected HTML Tailwind templates
- verifies focus order and `PageDown` scrolling in Chromium

## Stack

Stacked on #2451. Merge #2451 first; this PR then contains only the overflow accessibility layer.

## Verification

- `pnpm -F @videojs/core test`
- `pnpm -F @videojs/html test`
- `pnpm -F @videojs/react test`
- `pnpm -F @videojs/skins test`
- `pnpm -F @videojs/e2e e2e tests/error-dialog.spec.ts --project=vite-chromium`
- `pnpm -F @videojs/e2e e2e tests/sandbox-skin-styling.spec.ts --project=sandbox-chromium --grep "contains the error dialog" --workers=1`
- `pnpm -F site api-docs`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`