### PR TITLE
fix(packages): share input action defaults

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   // Vite+ provides linting and formatting through Oxc.
   "eslint.enable": false,
+  "biome.enabled": false,
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file",
 

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -16,6 +16,7 @@ export * from './ui/container/core';
 export * from './ui/container/data';
 export * from './ui/controls/core';
 export * from './ui/controls/data';
+export * from './ui/constants';
 export * from './ui/dialog/core';
 export * from './ui/dialog/data';
 export * from './ui/error-dialog/core';

--- a/packages/core/src/core/ui/constants.ts
+++ b/packages/core/src/core/ui/constants.ts
@@ -1,0 +1,5 @@
+/** Default time adjustment in seconds for seek controls. */
+export const DEFAULT_SEEK_STEP = 10;
+
+/** Default volume adjustment in percentage points for volume controls. */
+export const DEFAULT_VOLUME_STEP = 5;

--- a/packages/core/src/core/ui/gesture/core.ts
+++ b/packages/core/src/core/ui/gesture/core.ts
@@ -18,7 +18,7 @@ export interface GestureProps {
   type: GestureType;
   /** Built-in player action or same-named custom store action to run when the gesture is recognized. */
   action: GestureActionName | (string & {});
-  /** Numeric value passed to actions such as `seekStep` and `volumeStep`. */
+  /** Numeric value passed to actions such as `seekStep` and `volumeStep`. Uses their shared step when omitted. */
   value?: number | undefined;
   /** Pointer type that may activate the gesture. All pointer types are accepted when omitted. */
   pointer?: GesturePointerType | undefined;

--- a/packages/core/src/core/ui/hotkey/core.ts
+++ b/packages/core/src/core/ui/hotkey/core.ts
@@ -15,7 +15,10 @@ export interface HotkeyProps {
   keys: string;
   /** Player action to run when the key pattern matches. */
   action: HotkeyActionName;
-  /** Numeric value passed to actions such as `seekStep`, `volumeStep`, and `seekToPercent`. */
+  /**
+   * Numeric value passed to actions such as `seekStep`, `volumeStep`, and `seekToPercent`. Arrow-key seek and volume
+   * actions use their shared input-action step when omitted.
+   */
   value?: number | undefined;
   /** Whether the hotkey is disabled. */
   disabled?: boolean | undefined;

--- a/packages/core/src/core/ui/volume-slider/core.ts
+++ b/packages/core/src/core/ui/volume-slider/core.ts
@@ -5,6 +5,7 @@ import type { NonNullableObject } from '@videojs/utils/types';
 
 import type { Text } from '../../i18n';
 import { labelText, mutedValueText } from '../../i18n/text/volume';
+import { DEFAULT_VOLUME_STEP } from '../constants';
 import { SliderCore, type SliderProps, type SliderState } from '../slider/core';
 
 export interface VolumeSliderProps extends SliderProps {
@@ -28,7 +29,8 @@ export class VolumeSliderCore extends SliderCore {
   static override readonly defaultProps: NonNullableObject<VolumeSliderProps> = {
     ...SliderCore.defaultProps,
     label: '',
-    wheelStep: 5,
+    step: DEFAULT_VOLUME_STEP,
+    wheelStep: DEFAULT_VOLUME_STEP,
   };
 
   #media: MediaVolumeState | null = null;

--- a/packages/core/src/core/ui/volume-slider/tests/core.test.ts
+++ b/packages/core/src/core/ui/volume-slider/tests/core.test.ts
@@ -33,7 +33,7 @@ describe('VolumeSliderCore', () => {
     it('has expected defaults', () => {
       expect(VolumeSliderCore.defaultProps).toEqual({
         label: '',
-        step: 1,
+        step: 5,
         largeStep: 10,
         wheelStep: 5,
         orientation: 'horizontal',

--- a/packages/core/src/dom/gesture/action-value.ts
+++ b/packages/core/src/dom/gesture/action-value.ts
@@ -1,0 +1,16 @@
+import { isUndefined } from '@videojs/utils/predicate';
+
+import { DEFAULT_SEEK_STEP } from '../../core/ui/constants';
+import { getMediaInputActionValue } from '../media-actions';
+import type { GestureRegion } from './gesture';
+
+/** Resolves the effective value for a gesture action from its explicit value and region. */
+export function getGestureActionValue(
+  action: string,
+  region: GestureRegion | undefined,
+  value?: number | undefined
+): number | undefined {
+  if (action === 'seekStep' && isUndefined(value) && region === 'left') return -DEFAULT_SEEK_STEP;
+
+  return getMediaInputActionValue(action, undefined, value);
+}

--- a/packages/core/src/dom/gesture/coordinator.ts
+++ b/packages/core/src/dom/gesture/coordinator.ts
@@ -1,6 +1,7 @@
 import { isInteractiveTarget, listen } from '@videojs/utils/dom';
 
 import { isInteractionLocked } from '../ui/interaction-lock';
+import { getGestureActionValue } from './action-value';
 import type {
   GestureActivateEvent,
   GestureBinding,
@@ -50,15 +51,17 @@ export class GestureCoordinator {
   }
 
   add(binding: GestureBinding): () => void {
+    const value = getGestureActionValue(binding.action ?? '', binding.region, binding.value);
     const wrapped: GestureBinding = {
       ...binding,
+      value,
       onActivate: (event) => {
         if (this.#subscribers.size > 0) {
           const activateEvent: GestureActivateEvent = {
             type: binding.type,
             source: 'gesture',
             action: binding.action,
-            value: binding.value,
+            value,
             region: binding.region,
             pointer: binding.pointer,
             event,

--- a/packages/core/src/dom/gesture/tests/action-value.test.ts
+++ b/packages/core/src/dom/gesture/tests/action-value.test.ts
@@ -1,0 +1,19 @@
+import { DEFAULT_SEEK_STEP, DEFAULT_VOLUME_STEP } from '@videojs/core';
+import { describe, expect, it } from 'vite-plus/test';
+
+import { getGestureActionValue } from '../action-value';
+
+describe('getGestureActionValue', () => {
+  it('uses the seek direction from the region', () => {
+    expect(getGestureActionValue('seekStep', 'left')).toBe(-DEFAULT_SEEK_STEP);
+    expect(getGestureActionValue('seekStep', 'right')).toBe(DEFAULT_SEEK_STEP);
+  });
+
+  it('uses the default volume step', () => {
+    expect(getGestureActionValue('volumeStep', 'left')).toBe(DEFAULT_VOLUME_STEP / 100);
+  });
+
+  it('preserves an explicit value', () => {
+    expect(getGestureActionValue('seekStep', 'left', 5)).toBe(5);
+  });
+});

--- a/packages/core/src/dom/gesture/tests/actions.test.ts
+++ b/packages/core/src/dom/gesture/tests/actions.test.ts
@@ -85,15 +85,24 @@ describe('seekStep', () => {
     expect(seek).toHaveBeenCalledWith(15);
   });
 
-  it('does nothing without value', () => {
+  it('uses the default without value', () => {
     const seek = vi.fn();
 
     resolveGestureAction('seekStep')!(ctx({ currentTime: 10, duration: 60, seeking: false, seek }));
-    expect(seek).not.toHaveBeenCalled();
+    expect(seek).toHaveBeenCalledWith(20);
   });
 });
 
 describe('volumeStep', () => {
+  it('uses the default without value', () => {
+    const setVolume = vi.fn();
+
+    resolveGestureAction('volumeStep')!(
+      ctx({ volume: 0.5, muted: false, volumeAvailability: 'available', setVolume, toggleMuted: vi.fn() })
+    );
+    expect(setVolume).toHaveBeenCalledWith(0.55);
+  });
+
   it('adjusts volume by value offset', () => {
     const setVolume = vi.fn();
 

--- a/packages/core/src/dom/hotkey/hotkey.ts
+++ b/packages/core/src/dom/hotkey/hotkey.ts
@@ -1,6 +1,7 @@
 import { isMacOS } from '@videojs/utils/dom';
 
 import type { HotkeyProps } from '../../core/ui/hotkey/core';
+import { getMediaInputActionValue } from '../media-actions';
 import { HotkeyCoordinator } from './coordinator';
 
 export type HotkeyModifierKey = 'shift' | 'ctrl' | 'alt' | 'meta';
@@ -143,6 +144,10 @@ export function getHotkeyCoordinator(target: HTMLElement): HotkeyCoordinator {
  */
 export function createHotkey(target: HTMLElement, options: HotkeyOptions): () => void {
   const coordinator = getHotkeyCoordinator(target);
+  const key = parseHotkeyPattern(options.keys)[0]?.originalKey;
 
-  return coordinator.add(options);
+  return coordinator.add({
+    ...options,
+    value: getMediaInputActionValue(options.action ?? '', key, options.value),
+  });
 }

--- a/packages/core/src/dom/hotkey/tests/actions.test.ts
+++ b/packages/core/src/dom/hotkey/tests/actions.test.ts
@@ -115,6 +115,24 @@ describe('toggleFullscreen', () => {
 });
 
 describe('seekStep', () => {
+  it('defaults ArrowRight to a ten second seek', () => {
+    const seek = vi.fn();
+    const store = mockStore({ currentTime: 10, duration: 100, seeking: false, seek });
+
+    resolveHotkeyAction('seekStep')!({ store, key: 'ArrowRight' });
+
+    expect(seek).toHaveBeenCalledWith(20);
+  });
+
+  it('defaults ArrowLeft to a negative ten second seek', () => {
+    const seek = vi.fn();
+    const store = mockStore({ currentTime: 20, duration: 100, seeking: false, seek });
+
+    resolveHotkeyAction('seekStep')!({ store, key: 'ArrowLeft' });
+
+    expect(seek).toHaveBeenCalledWith(10);
+  });
+
   it('seeks forward by value', () => {
     const seek = vi.fn();
     const store = mockStore({ currentTime: 10, duration: 100, seeking: false, seek });
@@ -133,17 +151,47 @@ describe('seekStep', () => {
     expect(seek).toHaveBeenCalledWith(5);
   });
 
-  it('no-ops without value', () => {
+  it('uses the default without a value', () => {
     const seek = vi.fn();
     const store = mockStore({ currentTime: 10, duration: 100, seeking: false, seek });
 
     resolveHotkeyAction('seekStep')!({ store, key: '' });
 
-    expect(seek).not.toHaveBeenCalled();
+    expect(seek).toHaveBeenCalledWith(20);
   });
 });
 
 describe('volumeStep', () => {
+  it('defaults ArrowUp to a five percent increase', () => {
+    const setVolume = vi.fn();
+    const store = mockStore({
+      volume: 0.5,
+      muted: false,
+      volumeAvailability: 'available',
+      setVolume,
+      toggleMuted: vi.fn(),
+    });
+
+    resolveHotkeyAction('volumeStep')!({ store, key: 'ArrowUp' });
+
+    expect(setVolume).toHaveBeenCalledWith(0.55);
+  });
+
+  it('defaults ArrowDown to a five percent decrease', () => {
+    const setVolume = vi.fn();
+    const store = mockStore({
+      volume: 0.5,
+      muted: false,
+      volumeAvailability: 'available',
+      setVolume,
+      toggleMuted: vi.fn(),
+    });
+
+    resolveHotkeyAction('volumeStep')!({ store, key: 'ArrowDown' });
+
+    expect(setVolume).toHaveBeenCalledWith(0.45);
+  });
+
   it('increases volume by value', () => {
     const setVolume = vi.fn();
     const store = mockStore({

--- a/packages/core/src/dom/hotkey/tests/hotkey.test.ts
+++ b/packages/core/src/dom/hotkey/tests/hotkey.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
-import { createHotkey, matchesHotkeyEvent, parseHotkeyPattern } from '../hotkey';
+import { DEFAULT_SEEK_STEP } from '../../../core/ui/constants';
+import { createHotkey, findHotkeyCoordinator, matchesHotkeyEvent, parseHotkeyPattern } from '../hotkey';
 
 describe('parseHotkeyPattern', () => {
   it('parses a single key with no modifiers', () => {
@@ -308,6 +309,19 @@ describe('createHotkey', () => {
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
 
     expect(onActivate).toHaveBeenCalledWith(expect.any(KeyboardEvent), 'ArrowRight');
+
+    cleanup();
+  });
+
+  it('uses the parsed key to resolve the default action value', () => {
+    const el = setup();
+    const cleanup = createHotkey(el, {
+      keys: 'Shift+ArrowLeft',
+      action: 'seekStep',
+      onActivate: vi.fn(),
+    });
+
+    expect(findHotkeyCoordinator(el)!.getShortcut('seekStep', -DEFAULT_SEEK_STEP).shortcut).toBe('Shift+ArrowLeft');
 
     cleanup();
   });

--- a/packages/core/src/dom/index.ts
+++ b/packages/core/src/dom/index.ts
@@ -1,4 +1,5 @@
 export * from './feature';
+export * from './gesture/action-value';
 export * from './gesture/actions';
 export * from './gesture/coordinator';
 export * from './gesture/create-tap-gesture';

--- a/packages/core/src/dom/media-actions.ts
+++ b/packages/core/src/dom/media-actions.ts
@@ -1,5 +1,6 @@
 import { isUndefined } from '@videojs/utils/predicate';
 
+import { DEFAULT_SEEK_STEP, DEFAULT_VOLUME_STEP } from '../core/ui/constants';
 import type { AnyPlayerStore } from './player';
 import { selectPlaybackRate, selectTime, selectVolume } from './store/selectors';
 
@@ -8,27 +9,50 @@ export type MediaInputActionName = 'seekStep' | 'volumeStep' | 'speedUp' | 'spee
 export interface MediaInputActionContext {
   store: AnyPlayerStore;
   value?: number | undefined;
+  key?: string | undefined;
 }
 
 export type MediaInputActionResolver = (context: MediaInputActionContext) => void;
 
+export function getMediaInputActionValue(
+  action: string,
+  key: string | undefined,
+  value?: number | undefined
+): number | undefined {
+  if (!isUndefined(value)) return value;
+
+  const normalizedKey = key?.toLowerCase();
+
+  if (action === 'seekStep') {
+    return normalizedKey === 'arrowleft' || normalizedKey === 'j' ? -DEFAULT_SEEK_STEP : DEFAULT_SEEK_STEP;
+  }
+
+  if (action === 'volumeStep') {
+    const step = DEFAULT_VOLUME_STEP / 100;
+
+    return normalizedKey === 'arrowdown' ? -step : step;
+  }
+
+  return undefined;
+}
+
 export const MEDIA_INPUT_ACTION_OVERRIDES: Record<MediaInputActionName, MediaInputActionResolver> = {
-  seekStep({ store, value }) {
-    if (isUndefined(value)) return;
+  seekStep({ store, value, key }) {
+    const step = getMediaInputActionValue('seekStep', key, value)!;
 
     const time = selectTime(store.state);
     if (!time) return;
 
-    time.seek(time.currentTime + value);
+    time.seek(time.currentTime + step);
   },
 
-  volumeStep({ store, value }) {
-    if (isUndefined(value)) return;
+  volumeStep({ store, value, key }) {
+    const step = getMediaInputActionValue('volumeStep', key, value)!;
 
     const vol = selectVolume(store.state);
     if (!vol) return;
 
-    vol.setVolume(vol.volume + value);
+    vol.setVolume(vol.volume + step);
   },
 
   speedUp({ store }) {

--- a/packages/core/src/dom/tests/media-actions.test.ts
+++ b/packages/core/src/dom/tests/media-actions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { DEFAULT_SEEK_STEP, DEFAULT_VOLUME_STEP } from '../../core/ui/constants';
+import { getMediaInputActionValue } from '../media-actions';
+
+describe('getMediaInputActionValue', () => {
+  it('defaults forward and backward seek steps', () => {
+    expect(getMediaInputActionValue('seekStep', 'ArrowRight')).toBe(DEFAULT_SEEK_STEP);
+    expect(getMediaInputActionValue('seekStep', 'ArrowLeft')).toBe(-DEFAULT_SEEK_STEP);
+    expect(getMediaInputActionValue('seekStep', 'l')).toBe(DEFAULT_SEEK_STEP);
+    expect(getMediaInputActionValue('seekStep', 'j')).toBe(-DEFAULT_SEEK_STEP);
+  });
+
+  it('defaults volume steps', () => {
+    expect(getMediaInputActionValue('volumeStep', 'ArrowUp')).toBe(DEFAULT_VOLUME_STEP / 100);
+    expect(getMediaInputActionValue('volumeStep', 'ArrowDown')).toBe(-DEFAULT_VOLUME_STEP / 100);
+  });
+
+  it('preserves explicit values', () => {
+    expect(getMediaInputActionValue('volumeStep', 'ArrowDown', 0.1)).toBe(0.1);
+  });
+
+  it('does not default other actions', () => {
+    expect(getMediaInputActionValue('togglePaused', 'Space')).toBeUndefined();
+  });
+});

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -270,6 +270,7 @@ export function createSlider(options: SliderOptions): SliderApi {
 
   // --- Thumb props ---
   const thumbProps: SliderThumbProps = {
+    // Capture before the player hotkey coordinator handles the same key on the container.
     onKeyDownCapture(event) {
       if (options.isDisabled()) {
         if (event.key !== 'Tab') event.preventDefault();

--- a/packages/html/src/constants.ts
+++ b/packages/html/src/constants.ts
@@ -1,0 +1,1 @@
+export { DEFAULT_SEEK_STEP } from '@videojs/core';

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -1,4 +1,5 @@
 // Core
+export * from './constants';
 export * from '@videojs/core/dom';
 export type {
   Destroyable,

--- a/packages/html/src/presets/audio/minimal-skin.ts
+++ b/packages/html/src/presets/audio/minimal-skin.ts
@@ -1,12 +1,10 @@
 import { renderIcon } from '@videojs/icons/render/minimal';
 import { createShadowStyle, createTemplate } from '@videojs/utils/dom';
 
+import { DEFAULT_SEEK_STEP } from '../../constants';
 import { SkinElement } from '../skin';
 
 import styles from '../../define/audio/minimal-skin.css?inline';
-
-const VOLUME_STEP = 5;
-const SEEK_TIME = 10;
 
 function getTemplateHTML() {
   return /*html*/ `
@@ -47,10 +45,10 @@ function getTemplateHTML() {
               </media-tooltip>
             </span>
 
-            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="media-button media-button--subtle media-button--icon media-button--seek">
+            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-DEFAULT_SEEK_STEP}" class="media-button media-button--subtle media-button--icon media-button--seek">
               <span class="media-icon__container">
                 ${renderIcon('seek', { class: 'media-icon media-icon--seek media-icon--flipped' })}
-                <span class="media-icon__label">${SEEK_TIME}</span>
+                <span class="media-icon__label">${DEFAULT_SEEK_STEP}</span>
               </span>
             </media-seek-button>
             <media-tooltip id="seek-backward-tooltip" side="top" boundary="viewport" class="media-tooltip">
@@ -58,10 +56,10 @@ function getTemplateHTML() {
               <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
             </media-tooltip>
 
-            <media-seek-button commandfor="seek-forward-tooltip" seconds="${SEEK_TIME}" class="media-button media-button--subtle media-button--icon media-button--seek">
+            <media-seek-button commandfor="seek-forward-tooltip" seconds="${DEFAULT_SEEK_STEP}" class="media-button media-button--subtle media-button--icon media-button--seek">
               <span class="media-icon__container">
                 ${renderIcon('seek', { class: 'media-icon media-icon--seek' })}
-                <span class="media-icon__label">${SEEK_TIME}</span>
+                <span class="media-icon__label">${DEFAULT_SEEK_STEP}</span>
               </span>
             </media-seek-button>
             <media-tooltip id="seek-forward-tooltip" side="top" boundary="viewport" class="media-tooltip">
@@ -101,7 +99,7 @@ function getTemplateHTML() {
             </media-tooltip>
 
             <media-popover id="audio-volume-popover" open-on-hover delay="200" close-delay="100" side="left" boundary="viewport" class="media-popover media-popover--volume">
-              <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="horizontal" thumb-alignment="edge">
+              <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">
                 <media-slider-track class="media-slider__track">
                   <media-slider-fill class="media-slider__fill"></media-slider-fill>
                 </media-slider-track>
@@ -137,12 +135,12 @@ function getTemplateHTML() {
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
-      <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
-      <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
-      <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
-      <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowRight" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowLeft" action="seekStep"></media-hotkey>
+      <media-hotkey keys="l" action="seekStep"></media-hotkey>
+      <media-hotkey keys="j" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>

--- a/packages/html/src/presets/audio/skin.ts
+++ b/packages/html/src/presets/audio/skin.ts
@@ -1,12 +1,10 @@
 import { renderIcon } from '@videojs/icons/render';
 import { createShadowStyle, createTemplate } from '@videojs/utils/dom';
 
+import { DEFAULT_SEEK_STEP } from '../../constants';
 import { SkinElement } from '../skin';
 
 import styles from '../../define/audio/skin.css?inline';
-
-const VOLUME_STEP = 5;
-const SEEK_TIME = 10;
 
 function getTemplateHTML() {
   return /*html*/ `
@@ -47,10 +45,10 @@ function getTemplateHTML() {
               </media-tooltip>
             </span>
 
-            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="media-button media-button--subtle media-button--icon media-button--seek">
+            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-DEFAULT_SEEK_STEP}" class="media-button media-button--subtle media-button--icon media-button--seek">
               <span class="media-icon__container">
                 ${renderIcon('seek', { class: 'media-icon media-icon--seek media-icon--flipped' })}
-                <span class="media-icon__label">${SEEK_TIME}</span>
+                <span class="media-icon__label">${DEFAULT_SEEK_STEP}</span>
               </span>
             </media-seek-button>
             <media-tooltip id="seek-backward-tooltip" side="top" boundary="viewport" class="media-surface media-tooltip">
@@ -58,10 +56,10 @@ function getTemplateHTML() {
               <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
             </media-tooltip>
 
-            <media-seek-button commandfor="seek-forward-tooltip" seconds="${SEEK_TIME}" class="media-button media-button--subtle media-button--icon media-button--seek">
+            <media-seek-button commandfor="seek-forward-tooltip" seconds="${DEFAULT_SEEK_STEP}" class="media-button media-button--subtle media-button--icon media-button--seek">
               <span class="media-icon__container">
                 ${renderIcon('seek', { class: 'media-icon media-icon--seek' })}
-                <span class="media-icon__label">${SEEK_TIME}</span>
+                <span class="media-icon__label">${DEFAULT_SEEK_STEP}</span>
               </span>
             </media-seek-button>
             <media-tooltip id="seek-forward-tooltip" side="top" boundary="viewport" class="media-surface media-tooltip">
@@ -113,7 +111,7 @@ function getTemplateHTML() {
             </media-mute-button>
 
             <media-popover id="audio-volume-popover" open-on-hover delay="200" close-delay="100" side="top" boundary="viewport" class="media-surface media-popover media-popover--volume">
-              <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="vertical" thumb-alignment="edge">
+              <media-volume-slider class="media-slider" orientation="vertical" thumb-alignment="edge">
                 <media-slider-track class="media-slider__track">
                   <media-slider-fill class="media-slider__fill"></media-slider-fill>
                 </media-slider-track>
@@ -128,12 +126,12 @@ function getTemplateHTML() {
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
-      <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
-      <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
-      <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
-      <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowRight" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowLeft" action="seekStep"></media-hotkey>
+      <media-hotkey keys="l" action="seekStep"></media-hotkey>
+      <media-hotkey keys="j" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>

--- a/packages/html/src/presets/live-audio/minimal-skin.ts
+++ b/packages/html/src/presets/live-audio/minimal-skin.ts
@@ -5,8 +5,6 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/live-audio/minimal-skin.css?inline';
 
-const VOLUME_STEP = 5;
-
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-minimal-skin media-minimal-skin--audio">
@@ -63,7 +61,7 @@ function getTemplateHTML() {
             </media-tooltip>
 
             <media-popover id="live-audio-volume-popover" open-on-hover delay="200" close-delay="100" side="left" boundary="viewport" class="media-popover media-popover--volume">
-              <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="horizontal" thumb-alignment="edge">
+              <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">
                 <media-slider-track class="media-slider__track">
                   <media-slider-fill class="media-slider__fill"></media-slider-fill>
                 </media-slider-track>
@@ -78,8 +76,8 @@ function getTemplateHTML() {
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
     </media-container>
   `;
 }

--- a/packages/html/src/presets/live-audio/skin.ts
+++ b/packages/html/src/presets/live-audio/skin.ts
@@ -5,8 +5,6 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/live-audio/skin.css?inline';
 
-const VOLUME_STEP = 5;
-
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-default-skin media-default-skin--audio">
@@ -59,7 +57,7 @@ function getTemplateHTML() {
             </media-mute-button>
 
             <media-popover id="live-audio-volume-popover" open-on-hover delay="200" close-delay="100" side="top" boundary="viewport" class="media-surface media-popover media-popover--volume">
-              <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="vertical" thumb-alignment="edge">
+              <media-volume-slider class="media-slider" orientation="vertical" thumb-alignment="edge">
                 <media-slider-track class="media-slider__track">
                   <media-slider-fill class="media-slider__fill"></media-slider-fill>
                 </media-slider-track>
@@ -74,8 +72,8 @@ function getTemplateHTML() {
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
     </media-container>
   `;
 }

--- a/packages/html/src/presets/live-video/minimal-skin.ts
+++ b/packages/html/src/presets/live-video/minimal-skin.ts
@@ -5,8 +5,6 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/live-video/minimal-skin.css?inline';
 
-const VOLUME_STEP = 5;
-
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-minimal-skin media-minimal-skin--video">
@@ -65,7 +63,7 @@ function getTemplateHTML() {
               </media-tooltip>
 
               <media-popover id="live-video-volume-popover" open-on-hover delay="200" close-delay="100" side="right" class="media-popover media-popover--volume">
-                <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="horizontal" thumb-alignment="edge">
+                <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">
                   <media-slider-track class="media-slider__track">
                     <media-slider-fill class="media-slider__fill"></media-slider-fill>
                   </media-slider-track>
@@ -147,8 +145,8 @@ function getTemplateHTML() {
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
       <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
 
       <!-- Gestures -->
       <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>

--- a/packages/html/src/presets/live-video/skin.ts
+++ b/packages/html/src/presets/live-video/skin.ts
@@ -5,8 +5,6 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/live-video/skin.css?inline';
 
-const VOLUME_STEP = 5;
-
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-default-skin media-default-skin--video">
@@ -66,7 +64,7 @@ function getTemplateHTML() {
                 </media-mute-button>
 
                 <media-popover id="live-video-volume-popover" open-on-hover delay="200" close-delay="100" side="top" class="media-surface media-popover media-popover--volume">
-                  <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="vertical" thumb-alignment="edge">
+                  <media-volume-slider class="media-slider" orientation="vertical" thumb-alignment="edge">
                     <media-slider-track class="media-slider__track">
                       <media-slider-fill class="media-slider__fill"></media-slider-fill>
                     </media-slider-track>
@@ -146,8 +144,8 @@ function getTemplateHTML() {
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
       <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
 
       <!-- Gestures -->
       <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>

--- a/packages/html/src/presets/video/minimal-skin.ts
+++ b/packages/html/src/presets/video/minimal-skin.ts
@@ -7,8 +7,6 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/video/minimal-skin.css?inline';
 
-const VOLUME_STEP = 5;
-
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-minimal-skin media-minimal-skin--video">
@@ -65,7 +63,7 @@ function getTemplateHTML() {
               </media-tooltip>
 
               <media-popover id="video-volume-popover" open-on-hover delay="200" close-delay="100" side="right" class="media-popover media-popover--volume">
-                <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="horizontal" thumb-alignment="edge">
+                <media-volume-slider class="media-slider" orientation="horizontal" thumb-alignment="edge">
                   <media-slider-track class="media-slider__track">
                     <media-slider-fill class="media-slider__fill"></media-slider-fill>
                   </media-slider-track>
@@ -280,12 +278,12 @@ function getTemplateHTML() {
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
       <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
-      <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
-      <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
-      <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
-      <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowRight" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowLeft" action="seekStep"></media-hotkey>
+      <media-hotkey keys="l" action="seekStep"></media-hotkey>
+      <media-hotkey keys="j" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>
@@ -295,9 +293,9 @@ function getTemplateHTML() {
       <!-- Gestures -->
       <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>
       <media-gesture type="tap" action="toggleControls" pointer="touch"></media-gesture>
-      <media-gesture type="doubletap" action="seekStep" value="-10" region="left"></media-gesture>
+      <media-gesture type="doubletap" action="seekStep" region="left"></media-gesture>
       <media-gesture type="doubletap" action="toggleFullscreen" region="center"></media-gesture>
-      <media-gesture type="doubletap" action="seekStep" value="10" region="right"></media-gesture>
+      <media-gesture type="doubletap" action="seekStep" region="right"></media-gesture>
 
       <!-- Input Indicators -->
       <media-status-announcer class="media-sr-only"></media-status-announcer>

--- a/packages/html/src/presets/video/skin.ts
+++ b/packages/html/src/presets/video/skin.ts
@@ -7,8 +7,6 @@ import { SkinElement } from '../skin';
 
 import styles from '../../define/video/skin.css?inline';
 
-const VOLUME_STEP = 5;
-
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-default-skin media-default-skin--video">
@@ -62,7 +60,7 @@ function getTemplateHTML() {
                 </media-mute-button>
 
                 <media-popover id="video-volume-popover" open-on-hover delay="200" close-delay="100" side="top" class="media-surface media-popover media-popover--volume">
-                  <media-volume-slider step="${VOLUME_STEP}" class="media-slider" orientation="vertical" thumb-alignment="edge">
+                  <media-volume-slider class="media-slider" orientation="vertical" thumb-alignment="edge">
                     <media-slider-track class="media-slider__track">
                       <media-slider-fill class="media-slider__fill"></media-slider-fill>
                     </media-slider-track>
@@ -278,12 +276,12 @@ function getTemplateHTML() {
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
       <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
-      <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
-      <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
-      <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
-      <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="${VOLUME_STEP / 100}"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="${-VOLUME_STEP / 100}"></media-hotkey>
+      <media-hotkey keys="ArrowRight" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowLeft" action="seekStep"></media-hotkey>
+      <media-hotkey keys="l" action="seekStep"></media-hotkey>
+      <media-hotkey keys="j" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>
@@ -293,9 +291,9 @@ function getTemplateHTML() {
       <!-- Gestures -->
       <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>
       <media-gesture type="tap" action="toggleControls" pointer="touch"></media-gesture>
-      <media-gesture type="doubletap" action="seekStep" value="-10" region="left"></media-gesture>
+      <media-gesture type="doubletap" action="seekStep" region="left"></media-gesture>
       <media-gesture type="doubletap" action="toggleFullscreen" region="center"></media-gesture>
-      <media-gesture type="doubletap" action="seekStep" value="10" region="right"></media-gesture>
+      <media-gesture type="doubletap" action="seekStep" region="right"></media-gesture>
 
       <!-- Input Indicators -->
       <media-status-announcer class="media-sr-only"></media-status-announcer>

--- a/packages/html/src/ui/gesture/gesture-element.ts
+++ b/packages/html/src/ui/gesture/gesture-element.ts
@@ -1,5 +1,10 @@
 import type { GestureProps } from '@videojs/core';
-import { createDoubleTapGesture, createTapGesture, resolveGestureAction } from '@videojs/core/dom';
+import {
+  createDoubleTapGesture,
+  createTapGesture,
+  getGestureActionValue,
+  resolveGestureAction,
+} from '@videojs/core/dom';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextConsumer } from '@videojs/element/context';
 
@@ -63,18 +68,19 @@ export class GestureElement extends UIElement {
     const resolver = resolveGestureAction(this.action);
     if (!resolver) return;
 
-    const { value } = this;
+    const { value, region } = this;
+    const actionValue = getGestureActionValue(this.action, region, value);
 
     const onActivate = (event: PointerEvent) => {
-      resolver({ store, value, event });
+      resolver({ store, value: actionValue, event });
     };
 
     const options = {
       pointer: this.pointer,
-      region: this.region,
+      region,
       disabled: this.disabled,
       action: this.action,
-      value: this.value,
+      value: actionValue,
     };
 
     if (this.type === 'doubletap') {

--- a/packages/html/src/ui/gesture/tests/gesture-element.test.ts
+++ b/packages/html/src/ui/gesture/tests/gesture-element.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SEEK_STEP } from '@videojs/core';
 import { type AnyPlayerStore, getGestureCoordinator } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
@@ -72,5 +73,21 @@ describe('GestureElement', () => {
     document.body.append(provider);
 
     expect(getGestureCoordinator(provider).bindings).toHaveLength(0);
+  });
+
+  it('defaults a left seek gesture to the backward step', async () => {
+    const provider = document.createElement('test-gesture-provider');
+    const el = document.createElement('media-gesture') as GestureElement;
+
+    el.type = 'doubletap';
+    el.action = 'seekStep';
+    el.region = 'left';
+    provider.append(el);
+    document.body.append(provider);
+    await el.updateComplete;
+
+    expect(getGestureCoordinator(provider).bindings).toEqual([
+      expect.objectContaining({ action: 'seekStep', region: 'left', value: -DEFAULT_SEEK_STEP }),
+    ]);
   });
 });

--- a/packages/html/src/ui/hotkey/tests/hotkey-element.test.ts
+++ b/packages/html/src/ui/hotkey/tests/hotkey-element.test.ts
@@ -1,7 +1,8 @@
+import { type AnyPlayerStore, findHotkeyCoordinator } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
 
-import { containerContext } from '../../../player/context';
+import { containerContext, playerContext } from '../../../player/context';
 import { UIElement } from '../../ui-element';
 import { AriaKeyShortcutsController } from '../aria-key-shortcuts-controller';
 import { HotkeyElement } from '../hotkey-element';
@@ -22,6 +23,19 @@ function createElement<Element extends HTMLElement>(Base: abstract new () => Ele
 afterEach(() => {
   document.body.innerHTML = '';
 });
+
+class TestHotkeyProviderElement extends UIElement {
+  readonly #store = { state: {}, subscribe: () => () => {} } as unknown as AnyPlayerStore;
+  readonly containerProvider = new ContextProvider(this, {
+    context: containerContext,
+    initialValue: { container: this, registerContainer: () => () => {} },
+  });
+  readonly playerProvider = new ContextProvider(this, { context: playerContext, initialValue: this.#store });
+}
+
+if (!customElements.get('test-hotkey-provider')) {
+  customElements.define('test-hotkey-provider', TestHotkeyProviderElement);
+}
 
 describe('HotkeyElement', () => {
   it('has the correct tag name', () => {
@@ -44,6 +58,26 @@ describe('HotkeyElement', () => {
     document.body.appendChild(el);
 
     expect(el.style.display).toBe('none');
+  });
+
+  it('registers the default ArrowDown volume step', () => {
+    const provider = document.createElement('test-hotkey-provider');
+    const el = createElement(HotkeyElement);
+
+    el.keys = 'ArrowDown';
+    el.action = 'volumeStep';
+    provider.append(el);
+    document.body.append(provider);
+
+    const coordinator = findHotkeyCoordinator(provider)!;
+    let value: number | undefined;
+
+    coordinator.subscribe((event) => {
+      value = event.value;
+    });
+    provider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+    expect(value).toBe(-0.05);
   });
 });
 

--- a/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
+++ b/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
@@ -66,7 +66,7 @@ describe('VolumeSliderElement', () => {
     const slider = createElement(VolumeSliderElement);
 
     expect(slider.label).toBe('');
-    expect(slider.step).toBe(1);
+    expect(slider.step).toBe(5);
     expect(slider.largeStep).toBe(10);
     expect(slider.orientation).toBe('horizontal');
     expect(slider.disabled).toBe(false);

--- a/packages/react/src/constants.ts
+++ b/packages/react/src/constants.ts
@@ -1,0 +1,1 @@
+export { DEFAULT_SEEK_STEP } from '@videojs/core';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,7 @@
 'use client';
 
 export type { IndicatorStatus, InputAction, InputIndicatorLabels } from '@videojs/core';
+export * from './constants';
 // Core
 export * from '@videojs/core/dom';
 // Media predicates

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -22,6 +22,7 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
+import { DEFAULT_SEEK_STEP } from '@/constants';
 import { useTranslator } from '@/i18n/context';
 import {
   CheckIcon,
@@ -54,9 +55,6 @@ import { Tooltip } from '@/ui/tooltip';
 import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { MinimalAudioSkinProps } from './minimal-skin';
-
-const VOLUME_STEP = 5;
-const SEEK_TIME = 10;
 
 /* --------------------------------------- Components ---------------------------------------- */
 
@@ -140,7 +138,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className={cn(popup.volume)}>
-        <VolumeSlider.Root step={VOLUME_STEP} orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -246,10 +244,10 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger
                 render={
-                  <SeekButton seconds={-SEEK_TIME} render={<Button />}>
+                  <SeekButton seconds={-DEFAULT_SEEK_STEP} render={<Button />}>
                     <span className={iconContainer}>
                       <SeekIcon className={cn(icon, iconFlipped)} />
-                      <span className={cn(seek.label, seek.labelBackward)}>{SEEK_TIME}</span>
+                      <span className={cn(seek.label, seek.labelBackward)}>{DEFAULT_SEEK_STEP}</span>
                     </span>
                   </SeekButton>
                 }
@@ -263,10 +261,10 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger
                 render={
-                  <SeekButton seconds={SEEK_TIME} render={<Button />}>
+                  <SeekButton seconds={DEFAULT_SEEK_STEP} render={<Button />}>
                     <span className={iconContainer}>
                       <SeekIcon className={icon} />
-                      <span className={cn(seek.label, seek.labelForward)}>{SEEK_TIME}</span>
+                      <span className={cn(seek.label, seek.labelForward)}>{DEFAULT_SEEK_STEP}</span>
                     </span>
                   </SeekButton>
                 }
@@ -316,12 +314,12 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowRight" action="seekStep" value={5} />
-      <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
-      <Hotkey keys="l" action="seekStep" value={10} />
-      <Hotkey keys="j" action="seekStep" value={-10} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowRight" action="seekStep" />
+      <Hotkey keys="ArrowLeft" action="seekStep" />
+      <Hotkey keys="l" action="seekStep" />
+      <Hotkey keys="j" action="seekStep" />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -4,6 +4,7 @@ import { playbackRateText } from '@videojs/core/i18n/text/menu';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
+import { DEFAULT_SEEK_STEP } from '@/constants';
 import { useTranslator } from '@/i18n/context';
 import {
   CheckIcon,
@@ -38,9 +39,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 import type { BaseSkinProps } from '../types';
 
 export type MinimalAudioSkinProps = BaseSkinProps;
-
-const VOLUME_STEP = 5;
-const SEEK_TIME = 10;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return (
@@ -86,7 +84,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
-        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="horizontal" thumbAlignment="edge">
+        <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -190,10 +188,10 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger
                 render={
-                  <SeekButton seconds={-SEEK_TIME} className="media-button--seek" render={<Button />}>
+                  <SeekButton seconds={-DEFAULT_SEEK_STEP} className="media-button--seek" render={<Button />}>
                     <span className="media-icon__container">
                       <SeekIcon className="media-icon media-icon--seek media-icon--flipped" />
-                      <span className="media-icon__label">{SEEK_TIME}</span>
+                      <span className="media-icon__label">{DEFAULT_SEEK_STEP}</span>
                     </span>
                   </SeekButton>
                 }
@@ -207,10 +205,10 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger
                 render={
-                  <SeekButton seconds={SEEK_TIME} className="media-button--seek" render={<Button />}>
+                  <SeekButton seconds={DEFAULT_SEEK_STEP} className="media-button--seek" render={<Button />}>
                     <span className="media-icon__container">
                       <SeekIcon className="media-icon media-icon--seek" />
-                      <span className="media-icon__label">{SEEK_TIME}</span>
+                      <span className="media-icon__label">{DEFAULT_SEEK_STEP}</span>
                     </span>
                   </SeekButton>
                 }
@@ -260,12 +258,12 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowRight" action="seekStep" value={5} />
-      <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
-      <Hotkey keys="l" action="seekStep" value={10} />
-      <Hotkey keys="j" action="seekStep" value={-10} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowRight" action="seekStep" />
+      <Hotkey keys="ArrowLeft" action="seekStep" />
+      <Hotkey keys="l" action="seekStep" />
+      <Hotkey keys="j" action="seekStep" />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -22,6 +22,7 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
+import { DEFAULT_SEEK_STEP } from '@/constants';
 import { useTranslator } from '@/i18n/context';
 import {
   CheckIcon,
@@ -54,9 +55,6 @@ import { Tooltip } from '@/ui/tooltip';
 import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { AudioSkinProps } from './skin';
-
-const VOLUME_STEP = 5;
-const SEEK_TIME = 10;
 
 /* --------------------------------------- Components ---------------------------------------- */
 
@@ -124,7 +122,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className={cn(popup.popover, popup.volume)}>
-        <VolumeSlider.Root step={VOLUME_STEP} orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -230,10 +228,10 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger
                 render={
-                  <SeekButton seconds={-SEEK_TIME} render={<Button className={button.seek} />}>
+                  <SeekButton seconds={-DEFAULT_SEEK_STEP} render={<Button className={button.seek} />}>
                     <span className={iconContainer}>
                       <SeekIcon className={cn(icon, iconFlipped)} />
-                      <span className={cn(seek.label, seek.labelBackward)}>{SEEK_TIME}</span>
+                      <span className={cn(seek.label, seek.labelBackward)}>{DEFAULT_SEEK_STEP}</span>
                     </span>
                   </SeekButton>
                 }
@@ -247,10 +245,10 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger
                 render={
-                  <SeekButton seconds={SEEK_TIME} render={<Button className={button.seek} />}>
+                  <SeekButton seconds={DEFAULT_SEEK_STEP} render={<Button className={button.seek} />}>
                     <span className={iconContainer}>
                       <SeekIcon className={icon} />
-                      <span className={cn(seek.label, seek.labelForward)}>{SEEK_TIME}</span>
+                      <span className={cn(seek.label, seek.labelForward)}>{DEFAULT_SEEK_STEP}</span>
                     </span>
                   </SeekButton>
                 }
@@ -296,12 +294,12 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowRight" action="seekStep" value={5} />
-      <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
-      <Hotkey keys="l" action="seekStep" value={10} />
-      <Hotkey keys="j" action="seekStep" value={-10} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowRight" action="seekStep" />
+      <Hotkey keys="ArrowLeft" action="seekStep" />
+      <Hotkey keys="l" action="seekStep" />
+      <Hotkey keys="j" action="seekStep" />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -4,6 +4,7 @@ import { playbackRateText } from '@videojs/core/i18n/text/menu';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
+import { DEFAULT_SEEK_STEP } from '@/constants';
 import { useTranslator } from '@/i18n/context';
 import {
   CheckIcon,
@@ -37,9 +38,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseSkinProps } from '../types';
 
-const VOLUME_STEP = 5;
-const SEEK_TIME = 10;
-
 export type AudioSkinProps = BaseSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
@@ -70,7 +68,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className="media-surface media-popover media-popover--volume">
-        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="vertical" thumbAlignment="edge">
+        <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -174,10 +172,10 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger
                 render={
-                  <SeekButton seconds={-SEEK_TIME} className="media-button--seek" render={<Button />}>
+                  <SeekButton seconds={-DEFAULT_SEEK_STEP} className="media-button--seek" render={<Button />}>
                     <span className="media-icon__container">
                       <SeekIcon className="media-icon media-icon--seek media-icon--flipped" />
-                      <span className="media-icon__label">{SEEK_TIME}</span>
+                      <span className="media-icon__label">{DEFAULT_SEEK_STEP}</span>
                     </span>
                   </SeekButton>
                 }
@@ -191,10 +189,10 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger
                 render={
-                  <SeekButton seconds={SEEK_TIME} className="media-button--seek" render={<Button />}>
+                  <SeekButton seconds={DEFAULT_SEEK_STEP} className="media-button--seek" render={<Button />}>
                     <span className="media-icon__container">
                       <SeekIcon className="media-icon media-icon--seek" />
-                      <span className="media-icon__label">{SEEK_TIME}</span>
+                      <span className="media-icon__label">{DEFAULT_SEEK_STEP}</span>
                     </span>
                   </SeekButton>
                 }
@@ -243,12 +241,12 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowRight" action="seekStep" value={5} />
-      <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
-      <Hotkey keys="l" action="seekStep" value={10} />
-      <Hotkey keys="j" action="seekStep" value={-10} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowRight" action="seekStep" />
+      <Hotkey keys="ArrowLeft" action="seekStep" />
+      <Hotkey keys="l" action="seekStep" />
+      <Hotkey keys="j" action="seekStep" />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -40,8 +40,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { MinimalLiveAudioSkinProps } from './minimal-skin';
 
-const VOLUME_STEP = 5;
-
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return (
     <button ref={ref} type="button" className={cn(button.base, button.subtle, button.icon, className)} {...props} />
@@ -118,7 +116,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className={cn(popup.volume)}>
-        <VolumeSlider.Root step={VOLUME_STEP} orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -193,8 +191,8 @@ export function MinimalLiveAudioSkinTailwind(props: MinimalLiveAudioSkinProps): 
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
 
       {/* Input Feedback */}
       <StatusAnnouncer className="sr-only" />

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -27,8 +27,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseSkinProps } from '../types';
 
-const VOLUME_STEP = 5;
-
 export type MinimalLiveAudioSkinProps = BaseSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
@@ -75,7 +73,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
-        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="horizontal" thumbAlignment="edge">
+        <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -155,8 +153,8 @@ export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNod
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
 
       {/* Input Feedback */}
       <StatusAnnouncer className="media-sr-only" />

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -32,8 +32,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { LiveAudioSkinProps } from './skin';
 
-const VOLUME_STEP = 5;
-
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return (
     <button ref={ref} type="button" className={cn(button.base, button.subtle, button.icon, className)} {...props} />
@@ -94,7 +92,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className={cn(popup.popover, popup.volume)}>
-        <VolumeSlider.Root step={VOLUME_STEP} orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -169,8 +167,8 @@ export function LiveAudioSkinTailwind(props: LiveAudioSkinProps): ReactNode {
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
 
       {/* Input Feedback */}
       <StatusAnnouncer className="sr-only" />

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -19,8 +19,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseSkinProps } from '../types';
 
-const VOLUME_STEP = 5;
-
 export type LiveAudioSkinProps = BaseSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
@@ -51,7 +49,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className="media-surface media-popover media-popover--volume">
-        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="vertical" thumbAlignment="edge">
+        <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -137,8 +135,8 @@ export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {
       <Hotkey keys="Space" action="togglePaused" />
       <Hotkey keys="k" action="togglePaused" />
       <Hotkey keys="m" action="toggleMuted" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
 
       {/* Input Feedback */}
       <StatusAnnouncer className="media-sr-only" />

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -72,7 +72,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { MinimalLiveVideoSkinProps } from './minimal-skin';
 
-const VOLUME_STEP = 5;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -152,7 +151,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className={cn(popup.volume)}>
-        <VolumeSlider.Root step={VOLUME_STEP} orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -355,8 +354,8 @@ export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): 
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
 
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -52,7 +52,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseVideoSkinProps } from '../types';
 
-const VOLUME_STEP = 5;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -102,7 +101,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
-        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="horizontal" thumbAlignment="edge">
+        <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -319,8 +318,8 @@ export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNod
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
 
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -73,7 +73,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { LiveVideoSkinProps } from './skin';
 
-const VOLUME_STEP = 5;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -137,7 +136,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className={cn(popup.popover, popup.volume)}>
-        <VolumeSlider.Root step={VOLUME_STEP} orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -342,8 +341,8 @@ export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
 
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -52,7 +52,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseVideoSkinProps } from '../types';
 
-const VOLUME_STEP = 5;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -86,7 +85,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className="media-surface media-popover media-popover--volume">
-        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="vertical" thumbAlignment="edge">
+        <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -303,8 +302,8 @@ export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
 
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -97,8 +97,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { MinimalVideoSkinProps } from './minimal-skin';
 
-const VOLUME_STEP = 5;
-const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -180,7 +178,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className={popup.volume}>
-        <VolumeSlider.Root step={VOLUME_STEP} orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root orientation="horizontal" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -573,12 +571,12 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowRight" action="seekStep" value={SEEK_TIME / 2} />
-      <Hotkey keys="ArrowLeft" action="seekStep" value={-(SEEK_TIME / 2)} />
-      <Hotkey keys="l" action="seekStep" value={SEEK_TIME} />
-      <Hotkey keys="j" action="seekStep" value={-SEEK_TIME} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowRight" action="seekStep" />
+      <Hotkey keys="ArrowLeft" action="seekStep" />
+      <Hotkey keys="l" action="seekStep" />
+      <Hotkey keys="j" action="seekStep" />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />
@@ -588,9 +586,9 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
       <Gesture type="tap" action="toggleControls" pointer="touch" />
-      <Gesture type="doubletap" action="seekStep" value={-SEEK_TIME} region="left" />
+      <Gesture type="doubletap" action="seekStep" region="left" />
       <Gesture type="doubletap" action="toggleFullscreen" region="center" />
-      <Gesture type="doubletap" action="seekStep" value={SEEK_TIME} region="right" />
+      <Gesture type="doubletap" action="seekStep" region="right" />
 
       {/* Input Indicators */}
       <StatusAnnouncer className="sr-only" />

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -73,8 +73,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseVideoSkinProps } from '../types';
 
-const VOLUME_STEP = 5;
-const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -125,7 +123,7 @@ function VolumePopover(): ReactNode {
         </Tooltip.Popup>
       </Tooltip.Root>
       <Popover.Popup className="media-popover media-popover--volume">
-        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="horizontal" thumbAlignment="edge">
+        <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -518,12 +516,12 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowRight" action="seekStep" value={SEEK_TIME / 2} />
-      <Hotkey keys="ArrowLeft" action="seekStep" value={-(SEEK_TIME / 2)} />
-      <Hotkey keys="l" action="seekStep" value={SEEK_TIME} />
-      <Hotkey keys="j" action="seekStep" value={-SEEK_TIME} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowRight" action="seekStep" />
+      <Hotkey keys="ArrowLeft" action="seekStep" />
+      <Hotkey keys="l" action="seekStep" />
+      <Hotkey keys="j" action="seekStep" />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />
@@ -533,9 +531,9 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
       <Gesture type="tap" action="toggleControls" pointer="touch" />
-      <Gesture type="doubletap" action="seekStep" value={-SEEK_TIME} region="left" />
+      <Gesture type="doubletap" action="seekStep" region="left" />
       <Gesture type="doubletap" action="toggleFullscreen" region="center" />
-      <Gesture type="doubletap" action="seekStep" value={SEEK_TIME} region="right" />
+      <Gesture type="doubletap" action="seekStep" region="right" />
 
       {/* Input Indicators */}
       <StatusAnnouncer className="media-sr-only" />

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -99,8 +99,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { VideoSkinProps } from './skin';
 
-const VOLUME_STEP = 5;
-const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -166,7 +164,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className={cn(popup.popover, popup.volume)}>
-        <VolumeSlider.Root step={VOLUME_STEP} orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
+        <VolumeSlider.Root orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
           <VolumeSlider.Track render={<SliderTrack />}>
             <VolumeSlider.Fill render={<SliderFill />} />
           </VolumeSlider.Track>
@@ -561,12 +559,12 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowRight" action="seekStep" value={SEEK_TIME / 2} />
-      <Hotkey keys="ArrowLeft" action="seekStep" value={-(SEEK_TIME / 2)} />
-      <Hotkey keys="l" action="seekStep" value={SEEK_TIME} />
-      <Hotkey keys="j" action="seekStep" value={-SEEK_TIME} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowRight" action="seekStep" />
+      <Hotkey keys="ArrowLeft" action="seekStep" />
+      <Hotkey keys="l" action="seekStep" />
+      <Hotkey keys="j" action="seekStep" />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />
@@ -576,9 +574,9 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
       <Gesture type="tap" action="toggleControls" pointer="touch" />
-      <Gesture type="doubletap" action="seekStep" value={-SEEK_TIME} region="left" />
+      <Gesture type="doubletap" action="seekStep" region="left" />
       <Gesture type="doubletap" action="toggleFullscreen" region="center" />
-      <Gesture type="doubletap" action="seekStep" value={SEEK_TIME} region="right" />
+      <Gesture type="doubletap" action="seekStep" region="right" />
 
       {/* Input Indicators */}
       <StatusAnnouncer className="sr-only" />

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -73,8 +73,6 @@ import { VolumeSlider } from '@/ui/volume-slider';
 
 import type { BaseVideoSkinProps } from '../types';
 
-const VOLUME_STEP = 5;
-const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
@@ -109,7 +107,7 @@ function VolumePopover(): ReactNode {
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
       <Popover.Trigger render={muteButton} />
       <Popover.Popup className="media-surface media-popover media-popover--volume">
-        <VolumeSlider.Root step={VOLUME_STEP} className="media-slider" orientation="vertical" thumbAlignment="edge">
+        <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
           <VolumeSlider.Track className="media-slider__track">
             <VolumeSlider.Fill className="media-slider__fill" />
           </VolumeSlider.Track>
@@ -523,12 +521,12 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
       <Hotkey keys="f" action="toggleFullscreen" />
       <Hotkey keys="c" action="toggleSubtitles" />
       <Hotkey keys="i" action="togglePictureInPicture" />
-      <Hotkey keys="ArrowRight" action="seekStep" value={SEEK_TIME / 2} />
-      <Hotkey keys="ArrowLeft" action="seekStep" value={-(SEEK_TIME / 2)} />
-      <Hotkey keys="l" action="seekStep" value={SEEK_TIME} />
-      <Hotkey keys="j" action="seekStep" value={-SEEK_TIME} />
-      <Hotkey keys="ArrowUp" action="volumeStep" value={VOLUME_STEP / 100} />
-      <Hotkey keys="ArrowDown" action="volumeStep" value={-VOLUME_STEP / 100} />
+      <Hotkey keys="ArrowRight" action="seekStep" />
+      <Hotkey keys="ArrowLeft" action="seekStep" />
+      <Hotkey keys="l" action="seekStep" />
+      <Hotkey keys="j" action="seekStep" />
+      <Hotkey keys="ArrowUp" action="volumeStep" />
+      <Hotkey keys="ArrowDown" action="volumeStep" />
       <Hotkey keys="0-9" action="seekToPercent" />
       <Hotkey keys="Home" action="seekToPercent" value={0} />
       <Hotkey keys="End" action="seekToPercent" value={100} />
@@ -538,9 +536,9 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
       {/* Gestures */}
       <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
       <Gesture type="tap" action="toggleControls" pointer="touch" />
-      <Gesture type="doubletap" action="seekStep" value={-SEEK_TIME} region="left" />
+      <Gesture type="doubletap" action="seekStep" region="left" />
       <Gesture type="doubletap" action="toggleFullscreen" region="center" />
-      <Gesture type="doubletap" action="seekStep" value={SEEK_TIME} region="right" />
+      <Gesture type="doubletap" action="seekStep" region="right" />
 
       {/* Input Indicators */}
       <StatusAnnouncer className="media-sr-only" />

--- a/packages/react/src/ui/gesture/gesture.tsx
+++ b/packages/react/src/ui/gesture/gesture.tsx
@@ -1,6 +1,11 @@
 import type { GestureProps as CoreGestureProps } from '@videojs/core';
 import type { AnyPlayerStore } from '@videojs/core/dom';
-import { createDoubleTapGesture, createTapGesture, resolveGestureAction } from '@videojs/core/dom';
+import {
+  createDoubleTapGesture,
+  createTapGesture,
+  getGestureActionValue,
+  resolveGestureAction,
+} from '@videojs/core/dom';
 import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 
@@ -18,11 +23,13 @@ export function Gesture({ type, action, value, pointer, region, disabled }: Gest
     const resolver = resolveGestureAction(action);
     if (!resolver) return;
 
+    const actionValue = getGestureActionValue(action, region, value);
+
     const onActivate = (event: PointerEvent) => {
-      resolver({ store, value, event });
+      resolver({ store, value: actionValue, event });
     };
 
-    const options = { pointer, region, action, value };
+    const options = { pointer, region, action, value: actionValue };
 
     if (type === 'doubletap') {
       return createDoubleTapGesture(container, onActivate, options);

--- a/packages/react/src/ui/gesture/tests/gesture.test.tsx
+++ b/packages/react/src/ui/gesture/tests/gesture.test.tsx
@@ -1,0 +1,42 @@
+import { render, waitFor } from '@testing-library/react';
+import { DEFAULT_SEEK_STEP } from '@videojs/core';
+import { getGestureCoordinator } from '@videojs/core/dom';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+import { PlayerContextProvider, type PlayerContextValue } from '../../../player/context';
+import { createMockStore } from '../../../testing/mocks';
+import { Gesture } from '../gesture';
+
+function createContextValue(container: HTMLElement): PlayerContextValue {
+  return {
+    store: createMockStore() as any,
+    media: null,
+    setMedia: vi.fn(),
+    container,
+    setContainer: vi.fn(),
+  };
+}
+
+function Wrapper({ children, value }: { children: ReactNode; value: PlayerContextValue }) {
+  return <PlayerContextProvider value={value}>{children}</PlayerContextProvider>;
+}
+
+describe('Gesture', () => {
+  it('defaults a left seek gesture to the backward step', async () => {
+    const container = document.createElement('div');
+    const value = createContextValue(container);
+
+    render(
+      <Wrapper value={value}>
+        <Gesture type="doubletap" action="seekStep" region="left" />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(getGestureCoordinator(container).bindings).toEqual([
+        expect.objectContaining({ action: 'seekStep', region: 'left', value: -DEFAULT_SEEK_STEP }),
+      ]);
+    });
+  });
+});

--- a/packages/react/src/ui/hotkey/tests/use-hotkey-shortcut.test.tsx
+++ b/packages/react/src/ui/hotkey/tests/use-hotkey-shortcut.test.tsx
@@ -1,4 +1,5 @@
 import { render, waitFor } from '@testing-library/react';
+import { findHotkeyCoordinator } from '@videojs/core/dom';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vite-plus/test';
 
@@ -54,5 +55,27 @@ describe('useHotkeyShortcut', () => {
 
     await waitFor(() => expect(document.querySelector('[data-testid="shortcut"]')?.textContent).toBe('P'));
     expect(document.querySelector('[data-testid="aria"]')?.textContent).toBe('p');
+  });
+});
+
+describe('Hotkey', () => {
+  it('registers the default ArrowUp volume step', async () => {
+    const container = document.createElement('div');
+    const value = createContextValue(container);
+
+    render(
+      <Wrapper value={value}>
+        <Hotkey keys="ArrowUp" action="volumeStep" />
+      </Wrapper>
+    );
+
+    await waitFor(() => expect(findHotkeyCoordinator(container)).toBeDefined());
+
+    const activate = vi.fn();
+
+    findHotkeyCoordinator(container)!.subscribe(activate);
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+
+    expect(activate).toHaveBeenCalledWith(expect.objectContaining({ value: 0.05 }));
   });
 });

--- a/site/scripts/ejected-skins/templates/html/audio/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/audio/minimal-skin.tailwind.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SEEK_STEP } from '@videojs/html';
 import { renderIcon } from '@videojs/icons/render/minimal';
 import {
   button,
@@ -18,8 +19,6 @@ import {
   time,
 } from '@videojs/skins/minimal/tailwind/audio.tailwind';
 import { cn } from '@videojs/utils/style';
-
-const SEEK_TIME = 10;
 
 export function getTemplateHTML() {
   return /*html*/ `
@@ -60,10 +59,10 @@ export function getTemplateHTML() {
               </media-tooltip>
             </span>
 
-            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon)}">
+            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-DEFAULT_SEEK_STEP}" class="${cn(button.base, button.subtle, button.icon)}">
               <span class="${iconContainer}">
                 ${renderIcon('seek', { class: cn(icon, iconFlipped) })}
-                <span class="${cn(seek.label, seek.labelBackward)}">${SEEK_TIME}</span>
+                <span class="${cn(seek.label, seek.labelBackward)}">${DEFAULT_SEEK_STEP}</span>
               </span>
             </media-seek-button>
             <media-tooltip id="seek-backward-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}">
@@ -71,10 +70,10 @@ export function getTemplateHTML() {
               <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
             </media-tooltip>
 
-            <media-seek-button commandfor="seek-forward-tooltip" seconds="${SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon)}">
+            <media-seek-button commandfor="seek-forward-tooltip" seconds="${DEFAULT_SEEK_STEP}" class="${cn(button.base, button.subtle, button.icon)}">
               <span class="${iconContainer}">
                 ${renderIcon('seek', { class: icon })}
-                <span class="${cn(seek.label, seek.labelForward)}">${SEEK_TIME}</span>
+                <span class="${cn(seek.label, seek.labelForward)}">${DEFAULT_SEEK_STEP}</span>
               </span>
             </media-seek-button>
             <media-tooltip id="seek-forward-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}">
@@ -151,12 +150,12 @@ export function getTemplateHTML() {
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
-      <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
-      <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
-      <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
-      <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowRight" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowLeft" action="seekStep"></media-hotkey>
+      <media-hotkey keys="l" action="seekStep"></media-hotkey>
+      <media-hotkey keys="j" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>

--- a/site/scripts/ejected-skins/templates/html/audio/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/audio/skin.tailwind.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SEEK_STEP } from '@videojs/html';
 import { renderIcon } from '@videojs/icons/render';
 import {
   button,
@@ -18,8 +19,6 @@ import {
   time,
 } from '@videojs/skins/default/tailwind/audio.tailwind';
 import { cn } from '@videojs/utils/style';
-
-const SEEK_TIME = 10;
 
 export function getTemplateHTML() {
   return /*html*/ `
@@ -60,10 +59,10 @@ export function getTemplateHTML() {
               </media-tooltip>
             </span>
 
-            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon, button.seek)}">
+            <media-seek-button commandfor="seek-backward-tooltip" seconds="${-DEFAULT_SEEK_STEP}" class="${cn(button.base, button.subtle, button.icon, button.seek)}">
               <span class="${iconContainer}">
                 ${renderIcon('seek', { class: cn(icon, iconFlipped) })}
-                <span class="${cn(seek.label, seek.labelBackward)}">${SEEK_TIME}</span>
+                <span class="${cn(seek.label, seek.labelBackward)}">${DEFAULT_SEEK_STEP}</span>
               </span>
             </media-seek-button>
             <media-tooltip id="seek-backward-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}">
@@ -71,10 +70,10 @@ export function getTemplateHTML() {
               <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
             </media-tooltip>
 
-            <media-seek-button commandfor="seek-forward-tooltip" seconds="${SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon, button.seek)}">
+            <media-seek-button commandfor="seek-forward-tooltip" seconds="${DEFAULT_SEEK_STEP}" class="${cn(button.base, button.subtle, button.icon, button.seek)}">
               <span class="${iconContainer}">
                 ${renderIcon('seek', { class: icon })}
-                <span class="${cn(seek.label, seek.labelForward)}">${SEEK_TIME}</span>
+                <span class="${cn(seek.label, seek.labelForward)}">${DEFAULT_SEEK_STEP}</span>
               </span>
             </media-seek-button>
             <media-tooltip id="seek-forward-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}">
@@ -141,12 +140,12 @@ export function getTemplateHTML() {
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
-      <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
-      <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
-      <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
-      <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowRight" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowLeft" action="seekStep"></media-hotkey>
+      <media-hotkey keys="l" action="seekStep"></media-hotkey>
+      <media-hotkey keys="j" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>

--- a/site/scripts/ejected-skins/templates/html/live-audio/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-audio/minimal-skin.tailwind.ts
@@ -85,8 +85,8 @@ export function getTemplateHTML() {
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
     </media-container>
   `;
 }

--- a/site/scripts/ejected-skins/templates/html/live-audio/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-audio/skin.tailwind.ts
@@ -81,8 +81,8 @@ export function getTemplateHTML() {
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
     </media-container>
   `;
 }

--- a/site/scripts/ejected-skins/templates/html/live-video/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-video/minimal-skin.tailwind.ts
@@ -157,8 +157,8 @@ export function getTemplateHTML() {
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
       <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
 
       <!-- Gestures -->
       <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>

--- a/site/scripts/ejected-skins/templates/html/live-video/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/live-video/skin.tailwind.ts
@@ -159,8 +159,8 @@ export function getTemplateHTML() {
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
       <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
 
       <!-- Gestures -->
       <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>

--- a/site/scripts/ejected-skins/templates/html/video/minimal-skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/video/minimal-skin.tailwind.ts
@@ -294,12 +294,12 @@ export function getTemplateHTML() {
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
       <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
-      <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
-      <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
-      <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
-      <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowRight" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowLeft" action="seekStep"></media-hotkey>
+      <media-hotkey keys="l" action="seekStep"></media-hotkey>
+      <media-hotkey keys="j" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>
@@ -309,9 +309,9 @@ export function getTemplateHTML() {
       <!-- Gestures -->
       <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>
       <media-gesture type="tap" action="toggleControls" pointer="touch"></media-gesture>
-      <media-gesture type="doubletap" action="seekStep" value="-10" region="left"></media-gesture>
+      <media-gesture type="doubletap" action="seekStep" region="left"></media-gesture>
       <media-gesture type="doubletap" action="toggleFullscreen" region="center"></media-gesture>
-      <media-gesture type="doubletap" action="seekStep" value="10" region="right"></media-gesture>
+      <media-gesture type="doubletap" action="seekStep" region="right"></media-gesture>
 
       <!-- Input Indicators -->
       <media-status-announcer class="sr-only"></media-status-announcer>

--- a/site/scripts/ejected-skins/templates/html/video/skin.tailwind.ts
+++ b/site/scripts/ejected-skins/templates/html/video/skin.tailwind.ts
@@ -295,12 +295,12 @@ export function getTemplateHTML() {
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
       <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
-      <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
-      <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
-      <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
-      <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
-      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
-      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+      <media-hotkey keys="ArrowRight" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowLeft" action="seekStep"></media-hotkey>
+      <media-hotkey keys="l" action="seekStep"></media-hotkey>
+      <media-hotkey keys="j" action="seekStep"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep"></media-hotkey>
       <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
       <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>
@@ -310,9 +310,9 @@ export function getTemplateHTML() {
       <!-- Gestures -->
       <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>
       <media-gesture type="tap" action="toggleControls" pointer="touch"></media-gesture>
-      <media-gesture type="doubletap" action="seekStep" value="-10" region="left"></media-gesture>
+      <media-gesture type="doubletap" action="seekStep" region="left"></media-gesture>
       <media-gesture type="doubletap" action="toggleFullscreen" region="center"></media-gesture>
-      <media-gesture type="doubletap" action="seekStep" value="10" region="right"></media-gesture>
+      <media-gesture type="doubletap" action="seekStep" region="right"></media-gesture>
 
       <!-- Input Indicators -->
       <media-status-announcer class="sr-only"></media-status-announcer>

--- a/site/src/content/docs/how-to/add-keyboard-shortcuts-and-gestures.mdx
+++ b/site/src/content/docs/how-to/add-keyboard-shortcuts-and-gestures.mdx
@@ -77,7 +77,7 @@ export default function App() {
 
 ## How it works
 
-- `Hotkey` binds keys to player actions: `togglePaused`, `toggleMuted`, `toggleFullscreen`, `toggleSubtitles`, `togglePictureInPicture`, `seekStep` and `volumeStep` (with a `value`), `seekToPercent`, `speedUp`, and `speedDown`. The actions call the same feature state actions your components use.
+- `Hotkey` binds keys to player actions: `togglePaused`, `toggleMuted`, `toggleFullscreen`, `toggleSubtitles`, `togglePictureInPicture`, `seekStep`, `volumeStep`, `seekToPercent`, `speedUp`, and `speedDown`. Step actions have shared defaults and accept a custom `value`. The actions call the same feature state actions your components use.
 - `Gesture` binds pointer input — `tap` and `doubletap` — to the same actions, minus `seekToPercent` and plus `toggleControls`. Bindings are scoped by `pointer` (`mouse` or `touch`) and `region` (`left`, `center`, `right`) — regions split the container's width, not the rendered video's — so double-tap-left rewinds while double-tap-right skips forward.
 - `StatusAnnouncer` announces action results to screen readers, and the input indicator components render transient on-screen feedback (volume level, captions on/off) the way native players do. The prebuilt skins wire these up.
 

--- a/site/src/content/docs/reference/gesture.mdx
+++ b/site/src/content/docs/reference/gesture.mdx
@@ -60,7 +60,7 @@ Use `pointer` to accept only `mouse`, `touch`, or `pen` input. Use `region` to d
 
 An unregional gesture acts as a fallback outside the active regions. When several registrations match the same gesture, the first registration wins.
 
-Choose a built-in `action` from the API reference below, or use an application-defined name to call a same-named action on the player store. Pass `value` as seconds for `seekStep` or as a volume delta such as `0.05` or `-0.05` for `volumeStep`. Unknown action names do nothing and warn in development.
+Choose a built-in `action` from the API reference below, or use an application-defined name to call a same-named action on the player store. Pass `value` as seconds for `seekStep` or as a volume delta such as `0.05` or `-0.05` for `volumeStep`. When omitted, these actions use the 10-second or five-percentage-point default. A left-region seek gesture uses the negative step. Unknown action names do nothing and warn in development.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/hotkey.mdx
+++ b/site/src/content/docs/reference/hotkey.mdx
@@ -52,7 +52,7 @@ Key patterns are case-insensitive and may use:
 - `Mod` for `Meta` on macOS and `Ctrl` elsewhere.
 - The special `0-9` range for digit-based seeking.
 
-Choose an `action` from the API reference below. Pass `value` as seconds for `seekStep`, a volume delta such as `0.05` or `-0.05` for `volumeStep`, or a percentage from 0 to 100 for `seekToPercent`. When `value` is omitted from `seekToPercent` with `keys="0-9"`, the pressed digit supplies the percentage.
+Choose an `action` from the API reference below. Pass `value` as seconds for `seekStep`, a volume delta such as `0.05` or `-0.05` for `volumeStep`, or a percentage from 0 to 100 for `seekToPercent`. When omitted, `seekStep` defaults to 10 seconds and `volumeStep` defaults to five percentage points; `ArrowLeft`, `j`, and `ArrowDown` use the negative step. When `value` is omitted from `seekToPercent` with `keys="0-9"`, the pressed digit supplies the percentage.
 
 Toggle actions ignore held-key repeats. Step, rate, and percentage actions may repeat. A matched shortcut prevents the browser's default behavior. Unmodified shortcuts are ignored in editable fields, and <kbd>Space</kbd> or <kbd>Enter</kbd> still activates focused buttons, links, and sliders normally.
 
@@ -64,7 +64,7 @@ Hotkeys supplement operable controls; they should never be the only way to perfo
 
 ### Basic Usage
 
-This player uses <kbd>Space</kbd> to play or pause, <kbd>M</kbd> to mute, and the arrow keys to seek by five seconds. Click the player first to focus its container.
+This player uses <kbd>Space</kbd> to play or pause, <kbd>M</kbd> to mute, and the arrow keys to seek by ten seconds. Click the player first to focus its container.
 
 <FrameworkCase frameworks={["react"]}>
   <StyleCase styles={["css"]}>


### PR DESCRIPTION
Refs #2474

## Summary

Centralize the default seek and volume steps so hotkeys, gestures, sliders, and preset controls share the same behavior. This actions the follow-up review feedback from #2474 and keeps ejected skins on the public HTML and React package surfaces.

## Changes

- Apply shared 10-second seek and 5% volume defaults when input actions omit a value
- Remove duplicated action values from HTML and React skins while preserving directional gesture behavior
- Re-export the seek default from the HTML and React packages for ejected skins and preset controls
- Cover the default resolution in Core, HTML, and React tests and update the related documentation

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `node_modules/.bin/vp run @videojs/core#build`
- `node_modules/.bin/vp run @videojs/html#build`
- `node_modules/.bin/vp run @videojs/react#build`
- `pnpm -F site test scripts/tests/ejected-skins.test.ts`
- `pnpm exec tsx site/scripts/build-ejected-skins.ts`
- `pnpm -F site api-docs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible playback controls change: bundled skins unify arrow-key seek to 10 seconds and centralize default resolution for all hotkey/gesture bindings.
> 
> **Overview**
> Introduces shared **`DEFAULT_SEEK_STEP` (10s)** and **`DEFAULT_VOLUME_STEP` (5%)** in core and wires them through hotkeys, gestures, volume sliders, and preset skins so step actions no longer need duplicated `value` / `step` attributes.
> 
> **`getMediaInputActionValue`** and **`getGestureActionValue`** fill in seek/volume deltas when `value` is omitted (key direction for hotkeys, left region for backward seek gestures). **`seekStep` / `volumeStep` no longer no-op** without a value—they apply those defaults. Volume slider keyboard/wheel stepping aligns with the same 5% default.
> 
> HTML/React skins, ejected-skin templates, and docs drop inline hotkey/gesture values and rely on the framework; **`DEFAULT_SEEK_STEP`** is re-exported from `@videojs/html` and `@videojs/react` for seek buttons and ejected skins. **Preset arrow-key seek is now 10s** everywhere (previously 5s on arrows in some skins while `j`/`l` used 10s).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082157565ac9c4fcba8d7fc95bc421f7f6ad3f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->