### PR TITLE
feat(cli): eject packaged skins to source

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,6 +47,14 @@ videojs add skin video --diff
 
 Existing source files are never replaced unless `--overwrite` is explicit. Use `--path` to select an installation directory and `--json` for a machine-readable plan.
 
+Replace a recognized packaged skin import and static usage with the equivalent owned source:
+
+```bash
+videojs eject skin video
+```
+
+Eject only applies narrow, verified replacements. Unsupported or ambiguous source is left untouched with manual next steps.
+
 Read a doc page:
 
 ```bash

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,8 +26,12 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.10.1",
+    "@oxc-project/types": "0.146.0",
     "commander": "^15.0.0",
-    "diff": "^8.0.4"
+    "diff": "^8.0.4",
+    "magic-string": "^1.2.2",
+    "oxc-parser": "0.146.0",
+    "oxc-walker": "^1.1.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",

--- a/packages/cli/scripts/test-source-output.ts
+++ b/packages/cli/scripts/test-source-output.ts
@@ -10,6 +10,15 @@ import { build, type InlineConfig, type PluginOption } from 'vite';
 type Framework = 'html' | 'react';
 type Style = 'css' | 'tailwind';
 
+interface PackagedSkinContract {
+  readonly packageSource: string;
+  readonly exportName: string;
+  readonly playerExport: string;
+  readonly stylesheet: string;
+  readonly registration: string;
+  readonly tag: string;
+}
+
 const execute = promisify(execFile);
 const cli = resolve(import.meta.dirname, '../dist/index.mjs');
 const skins = [
@@ -23,6 +32,28 @@ const skins = [
   'minimal-live-audio',
 ] as const;
 const components = ['play-button', 'mute-button'] as const;
+const packagedSkins = {
+  video: packagedSkin('video', 'VideoSkin', 'VideoPlayer', 'skin', 'video-skin'),
+  'minimal-video': packagedSkin('video', 'MinimalVideoSkin', 'VideoPlayer', 'minimal-skin', 'video-minimal-skin'),
+  audio: packagedSkin('audio', 'AudioSkin', 'AudioPlayer', 'skin', 'audio-skin'),
+  'minimal-audio': packagedSkin('audio', 'MinimalAudioSkin', 'AudioPlayer', 'minimal-skin', 'audio-minimal-skin'),
+  'live-video': packagedSkin('live-video', 'LiveVideoSkin', 'LiveVideoPlayer', 'skin', 'live-video-skin'),
+  'minimal-live-video': packagedSkin(
+    'live-video',
+    'MinimalLiveVideoSkin',
+    'LiveVideoPlayer',
+    'minimal-skin',
+    'live-video-minimal-skin'
+  ),
+  'live-audio': packagedSkin('live-audio', 'LiveAudioSkin', 'LiveAudioPlayer', 'skin', 'live-audio-skin'),
+  'minimal-live-audio': packagedSkin(
+    'live-audio',
+    'MinimalLiveAudioSkin',
+    'LiveAudioPlayer',
+    'minimal-skin',
+    'live-audio-minimal-skin'
+  ),
+} as const satisfies Readonly<Record<(typeof skins)[number], PackagedSkinContract>>;
 
 for (const framework of ['react', 'html'] as const) {
   for (const style of ['css', 'tailwind'] as const) await verifyFixture(framework, style);
@@ -41,6 +72,8 @@ async function verifyFixture(framework: Framework, style: Style): Promise<void> 
     for (const component of components) {
       await installItem(root, framework, style, 'component', component, 'src/videojs/components');
     }
+
+    await verifyPackagedReplacement(root, framework, style);
 
     await validateOwnedSource(root);
     await buildFixture(root, framework, style);
@@ -71,6 +104,7 @@ async function installItem(
 }
 
 interface ChangeSetResult {
+  readonly alreadyEjected?: boolean | undefined;
   readonly files: readonly { readonly path: string; readonly status: string }[];
 }
 
@@ -159,6 +193,13 @@ async function writeReactEntry(root: string): Promise<string> {
     imports.push(`void Component${index};`);
   }
 
+  const ejected = await walkFiles(resolve(root, 'src/packaged-skins'));
+
+  for (const [index, path] of ejected.entries()) {
+    imports.push(`import * as Ejected${index} from ${JSON.stringify(relativeImport(root, path))};`);
+    imports.push(`void Ejected${index};`);
+  }
+
   const entry = resolve(root, 'source-output.ts');
 
   await writeFile(entry, `${imports.join('\n')}\n`);
@@ -166,8 +207,8 @@ async function writeReactEntry(root: string): Promise<string> {
 }
 
 async function writeHtmlEntry(root: string, style: Style): Promise<string> {
-  const markup: string[] = [];
-  const imports: string[] = [];
+  const markup = [await readFile(resolve(root, 'src/packaged-skins.html'), 'utf8')];
+  const imports = [`import ${JSON.stringify(relativeImport(root, resolve(root, 'src/packaged-skins.ts')))};`];
 
   for (const skin of skins) {
     const directory = resolve(root, 'src/videojs', skin);
@@ -219,6 +260,93 @@ async function linkTailwind(root: string): Promise<void> {
 
   await mkdir(modules);
   await symlink(resolve(import.meta.dirname, '../node_modules/tailwindcss'), resolve(modules, 'tailwindcss'), 'dir');
+}
+
+async function verifyPackagedReplacement(root: string, framework: Framework, style: Style): Promise<void> {
+  if (framework === 'react') await writePackagedReactUsage(root, style);
+  else await writePackagedHtmlUsage(root, style);
+
+  for (const skin of skins) {
+    const path = `src/ejected/${skin}`;
+    const args = [
+      'eject',
+      'skin',
+      skin,
+      '--cwd',
+      root,
+      '--framework',
+      framework,
+      '--style',
+      style,
+      '--path',
+      path,
+      '--yes',
+    ];
+
+    await execute(process.execPath, [cli, ...args], { maxBuffer: 50 * 1024 * 1024 });
+
+    const replay = await execute(process.execPath, [cli, ...args, '--json'], { maxBuffer: 50 * 1024 * 1024 });
+    const result: ChangeSetResult = JSON.parse(replay.stdout);
+
+    if (!result.alreadyEjected || result.files.length > 0) {
+      throw new Error(`${framework}/${style}/skin/${skin} eject is not idempotent.`);
+    }
+  }
+}
+
+async function writePackagedReactUsage(root: string, style: Style): Promise<void> {
+  const directory = resolve(root, 'src/packaged-skins');
+
+  await mkdir(directory, { recursive: true });
+
+  for (const skin of skins) {
+    const contract = packagedSkins[skin];
+    const exportName = `${contract.exportName}${style === 'tailwind' ? 'Tailwind' : ''}`;
+    const stylesheet = style === 'css' ? `import ${JSON.stringify(contract.stylesheet)};\n` : '';
+    const source =
+      `import { ${contract.playerExport}, ${exportName} as Skin } from ${JSON.stringify(contract.packageSource)};\n` +
+      `${stylesheet}export const player = <Skin data-fixture=${JSON.stringify(skin)}><${contract.playerExport} /></Skin>;\n`;
+
+    await writeFile(resolve(directory, `${skin}.tsx`), source);
+  }
+}
+
+async function writePackagedHtmlUsage(root: string, style: Style): Promise<void> {
+  const imports: string[] = [];
+  const markup: string[] = [];
+
+  for (const skin of skins) {
+    const contract = packagedSkins[skin];
+    const registration = `${contract.registration}${style === 'tailwind' ? '.tailwind' : ''}`;
+    const tag = `${contract.tag}${style === 'tailwind' ? '-tailwind' : ''}`;
+    const media = skin.includes('video') ? '<media-video></media-video>' : '<media-audio></media-audio>';
+    const poster = skin.includes('video') ? `<img slot="poster" src="${skin}.jpg">` : '';
+
+    imports.push(`import ${JSON.stringify(registration)};`);
+    markup.push(`<${tag} class="fixture-${skin}" data-fixture="${skin}">${media}${poster}</${tag}>`);
+  }
+
+  await writeFile(resolve(root, 'src/packaged-skins.ts'), `${imports.join('\n')}\n`);
+  await writeFile(resolve(root, 'src/packaged-skins.html'), `${markup.join('\n')}\n`);
+}
+
+function packagedSkin(
+  preset: string,
+  exportName: string,
+  playerExport: string,
+  entry: string,
+  tag: string
+): PackagedSkinContract {
+  const packageSource = `@videojs/react/${preset}`;
+
+  return {
+    packageSource,
+    exportName,
+    playerExport,
+    stylesheet: `${packageSource}/${entry}.css`,
+    registration: `@videojs/html/${preset}/${entry}`,
+    tag,
+  };
 }
 
 function importSpecifiers(source: string): string[] {

--- a/packages/cli/src/commands/source.ts
+++ b/packages/cli/src/commands/source.ts
@@ -4,6 +4,7 @@ import { createPatch } from 'diff';
 import { catalogItems, resolveCatalogItem } from '../catalog/index.js';
 import type { CatalogFramework, CatalogKind, CatalogStyle } from '../catalog/schema.js';
 import { applyChangeSet, type ChangeSet, planAdd } from '../eject/change-set.js';
+import { planEject } from '../eject/plan.js';
 import { detectProject } from '../eject/project.js';
 
 export interface SourceCommandOptions {
@@ -96,6 +97,57 @@ export async function handleAdd(kindValue: string, name: string, options: Source
 
   await applyChangeSet(changeSet);
   console.log(`\nAdded ${item.kind} ${item.name}.`);
+
+  for (const instruction of changeSet.instructions) console.log(`- ${instruction}`);
+}
+
+export async function handleEject(kindValue: string, name: string, options: SourceCommandOptions): Promise<void> {
+  const project = await detectProject(options.cwd ?? process.cwd());
+  const selection = await resolveSelection(options, project.framework, project.style);
+  const item = resolveCatalogItem(parseKind(kindValue), name, selection.framework, selection.style);
+  const path =
+    options.diff === true || options.diff === undefined ? (options.path ?? project.defaultPath) : options.diff;
+  const plan = await planEject({ project, item, path, overwrite: Boolean(options.overwrite) });
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({ ...serializableChangeSet(plan.changeSet), alreadyEjected: plan.alreadyEjected }, null, 2)
+    );
+    return;
+  }
+
+  if (plan.alreadyEjected) {
+    console.log(`${item.kind} ${item.name} is already source-owned.`);
+    return;
+  }
+
+  const { changeSet } = plan;
+
+  printPlan(changeSet);
+
+  if (options.diff) {
+    printDiff(changeSet);
+    return;
+  }
+
+  if (options.dryRun) return;
+
+  if (changeSet.conflicts.length > 0) {
+    throw new Error(
+      `Existing files differ:\n${changeSet.conflicts.map((file) => `- ${file.relativePath}`).join('\n')}\n` +
+        'Recommendation: review with --diff, choose another --path, or pass --overwrite.'
+    );
+  }
+
+  if (!options.yes) {
+    if (!process.stdin.isTTY) throw new Error('Confirmation is required. Recommendation: rerun with --yes.');
+
+    const approved = await confirm({ message: `Write ${changedFiles(changeSet).length} files?` });
+    if (isCancel(approved) || !approved) return;
+  }
+
+  await applyChangeSet(changeSet);
+  console.log(`\nEjected ${item.kind} ${item.name}.`);
 
   for (const instruction of changeSet.instructions) console.log(`- ${instruction}`);
 }

--- a/packages/cli/src/eject/plan.ts
+++ b/packages/cli/src/eject/plan.ts
@@ -1,0 +1,148 @@
+import type { Dirent } from 'node:fs';
+import { readFile, readdir } from 'node:fs/promises';
+import { extname, relative, resolve, sep } from 'node:path';
+
+import type { ResolvedCatalogItem } from '../catalog/index.js';
+import { type ChangeSet, planAdd, type PlannedFile } from './change-set.js';
+import type { ProjectInfo } from './project.js';
+import {
+  type ProjectSourceFile,
+  transformHtmlSkinUsage,
+  transformReactSkinUsage,
+  type UsageTransform,
+} from './transform.js';
+
+const ignoredDirectories = new Set([
+  '.git',
+  '.next',
+  '.output',
+  '.turbo',
+  '.vite',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+]);
+const sourceExtensions = new Set(['.cjs', '.html', '.js', '.jsx', '.mjs', '.ts', '.tsx']);
+
+export interface EjectPlan {
+  readonly alreadyEjected: boolean;
+  readonly changeSet: ChangeSet;
+}
+
+export async function planEject(options: {
+  readonly project: ProjectInfo;
+  readonly item: ResolvedCatalogItem;
+  readonly path: string;
+  readonly overwrite: boolean;
+}): Promise<EjectPlan> {
+  if (options.item.kind !== 'skin') {
+    throw new Error(`Cannot eject ${options.item.kind} ${options.item.name}. Recommendation: use \`videojs add\`.`);
+  }
+
+  const add = await planAdd(options);
+  const outputRoot = resolve(options.project.cwd, options.path);
+  const sources = await projectSourceFiles(options.project.cwd, outputRoot);
+  const usage =
+    options.item.framework === 'react'
+      ? transformReactSkinUsage(sources, options.item, outputRoot)
+      : transformHtmlSkinUsage(sources, options.item, outputRoot);
+
+  if (usage.localUses > 0 && (usage.packagedUses > 0 || usage.edits.length > 0)) {
+    throw new Error(
+      `Could not safely eject skin ${options.item.name}.\nReason: local source and packaged skin resources both exist.\n` +
+        'Recommendation: resolve the partial migration manually, then rerun the command.'
+    );
+  }
+
+  if (usage.packagedUses === 0) {
+    if (usage.localUses > 0) return { alreadyEjected: true, changeSet: emptyChangeSet(options, usage) };
+
+    throw noUsageError(options.item);
+  }
+
+  const applicationFiles = usage.edits.map(
+    (edit): PlannedFile => ({
+      path: edit.path,
+      relativePath: relative(options.project.cwd, edit.path),
+      content: edit.content,
+      previous: edit.source,
+      status: edit.content === edit.source ? 'unchanged' : 'update',
+    })
+  );
+  const plannedPaths = new Set(add.files.map((file) => file.path));
+
+  for (const file of applicationFiles) {
+    if (plannedPaths.has(file.path)) {
+      throw new Error(`Eject output path overlaps application source: \`${file.relativePath}\`.`);
+    }
+  }
+
+  return {
+    alreadyEjected: false,
+    changeSet: {
+      ...add,
+      files: [...add.files, ...applicationFiles],
+      instructions: [...usage.instructions, ...add.instructions],
+    },
+  };
+}
+
+async function projectSourceFiles(cwd: string, outputRoot: string): Promise<ProjectSourceFile[]> {
+  const files = await walkProject(cwd, outputRoot);
+
+  return Promise.all(files.map(async (path) => ({ path, source: await readFile(path, 'utf8') })));
+}
+
+async function walkProject(directory: string, outputRoot: string): Promise<string[]> {
+  if (isWithin(directory, outputRoot) && directory === outputRoot) return [];
+
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map((entry: Dirent): Promise<string[]> | string[] => {
+      const path = resolve(directory, entry.name);
+
+      if (entry.isSymbolicLink()) return [];
+
+      if (entry.isDirectory()) {
+        if (ignoredDirectories.has(entry.name) || entry.name.startsWith('.')) return [];
+
+        return walkProject(path, outputRoot);
+      }
+
+      return entry.isFile() && sourceExtensions.has(extname(entry.name)) ? [path] : [];
+    })
+  );
+
+  return files.flat().sort();
+}
+
+function emptyChangeSet(
+  options: { readonly project: ProjectInfo; readonly item: ResolvedCatalogItem },
+  usage: UsageTransform
+): ChangeSet {
+  return {
+    cwd: options.project.cwd,
+    item: options.item,
+    files: [],
+    conflicts: [],
+    instructions: [...usage.instructions, 'The packaged skin has already been replaced by local source.'],
+  };
+}
+
+function noUsageError(item: ResolvedCatalogItem): Error {
+  const surface =
+    item.framework === 'react' ? 'named packaged skin import' : 'static registration import and HTML skin element';
+
+  return new Error(
+    `Could not safely eject ${item.framework} skin ${item.name}.\nReason: no supported ${surface} was found.\n` +
+      `Recommendation: run \`videojs add skin ${item.name}\` and replace the packaged skin manually.`
+  );
+}
+
+function isWithin(root: string, target: string): boolean {
+  const path = relative(root, target);
+
+  return path === '' || (path !== '..' && !path.startsWith(`..${sep}`));
+}

--- a/packages/cli/src/eject/skin-contract.ts
+++ b/packages/cli/src/eject/skin-contract.ts
@@ -1,0 +1,116 @@
+import type { ResolvedCatalogItem } from '../catalog/index.js';
+
+interface SkinNames {
+  readonly preset: 'audio' | 'live-audio' | 'live-video' | 'video';
+  readonly packaged: string;
+  readonly generated: string;
+  readonly tag: string;
+  readonly minimal: boolean;
+}
+
+export interface ReactSkinContract {
+  readonly packageSource: string;
+  readonly packagedExport: string;
+  readonly generatedExport: string;
+  readonly stylesheetSource?: string | undefined;
+}
+
+export interface HtmlSkinContract {
+  readonly registrationSource: string;
+  readonly tag: string;
+}
+
+const skinNames = {
+  video: {
+    preset: 'video',
+    packaged: 'VideoSkin',
+    generated: 'DefaultVideoSkin',
+    tag: 'video-skin',
+    minimal: false,
+  },
+  'minimal-video': {
+    preset: 'video',
+    packaged: 'MinimalVideoSkin',
+    generated: 'MinimalVideoSkin',
+    tag: 'video-minimal-skin',
+    minimal: true,
+  },
+  audio: {
+    preset: 'audio',
+    packaged: 'AudioSkin',
+    generated: 'DefaultAudioSkin',
+    tag: 'audio-skin',
+    minimal: false,
+  },
+  'minimal-audio': {
+    preset: 'audio',
+    packaged: 'MinimalAudioSkin',
+    generated: 'MinimalAudioSkin',
+    tag: 'audio-minimal-skin',
+    minimal: true,
+  },
+  'live-video': {
+    preset: 'live-video',
+    packaged: 'LiveVideoSkin',
+    generated: 'DefaultLiveVideoSkin',
+    tag: 'live-video-skin',
+    minimal: false,
+  },
+  'minimal-live-video': {
+    preset: 'live-video',
+    packaged: 'MinimalLiveVideoSkin',
+    generated: 'MinimalLiveVideoSkin',
+    tag: 'live-video-minimal-skin',
+    minimal: true,
+  },
+  'live-audio': {
+    preset: 'live-audio',
+    packaged: 'LiveAudioSkin',
+    generated: 'DefaultLiveAudioSkin',
+    tag: 'live-audio-skin',
+    minimal: false,
+  },
+  'minimal-live-audio': {
+    preset: 'live-audio',
+    packaged: 'MinimalLiveAudioSkin',
+    generated: 'MinimalLiveAudioSkin',
+    tag: 'live-audio-minimal-skin',
+    minimal: true,
+  },
+} as const satisfies Readonly<Record<string, SkinNames>>;
+
+export function reactSkinContract(item: ResolvedCatalogItem): ReactSkinContract {
+  const names = namesFor(item);
+  const packageSource = `@videojs/react/${names.preset}`;
+
+  return {
+    packageSource,
+    packagedExport: `${names.packaged}${item.style === 'tailwind' ? 'Tailwind' : ''}`,
+    generatedExport: names.generated,
+    stylesheetSource:
+      item.style === 'css' ? `${packageSource}/${names.minimal ? 'minimal-skin' : 'skin'}.css` : undefined,
+  };
+}
+
+export function htmlSkinContract(item: ResolvedCatalogItem): HtmlSkinContract {
+  const names = namesFor(item);
+  const entry = `${names.minimal ? 'minimal-skin' : 'skin'}${item.style === 'tailwind' ? '.tailwind' : ''}`;
+
+  return {
+    registrationSource: `@videojs/html/${names.preset}/${entry}`,
+    tag: `${names.tag}${item.style === 'tailwind' ? '-tailwind' : ''}`,
+  };
+}
+
+function namesFor(item: ResolvedCatalogItem): SkinNames {
+  if (item.kind !== 'skin')
+    throw new Error(`Cannot eject ${item.kind} ${item.name}. Recommendation: use \`videojs add\`.`);
+
+  if (!hasSkinName(item.name)) throw new Error(`Skin ${item.name} has no packaged replacement contract.`);
+
+  return skinNames[item.name];
+}
+
+function hasSkinName(name: string): name is keyof typeof skinNames {
+  return Object.hasOwn(skinNames, name);
+}

--- a/packages/cli/src/eject/tests/plan.test.ts
+++ b/packages/cli/src/eject/tests/plan.test.ts
@@ -1,0 +1,120 @@
+import { access, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vite-plus/test';
+
+import type { ResolvedCatalogItem } from '../../catalog/index.js';
+import { applyChangeSet } from '../change-set.js';
+import { planEject } from '../plan.js';
+import { detectProject } from '../project.js';
+
+const item: ResolvedCatalogItem = {
+  kind: 'skin',
+  name: 'video',
+  title: 'Video Skin',
+  description: 'Default video skin.',
+  framework: 'react',
+  style: 'css',
+  context: 'default-video',
+  entry: 'skins/default-video/skin.tsx',
+  stylesheet: 'styles/video.css',
+  files: [
+    {
+      path: 'skins/default-video/skin.tsx',
+      content: 'export function DefaultVideoSkin() { return null; }\n',
+    },
+    { path: 'styles/video.css', content: '.media-skin {}\n' },
+  ],
+  dependencies: ['@videojs/react', 'react'],
+  devDependencies: [],
+};
+
+describe('planEject', () => {
+  it('applies source and application edits atomically and is idempotent', async () => {
+    const cwd = await fixture();
+    const application = join(cwd, 'src/player.tsx');
+    const source =
+      "import { VideoPlayer, VideoSkin as Skin } from '@videojs/react/video';\n" +
+      "import '@videojs/react/video/skin.css';\n" +
+      'export const player = <Skin><VideoPlayer /></Skin>;\n';
+
+    await writeFile(application, source);
+
+    const options = {
+      project: await detectProject(cwd),
+      item,
+      path: 'src/videojs',
+      overwrite: false,
+    } as const;
+    const plan = await planEject(options);
+
+    expect(plan.alreadyEjected).toBe(false);
+    expect(plan.changeSet.files.map(({ relativePath, status }) => [relativePath, status])).toEqual([
+      ['src/videojs/skins/default-video/skin.tsx', 'create'],
+      ['src/videojs/styles/video.css', 'create'],
+      ['package.json', 'update'],
+      ['src/player.tsx', 'update'],
+    ]);
+
+    await applyChangeSet(plan.changeSet);
+
+    const transformed = await readFile(application, 'utf8');
+
+    expect(transformed).toContain('import { VideoPlayer } from "@videojs/react/video";');
+    expect(transformed).toContain('import { DefaultVideoSkin as Skin } from "./videojs/skins/default-video/skin";');
+    expect(transformed).not.toContain('skin.css');
+
+    const replay = await planEject({ ...options, project: await detectProject(cwd) });
+
+    expect(replay.alreadyEjected).toBe(true);
+    expect(replay.changeSet.files).toEqual([]);
+  });
+
+  it('refuses ambiguous source without writing generated files', async () => {
+    const cwd = await fixture();
+
+    await writeFile(join(cwd, 'src/player.tsx'), "import * as VideoPreset from '@videojs/react/video';\n");
+
+    await expect(
+      planEject({
+        project: await detectProject(cwd),
+        item,
+        path: 'src/videojs',
+        overwrite: false,
+      })
+    ).rejects.toThrow('namespace import');
+    await expect(access(join(cwd, 'src/videojs'))).rejects.toThrow();
+  });
+
+  it('refuses a partial local migration with a packaged stylesheet', async () => {
+    const cwd = await fixture();
+
+    await writeFile(
+      join(cwd, 'src/player.tsx'),
+      "import { DefaultVideoSkin } from './videojs/skins/default-video/skin';\n" +
+        "import '@videojs/react/video/skin.css';\n"
+    );
+
+    await expect(
+      planEject({
+        project: await detectProject(cwd),
+        item,
+        path: 'src/videojs',
+        overwrite: false,
+      })
+    ).rejects.toThrow('local source and packaged skin resources both exist');
+  });
+});
+
+async function fixture(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'videojs-cli-eject-'));
+
+  await writeFile(
+    join(cwd, 'package.json'),
+    `${JSON.stringify({ name: 'fixture', private: true, dependencies: { '@videojs/react': 'latest' } }, null, 2)}\n`
+  );
+  await mkdir(join(cwd, 'src'));
+
+  return cwd;
+}

--- a/packages/cli/src/eject/tests/transform.test.ts
+++ b/packages/cli/src/eject/tests/transform.test.ts
@@ -1,0 +1,195 @@
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vite-plus/test';
+
+import type { ResolvedCatalogItem } from '../../catalog/index.js';
+import { htmlSkinContract, reactSkinContract } from '../skin-contract.js';
+import { transformHtmlSkinUsage, transformReactSkinUsage } from '../transform.js';
+
+const names = [
+  'video',
+  'minimal-video',
+  'audio',
+  'minimal-audio',
+  'live-video',
+  'minimal-live-video',
+  'live-audio',
+  'minimal-live-audio',
+] as const;
+const root = resolve('/project/src/components/videojs');
+
+describe('transformReactSkinUsage', () => {
+  it('replaces every packaged skin contract while preserving package media imports and local aliases', () => {
+    for (const name of names) {
+      for (const style of ['css', 'tailwind'] as const) {
+        const item = fixtureItem(name, 'react', style);
+        const contract = reactSkinContract(item);
+        const stylesheet = contract.stylesheetSource ? `\nimport ${JSON.stringify(contract.stylesheetSource)};` : '';
+        const source =
+          `import { VideoPlayer, ${contract.packagedExport} as PlayerSkin } from ${JSON.stringify(contract.packageSource)};` +
+          `${stylesheet}\nexport const player = <PlayerSkin data-player><VideoPlayer /></PlayerSkin>;\n`;
+        const result = transformReactSkinUsage([{ path: '/project/src/player.tsx', source }], item, root);
+        const output = result.edits[0]?.content ?? '';
+
+        expect(result.packagedUses).toBe(1);
+        expect(output).toContain(`import { VideoPlayer } from ${JSON.stringify(contract.packageSource)};`);
+        expect(output).toContain(`import { ${contract.generatedExport} as PlayerSkin } from`);
+        expect(output).toContain('<PlayerSkin data-player>');
+
+        if (contract.stylesheetSource) expect(output).not.toContain(contract.stylesheetSource);
+      }
+    }
+  });
+
+  it('detects an already source-owned import and refuses namespace imports', () => {
+    const item = fixtureItem('video', 'react', 'css');
+    const local = `import { DefaultVideoSkin as VideoSkin } from './components/videojs/skins/default-video/skin';`;
+    const already = transformReactSkinUsage([{ path: '/project/src/player.tsx', source: local }], item, root);
+
+    expect(already).toMatchObject({ packagedUses: 0, localUses: 1, edits: [] });
+
+    expect(() =>
+      transformReactSkinUsage(
+        [{ path: '/project/src/player.tsx', source: `import * as VideoPreset from '@videojs/react/video';` }],
+        item,
+        root
+      )
+    ).toThrow('namespace import');
+
+    expect(() =>
+      transformReactSkinUsage(
+        [{ path: '/project/src/player.tsx', source: "void import('@videojs/react/video/skin.css');\n" }],
+        item,
+        root
+      )
+    ).toThrow('packaged stylesheet is loaded dynamically');
+  });
+});
+
+describe('transformHtmlSkinUsage', () => {
+  it('replaces every static packaged skin and preserves media, poster, and root attributes', () => {
+    for (const name of names) {
+      for (const style of ['css', 'tailwind'] as const) {
+        const item = fixtureItem(name, 'html', style);
+        const contract = htmlSkinContract(item);
+        const video = name.includes('video');
+        const children = `<media-${video ? 'video' : 'audio'} id="media"></media-${video ? 'video' : 'audio'}>`;
+        const poster = video ? '<img slot="poster" src="poster.jpg">' : '';
+        const result = transformHtmlSkinUsage(
+          [
+            {
+              path: '/project/src/player.ts',
+              source: `import ${JSON.stringify(contract.registrationSource)};\n`,
+            },
+            {
+              path: '/project/src/index.html',
+              source: `<${contract.tag} class="player" style="max-width: 40rem">${children}${poster}</${contract.tag}>`,
+            },
+          ],
+          item,
+          root
+        );
+        const script = result.edits.find((edit) => edit.path.endsWith('.ts'))?.content ?? '';
+        const html = result.edits.find((edit) => edit.path.endsWith('.html'))?.content ?? '';
+
+        expect(result.packagedUses).toBe(2);
+        expect(script).not.toContain(contract.registrationSource);
+        expect(script).toContain(`${name}.register`);
+        expect(script).toContain(`styles/${name}${style === 'tailwind' ? '.tailwind' : ''}.css`);
+        expect(html).not.toContain(`<${contract.tag}`);
+        expect(html).toContain('class="media-skin player"');
+        expect(html).toContain('style="max-width: 40rem"');
+        expect(html).toContain(children);
+
+        if (video) {
+          expect(html).toContain('<img src="poster.jpg">');
+          expect(html).not.toContain('slot="poster"');
+        }
+      }
+    }
+  });
+
+  it('refuses registration without static markup', () => {
+    const item = fixtureItem('video', 'html', 'css');
+    const contract = htmlSkinContract(item);
+
+    expect(() =>
+      transformHtmlSkinUsage(
+        [{ path: '/project/src/player.ts', source: `import ${JSON.stringify(contract.registrationSource)};\n` }],
+        item,
+        root
+      )
+    ).toThrow('without static <video-skin> markup');
+  });
+
+  it('refuses ambiguous poster ownership', () => {
+    const item = fixtureItem('video', 'html', 'css');
+    const contract = htmlSkinContract(item);
+
+    expect(() =>
+      transformHtmlSkinUsage(
+        [
+          { path: '/project/src/player.ts', source: `import ${JSON.stringify(contract.registrationSource)};\n` },
+          {
+            path: '/project/src/index.html',
+            source: `<${contract.tag}><img slot="poster"><img slot="poster"></${contract.tag}>`,
+          },
+        ],
+        item,
+        root
+      )
+    ).toThrow('more than one poster slot');
+  });
+
+  it('detects an already source-owned dotted registration module', () => {
+    const item = fixtureItem('video', 'html', 'css');
+    const result = transformHtmlSkinUsage(
+      [{ path: '/project/src/player.ts', source: "import './components/videojs/video.register';\n" }],
+      item,
+      root
+    );
+
+    expect(result).toMatchObject({ packagedUses: 0, localUses: 1, edits: [] });
+  });
+});
+
+function fixtureItem(
+  name: (typeof names)[number],
+  framework: 'html' | 'react',
+  style: 'css' | 'tailwind'
+): ResolvedCatalogItem {
+  const entry = framework === 'html' ? `${name}.html` : `skins/${skinContext(name)}/skin.tsx`;
+  const stylesheet = `styles/${name}${style === 'tailwind' ? '.tailwind' : ''}.css`;
+  const setup = framework === 'html' ? `${name}.register.ts` : undefined;
+  const contentMarker = framework === 'html' ? '<!-- Add your media element here. -->' : undefined;
+  const posterMarker = framework === 'html' && name.includes('video') ? '<!-- Poster -->' : undefined;
+  const markup = `<media-container class="media-skin">${contentMarker ?? ''}${
+    posterMarker ? `<media-poster>${posterMarker}<img alt=""></img></media-poster>` : ''
+  }</media-container>\n`;
+
+  return {
+    kind: 'skin',
+    name,
+    title: name,
+    description: `${name} fixture`,
+    framework,
+    style,
+    context: skinContext(name),
+    entry,
+    stylesheet,
+    setup,
+    contentMarker,
+    posterMarker,
+    files: [
+      { path: entry, content: framework === 'html' ? markup : 'export function Skin() {}\n' },
+      { path: stylesheet, content: '.media-skin {}\n' },
+      ...(setup ? [{ path: setup, content: 'export {};\n' }] : []),
+    ],
+    dependencies: [],
+    devDependencies: [],
+  };
+}
+
+function skinContext(name: string): string {
+  return name.startsWith('minimal-') ? `minimal-${name.slice('minimal-'.length)}` : `default-${name}`;
+}

--- a/packages/cli/src/eject/transform.ts
+++ b/packages/cli/src/eject/transform.ts
@@ -1,0 +1,428 @@
+import { dirname, extname, relative, resolve } from 'node:path';
+
+import type { ImportDeclaration, ImportSpecifier, Node } from '@oxc-project/types';
+import MagicString from 'magic-string';
+import { parseSync } from 'oxc-parser';
+import { walk } from 'oxc-walker';
+
+import type { ResolvedCatalogItem } from '../catalog/index.js';
+import { htmlSkinContract, reactSkinContract } from './skin-contract.js';
+
+export interface ProjectSourceFile {
+  readonly path: string;
+  readonly source: string;
+}
+
+export interface SourceEdit extends ProjectSourceFile {
+  readonly content: string;
+}
+
+export interface UsageTransform {
+  readonly edits: readonly SourceEdit[];
+  readonly packagedUses: number;
+  readonly localUses: number;
+  readonly instructions: readonly string[];
+}
+
+interface HtmlReplacement {
+  readonly source: string;
+  readonly count: number;
+}
+
+export function transformReactSkinUsage(
+  files: readonly ProjectSourceFile[],
+  item: ResolvedCatalogItem,
+  outputRoot: string
+): UsageTransform {
+  const contract = reactSkinContract(item);
+  const entry = resolve(outputRoot, item.entry);
+  const edits: SourceEdit[] = [];
+  const instructions: string[] = [];
+  let packagedUses = 0;
+  let localUses = 0;
+
+  for (const file of files.filter(isScriptFile)) {
+    if (
+      !file.source.includes(contract.packageSource) &&
+      !file.source.includes(contract.stylesheetSource ?? '\0') &&
+      !file.source.includes(relativeImport(file.path, entry))
+    ) {
+      continue;
+    }
+
+    const program = parseModule(file);
+    const magicString = new MagicString(file.source);
+    const skinImports: Array<{ declaration: ImportDeclaration; specifier: ImportSpecifier }> = [];
+    const stylesheetImports: ImportDeclaration[] = [];
+
+    walk(program, {
+      enter(node) {
+        if (node.type === 'ImportExpression') {
+          const source = importSource(node.source);
+
+          if (source === contract.packageSource)
+            throw unsafeReactError(item, 'the packaged preset is loaded dynamically');
+
+          if (source === contract.stylesheetSource)
+            throw unsafeReactError(item, 'the packaged stylesheet is loaded dynamically');
+        }
+
+        if (node.type !== 'ImportDeclaration') return;
+
+        if (matchesLocalModule(file.path, node.source.value, entry)) {
+          if (
+            node.specifiers.some(
+              (specifier) => specifier.type === 'ImportSpecifier' && importName(specifier) === contract.generatedExport
+            )
+          ) {
+            localUses++;
+          }
+
+          return;
+        }
+
+        if (node.source.value === contract.stylesheetSource) {
+          if (node.specifiers.length > 0)
+            throw unsafeReactError(item, 'the packaged stylesheet import is not side-effect-only');
+
+          stylesheetImports.push(node);
+          return;
+        }
+
+        if (node.source.value !== contract.packageSource) return;
+
+        if (node.specifiers.some((specifier) => specifier.type === 'ImportNamespaceSpecifier')) {
+          throw unsafeReactError(item, 'the packaged preset uses a namespace import');
+        }
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type === 'ImportSpecifier' && importName(specifier) === contract.packagedExport) {
+            if (node.importKind === 'type' || specifier.importKind === 'type') {
+              throw unsafeReactError(item, 'the packaged skin is imported as a type');
+            }
+
+            skinImports.push({ declaration: node, specifier });
+          }
+        }
+      },
+    });
+
+    if (skinImports.length > 1)
+      throw unsafeReactError(item, `more than one packaged skin import appears in ${file.path}`);
+
+    const skinImport = skinImports[0];
+
+    if (skinImport) {
+      replaceReactSkinImport(magicString, file, skinImport.declaration, skinImport.specifier, contract, entry);
+      packagedUses++;
+    }
+
+    for (const declaration of stylesheetImports) removeStatement(magicString, file.source, declaration);
+
+    if (magicString.hasChanged()) edits.push({ ...file, content: magicString.toString() });
+  }
+
+  if (packagedUses > 0)
+    instructions.push(`Replaced ${packagedUses} packaged React skin import${packagedUses === 1 ? '' : 's'}.`);
+
+  return { edits, packagedUses, localUses, instructions };
+}
+
+export function transformHtmlSkinUsage(
+  files: readonly ProjectSourceFile[],
+  item: ResolvedCatalogItem,
+  outputRoot: string
+): UsageTransform {
+  if (!item.setup || !item.contentMarker) throw new Error(`HTML skin ${item.name} has incomplete source metadata.`);
+
+  const contract = htmlSkinContract(item);
+  const setup = resolve(outputRoot, item.setup);
+  const stylesheet = resolve(outputRoot, item.stylesheet);
+  const entry = item.files.find((file) => file.path === item.entry);
+  if (!entry) throw new Error(`HTML skin ${item.name} has no markup entry.`);
+
+  const edits: SourceEdit[] = [];
+  let packagedImports = 0;
+  let localUses = 0;
+
+  for (const file of files.filter(isScriptFile)) {
+    if (!file.source.includes(contract.registrationSource) && !file.source.includes(relativeImport(file.path, setup))) {
+      continue;
+    }
+
+    const program = parseModule(file);
+    const magicString = new MagicString(file.source);
+
+    walk(program, {
+      enter(node) {
+        if (node.type === 'ImportExpression' && importSource(node.source) === contract.registrationSource) {
+          throw unsafeHtmlError(item, 'the packaged skin registration is loaded dynamically');
+        }
+
+        if (node.type !== 'ImportDeclaration') return;
+
+        if (matchesLocalModule(file.path, node.source.value, setup)) {
+          localUses++;
+          return;
+        }
+
+        if (node.source.value !== contract.registrationSource) return;
+
+        if (node.specifiers.length > 0)
+          throw unsafeHtmlError(item, 'the packaged skin registration import is not side-effect-only');
+
+        const setupImport = relativeImport(file.path, setup);
+        const styleImport = relativeImport(file.path, stylesheet);
+
+        magicString.overwrite(
+          node.start,
+          node.end,
+          `import ${JSON.stringify(setupImport)};\nimport ${JSON.stringify(styleImport)};`
+        );
+        packagedImports++;
+      },
+    });
+
+    if (magicString.hasChanged()) edits.push({ ...file, content: magicString.toString() });
+  }
+
+  let packagedTags = 0;
+
+  for (const file of files.filter((candidate) => extname(candidate.path) === '.html')) {
+    if (!file.source.toLowerCase().includes(`<${contract.tag}`)) continue;
+
+    const transformed = replaceHtmlSkinElements(file.source, contract.tag, entry.content, item);
+
+    packagedTags += transformed.count;
+
+    if (transformed.source !== file.source) edits.push({ ...file, content: transformed.source });
+  }
+
+  if ((packagedImports === 0) !== (packagedTags === 0)) {
+    const reason =
+      packagedImports === 0
+        ? `found <${contract.tag}> markup without its static package registration import`
+        : `found the package registration import without static <${contract.tag}> markup in an HTML file`;
+
+    throw unsafeHtmlError(item, reason);
+  }
+
+  if (packagedImports > 0 && packagedTags > 0) {
+    return {
+      edits,
+      packagedUses: packagedImports + packagedTags,
+      localUses,
+      instructions: [
+        `Replaced ${packagedImports} packaged HTML registration import${packagedImports === 1 ? '' : 's'}.`,
+        `Replaced ${packagedTags} <${contract.tag}> element${packagedTags === 1 ? '' : 's'} with owned markup.`,
+      ],
+    };
+  }
+
+  return { edits, packagedUses: 0, localUses, instructions: [] };
+}
+
+function replaceReactSkinImport(
+  magicString: MagicString,
+  file: ProjectSourceFile,
+  declaration: ImportDeclaration,
+  target: ImportSpecifier,
+  contract: ReturnType<typeof reactSkinContract>,
+  entry: string
+): void {
+  if (
+    declaration.attributes.length > 0 ||
+    declaration.specifiers.some((specifier) => specifier.type !== 'ImportSpecifier')
+  ) {
+    throw unsafeReactError({ name: contract.packagedExport }, 'the packaged preset import has an unsupported shape');
+  }
+
+  const remaining = declaration.specifiers.filter((specifier) => specifier !== target);
+  const localName = target.local.name;
+  const generated =
+    contract.generatedExport === localName ? contract.generatedExport : `${contract.generatedExport} as ${localName}`;
+  const localImport = `import { ${generated} } from ${JSON.stringify(relativeImport(file.path, entry))};`;
+  const packageImport =
+    remaining.length > 0
+      ? `import { ${remaining.map((specifier) => file.source.slice(specifier.start, specifier.end)).join(', ')} } from ${JSON.stringify(
+          contract.packageSource
+        )};\n`
+      : '';
+
+  magicString.overwrite(declaration.start, declaration.end, `${packageImport}${localImport}`);
+}
+
+function replaceHtmlSkinElements(
+  source: string,
+  tag: string,
+  ownedMarkup: string,
+  item: ResolvedCatalogItem
+): HtmlReplacement {
+  const expression = new RegExp(`<${escapeRegExp(tag)}(\\s[^<>]*?)?>([\\s\\S]*?)<\\/${escapeRegExp(tag)}\\s*>`, 'gi');
+  let count = 0;
+
+  const output = source.replace(expression, (_match, attributes: string | undefined, children: string) => {
+    count++;
+    return ownedHtmlMarkup(ownedMarkup, attributes ?? '', children, item);
+  });
+
+  const openings = source.match(new RegExp(`<${escapeRegExp(tag)}(?:\\s|>)`, 'gi'))?.length ?? 0;
+  if (openings !== count) throw unsafeHtmlError(item, `could not match every <${tag}> opening and closing tag`);
+
+  return { source: output, count };
+}
+
+function ownedHtmlMarkup(
+  markup: string,
+  attributes: string,
+  originalChildren: string,
+  item: ResolvedCatalogItem
+): string {
+  if (!item.contentMarker || !markup.includes(item.contentMarker)) {
+    throw new Error(`HTML skin ${item.name} has no media content marker.`);
+  }
+
+  if (/[{}<>]/.test(attributes))
+    throw unsafeHtmlError(item, 'the packaged skin element has dynamic or malformed attributes');
+
+  const poster = extractPoster(originalChildren, item);
+  const children = poster ? originalChildren.replace(poster.source, '') : originalChildren;
+  let output = markup.replace(item.contentMarker, children.trim());
+
+  if (poster) output = replacePosterFallback(output, poster.element, item);
+
+  return mergeRootAttributes(output, attributes, item);
+}
+
+function extractPoster(
+  children: string,
+  item: ResolvedCatalogItem
+): { readonly source: string; readonly element: string } | undefined {
+  const slots = [...children.matchAll(/\bslot\s*=\s*["']poster["']/gi)];
+  if (slots.length === 0) return;
+
+  if (slots.length > 1) throw unsafeHtmlError(item, 'more than one poster slot appears in the packaged skin');
+
+  const paired = /<([a-z][\w-]*)([^>]*\bslot\s*=\s*(["'])poster\3[^>]*)>([\s\S]*?)<\/\1\s*>/i.exec(children);
+  const image = /<img\b(?=[^>]*\bslot\s*=\s*(["'])poster\1)[^>]*>/i.exec(children);
+  const match = paired ?? image;
+  if (!match) throw unsafeHtmlError(item, 'the poster slot is not a static HTML element');
+
+  return {
+    source: match[0],
+    element: match[0].replace(/\s+slot\s*=\s*(["'])poster\1/i, ''),
+  };
+}
+
+function replacePosterFallback(markup: string, poster: string, item: ResolvedCatalogItem): string {
+  if (!item.posterMarker) throw unsafeHtmlError(item, 'the selected skin has no poster handoff point');
+
+  const marker = escapeRegExp(item.posterMarker);
+  const fallback = new RegExp(`${marker}\\s*<img\\b[^>]*>\\s*<\\/img>`);
+  if (!fallback.test(markup)) throw new Error(`HTML skin ${item.name} has no replaceable poster fallback.`);
+
+  return markup.replace(fallback, poster);
+}
+
+function mergeRootAttributes(markup: string, original: string, item: ResolvedCatalogItem): string {
+  let attributes = original.trim();
+  if (!attributes) return markup;
+
+  const classes = [...attributes.matchAll(/\bclass\s*=\s*(["'])(.*?)\1/gi)];
+  if (classes.length > 1) throw unsafeHtmlError(item, 'the packaged skin element has more than one class attribute');
+
+  const originalClass = classes[0]?.[2];
+
+  if (classes[0]) attributes = attributes.replace(classes[0][0], '').trim();
+
+  return markup.replace(/^<media-container\b([^>]*)>/, (_opening, generated: string) => {
+    let merged = generated;
+
+    if (originalClass) {
+      if (!/\bclass="[^"]*"/.test(merged)) throw new Error(`HTML skin ${item.name} has no root class attribute.`);
+
+      merged = merged.replace(
+        /\bclass="([^"]*)"/,
+        (_className, value: string) => `class="${value} ${originalClass.replaceAll('"', '&quot;')}"`
+      );
+    }
+
+    return `<media-container${merged}${attributes ? ` ${attributes}` : ''}>`;
+  });
+}
+
+function parseModule(file: ProjectSourceFile) {
+  const parsed = parseSync(file.path, file.source);
+
+  if (parsed.errors.length > 0) {
+    throw new Error(
+      `Could not parse \`${file.path}\`.\nReason: ${parsed.errors.map((error) => error.message).join('; ')}\n` +
+        'Recommendation: fix the source error or use `videojs add` and replace the packaged skin manually.'
+    );
+  }
+
+  return parsed.program;
+}
+
+function importName(specifier: ImportSpecifier): string {
+  return 'name' in specifier.imported ? specifier.imported.name : specifier.imported.value;
+}
+
+function importSource(node: Node): string | undefined {
+  if (node.type === 'Literal' && (node.raw?.startsWith('"') || node.raw?.startsWith("'"))) return String(node.value);
+
+  if (node.type === 'TemplateLiteral' && node.expressions.length === 0)
+    return node.quasis[0]?.value.cooked ?? undefined;
+
+  return;
+}
+
+function relativeImport(importer: string, target: string): string {
+  const extension = extname(target);
+  const sourceTarget = ['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx'].includes(extension)
+    ? target.slice(0, -extension.length)
+    : target;
+  const path = relative(dirname(importer), sourceTarget).split('\\').join('/');
+
+  return path.startsWith('.') ? path : `./${path}`;
+}
+
+function matchesLocalModule(importer: string, specifier: string, target: string): boolean {
+  if (!specifier.startsWith('.')) return false;
+
+  return moduleKey(resolve(dirname(importer), specifier)) === moduleKey(target);
+}
+
+function moduleKey(path: string): string {
+  const extension = extname(path);
+
+  return ['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx'].includes(extension) ? path.slice(0, -extension.length) : path;
+}
+
+function removeStatement(magicString: MagicString, source: string, node: ImportDeclaration): void {
+  const newline = source[node.end] === '\r' && source[node.end + 1] === '\n' ? 2 : source[node.end] === '\n' ? 1 : 0;
+
+  magicString.remove(node.start, node.end + newline);
+}
+
+function isScriptFile(file: ProjectSourceFile): boolean {
+  return ['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx'].includes(extname(file.path));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function unsafeReactError(item: Pick<ResolvedCatalogItem, 'name'>, reason: string): Error {
+  return new Error(
+    `Could not safely eject React skin ${item.name}.\nReason: ${reason}.\n` +
+      'Recommendation: run `videojs add` and replace the packaged skin import manually.'
+  );
+}
+
+function unsafeHtmlError(item: Pick<ResolvedCatalogItem, 'name'>, reason: string): Error {
+  return new Error(
+    `Could not safely eject HTML skin ${item.name}.\nReason: ${reason}.\n` +
+      'Recommendation: run `videojs add`, import its registration and stylesheet, then replace the packaged skin element manually.'
+  );
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ import { Command, Option } from 'commander';
 
 import { handleConfig } from './commands/config.js';
 import { handleDocs } from './commands/docs.js';
-import { handleAdd, handleList, type SourceCommandOptions, handleView } from './commands/source.js';
+import { handleAdd, handleEject, handleList, type SourceCommandOptions, handleView } from './commands/source.js';
 
 const program = new Command();
 
@@ -74,6 +74,11 @@ addSourceOptions(
   program.command('add <kind> <name>').description('Add editable Video.js UI source to a project.'),
   true
 ).action(async (kind: string, name: string, options: SourceCommandOptions) => handleAdd(kind, name, options));
+
+addSourceOptions(
+  program.command('eject <kind> <name>').description('Replace a packaged skin with editable local source.'),
+  true
+).action(async (kind: string, name: string, options: SourceCommandOptions) => handleEject(kind, name, options));
 
 try {
   await program.parseAsync();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,12 +226,24 @@ importers:
       '@clack/prompts':
         specifier: ^0.10.1
         version: 0.10.1
+      '@oxc-project/types':
+        specifier: 0.146.0
+        version: 0.146.0
       commander:
         specifier: ^15.0.0
         version: 15.0.0
       diff:
         specifier: ^8.0.4
         version: 8.0.4
+      magic-string:
+        specifier: ^1.2.2
+        version: 1.2.2
+      oxc-parser:
+        specifier: 0.146.0
+        version: 0.146.0
+      oxc-walker:
+        specifier: ^1.1.1
+        version: 1.1.1(@oxc-project/types@0.146.0)(oxc-parser@0.146.0)(rolldown@1.2.5)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.3


### PR DESCRIPTION
## Summary

- add `videojs eject skin <name>` over the same catalog and transactional change-set used by `add`
- replace recognized React skin imports with owned source using OXC, `oxc-walker`, and MagicString while preserving packaged Player/Media imports
- replace static HTML registration imports and skin elements with light-DOM owned markup while preserving root attributes, media children, and poster content
- refuse dynamic, ambiguous, partially migrated, or unsupported source with explicit Reason and Recommendation guidance
- dogfood all eight interactive skins across React/HTML and CSS/Tailwind, including idempotent reruns and clean consumer builds

Stacked on #2489.

Product context: [Video.js Eject PRD](https://www.notion.so/3ae97a7f89d080d0bcf3c02a15971e69)

## Verification

- `pnpm -F @videojs/cli test` (88 tests)
- `pnpm exec vp run @videojs/cli#test:ci` (all eight skins, React/HTML × CSS/Tailwind)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:workspace`

Closes #1975
