### PR TITLE
fix(packages): align dialog styles across skins

### DIFF
--- a/packages/html/src/presets/audio/minimal-skin.ts
+++ b/packages/html/src/presets/audio/minimal-skin.ts
@@ -17,14 +17,12 @@ function getTemplateHTML() {
 
       <media-error-dialog>
         <media-dialog-popup class="media-dialog__popup">
-          <div class="media-dialog__dialog">
           <div class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
           </div>
           <div class="media-dialog__actions">
-            <media-dialog-close class="media-button media-button--subtle"></media-dialog-close>
-          </div>
+            <media-dialog-close class="media-button media-button--primary"></media-dialog-close>
           </div>
         </media-dialog-popup>
       </media-error-dialog>

--- a/packages/html/src/presets/audio/skin.ts
+++ b/packages/html/src/presets/audio/skin.ts
@@ -17,14 +17,12 @@ function getTemplateHTML() {
 
       <media-error-dialog>
         <media-dialog-popup class="media-dialog__popup">
-          <div class="media-dialog__dialog">
           <div class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
           </div>
           <div class="media-dialog__actions">
-            <media-dialog-close class="media-button media-button--subtle"></media-dialog-close>
-          </div>
+            <media-dialog-close class="media-button media-button--primary"></media-dialog-close>
           </div>
         </media-dialog-popup>
       </media-error-dialog>

--- a/packages/html/src/presets/live-audio/minimal-skin.ts
+++ b/packages/html/src/presets/live-audio/minimal-skin.ts
@@ -16,14 +16,12 @@ function getTemplateHTML() {
 
       <media-error-dialog>
         <media-dialog-popup class="media-dialog__popup">
-          <div class="media-dialog__dialog">
           <div class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
           </div>
           <div class="media-dialog__actions">
-            <media-dialog-close class="media-button media-button--subtle"></media-dialog-close>
-          </div>
+            <media-dialog-close class="media-button media-button--primary"></media-dialog-close>
           </div>
         </media-dialog-popup>
       </media-error-dialog>

--- a/packages/html/src/presets/live-audio/skin.ts
+++ b/packages/html/src/presets/live-audio/skin.ts
@@ -16,14 +16,12 @@ function getTemplateHTML() {
 
       <media-error-dialog>
         <media-dialog-popup class="media-dialog__popup">
-          <div class="media-dialog__dialog">
           <div class="media-dialog__content">
             <media-dialog-title class="media-dialog__title"></media-dialog-title>
             <media-dialog-description class="media-dialog__description"></media-dialog-description>
           </div>
           <div class="media-dialog__actions">
-            <media-dialog-close class="media-button media-button--subtle"></media-dialog-close>
-          </div>
+            <media-dialog-close class="media-button media-button--primary"></media-dialog-close>
           </div>
         </media-dialog-popup>
       </media-error-dialog>

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -203,14 +203,12 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
 
       <ErrorDialog.Root>
         <ErrorDialog.Popup className={dialog.popup}>
-          <div className={dialog.dialog}>
-            <div className={dialog.content}>
-              <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
-              <ErrorDialog.Description className={dialog.description} />
-            </div>
-            <div className={dialog.actions}>
-              <ErrorDialog.Close className={cn(button.base, button.subtle)}></ErrorDialog.Close>
-            </div>
+          <div className={dialog.content}>
+            <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
+            <ErrorDialog.Description className={dialog.description} />
+          </div>
+          <div className={dialog.actions}>
+            <ErrorDialog.Close className={cn(button.base, button.primary)}></ErrorDialog.Close>
           </div>
         </ErrorDialog.Popup>
       </ErrorDialog.Root>

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -147,14 +147,12 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
 
       <ErrorDialog.Root>
         <ErrorDialog.Popup className="media-dialog__popup">
-          <div className="media-dialog__dialog">
-            <div className="media-dialog__content">
-              <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
-              <ErrorDialog.Description className="media-dialog__description" />
-            </div>
-            <div className="media-dialog__actions">
-              <ErrorDialog.Close className="media-button media-button--subtle"></ErrorDialog.Close>
-            </div>
+          <div className="media-dialog__content">
+            <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
+            <ErrorDialog.Description className="media-dialog__description" />
+          </div>
+          <div className="media-dialog__actions">
+            <ErrorDialog.Close className="media-button media-button--primary"></ErrorDialog.Close>
           </div>
         </ErrorDialog.Popup>
       </ErrorDialog.Root>

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -187,14 +187,12 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
 
       <ErrorDialog.Root>
         <ErrorDialog.Popup className={dialog.popup}>
-          <div className={dialog.dialog}>
-            <div className={dialog.content}>
-              <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
-              <ErrorDialog.Description className={dialog.description} />
-            </div>
-            <div className={dialog.actions}>
-              <ErrorDialog.Close className={cn(button.base, button.subtle)}></ErrorDialog.Close>
-            </div>
+          <div className={dialog.content}>
+            <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
+            <ErrorDialog.Description className={dialog.description} />
+          </div>
+          <div className={dialog.actions}>
+            <ErrorDialog.Close className={cn(button.base, button.primary)}></ErrorDialog.Close>
           </div>
         </ErrorDialog.Popup>
       </ErrorDialog.Root>

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -131,14 +131,12 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
 
       <ErrorDialog.Root>
         <ErrorDialog.Popup className="media-dialog__popup">
-          <div className="media-dialog__dialog">
-            <div className="media-dialog__content">
-              <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
-              <ErrorDialog.Description className="media-dialog__description" />
-            </div>
-            <div className="media-dialog__actions">
-              <ErrorDialog.Close className="media-button media-button--subtle"></ErrorDialog.Close>
-            </div>
+          <div className="media-dialog__content">
+            <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
+            <ErrorDialog.Description className="media-dialog__description" />
+          </div>
+          <div className="media-dialog__actions">
+            <ErrorDialog.Close className="media-button media-button--primary"></ErrorDialog.Close>
           </div>
         </ErrorDialog.Popup>
       </ErrorDialog.Root>

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -138,14 +138,12 @@ export function MinimalLiveAudioSkinTailwind(props: MinimalLiveAudioSkinProps): 
 
       <ErrorDialog.Root>
         <ErrorDialog.Popup className={dialog.popup}>
-          <div className={dialog.dialog}>
-            <div className={dialog.content}>
-              <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
-              <ErrorDialog.Description className={dialog.description} />
-            </div>
-            <div className={dialog.actions}>
-              <ErrorDialog.Close className={cn(button.base, button.subtle)}></ErrorDialog.Close>
-            </div>
+          <div className={dialog.content}>
+            <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
+            <ErrorDialog.Description className={dialog.description} />
+          </div>
+          <div className={dialog.actions}>
+            <ErrorDialog.Close className={cn(button.base, button.primary)}></ErrorDialog.Close>
           </div>
         </ErrorDialog.Popup>
       </ErrorDialog.Root>

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -100,14 +100,12 @@ export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNod
 
       <ErrorDialog.Root>
         <ErrorDialog.Popup className="media-dialog__popup">
-          <div className="media-dialog__dialog">
-            <div className="media-dialog__content">
-              <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
-              <ErrorDialog.Description className="media-dialog__description" />
-            </div>
-            <div className="media-dialog__actions">
-              <ErrorDialog.Close className="media-button media-button--subtle"></ErrorDialog.Close>
-            </div>
+          <div className="media-dialog__content">
+            <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
+            <ErrorDialog.Description className="media-dialog__description" />
+          </div>
+          <div className="media-dialog__actions">
+            <ErrorDialog.Close className="media-button media-button--primary"></ErrorDialog.Close>
           </div>
         </ErrorDialog.Popup>
       </ErrorDialog.Root>

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -114,14 +114,12 @@ export function LiveAudioSkinTailwind(props: LiveAudioSkinProps): ReactNode {
 
       <ErrorDialog.Root>
         <ErrorDialog.Popup className={dialog.popup}>
-          <div className={dialog.dialog}>
-            <div className={dialog.content}>
-              <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
-              <ErrorDialog.Description className={dialog.description} />
-            </div>
-            <div className={dialog.actions}>
-              <ErrorDialog.Close className={cn(button.base, button.subtle)}></ErrorDialog.Close>
-            </div>
+          <div className={dialog.content}>
+            <ErrorDialog.Title className={dialog.title}></ErrorDialog.Title>
+            <ErrorDialog.Description className={dialog.description} />
+          </div>
+          <div className={dialog.actions}>
+            <ErrorDialog.Close className={cn(button.base, button.primary)}></ErrorDialog.Close>
           </div>
         </ErrorDialog.Popup>
       </ErrorDialog.Root>

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -85,14 +85,12 @@ export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {
 
       <ErrorDialog.Root>
         <ErrorDialog.Popup className="media-dialog__popup">
-          <div className="media-dialog__dialog">
-            <div className="media-dialog__content">
-              <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
-              <ErrorDialog.Description className="media-dialog__description" />
-            </div>
-            <div className="media-dialog__actions">
-              <ErrorDialog.Close className="media-button media-button--subtle"></ErrorDialog.Close>
-            </div>
+          <div className="media-dialog__content">
+            <ErrorDialog.Title className="media-dialog__title"></ErrorDialog.Title>
+            <ErrorDialog.Description className="media-dialog__description" />
+          </div>
+          <div className="media-dialog__actions">
+            <ErrorDialog.Close className="media-button media-button--primary"></ErrorDialog.Close>
           </div>
         </ErrorDialog.Popup>
       </ErrorDialog.Root>

--- a/packages/skins/src/default/css/audio.css
+++ b/packages/skins/src/default/css/audio.css
@@ -53,33 +53,28 @@
   position: absolute;
   inset: 0;
   z-index: 20;
-}
-
-.media-default-skin--audio .media-dialog__dialog {
-  position: absolute;
-  inset: 0;
-  z-index: 20;
   display: flex;
   gap: calc(var(--media-spacing) * 3);
   align-items: center;
   padding-inline: calc(var(--media-spacing) * 5) calc(var(--media-spacing) * 1);
   color: var(--media-text-color);
-  background-color: var(--media-surface-background-color);
+  background-color: oklch(from var(--media-surface-background-color) l c h / 1);
   border-radius: calc(infinity * 1px);
   backdrop-filter: var(--media-surface-backdrop-filter);
   transition-delay: var(--media-dialog-transition-delay);
   transition-timing-function: ease-out;
   transition-duration: var(--media-dialog-transition-duration);
   transition-property: opacity, filter;
-}
 
-.media-default-skin .media-dialog__popup[data-starting-style] .media-dialog__dialog,
-.media-default-skin .media-dialog__popup[data-ending-style] .media-dialog__dialog {
-  opacity: 0;
-  filter: blur(4px);
-}
-.media-default-skin .media-dialog__popup[data-ending-style] .media-dialog__dialog {
-  transition-delay: 0ms;
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    filter: blur(4px);
+  }
+  &[data-ending-style] {
+    transition-duration: max(calc(var(--media-dialog-transition-duration) - 100ms), 50ms);
+    transition-delay: 0ms;
+  }
 }
 
 .media-default-skin--audio .media-dialog__content {

--- a/packages/skins/src/default/css/components/dialog.css
+++ b/packages/skins/src/default/css/components/dialog.css
@@ -2,7 +2,7 @@
   .media-dialog__backdrop {
     position: absolute;
     inset: 0;
-    z-index: 10;
+    z-index: 20;
     pointer-events: none;
     background: oklch(0 0 0 / 0.2);
     backdrop-filter: blur(16px) saturate(1.5);

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -144,6 +144,7 @@
   scale: 0.95;
 }
 .media-default-skin--video .media-dialog__popup[data-ending-style] {
+  transition-duration: max(calc(var(--media-dialog-transition-duration) - 100ms), 50ms);
   transition-delay: 0ms;
 }
 

--- a/packages/skins/src/default/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/default/tailwind/audio.tailwind.ts
@@ -84,17 +84,16 @@ export const popup = {
 
 export const dialog = {
   ...baseDialog,
-  popup: 'group/dialog absolute inset-0 z-20 not-data-open:hidden outline-none',
-  dialog: cn(
-    'absolute inset-0 z-20 flex items-center gap-3 rounded-full px-5 pr-0.5',
-    'bg-(--media-surface-background-color) text-(--media-text-color)',
-    'backdrop-blur-lg backdrop-saturate-150',
+  popup: cn(
+    'absolute inset-0 z-20 flex items-center gap-3 rounded-full ps-5 pe-1 not-data-open:hidden outline-none',
+    '[background-color:oklch(from_var(--media-surface-background-color)_l_c_h/1)] text-(--media-text-color)',
+    '[backdrop-filter:var(--media-surface-backdrop-filter)]',
     'transition-[opacity,filter] ease-out',
     'duration-(--media-dialog-transition-duration)',
     'delay-(--media-dialog-transition-delay)',
-    'group-data-starting-style/dialog:opacity-0 group-data-starting-style/dialog:blur-xs',
-    'group-data-ending-style/dialog:opacity-0 group-data-ending-style/dialog:blur-xs',
-    'group-data-ending-style/dialog:delay-0'
+    'data-starting-style:opacity-0 data-starting-style:blur-xs',
+    'data-ending-style:opacity-0 data-ending-style:blur-xs',
+    'data-ending-style:duration-[max(calc(var(--media-dialog-transition-duration)-100ms),50ms)] data-ending-style:delay-0'
   ),
   content: 'flex flex-1 items-center gap-2',
 };

--- a/packages/skins/src/default/tailwind/components/dialog.ts
+++ b/packages/skins/src/default/tailwind/components/dialog.ts
@@ -1,9 +1,9 @@
 import { cn } from '@videojs/utils/style';
 
 export const dialog = {
-  root: '',
+  root: '', // Needed for vjsc.
   backdrop: cn(
-    'absolute inset-0 z-10 pointer-events-none bg-black/20 backdrop-blur-lg backdrop-saturate-150 opacity-100 not-data-open:hidden',
+    'absolute inset-0 z-20 pointer-events-none bg-black/20 backdrop-blur-lg backdrop-saturate-150 opacity-100 not-data-open:hidden',
     'transition-opacity',
     'duration-(--media-dialog-transition-duration)',
     'delay-(--media-dialog-transition-delay)',
@@ -18,7 +18,8 @@ export const dialog = {
     'delay-(--media-dialog-transition-delay)',
     'ease-(--media-dialog-transition-timing-function)',
     'data-starting-style:scale-95 data-starting-style:opacity-0',
-    'data-ending-style:scale-95 data-ending-style:opacity-0 data-ending-style:delay-0',
+    'data-ending-style:scale-95 data-ending-style:opacity-0',
+    'data-ending-style:duration-[max(calc(var(--media-dialog-transition-duration)-100ms),50ms)] data-ending-style:delay-0',
     'motion-reduce:scale-100 motion-reduce:transition-opacity'
   ),
   content: 'flex min-h-0 flex-col gap-2 overflow-y-auto px-2 pt-2 pb-1.5',

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -1,6 +1,5 @@
 import { cn } from '@videojs/utils/style';
 
-import { bufferingIndicator as baseBufferingIndicator } from './components/buffering';
 import { buttonGroup as baseButtonGroup } from './components/button-group';
 import { container as baseContainer } from './components/container';
 import { controls as baseControls } from './components/controls';
@@ -194,10 +193,6 @@ export const menu = {
   settings: baseMenu.settings,
 };
 
-/* Buffering */
-
-export const bufferingIndicator = baseBufferingIndicator;
-
 /* Dialog (with video surface) */
 
 export const dialog = {
@@ -221,12 +216,13 @@ export const statusIndicator = {
 
 /* Shared components (no overrides) */
 
-export { iconState } from '../../shared/tailwind/icon-state';
-export { controlsBackdrop } from './components/controls-backdrop';
+export { bufferingIndicator } from './components/buffering';
 export { badge } from './components/badge';
 export { button } from './components/button';
 export { buttonGroup } from './components/button-group';
+export { controlsBackdrop } from './components/controls-backdrop';
 export { icon, iconContainer, iconFlipped, iconHidden } from './components/icon';
+export { iconState } from '../../shared/tailwind/icon-state';
 export { inputIndicator } from './components/input-indicator';
 export { playbackRate } from './components/playback-rate';
 export { poster } from './components/poster';

--- a/packages/skins/src/minimal/css/audio.css
+++ b/packages/skins/src/minimal/css/audio.css
@@ -57,12 +57,6 @@
   position: absolute;
   inset: 0;
   z-index: 20;
-}
-
-.media-minimal-skin--audio .media-dialog__dialog {
-  position: absolute;
-  inset: 0;
-  z-index: 20;
   display: flex;
   gap: calc(var(--media-spacing) * 4);
   align-items: center;
@@ -73,16 +67,17 @@
   transition-timing-function: ease-out;
   transition-duration: var(--media-dialog-transition-duration);
   transition-property: opacity, filter, scale;
-}
 
-.media-minimal-skin--audio .media-dialog__popup[data-starting-style] .media-dialog__dialog,
-.media-minimal-skin--audio .media-dialog__popup[data-ending-style] .media-dialog__dialog {
-  opacity: 0;
-  filter: blur(4px);
-  scale: 0.95;
-}
-.media-minimal-skin--audio .media-dialog__popup[data-ending-style] .media-dialog__dialog {
-  transition-delay: 0ms;
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    filter: blur(4px);
+    scale: 0.95;
+  }
+  &[data-ending-style] {
+    transition-duration: max(calc(var(--media-dialog-transition-duration) - 100ms), 50ms);
+    transition-delay: 0ms;
+  }
 }
 
 .media-minimal-skin--audio .media-dialog__content {

--- a/packages/skins/src/minimal/css/components/dialog.css
+++ b/packages/skins/src/minimal/css/components/dialog.css
@@ -2,7 +2,7 @@
   .media-dialog__backdrop {
     position: absolute;
     inset: 0;
-    z-index: 10;
+    z-index: 20;
     pointer-events: none;
     background: oklch(0 0 0 / 0.2);
     backdrop-filter: blur(16px) saturate(1.2);

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -145,6 +145,7 @@
     scale: 0.95;
   }
   &[data-ending-style] {
+    transition-duration: max(calc(var(--media-dialog-transition-duration) - 100ms), 50ms);
     transition-delay: 0ms;
   }
 }
@@ -160,10 +161,6 @@
 
 .media-minimal-skin--video .media-dialog__title {
   font-size: var(--media-font-size-medium);
-}
-
-.media-minimal-skin--video:has([role="alertdialog"][data-open]) .media-controls {
-  display: none;
 }
 
 /* Controls (hide/show behavior) */

--- a/packages/skins/src/minimal/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/audio.tailwind.ts
@@ -85,16 +85,15 @@ export const slider = {
 
 export const dialog = {
   ...baseDialog,
-  popup: 'group/dialog absolute inset-0 z-20 not-data-open:hidden outline-none',
-  dialog: cn(
-    'absolute inset-0 z-20 flex items-center gap-4 rounded-full px-5 pr-2',
-    'bg-(--media-controls-background-color)',
+  popup: cn(
+    'absolute inset-0 z-20 flex items-center gap-4 rounded-full ps-3 pe-1 not-data-open:hidden outline-none',
+    '[background-color:oklch(from_var(--media-controls-background-color)_l_c_h/1)]',
     'transition-[opacity,filter,scale] ease-out',
     'duration-(--media-dialog-transition-duration)',
     'delay-(--media-dialog-transition-delay)',
-    'group-data-starting-style/dialog:opacity-0 group-data-starting-style/dialog:blur-xs group-data-starting-style/dialog:scale-95',
-    'group-data-ending-style/dialog:opacity-0 group-data-ending-style/dialog:blur-xs group-data-ending-style/dialog:scale-95',
-    'group-data-ending-style/dialog:delay-0'
+    'data-starting-style:opacity-0 data-starting-style:blur-xs data-starting-style:scale-95',
+    'data-ending-style:opacity-0 data-ending-style:blur-xs data-ending-style:scale-95',
+    'data-ending-style:duration-[max(calc(var(--media-dialog-transition-duration)-100ms),50ms)] data-ending-style:delay-0'
   ),
   content: 'flex flex-1 items-center gap-2',
 };

--- a/packages/skins/src/minimal/tailwind/components/dialog.ts
+++ b/packages/skins/src/minimal/tailwind/components/dialog.ts
@@ -3,7 +3,7 @@ import { cn } from '@videojs/utils/style';
 export const dialog = {
   root: '',
   backdrop: cn(
-    'absolute inset-0 z-10 pointer-events-none bg-black/20 backdrop-blur-lg backdrop-saturate-120 opacity-100 not-data-open:hidden',
+    'absolute inset-0 z-20 pointer-events-none bg-black/20 backdrop-blur-lg backdrop-saturate-120 opacity-100 not-data-open:hidden',
     'transition-opacity',
     'duration-(--media-dialog-transition-duration)',
     'delay-(--media-dialog-transition-delay)',
@@ -19,7 +19,8 @@ export const dialog = {
     'delay-(--media-dialog-transition-delay)',
     'ease-(--media-dialog-transition-timing-function)',
     'data-starting-style:scale-95 data-starting-style:opacity-0',
-    'data-ending-style:scale-95 data-ending-style:opacity-0 data-ending-style:delay-0',
+    'data-ending-style:scale-95 data-ending-style:opacity-0',
+    'data-ending-style:duration-[max(calc(var(--media-dialog-transition-duration)-100ms),50ms)] data-ending-style:delay-0',
     'motion-reduce:scale-100 motion-reduce:transition-opacity'
   ),
   content: 'flex min-h-0 flex-col gap-2 overflow-y-auto py-1.5',

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -7,7 +7,6 @@ import { dialog as baseDialog } from './components/dialog';
 import { menu as baseMenu } from './components/menu';
 import { popup as basePopup } from './components/popup';
 import { slider as baseSlider } from './components/slider';
-import { thumbnail as baseThumbnail } from './components/thumbnail';
 import { time as baseTime } from './components/time';
 
 /* Container */
@@ -20,7 +19,6 @@ export const container = (isShadowDOM: boolean) =>
     '[&:has(.media-buffering-indicator[data-visible])_.media-controls-backdrop]:bg-black/35',
     '[&:has(.media-buffering-indicator[data-visible])_.media-controls-backdrop]:opacity-100',
     '[&:has(.media-buffering-indicator[data-visible])_.media-controls-backdrop]:backdrop-blur-sm',
-    '[&:has([role=alertdialog][data-open])_.media-controls]:hidden',
     // Border ring (::after)
     'after:absolute after:pointer-events-none after:rounded-[inherit] after:z-10',
     '[&:fullscreen]:after:hidden',
@@ -162,10 +160,6 @@ export const dialog = {
   title: 'text-(length:--media-font-size-medium)',
 };
 
-/* Thumbnail */
-
-export const thumbnail = baseThumbnail;
-
 /* Sliders */
 
 export const slider = {
@@ -198,11 +192,11 @@ export const menu = {
 /* Shared components (no overrides) */
 
 export { iconState } from '../../shared/tailwind/icon-state';
-export { controlsBackdrop } from './components/controls-backdrop';
 export { badge } from './components/badge';
 export { bufferingIndicator } from './components/buffering';
 export { button } from './components/button';
 export { buttonGroup } from './components/button-group';
+export { controlsBackdrop } from './components/controls-backdrop';
 export { icon, iconContainer, iconFlipped, iconHidden } from './components/icon';
 export { inputIndicator } from './components/input-indicator';
 export { playbackRate } from './components/playback-rate';
@@ -210,4 +204,5 @@ export { poster } from './components/poster';
 export { seek } from './components/seek';
 export { seekIndicator } from './components/seek-indicator';
 export { statusIndicator } from './components/status-indicator';
+export { thumbnail } from './components/thumbnail';
 export { volumeIndicator } from './components/volume-indicator';

--- a/packages/skins/vjsc/gaps.md
+++ b/packages/skins/vjsc/gaps.md
@@ -15,3 +15,10 @@ This file tracks observable behavior in `packages/skins/src` that is not yet imp
 - Gap: VJSC keeps the Minimal volume thumb visible, but it does not show a sticky mute tooltip while the volume popover is open and compact layouts retain the wider trigger-to-slider gap.
 - Affected: Minimal Video skin; HTML and React targets; CSS and Tailwind outputs.
 - Recommendation: Compose a sticky button tooltip around the Minimal volume-popover trigger, use zero side offset with internal horizontal padding, and add VJSC matrix coverage for the tooltip and popover remaining visible together.
+
+## Dialog exit duration
+
+- Source: `packages/skins/src/default/css/audio.css`, `packages/skins/src/default/css/video.css`, `packages/skins/src/minimal/css/audio.css`, and `packages/skins/src/minimal/css/video.css`
+- Gap: Legacy dialogs shorten their exit transition by 100ms with a 50ms minimum, while VJSC uses the full configured duration for both entry and exit.
+- Affected: Default and Minimal Audio and Video skins; HTML and React targets; CSS and Tailwind outputs.
+- Recommendation: Apply the shortened duration to VJSC dialog ending styles and verify entry and exit timing across the skin matrix.

--- a/site/scripts/ejected-skins/templates/html/audio/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/audio/minimal-skin.tailwind.ts
@@ -30,15 +30,13 @@ export function getTemplateHTML() {
 
       <media-error-dialog>
         <media-dialog-popup class="${dialog.popup}">
-        <div class="${dialog.dialog}">
           <div class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
           </div>
           <div class="${dialog.actions}">
-            <media-dialog-close class="${cn(button.base, button.subtle)}"></media-dialog-close>
+            <media-dialog-close class="${cn(button.base, button.primary)}"></media-dialog-close>
           </div>
-        </div>
         </media-dialog-popup>
       </media-error-dialog>
 

--- a/site/scripts/ejected-skins/templates/html/audio/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/audio/skin.tailwind.ts
@@ -30,15 +30,13 @@ export function getTemplateHTML() {
 
       <media-error-dialog>
         <media-dialog-popup class="${dialog.popup}">
-        <div class="${dialog.dialog}">
           <div class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
           </div>
           <div class="${dialog.actions}">
-            <media-dialog-close class="${cn(button.base, button.subtle)}"></media-dialog-close>
+            <media-dialog-close class="${cn(button.base, button.primary)}"></media-dialog-close>
           </div>
-        </div>
         </media-dialog-popup>
       </media-error-dialog>
 

--- a/site/scripts/ejected-skins/templates/html/live-audio/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-audio/minimal-skin.tailwind.ts
@@ -23,15 +23,13 @@ export function getTemplateHTML() {
 
       <media-error-dialog>
         <media-dialog-popup class="${dialog.popup}">
-        <div class="${dialog.dialog}">
           <div class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
           </div>
           <div class="${dialog.actions}">
-            <media-dialog-close class="${cn(button.base, button.subtle)}"></media-dialog-close>
+            <media-dialog-close class="${cn(button.base, button.primary)}"></media-dialog-close>
           </div>
-        </div>
         </media-dialog-popup>
       </media-error-dialog>
 

--- a/site/scripts/ejected-skins/templates/html/live-audio/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-audio/skin.tailwind.ts
@@ -23,15 +23,13 @@ export function getTemplateHTML() {
 
       <media-error-dialog>
         <media-dialog-popup class="${dialog.popup}">
-        <div class="${dialog.dialog}">
           <div class="${dialog.content}">
             <media-dialog-title class="${dialog.title}"></media-dialog-title>
             <media-dialog-description class="${dialog.description}"></media-dialog-description>
           </div>
           <div class="${dialog.actions}">
-            <media-dialog-close class="${cn(button.base, button.subtle)}"></media-dialog-close>
+            <media-dialog-close class="${cn(button.base, button.primary)}"></media-dialog-close>
           </div>
-        </div>
         </media-dialog-popup>
       </media-error-dialog>
 


### PR DESCRIPTION
## Summary

Keep Default and Minimal dialog styling consistent across vanilla CSS, Tailwind, HTML, React, and ejected skin templates. This also makes dialog exits complete sooner while preserving a minimum duration.

## Changes

- Apply matching dialog backgrounds, spacing, backdrop layering, and transition timing in CSS and Tailwind
- Style audio dialog popups directly and remove the redundant inner wrapper from presets
- Use the primary button variant for every dialog close action
- Remove the Minimal video control-hiding behavior while an alert dialog is open
- Record the remaining VJSC dialog exit-duration gap

## Testing

- `pnpm -F @videojs/skins test`
- `pnpm -F @videojs/html test src/presets/tests/presets.test.ts`
- `pnpm -F @videojs/react test src/presets/tests/player.test.tsx`
- `pnpm --dir site exec vp test run scripts/tests/ejected-skins.test.ts`
- `pnpm exec tsgo --project packages/skins/tsconfig.json --noEmit`
- `git diff origin/main --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to error-dialog DOM and skin CSS/Tailwind; no auth, data, or playback logic, with a small UX shift on Minimal video when errors are shown.
> 
> **Overview**
> Aligns **Default** and **Minimal** error-dialog behavior across CSS, Tailwind, HTML/React presets, and ejected templates.
> 
> **Markup:** Drops the extra `media-dialog__dialog` wrapper so title, description, and actions sit directly on `media-dialog__popup`. Error **close** buttons use the **primary** variant instead of subtle.
> 
> **Styling:** Audio dialogs apply layout, opaque surface background, and enter/exit motion on the popup itself (including blur/scale where applicable). Dialog **backdrop** `z-index` is raised to **20** to match the popup. **Exit** animations use a shorter duration (`max(duration − 100ms, 50ms)`) on `data-ending-style` for audio and video dialogs in both CSS and Tailwind.
> 
> **Behavior:** **Minimal video** no longer hides the control bar while an alert dialog is open (removed from CSS and Tailwind container rules). **VJSC** `gaps.md` notes that the shortened exit timing still needs to land in VJSC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce54629b1e82b73ff2792b6c39f37982cdcd42fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->