### PR TITLE
test(skin): harden background preset contract

### DIFF
--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -148,7 +148,15 @@ interface PageDef {
   framework: 'html' | 'react';
   media: string;
   resource: string;
-  category?: 'cdn' | 'ejected-html' | 'ejected-react' | 'captions' | 'background' | 'source-html' | 'source-react';
+  category?:
+    | 'cdn'
+    | 'ejected-html'
+    | 'ejected-react'
+    | 'captions'
+    | 'background'
+    | 'background-preset'
+    | 'source-html'
+    | 'source-react';
 }
 
 // ---------------------------------------------------------------------------
@@ -356,6 +364,55 @@ createRoot(document.getElementById('root')!).render(<App />);
 `;
 }
 
+/** The handwritten Background preset, kept separate from the engine-only fixtures above. */
+function backgroundPresetPage(framework: PageDef['framework'], resource: string): string {
+  if (framework === 'react') {
+    return `import {
+  BackgroundVideo,
+  BackgroundVideoPlayer,
+  BackgroundVideoSkin,
+} from '@videojs/react/background';
+import '@videojs/react/background/skin.css';
+import { createRoot } from 'react-dom/client';
+import { MEDIA } from '../resources';
+
+function App() {
+  return (
+    <BackgroundVideoPlayer>
+      <BackgroundVideoSkin
+        className="background-preset"
+        style={{ width: 640, height: 360, objectFit: 'contain' }}
+      >
+        <img alt="" data-background-poster src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" />
+        <BackgroundVideo data-background-media src={MEDIA.${resource}.url} />
+      </BackgroundVideoSkin>
+    </BackgroundVideoPlayer>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);
+`;
+  }
+
+  return `import '@videojs/html/background/player';
+import '@videojs/html/background/skin';
+import '@videojs/html/background/video';
+import { MEDIA } from '../resources';
+
+document.getElementById('root')!.innerHTML = String.raw\`
+  <background-video-player>
+    <background-video-skin
+      class="background-preset"
+      style="width: 640px; height: 360px; --media-object-fit: contain"
+    >
+      <img alt="" data-background-poster src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" />
+      <background-video data-background-media src="\${MEDIA.${resource}.url}"></background-video>
+    </background-video-skin>
+  </background-video-player>
+\`;
+`;
+}
+
 function captionsPage(resource: string): string {
   const captionVtt = 'WEBVTT\\n\\n00:00:00.000 --> 00:00:30.000\\nThis is a test caption';
 
@@ -544,6 +601,22 @@ const PAGES: PageDef[] = [
     resource: 'hlsFmp4',
     category: 'background',
   },
+  {
+    name: 'HTML Background Preset',
+    path: 'html-background-preset',
+    framework: 'html',
+    media: 'hls-background-video',
+    resource: 'mp4',
+    category: 'background-preset',
+  },
+  {
+    name: 'React Background Preset',
+    path: 'react-background-preset',
+    framework: 'react',
+    media: 'hls-background-video',
+    resource: 'mp4',
+    category: 'background-preset',
+  },
   { name: 'HTML DASH Video', path: 'html-dash-video', framework: 'html', media: 'dash-video', resource: 'dash' },
   {
     name: 'HTML Shaka Video HLS',
@@ -680,6 +753,8 @@ function generatePage(page: PageDef): { ts: string; html: string; ext: string } 
       page.framework === 'react'
         ? reactBackgroundVideoPage(page.media, page.resource)
         : backgroundVideoPage(config, page.resource);
+  } else if (page.category === 'background-preset') {
+    ts = backgroundPresetPage(page.framework, page.resource);
   } else if (page.category === 'captions') {
     ts = captionsPage(page.resource);
   } else if (page.category === 'ejected-html') {

--- a/apps/e2e/tests/background-preset.spec.ts
+++ b/apps/e2e/tests/background-preset.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+const variants = [
+  { framework: 'HTML', page: '/pages/html-background-preset.html' },
+  { framework: 'React', page: '/pages/react-background-preset.html' },
+] as const;
+
+for (const variant of variants) {
+  test.describe(`${variant.framework} Background preset`, () => {
+    test('preserves sizing, object fit, and media layering', async ({ page }) => {
+      await page.goto(variant.page);
+
+      const skin = page.locator('.background-preset');
+      const media = skin.locator('[data-background-media]');
+      const poster = skin.locator('[data-background-poster]');
+
+      await expect(skin).toBeVisible();
+      await expect(skin).toHaveCSS('position', 'relative');
+      await expect(skin).toHaveCSS('width', '640px');
+      await expect(skin).toHaveCSS('height', '360px');
+      await expect(skin).toHaveCSS('object-fit', 'contain');
+      await expect(media).toHaveCSS('position', 'absolute');
+      await expect(media).toHaveCSS('width', '640px');
+      await expect(media).toHaveCSS('height', '360px');
+      await expect(poster).toHaveCSS('width', '640px');
+      await expect(poster).toHaveCSS('height', '360px');
+      await expect(poster).toHaveCSS('object-fit', 'contain');
+
+      if (variant.framework === 'HTML') {
+        await expect(page.locator('background-video-player')).toHaveCSS('display', 'contents');
+
+        const videoFit = await media.evaluate(
+          (element) => getComputedStyle(element.shadowRoot!.querySelector('video')!).objectFit
+        );
+
+        expect(videoFit).toBe('contain');
+      } else {
+        await expect(media).toHaveCSS('object-fit', 'contain');
+      }
+    });
+  });
+}

--- a/packages/html/src/define/background/skin.css
+++ b/packages/html/src/define/background/skin.css
@@ -28,12 +28,12 @@ background-video-skin > :not(img, picture) {
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: inherit;
+  object-fit: var(--media-object-fit);
 }
 
 background-video-skin > img,
 background-video-skin > picture {
   width: 100%;
   height: 100%;
-  object-fit: inherit;
+  object-fit: var(--media-object-fit);
 }

--- a/packages/html/src/presets/background/tests/skin.test.ts
+++ b/packages/html/src/presets/background/tests/skin.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+
+import { BackgroundVideoSkinElement } from '../skin';
+
+let tagId = 0;
+
+function createSkin(): BackgroundVideoSkinElement {
+  const tag = `test-background-video-skin-${tagId++}`;
+
+  customElements.define(tag, class extends BackgroundVideoSkinElement {});
+  const skin = document.createElement(tag);
+  if (!(skin instanceof BackgroundVideoSkinElement)) throw new Error(`Failed to create ${tag}`);
+
+  return skin;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  document.getElementById('__media-background-styles')?.remove();
+});
+
+describe('BackgroundVideoSkinElement', () => {
+  it('creates the background container and legacy media slot', () => {
+    const skin = createSkin();
+
+    expect(skin.shadowRoot?.querySelector('media-container')).not.toBeNull();
+    expect(skin.shadowRoot?.querySelector('slot[name="media"]')).not.toBeNull();
+    expect(skin.shadowRoot?.querySelector('slot:not([name])')).not.toBeNull();
+  });
+
+  it('shares one light-DOM stylesheet across multiple instances', () => {
+    const first = createSkin();
+    const second = createSkin();
+
+    document.body.append(first, second);
+
+    const styles = document.querySelectorAll('#__media-background-styles');
+
+    expect(styles).toHaveLength(1);
+    expect(first.shadowRoot).not.toBe(second.shadowRoot);
+  });
+});

--- a/packages/react/src/presets/background/tests/skin.test.tsx
+++ b/packages/react/src/presets/background/tests/skin.test.tsx
@@ -1,0 +1,22 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+
+import { BackgroundVideoSkin } from '../skin';
+
+afterEach(cleanup);
+
+describe('BackgroundVideoSkin', () => {
+  it('renders an extensible background surface around its children', () => {
+    const { container } = render(
+      <BackgroundVideoSkin className="hero" style={{ objectFit: 'contain' }}>
+        <video />
+      </BackgroundVideoSkin>
+    );
+    const skin = container.firstElementChild;
+
+    expect(skin?.classList).toContain('media-background-skin');
+    expect(skin?.classList).toContain('hero');
+    expect(skin?.getAttribute('style')).toContain('object-fit: contain');
+    expect(skin?.querySelector('video')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Part of #2114

## Summary

- add focused React and HTML Background preset composition and multi-instance coverage
- add Chromium, WebKit, and Firefox coverage for sizing, layering, media/poster object fit, and package entry points
- apply the HTML `--media-object-fit` hook directly to slotted media and poster elements

## Architecture boundary

Background remains a small handwritten, control-free preset rather than a VJSC or public Shadcn registry item. This PR locks its observable contract before the later framework-generation layer moves the canonical React, HTML, and CSS sources into Skins and produces package output atomically.

## Verification

- React and HTML unit suites
- Background preset E2E across Chromium, WebKit, and Firefox
- Skins, React, and HTML package builds
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:workspace`

## Stack

- Depends on #2530.
- Followed by #2544.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and fixture additions plus a localized CSS change on background skin children; no auth, data, or core playback paths.
> 
> **Overview**
> Locks in the **handwritten Background preset** (HTML + React) with tests and a small styling hook so `object-fit` behavior is observable end-to-end.
> 
> **HTML skin CSS** now applies `object-fit: var(--media-object-fit)` on slotted media and poster nodes instead of `inherit`, so presets can drive fit via `--media-object-fit` on the skin (e.g. `contain` on the generated HTML preset page).
> 
> **E2E** adds `background-preset.spec.ts` against new `html-background-preset` / `react-background-preset` pages from `generate-pages` (`background-preset` category + `backgroundPresetPage` template). Assertions cover skin dimensions, layering, poster/media sizing, and object-fit (including shadow-DOM video for HTML).
> 
> **Unit tests** cover `BackgroundVideoSkinElement` (container/slots, single shared light-DOM stylesheet across instances) and React `BackgroundVideoSkin` (className/style/children).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf00270fca2b8283e1c0a60c3cef1c61d2149ab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->