### PR TITLE
docs(site): add skin API references

### DIFF
--- a/.agents/skills/write-api-reference/references/demo-patterns.md
+++ b/.agents/skills/write-api-reference/references/demo-patterns.md
@@ -16,18 +16,20 @@ site/src/components/docs/demos/{component}/
     └── BasicUsage.css        # Styles
 ```
 
-## BEM Naming
+## CSS Scoping
 
-Block = `{framework}-{component}-{variant}`, element = `__{part}`:
+Give every demo a unique root class using `{framework}-{component}-{variant}`. Use flat semantic names for additional
+component or part hooks:
 
 ```
-html-play-button-basic              /* HTML framework, block */
-html-play-button-basic__button      /* HTML framework, element */
-react-play-button-basic             /* React framework, block */
-react-play-button-basic__button     /* React framework, element */
+html-play-button-basic          /* HTML framework, root */
+html-play-button-basic-button   /* HTML framework, button */
+react-play-button-basic         /* React framework, root */
+react-play-button-basic-button  /* React framework, button */
 ```
 
-The framework prefix (`html-` / `react-`) prevents CSS leaking between HTML and React demos on the same page (both render but one is hidden).
+The framework prefix (`html-` / `react-`) prevents CSS leaking between HTML and React demos on the same page (both
+render but one is hidden). React and HTML demos for the same variant should use matching semantic hooks.
 
 ## HTML Demo Files
 
@@ -58,7 +60,7 @@ The `.astro` wrapper is required because only Astro `<script>` tags go through V
         playsinline
         loop
     ></video>
-    <media-mute-button class="html-mute-button-basic__button">
+    <media-mute-button class="html-mute-button-basic-button">
         <span class="show-when-muted">Unmute</span>
         <span class="show-when-unmuted">Mute</span>
     </media-mute-button>
@@ -80,7 +82,7 @@ The `.astro` wrapper is required because only Astro `<script>` tags go through V
   width: 100%;
 }
 
-.html-mute-button-basic__button {
+.html-mute-button-basic-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;
@@ -95,10 +97,10 @@ The `.astro` wrapper is required because only Astro `<script>` tags go through V
 }
 
 /* State-based visibility via data attributes */
-.html-mute-button-basic__button .show-when-muted { display: none; }
-.html-mute-button-basic__button .show-when-unmuted { display: none; }
-.html-mute-button-basic__button[data-muted] .show-when-muted { display: inline; }
-.html-mute-button-basic__button:not([data-muted]) .show-when-unmuted { display: inline; }
+.html-mute-button-basic-button .show-when-muted { display: none; }
+.html-mute-button-basic-button .show-when-unmuted { display: none; }
+.html-mute-button-basic-button[data-muted] .show-when-muted { display: inline; }
+.html-mute-button-basic-button:not([data-muted]) .show-when-unmuted { display: inline; }
 ```
 
 ### .ts (registration imports)
@@ -139,7 +141,7 @@ export default function BasicUsage() {
           loop
         />
         <MuteButton
-          className="react-mute-button-basic__button"
+          className="react-mute-button-basic-button"
           render={(props, state) => (
             <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>
           )}
@@ -159,7 +161,7 @@ Key patterns:
 
 ### .css (styles)
 
-Same base styling as HTML but with `react-` BEM prefix:
+Use the same semantic hooks as HTML with the `react-` demo prefix:
 
 ```css
 .react-mute-button-basic {
@@ -170,7 +172,7 @@ Same base styling as HTML but with `react-` BEM prefix:
   width: 100%;
 }
 
-.react-mute-button-basic__button {
+.react-mute-button-basic-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;
@@ -195,26 +197,26 @@ Components expose state via `data-*` attributes. CSS toggles visibility:
 
 ```css
 /* Hide all by default */
-.html-play-button-basic__button .show-when-paused { display: none; }
-.html-play-button-basic__button .show-when-playing { display: none; }
+.html-play-button-basic-button .show-when-paused { display: none; }
+.html-play-button-basic-button .show-when-playing { display: none; }
 
 /* Show based on state */
-.html-play-button-basic__button[data-paused] .show-when-paused { display: inline; }
-.html-play-button-basic__button:not([data-paused]) .show-when-playing { display: inline; }
+.html-play-button-basic-button[data-paused] .show-when-paused { display: inline; }
+.html-play-button-basic-button:not([data-paused]) .show-when-playing { display: inline; }
 ```
 
 For multi-value attributes (e.g., `data-volume-level`):
 
 ```css
-.html-mute-button-volume-levels__button .level-off,
-.html-mute-button-volume-levels__button .level-low,
-.html-mute-button-volume-levels__button .level-medium,
-.html-mute-button-volume-levels__button .level-high {
+.html-mute-button-volume-levels-button .level-off,
+.html-mute-button-volume-levels-button .level-low,
+.html-mute-button-volume-levels-button .level-medium,
+.html-mute-button-volume-levels-button .level-high {
   display: none;
 }
 
-.html-mute-button-volume-levels__button[data-volume-level="off"] .level-off { display: inline; }
-.html-mute-button-volume-levels__button[data-volume-level="low"] .level-low { display: inline; }
+.html-mute-button-volume-levels-button[data-volume-level="off"] .level-off { display: inline; }
+.html-mute-button-volume-levels-button[data-volume-level="low"] .level-low { display: inline; }
 ```
 
 ### React: Render prop
@@ -240,9 +242,9 @@ For multi-value attributes (e.g., `data-volume-level`):
 HTML uses `:not()` combinators to handle mutually exclusive states:
 
 ```css
-.html-play-button-basic__button[data-paused]:not([data-ended]) .show-when-paused { display: inline; }
-.html-play-button-basic__button:not([data-paused]) .show-when-playing { display: inline; }
-.html-play-button-basic__button[data-ended] .show-when-ended { display: inline; }
+.html-play-button-basic-button[data-paused]:not([data-ended]) .show-when-paused { display: inline; }
+.html-play-button-basic-button:not([data-paused]) .show-when-playing { display: inline; }
+.html-play-button-basic-button[data-ended] .show-when-ended { display: inline; }
 ```
 
 React uses nested ternary in the render prop:
@@ -263,7 +265,7 @@ render={(props, state) => (
 All button demos share this base overlay style:
 
 ```css
-.__button {
+.demo-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;

--- a/site/src/components/docs/api-reference/ComponentImports.astro
+++ b/site/src/components/docs/api-reference/ComponentImports.astro
@@ -2,7 +2,10 @@
 import type { BundledLanguage } from 'shiki';
 
 import ServerCode from '@/components/Code/ServerCode.astro';
+import RegistryInstall from '@/components/docs/RegistryInstall.astro';
 import CodeFrame from '@/components/typography/CodeFrame.astro';
+import { isValidFramework } from '@/types/docs';
+import { registryItemForComponent } from '@/utils/installation/shadcn-registry';
 import FrameworkCase from '../FrameworkCase.astro';
 
 interface Props {
@@ -11,6 +14,10 @@ interface Props {
 }
 
 const { component, html } = Astro.props;
+const framework = Astro.params.framework;
+if (!isValidFramework(framework)) throw new Error(`Unsupported framework: ${framework ?? 'missing'}.`);
+
+const registryItem = framework === 'react' ? await registryItemForComponent(component) : null;
 
 const imports: Array<{ code: string; framework: 'react' | 'html'; lang: BundledLanguage }> = [
   {
@@ -34,4 +41,16 @@ const imports: Array<{ code: string; framework: 'react' | 'html'; lang: BundledL
       </CodeFrame>
     </FrameworkCase>
   ))
+}
+
+{
+  registryItem ? (
+    <>
+      <h3 id="editable-source">Editable styled source</h3>
+      <p>
+        Install the styled component and its exact dependencies with Shadcn, or copy the same generated files manually.
+      </p>
+      <RegistryInstall framework="react" item={registryItem} />
+    </>
+  ) : null
 }

--- a/site/src/components/docs/api-reference/PresetReference.astro
+++ b/site/src/components/docs/api-reference/PresetReference.astro
@@ -12,6 +12,7 @@ import { isValidFramework } from '@/types/docs';
 import type { PresetReference as PresetReferenceType } from '@/types/preset-reference';
 import DocsLink from '../DocsLink.astro';
 import FrameworkCase from '../FrameworkCase.astro';
+import { skinGuides } from '../skins/skinGuides';
 import InlineMarkdown from './InlineMarkdown.astro';
 
 const entries = await getCollection('presetReference');
@@ -34,6 +35,17 @@ const { framework } = Astro.params;
 const pkg = framework && isValidFramework(framework) ? `@videojs/${framework}` : '@videojs/html';
 
 const listFormat = new Intl.ListFormat('en', { style: 'long', type: 'unit' });
+
+function getSkinReferenceSlug(name: string): string | undefined {
+  const entry = Object.entries(skinGuides).find(([, skin]) =>
+    skin.reactSkin === name || skin.htmlSkin === name
+  );
+  if (!entry) return;
+
+  return entry[0] === 'background'
+    ? 'reference/background-video-skin'
+    : `reference/${entry[0]}-skin`;
+}
 ---
 
 <ContentWidth>
@@ -125,16 +137,27 @@ const listFormat = new Intl.ListFormat('en', { style: 'long', type: 'unit' });
                       <dd>
                         <FrameworkCase frameworks={["react"]}>
                           {preset.react.skins.length > 0
-                            ? preset.react.skins.map((skin) => (
-                                <div class="mb-2 last:mb-0">
+                            ? preset.react.skins.map((skin) => {
+                                const slug = getSkinReferenceSlug(skin.name);
+                                const component = (
                                   <MarkdownCode class="inline-block whitespace-nowrap">{`<${skin.name}>`}</MarkdownCode>
-                                  {skin.cssImport && (
-                                    <div class="mt-0.5">
-                                      <MarkdownCode class="inline-block text-code whitespace-nowrap">{`import '${skin.cssImport}';`}</MarkdownCode>
-                                    </div>
-                                  )}
-                                </div>
-                              ))
+                                );
+
+                                return (
+                                  <div class="mb-2 last:mb-0">
+                                    {slug ? (
+                                      <DocsLink slug={slug}>{component}</DocsLink>
+                                    ) : (
+                                      component
+                                    )}
+                                    {skin.cssImport && (
+                                      <div class="mt-0.5">
+                                        <MarkdownCode class="inline-block text-code whitespace-nowrap">{`import '${skin.cssImport}';`}</MarkdownCode>
+                                      </div>
+                                    )}
+                                  </div>
+                                );
+                              })
                             : "–"}
                         </FrameworkCase>
                         <FrameworkCase frameworks={["html"]}>
@@ -145,13 +168,22 @@ const listFormat = new Intl.ListFormat('en', { style: 'long', type: 'unit' });
                                     (s) => s.tagName ?? s.name,
                                   ),
                                 )
-                                .map((part) =>
-                                  part.type === "element" ? (
+                                .map((part) => {
+                                  if (part.type !== "element") {
+                                    return <span>{part.value}</span>;
+                                  }
+
+                                  const slug = getSkinReferenceSlug(part.value);
+                                  const element = (
                                     <MarkdownCode class="inline-block whitespace-nowrap">{`<${part.value}>`}</MarkdownCode>
+                                  );
+
+                                  return slug ? (
+                                    <DocsLink slug={slug}>{element}</DocsLink>
                                   ) : (
-                                    <span>{part.value}</span>
-                                  ),
-                                )
+                                    element
+                                  );
+                                })
                             : "–"}
                         </FrameworkCase>
                       </dd>

--- a/site/src/components/docs/demos/add-background-video/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/add-background-video/html/css/BasicUsage.css
@@ -9,38 +9,38 @@
   isolation: isolate;
 }
 
-.add-background-video-html-demo__visual,
-.add-background-video-html-demo__poster,
-.add-background-video-html-demo__media {
+.add-background-video-html-demo-visual,
+.add-background-video-html-demo-poster,
+.add-background-video-html-demo-media {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
 }
 
-.add-background-video-html-demo__visual {
+.add-background-video-html-demo-visual {
   pointer-events: none;
 }
 
-.add-background-video-html-demo__visual::after {
+.add-background-video-html-demo-visual::after {
   position: absolute;
   inset: 0;
   content: "";
   background: linear-gradient(90deg, rgb(0 0 0 / 85%), rgb(0 0 0 / 55%));
 }
 
-.add-background-video-html-demo__poster,
-.add-background-video-html-demo__media {
+.add-background-video-html-demo-poster,
+.add-background-video-html-demo-media {
   display: block;
   object-fit: cover;
 }
 
-.add-background-video-html-demo__media {
+.add-background-video-html-demo-media {
   --media-object-fit: cover;
   --media-object-position: center;
 }
 
-.add-background-video-html-demo__content {
+.add-background-video-html-demo-content {
   position: relative;
   z-index: 1;
   display: grid;
@@ -50,13 +50,13 @@
   padding: 2rem;
 }
 
-.add-background-video-html-demo__content h3 {
+.add-background-video-html-demo-content h3 {
   margin: 0;
   font-size: 1.75rem;
   line-height: 1.1;
 }
 
-.add-background-video-html-demo__content a {
+.add-background-video-html-demo-content a {
   width: fit-content;
   padding: 0.625rem 1rem;
   color: black;
@@ -65,13 +65,13 @@
   border-radius: 0.25rem;
 }
 
-.add-background-video-html-demo__content a:focus-visible {
+.add-background-video-html-demo-content a:focus-visible {
   outline: 0.2rem solid white;
   outline-offset: 0.2rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .add-background-video-html-demo__media {
+  .add-background-video-html-demo-media {
     display: none;
   }
 }

--- a/site/src/components/docs/demos/add-background-video/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/add-background-video/html/css/BasicUsage.html
@@ -1,12 +1,12 @@
 <section class="add-background-video-html-demo">
-  <div class="add-background-video-html-demo__visual" aria-hidden="true">
-    <img class="add-background-video-html-demo__poster" src="{{VJS10_DEMO_BACKGROUND_VIDEO_POSTER}}" alt="" />
+  <div class="add-background-video-html-demo-visual" aria-hidden="true">
+    <img class="add-background-video-html-demo-poster" src="{{VJS10_DEMO_BACKGROUND_VIDEO_POSTER}}" alt="" />
     <background-video
-      class="add-background-video-html-demo__media"
+      class="add-background-video-html-demo-media"
       src="{{VJS10_DEMO_BACKGROUND_VIDEO_MP4}}"
     ></background-video>
   </div>
-  <div class="add-background-video-html-demo__content">
+  <div class="add-background-video-html-demo-content">
     <h3>Build the next great video experience</h3>
     <a href="#common-variations">Compare source options</a>
   </div>

--- a/site/src/components/docs/demos/add-background-video/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/add-background-video/react/css/BasicUsage.css
@@ -9,38 +9,38 @@
   isolation: isolate;
 }
 
-.add-background-video-react-demo__visual,
-.add-background-video-react-demo__poster,
-.add-background-video-react-demo__media {
+.add-background-video-react-demo-visual,
+.add-background-video-react-demo-poster,
+.add-background-video-react-demo-media {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
 }
 
-.add-background-video-react-demo__visual {
+.add-background-video-react-demo-visual {
   pointer-events: none;
 }
 
-.add-background-video-react-demo__visual::after {
+.add-background-video-react-demo-visual::after {
   position: absolute;
   inset: 0;
   content: "";
   background: linear-gradient(90deg, rgb(0 0 0 / 85%), rgb(0 0 0 / 55%));
 }
 
-.add-background-video-react-demo__poster,
-.add-background-video-react-demo__media {
+.add-background-video-react-demo-poster,
+.add-background-video-react-demo-media {
   display: block;
   object-fit: cover;
 }
 
-.add-background-video-react-demo__media {
+.add-background-video-react-demo-media {
   --media-object-fit: cover;
   --media-object-position: center;
 }
 
-.add-background-video-react-demo__content {
+.add-background-video-react-demo-content {
   position: relative;
   z-index: 1;
   display: grid;
@@ -50,13 +50,13 @@
   padding: 2rem;
 }
 
-.add-background-video-react-demo__content h3 {
+.add-background-video-react-demo-content h3 {
   margin: 0;
   font-size: 1.75rem;
   line-height: 1.1;
 }
 
-.add-background-video-react-demo__content a {
+.add-background-video-react-demo-content a {
   width: fit-content;
   padding: 0.625rem 1rem;
   color: black;
@@ -65,13 +65,13 @@
   border-radius: 0.25rem;
 }
 
-.add-background-video-react-demo__content a:focus-visible {
+.add-background-video-react-demo-content a:focus-visible {
   outline: 0.2rem solid white;
   outline-offset: 0.2rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .add-background-video-react-demo__media {
+  .add-background-video-react-demo-media {
     display: none;
   }
 }

--- a/site/src/components/docs/demos/add-background-video/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/add-background-video/react/css/BasicUsage.tsx
@@ -3,11 +3,11 @@ import { BackgroundVideo } from '@videojs/react/media/background-video';
 export default function BasicUsage() {
   return (
     <section className="add-background-video-react-demo">
-      <div className="add-background-video-react-demo__visual" aria-hidden="true">
-        <img className="add-background-video-react-demo__poster" src="{{VJS10_DEMO_BACKGROUND_VIDEO_POSTER}}" alt="" />
-        <BackgroundVideo className="add-background-video-react-demo__media" src="{{VJS10_DEMO_BACKGROUND_VIDEO_MP4}}" />
+      <div className="add-background-video-react-demo-visual" aria-hidden="true">
+        <img className="add-background-video-react-demo-poster" src="{{VJS10_DEMO_BACKGROUND_VIDEO_POSTER}}" alt="" />
+        <BackgroundVideo className="add-background-video-react-demo-media" src="{{VJS10_DEMO_BACKGROUND_VIDEO_MP4}}" />
       </div>
-      <div className="add-background-video-react-demo__content">
+      <div className="add-background-video-react-demo-content">
         <h3>Build the next great video experience</h3>
         <a href="#common-variations">Compare source options</a>
       </div>

--- a/site/src/components/docs/demos/alert-dialog/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/alert-dialog/html/css/BasicUsage.css
@@ -8,8 +8,8 @@
   border-radius: 12px;
 }
 
-.html-alert-dialog-basic__trigger,
-.html-alert-dialog-basic__close {
+.html-alert-dialog-basic-trigger,
+.html-alert-dialog-basic-close {
   padding: 8px 16px;
   color: #111827;
   cursor: pointer;
@@ -18,14 +18,14 @@
   border-radius: 9999px;
 }
 
-.html-alert-dialog-basic__backdrop {
+.html-alert-dialog-basic-backdrop {
   position: absolute;
   inset: 0;
   background: rgb(3 7 18 / 92%);
   transition: opacity 150ms ease;
 }
 
-.html-alert-dialog-basic__dialog {
+.html-alert-dialog-basic-dialog {
   position: absolute;
   inset: 0;
   z-index: 1;
@@ -38,32 +38,32 @@
   transition: opacity 150ms ease;
 }
 
-.html-alert-dialog-basic__backdrop:not([data-open]),
-.html-alert-dialog-basic__dialog:not([data-open]) {
+.html-alert-dialog-basic-backdrop:not([data-open]),
+.html-alert-dialog-basic-dialog:not([data-open]) {
   display: none;
 }
 
-.html-alert-dialog-basic__backdrop[data-starting-style],
-.html-alert-dialog-basic__backdrop[data-ending-style],
-.html-alert-dialog-basic__dialog[data-starting-style],
-.html-alert-dialog-basic__dialog[data-ending-style] {
+.html-alert-dialog-basic-backdrop[data-starting-style],
+.html-alert-dialog-basic-backdrop[data-ending-style],
+.html-alert-dialog-basic-dialog[data-starting-style],
+.html-alert-dialog-basic-dialog[data-ending-style] {
   opacity: 0;
 }
 
-.html-alert-dialog-basic__title,
-.html-alert-dialog-basic__description {
+.html-alert-dialog-basic-title,
+.html-alert-dialog-basic-description {
   display: block;
 }
 
-.html-alert-dialog-basic__title {
+.html-alert-dialog-basic-title {
   font-size: 20px;
   font-weight: 600;
 }
 
-.html-alert-dialog-basic__description {
+.html-alert-dialog-basic-description {
   color: #d1d5db;
 }
 
-.html-alert-dialog-basic__close {
+.html-alert-dialog-basic-close {
   justify-self: center;
 }

--- a/site/src/components/docs/demos/alert-dialog/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/alert-dialog/html/css/BasicUsage.html
@@ -1,13 +1,13 @@
 <div class="html-alert-dialog-basic">
-  <button class="html-alert-dialog-basic__trigger" type="button">Open alert dialog</button>
+  <button class="html-alert-dialog-basic-trigger" type="button">Open alert dialog</button>
   <media-alert-dialog>
-    <media-dialog-backdrop class="html-alert-dialog-basic__backdrop"></media-dialog-backdrop>
-    <media-dialog-popup class="html-alert-dialog-basic__dialog">
-      <media-dialog-title class="html-alert-dialog-basic__title">Stop playback?</media-dialog-title>
-      <media-dialog-description class="html-alert-dialog-basic__description">
+    <media-dialog-backdrop class="html-alert-dialog-basic-backdrop"></media-dialog-backdrop>
+    <media-dialog-popup class="html-alert-dialog-basic-dialog">
+      <media-dialog-title class="html-alert-dialog-basic-title">Stop playback?</media-dialog-title>
+      <media-dialog-description class="html-alert-dialog-basic-description">
         Your current playback position will be lost.
       </media-dialog-description>
-      <media-dialog-close class="html-alert-dialog-basic__close">Continue</media-dialog-close>
+      <media-dialog-close class="html-alert-dialog-basic-close">Continue</media-dialog-close>
     </media-dialog-popup>
   </media-alert-dialog>
 </div>

--- a/site/src/components/docs/demos/alert-dialog/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/alert-dialog/html/css/BasicUsage.ts
@@ -1,7 +1,7 @@
 import '@videojs/html/ui/alert-dialog';
 
 document.querySelectorAll<HTMLElement>('.html-alert-dialog-basic').forEach((demo) => {
-  const trigger = demo.querySelector<HTMLButtonElement>('.html-alert-dialog-basic__trigger');
+  const trigger = demo.querySelector<HTMLButtonElement>('.html-alert-dialog-basic-trigger');
   const dialog = demo.querySelector('media-alert-dialog');
 
   trigger?.addEventListener('click', () => {

--- a/site/src/components/docs/demos/alert-dialog/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/alert-dialog/react/css/BasicUsage.css
@@ -8,8 +8,8 @@
   border-radius: 12px;
 }
 
-.react-alert-dialog-basic__trigger,
-.react-alert-dialog-basic__close {
+.react-alert-dialog-basic-trigger,
+.react-alert-dialog-basic-close {
   padding: 8px 16px;
   color: #111827;
   cursor: pointer;
@@ -18,14 +18,14 @@
   border-radius: 9999px;
 }
 
-.react-alert-dialog-basic__backdrop {
+.react-alert-dialog-basic-backdrop {
   position: absolute;
   inset: 0;
   background: rgb(3 7 18 / 92%);
   transition: opacity 150ms ease;
 }
 
-.react-alert-dialog-basic__dialog {
+.react-alert-dialog-basic-dialog {
   position: absolute;
   inset: 0;
   z-index: 1;
@@ -38,22 +38,22 @@
   transition: opacity 150ms ease;
 }
 
-.react-alert-dialog-basic__backdrop[data-starting-style],
-.react-alert-dialog-basic__backdrop[data-ending-style],
-.react-alert-dialog-basic__dialog[data-starting-style],
-.react-alert-dialog-basic__dialog[data-ending-style] {
+.react-alert-dialog-basic-backdrop[data-starting-style],
+.react-alert-dialog-basic-backdrop[data-ending-style],
+.react-alert-dialog-basic-dialog[data-starting-style],
+.react-alert-dialog-basic-dialog[data-ending-style] {
   opacity: 0;
 }
 
-.react-alert-dialog-basic__title {
+.react-alert-dialog-basic-title {
   font-size: 20px;
   font-weight: 600;
 }
 
-.react-alert-dialog-basic__description {
+.react-alert-dialog-basic-description {
   color: #d1d5db;
 }
 
-.react-alert-dialog-basic__close {
+.react-alert-dialog-basic-close {
   justify-self: center;
 }

--- a/site/src/components/docs/demos/alert-dialog/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/alert-dialog/react/css/BasicUsage.tsx
@@ -6,17 +6,17 @@ export default function BasicUsage() {
 
   return (
     <div className="react-alert-dialog-basic">
-      <button className="react-alert-dialog-basic__trigger" type="button" onClick={() => setOpen(true)}>
+      <button className="react-alert-dialog-basic-trigger" type="button" onClick={() => setOpen(true)}>
         Open alert dialog
       </button>
       <AlertDialog.Root open={open} onOpenChange={setOpen}>
-        <AlertDialog.Backdrop className="react-alert-dialog-basic__backdrop" />
-        <AlertDialog.Popup className="react-alert-dialog-basic__dialog">
-          <AlertDialog.Title className="react-alert-dialog-basic__title">Stop playback?</AlertDialog.Title>
-          <AlertDialog.Description className="react-alert-dialog-basic__description">
+        <AlertDialog.Backdrop className="react-alert-dialog-basic-backdrop" />
+        <AlertDialog.Popup className="react-alert-dialog-basic-dialog">
+          <AlertDialog.Title className="react-alert-dialog-basic-title">Stop playback?</AlertDialog.Title>
+          <AlertDialog.Description className="react-alert-dialog-basic-description">
             Your current playback position will be lost.
           </AlertDialog.Description>
-          <AlertDialog.Close className="react-alert-dialog-basic__close">Continue</AlertDialog.Close>
+          <AlertDialog.Close className="react-alert-dialog-basic-close">Continue</AlertDialog.Close>
         </AlertDialog.Popup>
       </AlertDialog.Root>
     </div>

--- a/site/src/components/docs/demos/audio/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/audio/html/css/BasicUsage.css
@@ -7,6 +7,6 @@
   place-items: center;
 }
 
-.html-audio-basic__media {
+.html-audio-basic-media {
   width: 100%;
 }

--- a/site/src/components/docs/demos/audio/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/audio/html/css/BasicUsage.html
@@ -1,6 +1,6 @@
 <audio-player>
   <media-container class="html-audio-basic">
-    <audio class="html-audio-basic__media" controls preload="metadata">
+    <audio class="html-audio-basic-media" controls preload="metadata">
       <source src="{{VJS10_DEMO_VIDEO_MP4}}" />
     </audio>
   </media-container>

--- a/site/src/components/docs/demos/audio/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/audio/react/css/BasicUsage.css
@@ -7,6 +7,6 @@
   place-items: center;
 }
 
-.react-audio-basic__media {
+.react-audio-basic-media {
   width: 100%;
 }

--- a/site/src/components/docs/demos/audio/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/audio/react/css/BasicUsage.tsx
@@ -7,7 +7,7 @@ export default function BasicUsage() {
   return (
     <AudioPlayer>
       <Container className="react-audio-basic">
-        <Audio className="react-audio-basic__media" controls preload="metadata">
+        <Audio className="react-audio-basic-media" controls preload="metadata">
           <source src="{{VJS10_DEMO_VIDEO_MP4}}" />
         </Audio>
       </Container>

--- a/site/src/components/docs/demos/dialog/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/dialog/html/css/BasicUsage.css
@@ -3,7 +3,7 @@
   min-height: 320px;
 }
 
-.html-dialog-basic__trigger {
+.html-dialog-basic-trigger {
   display: grid;
   gap: 10px;
   width: min(100%, 420px);
@@ -16,14 +16,14 @@
   border-radius: 12px;
 }
 
-.html-dialog-basic__trigger img {
+.html-dialog-basic-trigger img {
   display: block;
   width: 100%;
   aspect-ratio: 16 / 9;
   object-fit: cover;
 }
 
-.html-dialog-basic__backdrop {
+.html-dialog-basic-backdrop {
   position: absolute;
   inset: 0;
   z-index: 1;
@@ -31,7 +31,7 @@
   transition: opacity 200ms ease;
 }
 
-.html-dialog-basic__dialog {
+.html-dialog-basic-dialog {
   position: absolute;
   inset: 0;
   z-index: 2;
@@ -42,19 +42,19 @@
   transition: opacity 150ms ease;
 }
 
-.html-dialog-basic__backdrop:not([data-open]),
-.html-dialog-basic__dialog:not([data-open]) {
+.html-dialog-basic-backdrop:not([data-open]),
+.html-dialog-basic-dialog:not([data-open]) {
   display: none;
 }
 
-.html-dialog-basic__backdrop[data-starting-style],
-.html-dialog-basic__backdrop[data-ending-style],
-.html-dialog-basic__dialog[data-starting-style],
-.html-dialog-basic__dialog[data-ending-style] {
+.html-dialog-basic-backdrop[data-starting-style],
+.html-dialog-basic-backdrop[data-ending-style],
+.html-dialog-basic-dialog[data-starting-style],
+.html-dialog-basic-dialog[data-ending-style] {
   opacity: 0;
 }
 
-.html-dialog-basic__popup {
+.html-dialog-basic-popup {
   position: relative;
   width: 100%;
   max-width: 560px;
@@ -64,19 +64,19 @@
   border-radius: 12px;
 }
 
-.html-dialog-basic__title {
+.html-dialog-basic-title {
   display: block;
   margin-bottom: 4px;
   font-size: 1.125rem;
   font-weight: 600;
 }
 
-.html-dialog-basic__description {
+.html-dialog-basic-description {
   display: block;
   margin-bottom: 12px;
 }
 
-.html-dialog-basic__close {
+.html-dialog-basic-close {
   position: absolute;
   top: 12px;
   right: 12px;
@@ -94,8 +94,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .html-dialog-basic__backdrop,
-  .html-dialog-basic__dialog {
+  .html-dialog-basic-backdrop,
+  .html-dialog-basic-dialog {
     transition: none;
   }
 }

--- a/site/src/components/docs/demos/dialog/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/dialog/html/css/BasicUsage.html
@@ -1,17 +1,17 @@
 <div class="html-dialog-basic">
-  <button class="html-dialog-basic__trigger" type="button" commandfor="html-video-dialog">
+  <button class="html-dialog-basic-trigger" type="button" commandfor="html-video-dialog">
     <img src="{{VJS10_DEMO_POSTER}}" alt="" />
     <span>Play the video</span>
   </button>
   <media-dialog id="html-video-dialog">
-    <media-dialog-backdrop class="html-dialog-basic__backdrop"></media-dialog-backdrop>
-    <media-dialog-popup class="html-dialog-basic__dialog">
-      <div class="html-dialog-basic__popup">
-        <media-dialog-title class="html-dialog-basic__title">Video title</media-dialog-title>
-        <media-dialog-description class="html-dialog-basic__description">
+    <media-dialog-backdrop class="html-dialog-basic-backdrop"></media-dialog-backdrop>
+    <media-dialog-popup class="html-dialog-basic-dialog">
+      <div class="html-dialog-basic-popup">
+        <media-dialog-title class="html-dialog-basic-title">Video title</media-dialog-title>
+        <media-dialog-description class="html-dialog-basic-description">
           A video opened from a thumbnail.
         </media-dialog-description>
-        <media-dialog-close class="html-dialog-basic__close">Close</media-dialog-close>
+        <media-dialog-close class="html-dialog-basic-close">Close</media-dialog-close>
         <video-player>
           <media-container>
             <video src="{{VJS10_DEMO_VIDEO_MP4}}" controls muted playsinline></video>

--- a/site/src/components/docs/demos/dialog/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/dialog/react/css/BasicUsage.css
@@ -3,7 +3,7 @@
   min-height: 320px;
 }
 
-.react-dialog-basic__trigger {
+.react-dialog-basic-trigger {
   display: grid;
   gap: 10px;
   width: min(100%, 420px);
@@ -16,14 +16,14 @@
   border-radius: 12px;
 }
 
-.react-dialog-basic__trigger img {
+.react-dialog-basic-trigger img {
   display: block;
   width: 100%;
   aspect-ratio: 16 / 9;
   object-fit: cover;
 }
 
-.react-dialog-basic__backdrop {
+.react-dialog-basic-backdrop {
   position: absolute;
   inset: 0;
   z-index: 1;
@@ -31,7 +31,7 @@
   transition: opacity 200ms ease;
 }
 
-.react-dialog-basic__dialog {
+.react-dialog-basic-dialog {
   position: absolute;
   inset: 0;
   z-index: 2;
@@ -42,14 +42,14 @@
   transition: opacity 150ms ease;
 }
 
-.react-dialog-basic__backdrop[data-starting-style],
-.react-dialog-basic__backdrop[data-ending-style],
-.react-dialog-basic__dialog[data-starting-style],
-.react-dialog-basic__dialog[data-ending-style] {
+.react-dialog-basic-backdrop[data-starting-style],
+.react-dialog-basic-backdrop[data-ending-style],
+.react-dialog-basic-dialog[data-starting-style],
+.react-dialog-basic-dialog[data-ending-style] {
   opacity: 0;
 }
 
-.react-dialog-basic__popup {
+.react-dialog-basic-popup {
   position: relative;
   width: 100%;
   max-width: 560px;
@@ -59,17 +59,17 @@
   border-radius: 12px;
 }
 
-.react-dialog-basic__title {
+.react-dialog-basic-title {
   margin: 0 0 4px;
   font-size: 1.125rem;
   font-weight: 600;
 }
 
-.react-dialog-basic__description {
+.react-dialog-basic-description {
   margin: 0 0 12px;
 }
 
-.react-dialog-basic__close {
+.react-dialog-basic-close {
   position: absolute;
   top: 12px;
   right: 12px;
@@ -87,8 +87,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .react-dialog-basic__backdrop,
-  .react-dialog-basic__dialog {
+  .react-dialog-basic-backdrop,
+  .react-dialog-basic-dialog {
     transition: none;
   }
 }

--- a/site/src/components/docs/demos/dialog/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/dialog/react/css/BasicUsage.tsx
@@ -21,18 +21,18 @@ export default function BasicUsage() {
   return (
     <div className="react-dialog-basic">
       <Dialog.Root open={open} onOpenChange={setOpen}>
-        <Dialog.Trigger className="react-dialog-basic__trigger">
+        <Dialog.Trigger className="react-dialog-basic-trigger">
           <img src="{{VJS10_DEMO_POSTER}}" alt="" />
           <span>Play the video</span>
         </Dialog.Trigger>
-        <Dialog.Backdrop className="react-dialog-basic__backdrop" />
-        <Dialog.Popup className="react-dialog-basic__dialog">
-          <div className="react-dialog-basic__popup">
-            <Dialog.Title className="react-dialog-basic__title">Video title</Dialog.Title>
-            <Dialog.Description className="react-dialog-basic__description">
+        <Dialog.Backdrop className="react-dialog-basic-backdrop" />
+        <Dialog.Popup className="react-dialog-basic-dialog">
+          <div className="react-dialog-basic-popup">
+            <Dialog.Title className="react-dialog-basic-title">Video title</Dialog.Title>
+            <Dialog.Description className="react-dialog-basic-description">
               A video opened from a thumbnail.
             </Dialog.Description>
-            <Dialog.Close className="react-dialog-basic__close">Close</Dialog.Close>
+            <Dialog.Close className="react-dialog-basic-close">Close</Dialog.Close>
             <Player>
               <Container>
                 <Video ref={videoRef} src="{{VJS10_DEMO_VIDEO_MP4}}" controls muted playsInline />

--- a/site/src/components/docs/demos/error-dialog/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/error-dialog/html/css/BasicUsage.css
@@ -1,17 +1,17 @@
-.html-error-dialog-basic__container {
+.html-error-dialog-basic-container {
   position: relative;
   display: block;
   overflow: hidden;
   border-radius: 12px;
 }
 
-.html-error-dialog-basic__video {
+.html-error-dialog-basic-video {
   display: block;
   width: 100%;
 }
 
-.html-error-dialog-basic__trigger,
-.html-error-dialog-basic__close {
+.html-error-dialog-basic-trigger,
+.html-error-dialog-basic-close {
   padding: 8px 16px;
   color: #111827;
   cursor: pointer;
@@ -20,20 +20,20 @@
   border-radius: 9999px;
 }
 
-.html-error-dialog-basic__trigger {
+.html-error-dialog-basic-trigger {
   position: absolute;
   bottom: 16px;
   left: 16px;
 }
 
-.html-error-dialog-basic__backdrop {
+.html-error-dialog-basic-backdrop {
   position: absolute;
   inset: 0;
   background: rgb(3 7 18 / 92%);
   transition: opacity 150ms ease;
 }
 
-.html-error-dialog-basic__dialog {
+.html-error-dialog-basic-dialog {
   position: absolute;
   inset: 0;
   z-index: 1;
@@ -46,32 +46,32 @@
   transition: opacity 150ms ease;
 }
 
-.html-error-dialog-basic__backdrop:not([data-open]),
-.html-error-dialog-basic__dialog:not([data-open]) {
+.html-error-dialog-basic-backdrop:not([data-open]),
+.html-error-dialog-basic-dialog:not([data-open]) {
   display: none;
 }
 
-.html-error-dialog-basic__backdrop[data-starting-style],
-.html-error-dialog-basic__backdrop[data-ending-style],
-.html-error-dialog-basic__dialog[data-starting-style],
-.html-error-dialog-basic__dialog[data-ending-style] {
+.html-error-dialog-basic-backdrop[data-starting-style],
+.html-error-dialog-basic-backdrop[data-ending-style],
+.html-error-dialog-basic-dialog[data-starting-style],
+.html-error-dialog-basic-dialog[data-ending-style] {
   opacity: 0;
 }
 
-.html-error-dialog-basic__title,
-.html-error-dialog-basic__description {
+.html-error-dialog-basic-title,
+.html-error-dialog-basic-description {
   display: block;
 }
 
-.html-error-dialog-basic__title {
+.html-error-dialog-basic-title {
   font-size: 20px;
   font-weight: 600;
 }
 
-.html-error-dialog-basic__description {
+.html-error-dialog-basic-description {
   color: #d1d5db;
 }
 
-.html-error-dialog-basic__close {
+.html-error-dialog-basic-close {
   justify-self: center;
 }

--- a/site/src/components/docs/demos/error-dialog/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/error-dialog/html/css/BasicUsage.html
@@ -1,20 +1,13 @@
 <video-player class="html-error-dialog-basic">
-  <media-container class="html-error-dialog-basic__container">
-    <video
-      class="html-error-dialog-basic__video"
-      src="{{VJS10_DEMO_VIDEO_MP4}}"
-      autoplay
-      muted
-      playsinline
-      loop
-    ></video>
-    <button class="html-error-dialog-basic__trigger" type="button">Trigger a playback error</button>
+  <media-container class="html-error-dialog-basic-container">
+    <video class="html-error-dialog-basic-video" src="{{VJS10_DEMO_VIDEO_MP4}}" autoplay muted playsinline loop></video>
+    <button class="html-error-dialog-basic-trigger" type="button">Trigger a playback error</button>
     <media-error-dialog>
-      <media-dialog-backdrop class="html-error-dialog-basic__backdrop"></media-dialog-backdrop>
-      <media-dialog-popup class="html-error-dialog-basic__dialog">
-        <media-dialog-title class="html-error-dialog-basic__title"></media-dialog-title>
-        <media-dialog-description class="html-error-dialog-basic__description"></media-dialog-description>
-        <media-dialog-close class="html-error-dialog-basic__close"></media-dialog-close>
+      <media-dialog-backdrop class="html-error-dialog-basic-backdrop"></media-dialog-backdrop>
+      <media-dialog-popup class="html-error-dialog-basic-dialog">
+        <media-dialog-title class="html-error-dialog-basic-title"></media-dialog-title>
+        <media-dialog-description class="html-error-dialog-basic-description"></media-dialog-description>
+        <media-dialog-close class="html-error-dialog-basic-close"></media-dialog-close>
       </media-dialog-popup>
     </media-error-dialog>
   </media-container>

--- a/site/src/components/docs/demos/error-dialog/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/error-dialog/html/css/BasicUsage.ts
@@ -5,7 +5,7 @@ const brokenSource = 'data:video/mp4;base64,AAAA';
 
 document.querySelectorAll<HTMLElement>('.html-error-dialog-basic').forEach((demo) => {
   const video = demo.querySelector('video');
-  const trigger = demo.querySelector<HTMLButtonElement>('.html-error-dialog-basic__trigger');
+  const trigger = demo.querySelector<HTMLButtonElement>('.html-error-dialog-basic-trigger');
 
   trigger?.addEventListener('click', () => {
     if (!video) return;

--- a/site/src/components/docs/demos/error-dialog/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/error-dialog/react/css/BasicUsage.css
@@ -5,13 +5,13 @@
   border-radius: 12px;
 }
 
-.react-error-dialog-basic__video {
+.react-error-dialog-basic-video {
   display: block;
   width: 100%;
 }
 
-.react-error-dialog-basic__trigger,
-.react-error-dialog-basic__close {
+.react-error-dialog-basic-trigger,
+.react-error-dialog-basic-close {
   padding: 8px 16px;
   color: #111827;
   cursor: pointer;
@@ -20,20 +20,20 @@
   border-radius: 9999px;
 }
 
-.react-error-dialog-basic__trigger {
+.react-error-dialog-basic-trigger {
   position: absolute;
   bottom: 16px;
   left: 16px;
 }
 
-.react-error-dialog-basic__backdrop {
+.react-error-dialog-basic-backdrop {
   position: absolute;
   inset: 0;
   background: rgb(3 7 18 / 92%);
   transition: opacity 150ms ease;
 }
 
-.react-error-dialog-basic__dialog {
+.react-error-dialog-basic-dialog {
   position: absolute;
   inset: 0;
   z-index: 1;
@@ -46,22 +46,22 @@
   transition: opacity 150ms ease;
 }
 
-.react-error-dialog-basic__backdrop[data-starting-style],
-.react-error-dialog-basic__backdrop[data-ending-style],
-.react-error-dialog-basic__dialog[data-starting-style],
-.react-error-dialog-basic__dialog[data-ending-style] {
+.react-error-dialog-basic-backdrop[data-starting-style],
+.react-error-dialog-basic-backdrop[data-ending-style],
+.react-error-dialog-basic-dialog[data-starting-style],
+.react-error-dialog-basic-dialog[data-ending-style] {
   opacity: 0;
 }
 
-.react-error-dialog-basic__title {
+.react-error-dialog-basic-title {
   font-size: 20px;
   font-weight: 600;
 }
 
-.react-error-dialog-basic__description {
+.react-error-dialog-basic-description {
   color: #d1d5db;
 }
 
-.react-error-dialog-basic__close {
+.react-error-dialog-basic-close {
   justify-self: center;
 }

--- a/site/src/components/docs/demos/error-dialog/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/error-dialog/react/css/BasicUsage.tsx
@@ -21,22 +21,22 @@ export default function BasicUsage() {
       <Container className="react-error-dialog-basic">
         <Video
           ref={videoRef}
-          className="react-error-dialog-basic__video"
+          className="react-error-dialog-basic-video"
           src="{{VJS10_DEMO_VIDEO_MP4}}"
           autoPlay
           muted
           playsInline
           loop
         />
-        <button className="react-error-dialog-basic__trigger" type="button" onClick={triggerError}>
+        <button className="react-error-dialog-basic-trigger" type="button" onClick={triggerError}>
           Trigger a playback error
         </button>
         <ErrorDialog.Root>
-          <ErrorDialog.Backdrop className="react-error-dialog-basic__backdrop" />
-          <ErrorDialog.Popup className="react-error-dialog-basic__dialog">
-            <ErrorDialog.Title className="react-error-dialog-basic__title" />
-            <ErrorDialog.Description className="react-error-dialog-basic__description" />
-            <ErrorDialog.Close className="react-error-dialog-basic__close" />
+          <ErrorDialog.Backdrop className="react-error-dialog-basic-backdrop" />
+          <ErrorDialog.Popup className="react-error-dialog-basic-dialog">
+            <ErrorDialog.Title className="react-error-dialog-basic-title" />
+            <ErrorDialog.Description className="react-error-dialog-basic-description" />
+            <ErrorDialog.Close className="react-error-dialog-basic-close" />
           </ErrorDialog.Popup>
         </ErrorDialog.Root>
       </Container>

--- a/site/src/components/docs/demos/gesture/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/gesture/html/css/BasicUsage.css
@@ -6,7 +6,7 @@
   width: 100%;
 }
 
-.html-gesture-basic__instructions {
+.html-gesture-basic-instructions {
   position: absolute;
   top: 10px;
   left: 10px;
@@ -18,7 +18,7 @@
   border-radius: 4px;
 }
 
-.html-gesture-basic__button {
+.html-gesture-basic-button {
   position: absolute;
   bottom: 10px;
   left: 10px;
@@ -30,14 +30,14 @@
   border-radius: 9999px;
 }
 
-.html-gesture-basic__button .show-when-paused,
-.html-gesture-basic__button .show-when-playing,
-.html-gesture-basic__button .show-when-ended {
+.html-gesture-basic-button .show-when-paused,
+.html-gesture-basic-button .show-when-playing,
+.html-gesture-basic-button .show-when-ended {
   display: none;
 }
 
-.html-gesture-basic__button[data-paused]:not([data-ended]) .show-when-paused,
-.html-gesture-basic__button:not([data-paused]) .show-when-playing,
-.html-gesture-basic__button[data-ended] .show-when-ended {
+.html-gesture-basic-button[data-paused]:not([data-ended]) .show-when-paused,
+.html-gesture-basic-button:not([data-paused]) .show-when-playing,
+.html-gesture-basic-button[data-ended] .show-when-ended {
   display: inline;
 }

--- a/site/src/components/docs/demos/gesture/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/gesture/html/css/BasicUsage.html
@@ -1,8 +1,8 @@
 <video-player>
   <media-container class="html-gesture-basic">
     <video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline></video>
-    <p class="html-gesture-basic__instructions">Click: play/pause · Double-click: −10s · fullscreen · +10s</p>
-    <media-play-button class="html-gesture-basic__button">
+    <p class="html-gesture-basic-instructions">Click: play/pause · Double-click: −10s · fullscreen · +10s</p>
+    <media-play-button class="html-gesture-basic-button">
       <span class="show-when-paused">Play</span>
       <span class="show-when-playing">Pause</span>
       <span class="show-when-ended">Replay</span>

--- a/site/src/components/docs/demos/gesture/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/gesture/react/css/BasicUsage.css
@@ -6,7 +6,7 @@
   width: 100%;
 }
 
-.react-gesture-basic__instructions {
+.react-gesture-basic-instructions {
   position: absolute;
   top: 10px;
   left: 10px;
@@ -18,7 +18,7 @@
   border-radius: 4px;
 }
 
-.react-gesture-basic__button {
+.react-gesture-basic-button {
   position: absolute;
   bottom: 10px;
   left: 10px;

--- a/site/src/components/docs/demos/gesture/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/gesture/react/css/BasicUsage.tsx
@@ -8,9 +8,9 @@ export default function BasicUsage() {
     <Player>
       <Container className="react-gesture-basic">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline />
-        <p className="react-gesture-basic__instructions">Click: play/pause · Double-click: −10s · fullscreen · +10s</p>
+        <p className="react-gesture-basic-instructions">Click: play/pause · Double-click: −10s · fullscreen · +10s</p>
         <PlayButton
-          className="react-gesture-basic__button"
+          className="react-gesture-basic-button"
           render={(props, state) => (
             <button {...props}>{state.ended ? 'Replay' : state.paused ? 'Play' : 'Pause'}</button>
           )}

--- a/site/src/components/docs/demos/hotkey/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/hotkey/html/css/BasicUsage.css
@@ -6,7 +6,7 @@
   width: 100%;
 }
 
-.html-hotkey-basic__instructions {
+.html-hotkey-basic-instructions {
   position: absolute;
   top: 10px;
   left: 10px;
@@ -17,7 +17,7 @@
   border-radius: 4px;
 }
 
-.html-hotkey-basic__button {
+.html-hotkey-basic-button {
   position: absolute;
   bottom: 10px;
   left: 10px;
@@ -29,14 +29,14 @@
   border-radius: 9999px;
 }
 
-.html-hotkey-basic__button .show-when-paused,
-.html-hotkey-basic__button .show-when-playing,
-.html-hotkey-basic__button .show-when-ended {
+.html-hotkey-basic-button .show-when-paused,
+.html-hotkey-basic-button .show-when-playing,
+.html-hotkey-basic-button .show-when-ended {
   display: none;
 }
 
-.html-hotkey-basic__button[data-paused]:not([data-ended]) .show-when-paused,
-.html-hotkey-basic__button:not([data-paused]) .show-when-playing,
-.html-hotkey-basic__button[data-ended] .show-when-ended {
+.html-hotkey-basic-button[data-paused]:not([data-ended]) .show-when-paused,
+.html-hotkey-basic-button:not([data-paused]) .show-when-playing,
+.html-hotkey-basic-button[data-ended] .show-when-ended {
   display: inline;
 }

--- a/site/src/components/docs/demos/hotkey/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/hotkey/html/css/BasicUsage.html
@@ -1,8 +1,8 @@
 <video-player>
   <media-container class="html-hotkey-basic">
     <video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline></video>
-    <p class="html-hotkey-basic__instructions">Space: play/pause · M: mute · ←/→: seek</p>
-    <media-play-button class="html-hotkey-basic__button">
+    <p class="html-hotkey-basic-instructions">Space: play/pause · M: mute · ←/→: seek</p>
+    <media-play-button class="html-hotkey-basic-button">
       <span class="show-when-paused">Play</span>
       <span class="show-when-playing">Pause</span>
       <span class="show-when-ended">Replay</span>

--- a/site/src/components/docs/demos/hotkey/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/hotkey/react/css/BasicUsage.css
@@ -6,7 +6,7 @@
   width: 100%;
 }
 
-.react-hotkey-basic__instructions {
+.react-hotkey-basic-instructions {
   position: absolute;
   top: 10px;
   left: 10px;
@@ -17,7 +17,7 @@
   border-radius: 4px;
 }
 
-.react-hotkey-basic__button {
+.react-hotkey-basic-button {
   position: absolute;
   bottom: 10px;
   left: 10px;

--- a/site/src/components/docs/demos/hotkey/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/hotkey/react/css/BasicUsage.tsx
@@ -8,9 +8,9 @@ export default function BasicUsage() {
     <Player>
       <Container className="react-hotkey-basic">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline />
-        <p className="react-hotkey-basic__instructions">Space: play/pause · M: mute · ←/→: seek</p>
+        <p className="react-hotkey-basic-instructions">Space: play/pause · M: mute · ←/→: seek</p>
         <PlayButton
-          className="react-hotkey-basic__button"
+          className="react-hotkey-basic-button"
           render={(props, state) => (
             <button {...props}>{state.ended ? 'Replay' : state.paused ? 'Play' : 'Pause'}</button>
           )}

--- a/site/src/components/docs/demos/i18n/react/css/Language.css
+++ b/site/src/components/docs/demos/i18n/react/css/Language.css
@@ -14,7 +14,7 @@
   padding: 4px 8px;
 }
 
-.react-i18n-language__player {
+.react-i18n-language-player {
   width: 100%;
   aspect-ratio: 16 / 9;
 }

--- a/site/src/components/docs/demos/i18n/react/css/Language.tsx
+++ b/site/src/components/docs/demos/i18n/react/css/Language.tsx
@@ -29,7 +29,7 @@ export default function Language() {
       </label>
       <Player>
         <I18nProvider locale={locale}>
-          <VideoSkin className="react-i18n-language__player">
+          <VideoSkin className="react-i18n-language-player">
             <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline />
           </VideoSkin>
         </I18nProvider>

--- a/site/src/components/docs/demos/live-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/live-button/html/css/BasicUsage.css
@@ -7,7 +7,7 @@
   width: 100%;
 }
 
-.html-live-button-basic__buttons {
+.html-live-button-basic-buttons {
   position: absolute;
   bottom: 10px;
   left: 10px;
@@ -15,8 +15,8 @@
   gap: 8px;
 }
 
-.html-live-button-basic__seek,
-.html-live-button-basic__live {
+.html-live-button-basic-seek,
+.html-live-button-basic-live {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -31,17 +31,17 @@
   backdrop-filter: blur(10px);
 }
 
-.html-live-button-basic__live[data-live-edge] {
+.html-live-button-basic-live[data-live-edge] {
   cursor: default;
 }
 
-.html-live-button-basic__dot {
+.html-live-button-basic-dot {
   width: 8px;
   height: 8px;
   background: gray;
   border-radius: 50%;
 }
 
-.html-live-button-basic__live[data-live-edge] .html-live-button-basic__dot {
+.html-live-button-basic-live[data-live-edge] .html-live-button-basic-dot {
   background: red;
 }

--- a/site/src/components/docs/demos/live-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/live-button/html/css/BasicUsage.html
@@ -1,10 +1,10 @@
 <live-video-player class="html-live-button-basic">
   <media-container>
     <hlsjs-video src="{{VJS10_DEMO_LIVE_HLS}}" autoplay muted playsinline></hlsjs-video>
-    <div class="html-live-button-basic__buttons">
-      <media-seek-button seconds="-30" class="html-live-button-basic__seek">&#9194; 30s</media-seek-button>
-      <media-live-button class="html-live-button-basic__live">
-        <span class="html-live-button-basic__dot"></span>
+    <div class="html-live-button-basic-buttons">
+      <media-seek-button seconds="-30" class="html-live-button-basic-seek">&#9194; 30s</media-seek-button>
+      <media-live-button class="html-live-button-basic-live">
+        <span class="html-live-button-basic-dot"></span>
         Live
       </media-live-button>
     </div>

--- a/site/src/components/docs/demos/live-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/live-button/react/css/BasicUsage.css
@@ -6,7 +6,7 @@
   width: 100%;
 }
 
-.react-live-button-basic__buttons {
+.react-live-button-basic-buttons {
   position: absolute;
   bottom: 10px;
   left: 10px;
@@ -14,8 +14,8 @@
   gap: 8px;
 }
 
-.react-live-button-basic__seek,
-.react-live-button-basic__live {
+.react-live-button-basic-seek,
+.react-live-button-basic-live {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -30,17 +30,17 @@
   backdrop-filter: blur(10px);
 }
 
-.react-live-button-basic__live[data-live-edge] {
+.react-live-button-basic-live[data-live-edge] {
   cursor: default;
 }
 
-.react-live-button-basic__dot {
+.react-live-button-basic-dot {
   width: 8px;
   height: 8px;
   background: gray;
   border-radius: 50%;
 }
 
-.react-live-button-basic__live[data-live-edge] .react-live-button-basic__dot {
+.react-live-button-basic-live[data-live-edge] .react-live-button-basic-dot {
   background: red;
 }

--- a/site/src/components/docs/demos/live-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/live-button/react/css/BasicUsage.tsx
@@ -9,12 +9,12 @@ export default function BasicUsage() {
     <Player>
       <Container className="react-live-button-basic">
         <HlsJsVideo src="{{VJS10_DEMO_LIVE_HLS}}" autoPlay muted playsInline />
-        <div className="react-live-button-basic__buttons">
-          <SeekButton seconds={-30} className="react-live-button-basic__seek">
+        <div className="react-live-button-basic-buttons">
+          <SeekButton seconds={-30} className="react-live-button-basic-seek">
             {'⏪'} 30s
           </SeekButton>
-          <LiveButton className="react-live-button-basic__live">
-            <span className="react-live-button-basic__dot" />
+          <LiveButton className="react-live-button-basic-live">
+            <span className="react-live-button-basic-dot" />
             Live
           </LiveButton>
         </div>

--- a/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.css
@@ -12,7 +12,7 @@
   width: 100%;
 }
 
-.html-seek-indicator-basic__instructions {
+.html-seek-indicator-basic-instructions {
   position: absolute;
   top: 10px;
   left: 50%;
@@ -25,7 +25,7 @@
   translate: -50%;
 }
 
-.html-seek-indicator-basic__indicator {
+.html-seek-indicator-basic-indicator {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -43,38 +43,38 @@
     scale 160ms ease-in-out;
 }
 
-.html-seek-indicator-basic__indicator::before {
+.html-seek-indicator-basic-indicator::before {
   font-size: 24px;
   line-height: 1;
   content: "↔";
 }
 
-.html-seek-indicator-basic__indicator[data-direction="backward"] {
+.html-seek-indicator-basic-indicator[data-direction="backward"] {
   right: auto;
   left: 16px;
   transform: translateY(-50%);
 }
 
-.html-seek-indicator-basic__indicator[data-direction="backward"]::before {
+.html-seek-indicator-basic-indicator[data-direction="backward"]::before {
   content: "↶";
 }
 
-.html-seek-indicator-basic__indicator[data-direction="forward"] {
+.html-seek-indicator-basic-indicator[data-direction="forward"] {
   right: 16px;
   left: auto;
   transform: translateY(-50%);
 }
 
-.html-seek-indicator-basic__indicator[data-direction="forward"]::before {
+.html-seek-indicator-basic-indicator[data-direction="forward"]::before {
   content: "↷";
 }
 
-.html-seek-indicator-basic__indicator[data-starting-style],
-.html-seek-indicator-basic__indicator[data-ending-style] {
+.html-seek-indicator-basic-indicator[data-starting-style],
+.html-seek-indicator-basic-indicator[data-ending-style] {
   opacity: 0;
   scale: 0.85;
 }
 
-.html-seek-indicator-basic__value {
+.html-seek-indicator-basic-value {
   font-variant-numeric: tabular-nums;
 }

--- a/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/seek-indicator/html/css/BasicUsage.html
@@ -1,9 +1,9 @@
 <video-player>
   <media-container class="html-seek-indicator-basic" tabindex="0">
     <video src="{{VJS10_DEMO_VIDEO_MP4}}" autoplay muted playsinline loop></video>
-    <p class="html-seek-indicator-basic__instructions">Focus the player · ←/→: seek 10s · 0–9: seek to percent</p>
-    <media-seek-indicator class="html-seek-indicator-basic__indicator" aria-hidden="true">
-      <media-seek-indicator-value class="html-seek-indicator-basic__value"></media-seek-indicator-value>
+    <p class="html-seek-indicator-basic-instructions">Focus the player · ←/→: seek 10s · 0–9: seek to percent</p>
+    <media-seek-indicator class="html-seek-indicator-basic-indicator" aria-hidden="true">
+      <media-seek-indicator-value class="html-seek-indicator-basic-value"></media-seek-indicator-value>
     </media-seek-indicator>
     <media-hotkey keys="ArrowLeft" action="seekStep" value="-10"></media-hotkey>
     <media-hotkey keys="ArrowRight" action="seekStep" value="10"></media-hotkey>

--- a/site/src/components/docs/demos/seek-indicator/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/seek-indicator/react/css/BasicUsage.css
@@ -12,7 +12,7 @@
   width: 100%;
 }
 
-.react-seek-indicator-basic__instructions {
+.react-seek-indicator-basic-instructions {
   position: absolute;
   top: 10px;
   left: 50%;
@@ -25,7 +25,7 @@
   translate: -50%;
 }
 
-.react-seek-indicator-basic__indicator {
+.react-seek-indicator-basic-indicator {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -43,38 +43,38 @@
     scale 160ms ease-in-out;
 }
 
-.react-seek-indicator-basic__indicator::before {
+.react-seek-indicator-basic-indicator::before {
   font-size: 24px;
   line-height: 1;
   content: "↔";
 }
 
-.react-seek-indicator-basic__indicator[data-direction="backward"] {
+.react-seek-indicator-basic-indicator[data-direction="backward"] {
   right: auto;
   left: 16px;
   transform: translateY(-50%);
 }
 
-.react-seek-indicator-basic__indicator[data-direction="backward"]::before {
+.react-seek-indicator-basic-indicator[data-direction="backward"]::before {
   content: "↶";
 }
 
-.react-seek-indicator-basic__indicator[data-direction="forward"] {
+.react-seek-indicator-basic-indicator[data-direction="forward"] {
   right: 16px;
   left: auto;
   transform: translateY(-50%);
 }
 
-.react-seek-indicator-basic__indicator[data-direction="forward"]::before {
+.react-seek-indicator-basic-indicator[data-direction="forward"]::before {
   content: "↷";
 }
 
-.react-seek-indicator-basic__indicator[data-starting-style],
-.react-seek-indicator-basic__indicator[data-ending-style] {
+.react-seek-indicator-basic-indicator[data-starting-style],
+.react-seek-indicator-basic-indicator[data-ending-style] {
   opacity: 0;
   scale: 0.85;
 }
 
-.react-seek-indicator-basic__value {
+.react-seek-indicator-basic-value {
   font-variant-numeric: tabular-nums;
 }

--- a/site/src/components/docs/demos/seek-indicator/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/seek-indicator/react/css/BasicUsage.tsx
@@ -10,11 +10,11 @@ export default function BasicUsage() {
     <Player>
       <Container className="react-seek-indicator-basic" tabIndex={0}>
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
-        <p className="react-seek-indicator-basic__instructions">
+        <p className="react-seek-indicator-basic-instructions">
           Focus the player · ←/→: seek 10s · 0–9: seek to percent
         </p>
-        <SeekIndicator.Root className="react-seek-indicator-basic__indicator" aria-hidden="true">
-          <SeekIndicator.Value className="react-seek-indicator-basic__value" />
+        <SeekIndicator.Root className="react-seek-indicator-basic-indicator" aria-hidden="true">
+          <SeekIndicator.Value className="react-seek-indicator-basic-value" />
         </SeekIndicator.Root>
         <Hotkey keys="ArrowLeft" action="seekStep" value={-10} />
         <Hotkey keys="ArrowRight" action="seekStep" value={10} />

--- a/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.css
@@ -7,7 +7,7 @@
   width: 100%;
 }
 
-.html-status-announcer-basic__instructions {
+.html-status-announcer-basic-instructions {
   position: absolute;
   top: 10px;
   left: 10px;
@@ -18,7 +18,7 @@
   border-radius: 4px;
 }
 
-.html-status-announcer-basic__controls {
+.html-status-announcer-basic-controls {
   position: absolute;
   right: 12px;
   bottom: 36px;
@@ -28,7 +28,7 @@
   align-items: center;
 }
 
-.html-status-announcer-basic__button {
+.html-status-announcer-basic-button {
   padding: 7px 14px;
   color: black;
   cursor: pointer;
@@ -37,24 +37,24 @@
   border-radius: 9999px;
 }
 
-.html-status-announcer-basic__button .show-when-paused,
-.html-status-announcer-basic__button .show-when-playing,
-.html-status-announcer-basic__button .show-when-ended,
-.html-status-announcer-basic__button .show-when-muted,
-.html-status-announcer-basic__button .show-when-unmuted {
+.html-status-announcer-basic-button .show-when-paused,
+.html-status-announcer-basic-button .show-when-playing,
+.html-status-announcer-basic-button .show-when-ended,
+.html-status-announcer-basic-button .show-when-muted,
+.html-status-announcer-basic-button .show-when-unmuted {
   display: none;
 }
 
-.html-status-announcer-basic__button[data-paused]:not([data-ended]) .show-when-paused,
-.html-status-announcer-basic__button:not([data-paused]) .show-when-playing,
-.html-status-announcer-basic__button[data-ended] .show-when-ended,
-.html-status-announcer-basic__button[data-muted] .show-when-muted,
-.html-status-announcer-basic__button:not([data-muted]) .show-when-unmuted {
+.html-status-announcer-basic-button[data-paused]:not([data-ended]) .show-when-paused,
+.html-status-announcer-basic-button:not([data-paused]) .show-when-playing,
+.html-status-announcer-basic-button[data-ended] .show-when-ended,
+.html-status-announcer-basic-button[data-muted] .show-when-muted,
+.html-status-announcer-basic-button:not([data-muted]) .show-when-unmuted {
   display: inline;
 }
 
-.html-status-announcer-basic__volume-slider,
-.html-status-announcer-basic__time-slider {
+.html-status-announcer-basic-volume-slider,
+.html-status-announcer-basic-time-slider {
   position: relative;
   display: flex;
   align-items: center;
@@ -62,18 +62,18 @@
   cursor: pointer;
 }
 
-.html-status-announcer-basic__volume-slider {
+.html-status-announcer-basic-volume-slider {
   width: 100px;
 }
 
-.html-status-announcer-basic__time-slider {
+.html-status-announcer-basic-time-slider {
   position: absolute;
   right: 12px;
   bottom: 8px;
   left: 12px;
 }
 
-.html-status-announcer-basic__track {
+.html-status-announcer-basic-track {
   position: absolute;
   right: 0;
   left: 0;
@@ -83,8 +83,8 @@
   border-radius: 9999px;
 }
 
-.html-status-announcer-basic__buffer,
-.html-status-announcer-basic__fill {
+.html-status-announcer-basic-buffer,
+.html-status-announcer-basic-fill {
   position: absolute;
   top: 0;
   left: 0;
@@ -92,17 +92,17 @@
   border-radius: inherit;
 }
 
-.html-status-announcer-basic__buffer {
+.html-status-announcer-basic-buffer {
   width: var(--media-slider-buffer);
   background: rgb(255 255 255 / 30%);
 }
 
-.html-status-announcer-basic__fill {
+.html-status-announcer-basic-fill {
   width: var(--media-slider-fill);
   background: white;
 }
 
-.html-status-announcer-basic__thumb {
+.html-status-announcer-basic-thumb {
   position: absolute;
   left: var(--media-slider-fill);
   width: 14px;
@@ -113,7 +113,7 @@
   translate: -50%;
 }
 
-.html-status-announcer-basic__announcer {
+.html-status-announcer-basic-announcer {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/status-announcer/html/css/BasicUsage.html
@@ -1,31 +1,31 @@
 <video-player>
   <media-container class="html-status-announcer-basic">
     <video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline></video>
-    <p class="html-status-announcer-basic__instructions">These controls announce status changes to screen readers.</p>
-    <div class="html-status-announcer-basic__controls">
-      <media-play-button class="html-status-announcer-basic__button">
+    <p class="html-status-announcer-basic-instructions">These controls announce status changes to screen readers.</p>
+    <div class="html-status-announcer-basic-controls">
+      <media-play-button class="html-status-announcer-basic-button">
         <span class="show-when-paused">Play</span>
         <span class="show-when-playing">Pause</span>
         <span class="show-when-ended">Replay</span>
       </media-play-button>
-      <media-mute-button class="html-status-announcer-basic__button">
+      <media-mute-button class="html-status-announcer-basic-button">
         <span class="show-when-muted">Unmute</span>
         <span class="show-when-unmuted">Mute</span>
       </media-mute-button>
-      <media-volume-slider class="html-status-announcer-basic__volume-slider">
-        <media-slider-track class="html-status-announcer-basic__track">
-          <media-slider-fill class="html-status-announcer-basic__fill"></media-slider-fill>
+      <media-volume-slider class="html-status-announcer-basic-volume-slider">
+        <media-slider-track class="html-status-announcer-basic-track">
+          <media-slider-fill class="html-status-announcer-basic-fill"></media-slider-fill>
         </media-slider-track>
-        <media-slider-thumb class="html-status-announcer-basic__thumb"></media-slider-thumb>
+        <media-slider-thumb class="html-status-announcer-basic-thumb"></media-slider-thumb>
       </media-volume-slider>
     </div>
-    <media-time-slider class="html-status-announcer-basic__time-slider">
-      <media-slider-track class="html-status-announcer-basic__track">
-        <media-slider-buffer class="html-status-announcer-basic__buffer"></media-slider-buffer>
-        <media-slider-fill class="html-status-announcer-basic__fill"></media-slider-fill>
+    <media-time-slider class="html-status-announcer-basic-time-slider">
+      <media-slider-track class="html-status-announcer-basic-track">
+        <media-slider-buffer class="html-status-announcer-basic-buffer"></media-slider-buffer>
+        <media-slider-fill class="html-status-announcer-basic-fill"></media-slider-fill>
       </media-slider-track>
-      <media-slider-thumb class="html-status-announcer-basic__thumb"></media-slider-thumb>
+      <media-slider-thumb class="html-status-announcer-basic-thumb"></media-slider-thumb>
     </media-time-slider>
-    <media-status-announcer class="html-status-announcer-basic__announcer"></media-status-announcer>
+    <media-status-announcer class="html-status-announcer-basic-announcer"></media-status-announcer>
   </media-container>
 </video-player>

--- a/site/src/components/docs/demos/status-announcer/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/status-announcer/react/css/BasicUsage.css
@@ -7,7 +7,7 @@
   width: 100%;
 }
 
-.react-status-announcer-basic__instructions {
+.react-status-announcer-basic-instructions {
   position: absolute;
   top: 10px;
   left: 10px;
@@ -18,7 +18,7 @@
   border-radius: 4px;
 }
 
-.react-status-announcer-basic__controls {
+.react-status-announcer-basic-controls {
   position: absolute;
   right: 12px;
   bottom: 36px;
@@ -28,7 +28,7 @@
   align-items: center;
 }
 
-.react-status-announcer-basic__button {
+.react-status-announcer-basic-button {
   padding: 7px 14px;
   color: black;
   cursor: pointer;
@@ -37,8 +37,8 @@
   border-radius: 9999px;
 }
 
-.react-status-announcer-basic__volume-slider,
-.react-status-announcer-basic__time-slider {
+.react-status-announcer-basic-volume-slider,
+.react-status-announcer-basic-time-slider {
   position: relative;
   display: flex;
   align-items: center;
@@ -46,18 +46,18 @@
   cursor: pointer;
 }
 
-.react-status-announcer-basic__volume-slider {
+.react-status-announcer-basic-volume-slider {
   width: 100px;
 }
 
-.react-status-announcer-basic__time-slider {
+.react-status-announcer-basic-time-slider {
   position: absolute;
   right: 12px;
   bottom: 8px;
   left: 12px;
 }
 
-.react-status-announcer-basic__track {
+.react-status-announcer-basic-track {
   position: absolute;
   right: 0;
   left: 0;
@@ -67,8 +67,8 @@
   border-radius: 9999px;
 }
 
-.react-status-announcer-basic__buffer,
-.react-status-announcer-basic__fill {
+.react-status-announcer-basic-buffer,
+.react-status-announcer-basic-fill {
   position: absolute;
   top: 0;
   left: 0;
@@ -76,17 +76,17 @@
   border-radius: inherit;
 }
 
-.react-status-announcer-basic__buffer {
+.react-status-announcer-basic-buffer {
   width: var(--media-slider-buffer);
   background: rgb(255 255 255 / 30%);
 }
 
-.react-status-announcer-basic__fill {
+.react-status-announcer-basic-fill {
   width: var(--media-slider-fill);
   background: white;
 }
 
-.react-status-announcer-basic__thumb {
+.react-status-announcer-basic-thumb {
   position: absolute;
   left: var(--media-slider-fill);
   width: 14px;
@@ -97,7 +97,7 @@
   translate: -50%;
 }
 
-.react-status-announcer-basic__announcer {
+.react-status-announcer-basic-announcer {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/site/src/components/docs/demos/status-announcer/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/status-announcer/react/css/BasicUsage.tsx
@@ -18,35 +18,35 @@ export default function BasicUsage() {
     <Player>
       <Container className="react-status-announcer-basic">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline />
-        <p className="react-status-announcer-basic__instructions">
+        <p className="react-status-announcer-basic-instructions">
           These controls announce status changes to screen readers.
         </p>
-        <div className="react-status-announcer-basic__controls">
+        <div className="react-status-announcer-basic-controls">
           <PlayButton
-            className="react-status-announcer-basic__button"
+            className="react-status-announcer-basic-button"
             render={(props, state) => (
               <button {...props}>{state.ended ? 'Replay' : state.paused ? 'Play' : 'Pause'}</button>
             )}
           />
           <MuteButton
-            className="react-status-announcer-basic__button"
+            className="react-status-announcer-basic-button"
             render={(props, state) => <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>}
           />
-          <VolumeSlider.Root className="react-status-announcer-basic__volume-slider">
-            <VolumeSlider.Track className="react-status-announcer-basic__track">
-              <VolumeSlider.Fill className="react-status-announcer-basic__fill" />
+          <VolumeSlider.Root className="react-status-announcer-basic-volume-slider">
+            <VolumeSlider.Track className="react-status-announcer-basic-track">
+              <VolumeSlider.Fill className="react-status-announcer-basic-fill" />
             </VolumeSlider.Track>
-            <VolumeSlider.Thumb className="react-status-announcer-basic__thumb" />
+            <VolumeSlider.Thumb className="react-status-announcer-basic-thumb" />
           </VolumeSlider.Root>
         </div>
-        <TimeSlider.Root className="react-status-announcer-basic__time-slider">
-          <TimeSlider.Track className="react-status-announcer-basic__track">
-            <TimeSlider.Buffer className="react-status-announcer-basic__buffer" />
-            <TimeSlider.Fill className="react-status-announcer-basic__fill" />
+        <TimeSlider.Root className="react-status-announcer-basic-time-slider">
+          <TimeSlider.Track className="react-status-announcer-basic-track">
+            <TimeSlider.Buffer className="react-status-announcer-basic-buffer" />
+            <TimeSlider.Fill className="react-status-announcer-basic-fill" />
           </TimeSlider.Track>
-          <TimeSlider.Thumb className="react-status-announcer-basic__thumb" />
+          <TimeSlider.Thumb className="react-status-announcer-basic-thumb" />
         </TimeSlider.Root>
-        <StatusAnnouncer className="react-status-announcer-basic__announcer" />
+        <StatusAnnouncer className="react-status-announcer-basic-announcer" />
       </Container>
     </Player>
   );

--- a/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.css
@@ -12,7 +12,7 @@
   width: 100%;
 }
 
-.html-status-indicator-basic__instructions {
+.html-status-indicator-basic-instructions {
   position: absolute;
   top: 10px;
   right: 10px;
@@ -25,7 +25,7 @@
   border-radius: 4px;
 }
 
-.html-status-indicator-basic__indicator {
+.html-status-indicator-basic-indicator {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -43,65 +43,65 @@
     scale 160ms ease-in-out;
 }
 
-.html-status-indicator-basic__indicator::before {
+.html-status-indicator-basic-indicator::before {
   font-size: 28px;
   font-weight: 700;
   line-height: 1;
 }
 
-.html-status-indicator-basic__indicator[data-status="play"]::before {
+.html-status-indicator-basic-indicator[data-status="play"]::before {
   content: "▶";
 }
 
-.html-status-indicator-basic__indicator[data-status="pause"]::before {
+.html-status-indicator-basic-indicator[data-status="pause"]::before {
   content: "Ⅱ";
 }
 
-.html-status-indicator-basic__indicator[data-status="volume-off"]::before {
+.html-status-indicator-basic-indicator[data-status="volume-off"]::before {
   content: "🔇";
 }
 
-.html-status-indicator-basic__indicator[data-status="volume-low"]::before {
+.html-status-indicator-basic-indicator[data-status="volume-low"]::before {
   content: "🔉";
 }
 
-.html-status-indicator-basic__indicator[data-status="volume-high"]::before {
+.html-status-indicator-basic-indicator[data-status="volume-high"]::before {
   content: "🔊";
 }
 
-.html-status-indicator-basic__indicator[data-status="captions-on"]::before,
-.html-status-indicator-basic__indicator[data-status="captions-off"]::before {
+.html-status-indicator-basic-indicator[data-status="captions-on"]::before,
+.html-status-indicator-basic-indicator[data-status="captions-off"]::before {
   content: "CC";
 }
 
-.html-status-indicator-basic__indicator[data-status="captions-off"]::before {
+.html-status-indicator-basic-indicator[data-status="captions-off"]::before {
   text-decoration: line-through;
 }
 
-.html-status-indicator-basic__indicator[data-status="fullscreen"]::before {
+.html-status-indicator-basic-indicator[data-status="fullscreen"]::before {
   content: "⛶";
 }
 
-.html-status-indicator-basic__indicator[data-status="exit-fullscreen"]::before {
+.html-status-indicator-basic-indicator[data-status="exit-fullscreen"]::before {
   content: "⊠";
 }
 
-.html-status-indicator-basic__indicator[data-status="pip"]::before,
-.html-status-indicator-basic__indicator[data-status="exit-pip"]::before {
+.html-status-indicator-basic-indicator[data-status="pip"]::before,
+.html-status-indicator-basic-indicator[data-status="exit-pip"]::before {
   content: "▣";
 }
 
-.html-status-indicator-basic__indicator[data-status="exit-pip"]::before {
+.html-status-indicator-basic-indicator[data-status="exit-pip"]::before {
   text-decoration: line-through;
 }
 
-.html-status-indicator-basic__indicator[data-starting-style],
-.html-status-indicator-basic__indicator[data-ending-style] {
+.html-status-indicator-basic-indicator[data-starting-style],
+.html-status-indicator-basic-indicator[data-ending-style] {
   opacity: 0;
   scale: 0.85;
 }
 
-.html-status-indicator-basic__value {
+.html-status-indicator-basic-value {
   margin-top: 8px;
   font-variant-numeric: tabular-nums;
 }

--- a/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/status-indicator/html/css/BasicUsage.html
@@ -3,15 +3,15 @@
     <video src="{{VJS10_DEMO_VIDEO_MP4}}" autoplay muted playsinline loop>
       <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srclang="en" label="English" />
     </video>
-    <p class="html-status-indicator-basic__instructions">
+    <p class="html-status-indicator-basic-instructions">
       Focus the player · K: play/pause · M: mute · F: fullscreen · C: captions · I: picture-in-picture
     </p>
     <media-status-indicator
-      class="html-status-indicator-basic__indicator"
+      class="html-status-indicator-basic-indicator"
       actions="togglePaused toggleMuted toggleSubtitles toggleFullscreen togglePictureInPicture"
       aria-hidden="true"
     >
-      <media-status-indicator-value class="html-status-indicator-basic__value"></media-status-indicator-value>
+      <media-status-indicator-value class="html-status-indicator-basic-value"></media-status-indicator-value>
     </media-status-indicator>
     <media-hotkey keys="k" action="togglePaused"></media-hotkey>
     <media-hotkey keys="m" action="toggleMuted"></media-hotkey>

--- a/site/src/components/docs/demos/status-indicator/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/status-indicator/react/css/BasicUsage.css
@@ -12,7 +12,7 @@
   width: 100%;
 }
 
-.react-status-indicator-basic__instructions {
+.react-status-indicator-basic-instructions {
   position: absolute;
   top: 10px;
   right: 10px;
@@ -25,7 +25,7 @@
   border-radius: 4px;
 }
 
-.react-status-indicator-basic__indicator {
+.react-status-indicator-basic-indicator {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -43,65 +43,65 @@
     scale 160ms ease-in-out;
 }
 
-.react-status-indicator-basic__indicator::before {
+.react-status-indicator-basic-indicator::before {
   font-size: 28px;
   font-weight: 700;
   line-height: 1;
 }
 
-.react-status-indicator-basic__indicator[data-status="play"]::before {
+.react-status-indicator-basic-indicator[data-status="play"]::before {
   content: "▶";
 }
 
-.react-status-indicator-basic__indicator[data-status="pause"]::before {
+.react-status-indicator-basic-indicator[data-status="pause"]::before {
   content: "Ⅱ";
 }
 
-.react-status-indicator-basic__indicator[data-status="volume-off"]::before {
+.react-status-indicator-basic-indicator[data-status="volume-off"]::before {
   content: "🔇";
 }
 
-.react-status-indicator-basic__indicator[data-status="volume-low"]::before {
+.react-status-indicator-basic-indicator[data-status="volume-low"]::before {
   content: "🔉";
 }
 
-.react-status-indicator-basic__indicator[data-status="volume-high"]::before {
+.react-status-indicator-basic-indicator[data-status="volume-high"]::before {
   content: "🔊";
 }
 
-.react-status-indicator-basic__indicator[data-status="captions-on"]::before,
-.react-status-indicator-basic__indicator[data-status="captions-off"]::before {
+.react-status-indicator-basic-indicator[data-status="captions-on"]::before,
+.react-status-indicator-basic-indicator[data-status="captions-off"]::before {
   content: "CC";
 }
 
-.react-status-indicator-basic__indicator[data-status="captions-off"]::before {
+.react-status-indicator-basic-indicator[data-status="captions-off"]::before {
   text-decoration: line-through;
 }
 
-.react-status-indicator-basic__indicator[data-status="fullscreen"]::before {
+.react-status-indicator-basic-indicator[data-status="fullscreen"]::before {
   content: "⛶";
 }
 
-.react-status-indicator-basic__indicator[data-status="exit-fullscreen"]::before {
+.react-status-indicator-basic-indicator[data-status="exit-fullscreen"]::before {
   content: "⊠";
 }
 
-.react-status-indicator-basic__indicator[data-status="pip"]::before,
-.react-status-indicator-basic__indicator[data-status="exit-pip"]::before {
+.react-status-indicator-basic-indicator[data-status="pip"]::before,
+.react-status-indicator-basic-indicator[data-status="exit-pip"]::before {
   content: "▣";
 }
 
-.react-status-indicator-basic__indicator[data-status="exit-pip"]::before {
+.react-status-indicator-basic-indicator[data-status="exit-pip"]::before {
   text-decoration: line-through;
 }
 
-.react-status-indicator-basic__indicator[data-starting-style],
-.react-status-indicator-basic__indicator[data-ending-style] {
+.react-status-indicator-basic-indicator[data-starting-style],
+.react-status-indicator-basic-indicator[data-ending-style] {
   opacity: 0;
   scale: 0.85;
 }
 
-.react-status-indicator-basic__value {
+.react-status-indicator-basic-value {
   margin-top: 8px;
   font-variant-numeric: tabular-nums;
 }

--- a/site/src/components/docs/demos/status-indicator/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/status-indicator/react/css/BasicUsage.tsx
@@ -20,15 +20,15 @@ export default function BasicUsage() {
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop>
           <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
         </Video>
-        <p className="react-status-indicator-basic__instructions">
+        <p className="react-status-indicator-basic-instructions">
           Focus the player · K: play/pause · M: mute · F: fullscreen · C: captions · I: picture-in-picture
         </p>
         <StatusIndicator.Root
-          className="react-status-indicator-basic__indicator"
+          className="react-status-indicator-basic-indicator"
           actions={statusActions}
           aria-hidden="true"
         >
-          <StatusIndicator.Value className="react-status-indicator-basic__value" />
+          <StatusIndicator.Value className="react-status-indicator-basic-value" />
         </StatusIndicator.Root>
         <Hotkey keys="k" action="togglePaused" />
         <Hotkey keys="m" action="toggleMuted" />

--- a/site/src/components/docs/demos/time-slider/html/css/WithParts.css
+++ b/site/src/components/docs/demos/time-slider/html/css/WithParts.css
@@ -36,20 +36,24 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: var(--media-slider-buffer);
+  width: 100%;
   height: 100%;
   background: rgba(255, 255, 255, 0.4);
   border-radius: 9999px;
+  clip-path: inset(0 calc(100% - var(--media-slider-buffer)) 0 0 round 9999px);
+  transition: clip-path 100ms ease-out;
 }
 
 .media-slider-fill {
   position: absolute;
   top: 0;
   left: 0;
-  width: var(--media-slider-fill);
+  width: 100%;
   height: 100%;
   background: white;
   border-radius: 9999px;
+  clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round 9999px);
+  transition: clip-path 100ms ease-out;
 }
 
 .media-slider-thumb {
@@ -74,23 +78,23 @@
 }
 
 .media-time-slider[data-dragging] .media-slider-fill {
-  width: var(--media-slider-pointer);
+  clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round 9999px);
+  transition-duration: 0ms;
+}
+
+.media-slider-preview {
+  bottom: 100%;
+  margin-bottom: 6px;
 }
 
 .media-slider-value {
-  position: absolute;
-  bottom: 100%;
-  left: var(--media-slider-pointer);
   padding: 2px 6px;
-  margin-bottom: 6px;
   font-size: 12px;
   color: white;
   white-space: nowrap;
-  pointer-events: none;
   background: rgba(0, 0, 0, 0.8);
   border-radius: 4px;
   opacity: 0;
-  transform: translateX(-50%);
   transition: opacity 150ms ease;
 }
 

--- a/site/src/components/docs/demos/time-slider/html/css/WithParts.html
+++ b/site/src/components/docs/demos/time-slider/html/css/WithParts.html
@@ -7,7 +7,9 @@
         <media-slider-fill class="media-slider-fill"></media-slider-fill>
       </media-slider-track>
       <media-slider-thumb class="media-slider-thumb"></media-slider-thumb>
-      <media-slider-value type="pointer" class="media-slider-value"></media-slider-value>
+      <media-slider-preview class="media-slider-preview">
+        <media-slider-value type="pointer" class="media-slider-value"></media-slider-value>
+      </media-slider-preview>
     </media-time-slider>
   </media-container>
 </video-player>

--- a/site/src/components/docs/demos/time-slider/react/css/WithParts.css
+++ b/site/src/components/docs/demos/time-slider/react/css/WithParts.css
@@ -35,20 +35,24 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: var(--media-slider-buffer);
+  width: 100%;
   height: 100%;
   background: rgba(255, 255, 255, 0.4);
   border-radius: 9999px;
+  clip-path: inset(0 calc(100% - var(--media-slider-buffer)) 0 0 round 9999px);
+  transition: clip-path 100ms ease-out;
 }
 
 .media-slider-fill {
   position: absolute;
   top: 0;
   left: 0;
-  width: var(--media-slider-fill);
+  width: 100%;
   height: 100%;
   background: white;
   border-radius: 9999px;
+  clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round 9999px);
+  transition: clip-path 100ms ease-out;
 }
 
 .media-slider-thumb {
@@ -73,23 +77,23 @@
 }
 
 .media-time-slider[data-dragging] .media-slider-fill {
-  width: var(--media-slider-pointer);
+  clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round 9999px);
+  transition-duration: 0ms;
+}
+
+.media-slider-preview {
+  bottom: 100%;
+  margin-bottom: 6px;
 }
 
 .media-slider-value {
-  position: absolute;
-  bottom: 100%;
-  left: var(--media-slider-pointer);
   padding: 2px 6px;
-  margin-bottom: 6px;
   font-size: 12px;
   color: white;
   white-space: nowrap;
-  pointer-events: none;
   background: rgba(0, 0, 0, 0.8);
   border-radius: 4px;
   opacity: 0;
-  transform: translateX(-50%);
   transition: opacity 150ms ease;
 }
 

--- a/site/src/components/docs/demos/time-slider/react/css/WithParts.tsx
+++ b/site/src/components/docs/demos/time-slider/react/css/WithParts.tsx
@@ -14,7 +14,9 @@ export default function WithParts() {
             <TimeSlider.Fill className="media-slider-fill" />
           </TimeSlider.Track>
           <TimeSlider.Thumb className="media-slider-thumb" />
-          <TimeSlider.Value type="pointer" className="media-slider-value" />
+          <TimeSlider.Preview className="media-slider-preview">
+            <TimeSlider.Value type="pointer" className="media-slider-value" />
+          </TimeSlider.Preview>
         </TimeSlider.Root>
       </Container>
     </Player>

--- a/site/src/components/docs/demos/title/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/title/html/css/BasicUsage.css
@@ -10,7 +10,7 @@
 
 /* The element sets native `hidden` until a title resolves, so the gradient
    never sits over empty space without this demo doing anything. */
-.html-title-basic__title {
+.html-title-basic-title {
   position: absolute;
   inset-inline: 0;
   top: 0;
@@ -23,7 +23,7 @@
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent);
 }
 
-.html-title-basic__button {
+.html-title-basic-button {
   position: absolute;
   bottom: 10px;
   left: 10px;
@@ -37,18 +37,18 @@
   backdrop-filter: blur(10px);
 }
 
-.html-title-basic__button .show-when-paused {
+.html-title-basic-button .show-when-paused {
   display: none;
 }
 
-.html-title-basic__button .show-when-playing {
+.html-title-basic-button .show-when-playing {
   display: none;
 }
 
-.html-title-basic__button[data-paused] .show-when-paused {
+.html-title-basic-button[data-paused] .show-when-paused {
   display: inline;
 }
 
-.html-title-basic__button:not([data-paused]) .show-when-playing {
+.html-title-basic-button:not([data-paused]) .show-when-playing {
   display: inline;
 }

--- a/site/src/components/docs/demos/title/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/title/html/css/BasicUsage.html
@@ -1,8 +1,8 @@
 <video-player content-title="Big Buck Bunny">
   <media-container class="html-title-basic">
     <video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline loop></video>
-    <media-title class="html-title-basic__title"></media-title>
-    <media-play-button class="html-title-basic__button">
+    <media-title class="html-title-basic-title"></media-title>
+    <media-play-button class="html-title-basic-button">
       <span class="show-when-paused">Play</span>
       <span class="show-when-playing">Pause</span>
     </media-play-button>

--- a/site/src/components/docs/demos/title/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/title/react/css/BasicUsage.css
@@ -10,7 +10,7 @@
 
 /* React renders nothing until a title resolves, so the gradient never sits
    over empty space without this demo doing anything. */
-.react-title-basic__title {
+.react-title-basic-title {
   position: absolute;
   inset-inline: 0;
   top: 0;
@@ -23,7 +23,7 @@
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent);
 }
 
-.react-title-basic__button {
+.react-title-basic-button {
   position: absolute;
   bottom: 10px;
   left: 10px;

--- a/site/src/components/docs/demos/title/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/title/react/css/BasicUsage.tsx
@@ -10,9 +10,9 @@ export default function BasicUsage() {
     <Player title="Big Buck Bunny">
       <Container className="react-title-basic">
         <Video loop muted playsInline src="{{VJS10_DEMO_VIDEO_MP4}}" />
-        <Title className="react-title-basic__title" />
+        <Title className="react-title-basic-title" />
         <PlayButton
-          className="react-title-basic__button"
+          className="react-title-basic-button"
           render={(props, state) => <button {...props}>{state.paused ? 'Play' : 'Pause'}</button>}
         />
       </Container>

--- a/site/src/components/docs/demos/use-locale/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/use-locale/react/css/BasicUsage.css
@@ -5,7 +5,7 @@
 }
 
 .react-use-locale-basic label,
-.react-use-locale-basic__output div {
+.react-use-locale-basic-output div {
   display: flex;
   gap: 8px;
   align-items: center;
@@ -15,16 +15,16 @@
   padding: 4px 8px;
 }
 
-.react-use-locale-basic__output {
+.react-use-locale-basic-output {
   display: grid;
   gap: 8px;
   margin: 0;
 }
 
-.react-use-locale-basic__output dt {
+.react-use-locale-basic-output dt {
   color: #6b7280;
 }
 
-.react-use-locale-basic__output dd {
+.react-use-locale-basic-output dd {
   margin: 0;
 }

--- a/site/src/components/docs/demos/use-locale/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/use-locale/react/css/BasicUsage.tsx
@@ -15,7 +15,7 @@ function LocaleDetails() {
   }).format(new Date('2026-01-15T12:00:00Z'));
 
   return (
-    <dl className="react-use-locale-basic__output">
+    <dl className="react-use-locale-basic-output">
       <div>
         <dt>Active locale</dt>
         <dd>{locale}</dd>

--- a/site/src/components/docs/demos/use-translator/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/use-translator/react/css/BasicUsage.css
@@ -5,7 +5,7 @@
 }
 
 .react-use-translator-basic label,
-.react-use-translator-basic__output div {
+.react-use-translator-basic-output div {
   display: flex;
   gap: 8px;
   align-items: center;
@@ -15,16 +15,16 @@
   padding: 4px 8px;
 }
 
-.react-use-translator-basic__output {
+.react-use-translator-basic-output {
   display: grid;
   gap: 8px;
   margin: 0;
 }
 
-.react-use-translator-basic__output dt {
+.react-use-translator-basic-output dt {
   color: #6b7280;
 }
 
-.react-use-translator-basic__output dd {
+.react-use-translator-basic-output dd {
   margin: 0;
 }

--- a/site/src/components/docs/demos/use-translator/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/use-translator/react/css/BasicUsage.tsx
@@ -20,7 +20,7 @@ function Labels() {
   const t = useTranslator();
 
   return (
-    <dl className="react-use-translator-basic__output">
+    <dl className="react-use-translator-basic-output">
       <div>
         <dt>Button</dt>
         <dd>{t('buttons.play', { default: 'Play' })}</dd>

--- a/site/src/components/docs/demos/video/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/video/html/css/BasicUsage.css
@@ -5,7 +5,7 @@
   border-radius: 8px;
 }
 
-.html-video-basic__media {
+.html-video-basic-media {
   display: block;
   width: 100%;
   aspect-ratio: 16 / 9;

--- a/site/src/components/docs/demos/video/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/video/html/css/BasicUsage.html
@@ -1,6 +1,6 @@
 <video-player>
   <media-container class="html-video-basic">
-    <video class="html-video-basic__media" controls playsinline preload="metadata">
+    <video class="html-video-basic-media" controls playsinline preload="metadata">
       <source src="{{VJS10_DEMO_VIDEO_MP4}}" type="video/mp4" />
       <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srclang="en" label="English" />
     </video>

--- a/site/src/components/docs/demos/video/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/video/react/css/BasicUsage.css
@@ -5,7 +5,7 @@
   border-radius: 8px;
 }
 
-.react-video-basic__media {
+.react-video-basic-media {
   display: block;
   width: 100%;
   aspect-ratio: 16 / 9;

--- a/site/src/components/docs/demos/video/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/video/react/css/BasicUsage.tsx
@@ -7,7 +7,7 @@ export default function BasicUsage() {
   return (
     <VideoPlayer>
       <Container className="react-video-basic">
-        <Video className="react-video-basic__media" controls playsInline preload="metadata">
+        <Video className="react-video-basic-media" controls playsInline preload="metadata">
           <source src="{{VJS10_DEMO_VIDEO_MP4}}" type="video/mp4" />
           <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
         </Video>

--- a/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.css
@@ -12,7 +12,7 @@
   width: 100%;
 }
 
-.html-volume-indicator-basic__instructions {
+.html-volume-indicator-basic-instructions {
   position: absolute;
   top: 10px;
   left: 50%;
@@ -25,7 +25,7 @@
   translate: -50%;
 }
 
-.html-volume-indicator-basic__indicator {
+.html-volume-indicator-basic-indicator {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -43,25 +43,25 @@
     scale 160ms ease-in-out;
 }
 
-.html-volume-indicator-basic__indicator::before {
+.html-volume-indicator-basic-indicator::before {
   margin-bottom: 12px;
   font-size: 28px;
   line-height: 1;
 }
 
-.html-volume-indicator-basic__indicator[data-level="off"]::before {
+.html-volume-indicator-basic-indicator[data-level="off"]::before {
   content: "🔇";
 }
 
-.html-volume-indicator-basic__indicator[data-level="low"]::before {
+.html-volume-indicator-basic-indicator[data-level="low"]::before {
   content: "🔉";
 }
 
-.html-volume-indicator-basic__indicator[data-level="high"]::before {
+.html-volume-indicator-basic-indicator[data-level="high"]::before {
   content: "🔊";
 }
 
-.html-volume-indicator-basic__fill {
+.html-volume-indicator-basic-fill {
   position: relative;
   width: 180px;
   height: 10px;
@@ -69,7 +69,7 @@
   border-radius: 9999px;
 }
 
-.html-volume-indicator-basic__fill::before {
+.html-volume-indicator-basic-fill::before {
   position: absolute;
   inset-block: 0;
   left: 0;
@@ -80,7 +80,7 @@
   transition: width 160ms linear;
 }
 
-.html-volume-indicator-basic__value {
+.html-volume-indicator-basic-value {
   position: absolute;
   top: calc(100% + 6px);
   left: 50%;
@@ -88,15 +88,15 @@
   translate: -50%;
 }
 
-.html-volume-indicator-basic__indicator[data-starting-style],
-.html-volume-indicator-basic__indicator[data-ending-style] {
+.html-volume-indicator-basic-indicator[data-starting-style],
+.html-volume-indicator-basic-indicator[data-ending-style] {
   opacity: 0;
   scale: 0.85;
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .html-volume-indicator-basic__indicator[data-min],
-  .html-volume-indicator-basic__indicator[data-max] {
+  .html-volume-indicator-basic-indicator[data-min],
+  .html-volume-indicator-basic-indicator[data-max] {
     animation: html-volume-indicator-basic-shake 300ms linear;
   }
 }

--- a/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/volume-indicator/html/css/BasicUsage.html
@@ -1,10 +1,10 @@
 <video-player>
   <media-container class="html-volume-indicator-basic" tabindex="0">
     <video src="{{VJS10_DEMO_VIDEO_MP4}}" autoplay muted playsinline loop></video>
-    <p class="html-volume-indicator-basic__instructions">Focus the player · M: mute · ↑/↓: volume ±5%</p>
-    <media-volume-indicator class="html-volume-indicator-basic__indicator" aria-hidden="true">
-      <media-volume-indicator-fill class="html-volume-indicator-basic__fill">
-        <media-volume-indicator-value class="html-volume-indicator-basic__value"></media-volume-indicator-value>
+    <p class="html-volume-indicator-basic-instructions">Focus the player · M: mute · ↑/↓: volume ±5%</p>
+    <media-volume-indicator class="html-volume-indicator-basic-indicator" aria-hidden="true">
+      <media-volume-indicator-fill class="html-volume-indicator-basic-fill">
+        <media-volume-indicator-value class="html-volume-indicator-basic-value"></media-volume-indicator-value>
       </media-volume-indicator-fill>
     </media-volume-indicator>
     <media-hotkey keys="m" action="toggleMuted"></media-hotkey>

--- a/site/src/components/docs/demos/volume-indicator/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/volume-indicator/react/css/BasicUsage.css
@@ -12,7 +12,7 @@
   width: 100%;
 }
 
-.react-volume-indicator-basic__instructions {
+.react-volume-indicator-basic-instructions {
   position: absolute;
   top: 10px;
   left: 50%;
@@ -25,7 +25,7 @@
   translate: -50%;
 }
 
-.react-volume-indicator-basic__indicator {
+.react-volume-indicator-basic-indicator {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -43,25 +43,25 @@
     scale 160ms ease-in-out;
 }
 
-.react-volume-indicator-basic__indicator::before {
+.react-volume-indicator-basic-indicator::before {
   margin-bottom: 12px;
   font-size: 28px;
   line-height: 1;
 }
 
-.react-volume-indicator-basic__indicator[data-level="off"]::before {
+.react-volume-indicator-basic-indicator[data-level="off"]::before {
   content: "🔇";
 }
 
-.react-volume-indicator-basic__indicator[data-level="low"]::before {
+.react-volume-indicator-basic-indicator[data-level="low"]::before {
   content: "🔉";
 }
 
-.react-volume-indicator-basic__indicator[data-level="high"]::before {
+.react-volume-indicator-basic-indicator[data-level="high"]::before {
   content: "🔊";
 }
 
-.react-volume-indicator-basic__fill {
+.react-volume-indicator-basic-fill {
   position: relative;
   width: 180px;
   height: 10px;
@@ -69,7 +69,7 @@
   border-radius: 9999px;
 }
 
-.react-volume-indicator-basic__fill::before {
+.react-volume-indicator-basic-fill::before {
   position: absolute;
   inset-block: 0;
   left: 0;
@@ -80,7 +80,7 @@
   transition: width 160ms linear;
 }
 
-.react-volume-indicator-basic__value {
+.react-volume-indicator-basic-value {
   position: absolute;
   top: calc(100% + 6px);
   left: 50%;
@@ -88,15 +88,15 @@
   translate: -50%;
 }
 
-.react-volume-indicator-basic__indicator[data-starting-style],
-.react-volume-indicator-basic__indicator[data-ending-style] {
+.react-volume-indicator-basic-indicator[data-starting-style],
+.react-volume-indicator-basic-indicator[data-ending-style] {
   opacity: 0;
   scale: 0.85;
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .react-volume-indicator-basic__indicator[data-min],
-  .react-volume-indicator-basic__indicator[data-max] {
+  .react-volume-indicator-basic-indicator[data-min],
+  .react-volume-indicator-basic-indicator[data-max] {
     animation: react-volume-indicator-basic-shake 300ms linear;
   }
 }

--- a/site/src/components/docs/demos/volume-indicator/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/volume-indicator/react/css/BasicUsage.tsx
@@ -19,10 +19,10 @@ export default function BasicUsage() {
           playsInline
           loop
         />
-        <p className="react-volume-indicator-basic__instructions">Focus the player · M: mute · ↑/↓: volume ±5%</p>
-        <VolumeIndicator.Root className="react-volume-indicator-basic__indicator" aria-hidden="true">
-          <VolumeIndicator.Fill className="react-volume-indicator-basic__fill">
-            <VolumeIndicator.Value className="react-volume-indicator-basic__value" />
+        <p className="react-volume-indicator-basic-instructions">Focus the player · M: mute · ↑/↓: volume ±5%</p>
+        <VolumeIndicator.Root className="react-volume-indicator-basic-indicator" aria-hidden="true">
+          <VolumeIndicator.Fill className="react-volume-indicator-basic-fill">
+            <VolumeIndicator.Value className="react-volume-indicator-basic-value" />
           </VolumeIndicator.Fill>
         </VolumeIndicator.Root>
         <Hotkey keys="m" action="toggleMuted" />

--- a/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.css
@@ -7,13 +7,13 @@
   width: 100%;
 }
 
-.html-volume-popover-basic__controls {
+.html-volume-popover-basic-controls {
   position: absolute;
   bottom: 10px;
   left: 10px;
 }
 
-.html-volume-popover-basic__trigger {
+.html-volume-popover-basic-trigger {
   padding: 8px 20px;
   color: black;
   cursor: pointer;
@@ -23,17 +23,17 @@
   backdrop-filter: blur(10px);
 }
 
-.html-volume-popover-basic__trigger .muted,
-.html-volume-popover-basic__trigger .unmuted {
+.html-volume-popover-basic-trigger .muted,
+.html-volume-popover-basic-trigger .unmuted {
   display: none;
 }
 
-.html-volume-popover-basic__trigger[data-muted] .muted,
-.html-volume-popover-basic__trigger:not([data-muted]) .unmuted {
+.html-volume-popover-basic-trigger[data-muted] .muted,
+.html-volume-popover-basic-trigger:not([data-muted]) .unmuted {
   display: inline;
 }
 
-.html-volume-popover-basic__popup {
+.html-volume-popover-basic-popup {
   --media-popover-side-offset: 8px;
   width: 40px;
   height: 120px;
@@ -44,7 +44,7 @@
   border-radius: 8px;
 }
 
-.html-volume-popover-basic__slider {
+.html-volume-popover-basic-slider {
   position: relative;
   display: block;
   width: 16px;
@@ -53,7 +53,7 @@
   cursor: pointer;
 }
 
-.html-volume-popover-basic__track {
+.html-volume-popover-basic-track {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -63,7 +63,7 @@
   border-radius: 9999px;
 }
 
-.html-volume-popover-basic__fill {
+.html-volume-popover-basic-fill {
   position: absolute;
   right: 0;
   bottom: 0;
@@ -73,7 +73,7 @@
   border-radius: inherit;
 }
 
-.html-volume-popover-basic__thumb {
+.html-volume-popover-basic-thumb {
   position: absolute;
   bottom: var(--media-slider-fill);
   left: 1px;

--- a/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/volume-popover/html/css/BasicUsage.html
@@ -1,17 +1,17 @@
 <video-player class="html-volume-popover-basic">
   <media-container>
     <video src="{{VJS10_DEMO_VIDEO_MP4}}" autoplay muted playsinline loop></video>
-    <div class="html-volume-popover-basic__controls">
-      <media-mute-button commandfor="volume-popover-demo" class="html-volume-popover-basic__trigger">
+    <div class="html-volume-popover-basic-controls">
+      <media-mute-button commandfor="volume-popover-demo" class="html-volume-popover-basic-trigger">
         <span class="muted">Unmute</span>
         <span class="unmuted">Mute</span>
       </media-mute-button>
-      <media-volume-popover id="volume-popover-demo" open-on-hover side="top" class="html-volume-popover-basic__popup">
-        <media-volume-slider orientation="vertical" class="html-volume-popover-basic__slider">
-          <media-slider-track class="html-volume-popover-basic__track">
-            <media-slider-fill class="html-volume-popover-basic__fill"></media-slider-fill>
+      <media-volume-popover id="volume-popover-demo" open-on-hover side="top" class="html-volume-popover-basic-popup">
+        <media-volume-slider orientation="vertical" class="html-volume-popover-basic-slider">
+          <media-slider-track class="html-volume-popover-basic-track">
+            <media-slider-fill class="html-volume-popover-basic-fill"></media-slider-fill>
           </media-slider-track>
-          <media-slider-thumb class="html-volume-popover-basic__thumb"></media-slider-thumb>
+          <media-slider-thumb class="html-volume-popover-basic-thumb"></media-slider-thumb>
         </media-volume-slider>
       </media-volume-popover>
     </div>

--- a/site/src/components/docs/demos/volume-popover/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/volume-popover/react/css/BasicUsage.css
@@ -6,13 +6,13 @@
   width: 100%;
 }
 
-.react-volume-popover-basic__controls {
+.react-volume-popover-basic-controls {
   position: absolute;
   bottom: 10px;
   left: 10px;
 }
 
-.react-volume-popover-basic__trigger {
+.react-volume-popover-basic-trigger {
   padding: 8px 20px;
   color: black;
   cursor: pointer;
@@ -22,7 +22,7 @@
   backdrop-filter: blur(10px);
 }
 
-.react-volume-popover-basic__popup {
+.react-volume-popover-basic-popup {
   --media-popover-side-offset: 8px;
   width: 40px;
   height: 120px;
@@ -33,7 +33,7 @@
   border-radius: 8px;
 }
 
-.react-volume-popover-basic__slider {
+.react-volume-popover-basic-slider {
   position: relative;
   width: 16px;
   height: 96px;
@@ -41,7 +41,7 @@
   cursor: pointer;
 }
 
-.react-volume-popover-basic__track {
+.react-volume-popover-basic-track {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -51,7 +51,7 @@
   border-radius: 9999px;
 }
 
-.react-volume-popover-basic__fill {
+.react-volume-popover-basic-fill {
   position: absolute;
   right: 0;
   bottom: 0;
@@ -61,7 +61,7 @@
   border-radius: inherit;
 }
 
-.react-volume-popover-basic__thumb {
+.react-volume-popover-basic-thumb {
   position: absolute;
   bottom: var(--media-slider-fill);
   left: 1px;

--- a/site/src/components/docs/demos/volume-popover/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/volume-popover/react/css/BasicUsage.tsx
@@ -8,20 +8,20 @@ export default function BasicUsage() {
     <Player>
       <Container className="react-volume-popover-basic">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
-        <div className="react-volume-popover-basic__controls">
+        <div className="react-volume-popover-basic-controls">
           <VolumePopover.Root openOnHover side="top">
             <VolumePopover.Trigger
-              className="react-volume-popover-basic__trigger"
+              className="react-volume-popover-basic-trigger"
               render={
                 <MuteButton render={(props, state) => <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>} />
               }
             />
-            <VolumePopover.Popup className="react-volume-popover-basic__popup">
-              <VolumeSlider.Root orientation="vertical" className="react-volume-popover-basic__slider">
-                <VolumeSlider.Track className="react-volume-popover-basic__track">
-                  <VolumeSlider.Fill className="react-volume-popover-basic__fill" />
+            <VolumePopover.Popup className="react-volume-popover-basic-popup">
+              <VolumeSlider.Root orientation="vertical" className="react-volume-popover-basic-slider">
+                <VolumeSlider.Track className="react-volume-popover-basic-track">
+                  <VolumeSlider.Fill className="react-volume-popover-basic-fill" />
                 </VolumeSlider.Track>
-                <VolumeSlider.Thumb className="react-volume-popover-basic__thumb" />
+                <VolumeSlider.Thumb className="react-volume-popover-basic-thumb" />
               </VolumeSlider.Root>
             </VolumePopover.Popup>
           </VolumePopover.Root>

--- a/site/src/components/docs/demos/volume-slider/html/css/WithParts.css
+++ b/site/src/components/docs/demos/volume-slider/html/css/WithParts.css
@@ -64,10 +64,12 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: var(--media-slider-fill);
+  width: 100%;
   height: 100%;
   background: white;
   border-radius: 9999px;
+  clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round 9999px);
+  transition: clip-path 100ms ease-out;
 }
 
 .media-slider-thumb {
@@ -90,20 +92,24 @@
   transform: translateX(-50%) scale(1.1);
 }
 
-.media-slider-value {
-  position: absolute;
+.media-volume-slider[data-dragging] .media-slider-fill {
+  clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round 9999px);
+  transition-duration: 0ms;
+}
+
+.media-slider-preview {
   bottom: 100%;
-  left: var(--media-slider-pointer);
-  padding: 2px 6px;
   margin-bottom: 6px;
+}
+
+.media-slider-value {
+  padding: 2px 6px;
   font-size: 12px;
   color: white;
   white-space: nowrap;
-  pointer-events: none;
   background: rgba(0, 0, 0, 0.8);
   border-radius: 4px;
   opacity: 0;
-  transform: translateX(-50%);
   transition: opacity 150ms ease;
 }
 

--- a/site/src/components/docs/demos/volume-slider/html/css/WithParts.html
+++ b/site/src/components/docs/demos/volume-slider/html/css/WithParts.html
@@ -10,7 +10,9 @@
         <media-slider-fill class="media-slider-fill"></media-slider-fill>
       </media-slider-track>
       <media-slider-thumb class="media-slider-thumb"></media-slider-thumb>
-      <media-slider-value type="pointer" class="media-slider-value"></media-slider-value>
+      <media-slider-preview class="media-slider-preview">
+        <media-slider-value type="pointer" class="media-slider-value"></media-slider-value>
+      </media-slider-preview>
     </media-volume-slider>
   </media-container>
 </video-player>

--- a/site/src/components/docs/demos/volume-slider/react/css/WithParts.css
+++ b/site/src/components/docs/demos/volume-slider/react/css/WithParts.css
@@ -50,10 +50,12 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: var(--media-slider-fill);
+  width: 100%;
   height: 100%;
   background: white;
   border-radius: 9999px;
+  clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round 9999px);
+  transition: clip-path 100ms ease-out;
 }
 
 .media-slider-thumb {
@@ -76,20 +78,24 @@
   transform: translateX(-50%) scale(1.1);
 }
 
-.media-slider-value {
-  position: absolute;
+.media-volume-slider[data-dragging] .media-slider-fill {
+  clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round 9999px);
+  transition-duration: 0ms;
+}
+
+.media-slider-preview {
   bottom: 100%;
-  left: var(--media-slider-pointer);
-  padding: 2px 6px;
   margin-bottom: 6px;
+}
+
+.media-slider-value {
+  padding: 2px 6px;
   font-size: 12px;
   color: white;
   white-space: nowrap;
-  pointer-events: none;
   background: rgba(0, 0, 0, 0.8);
   border-radius: 4px;
   opacity: 0;
-  transform: translateX(-50%);
   transition: opacity 150ms ease;
 }
 

--- a/site/src/components/docs/demos/volume-slider/react/css/WithParts.tsx
+++ b/site/src/components/docs/demos/volume-slider/react/css/WithParts.tsx
@@ -17,7 +17,9 @@ export default function WithParts() {
             <VolumeSlider.Fill className="media-slider-fill" />
           </VolumeSlider.Track>
           <VolumeSlider.Thumb className="media-slider-thumb" />
-          <VolumeSlider.Value type="pointer" className="media-slider-value" />
+          <VolumeSlider.Preview className="media-slider-preview">
+            <VolumeSlider.Value type="pointer" className="media-slider-value" />
+          </VolumeSlider.Preview>
         </VolumeSlider.Root>
       </Container>
     </Player>

--- a/site/src/components/docs/skins/SkinGuide.astro
+++ b/site/src/components/docs/skins/SkinGuide.astro
@@ -2,6 +2,7 @@
 import ServerCode from '@/components/Code/ServerCode.astro';
 import Aside from '@/components/Aside.astro';
 import DocsLink from '@/components/docs/DocsLink.astro';
+import RegistryInstall from '@/components/docs/RegistryInstall.astro';
 import MinimalFrame from '@/components/frames/Minimal.astro';
 import { Tab, TabsList, TabsPanel, TabsRoot } from '@/components/Tabs.tsx';
 import H2 from '@/components/typography/H2.astro';
@@ -9,6 +10,7 @@ import Li from '@/components/typography/Li.astro';
 import MarkdownCode from '@/components/typography/MarkdownCode.astro';
 import P from '@/components/typography/P.astro';
 import Ul from '@/components/typography/Ul.astro';
+import { isValidFramework } from '@/types/docs';
 import SkinPreview from './SkinPreview';
 import SkinPreviewHtml from './SkinPreviewHtml.astro';
 import type { SkinGuideDefinition } from './skinGuides';
@@ -19,6 +21,8 @@ interface Props {
 
 const { definition } = Astro.props;
 const framework = Astro.params.framework;
+if (!isValidFramework(framework)) throw new Error(`Unsupported framework: ${framework ?? 'missing'}.`);
+
 const live = definition.preset.startsWith('live-');
 const packageName = `@videojs/${framework}/${definition.preset}`;
 const stylesheet = `${packageName}/${definition.htmlRegistration}.css`;
@@ -80,6 +84,7 @@ const usage = definition.preset === 'background'
   : framework === 'react'
     ? reactUsage
     : htmlUsage;
+const registryItem = `${definition.preset}${definition.variant === 'minimal' ? '-minimal' : ''}`;
 ---
 
 <P>{definition.when}</P>
@@ -104,6 +109,18 @@ const usage = definition.preset === 'background'
     <ServerCode code={usage} lang={framework === "react" ? "tsx" : "html"} />
   </TabsPanel>
 </TabsRoot>
+
+{
+  definition.preset !== "background" ? (
+    <>
+      <H2 id="install-editable-source">Install editable source</H2>
+      <P>
+        Install this Skin and its exact dependencies with Shadcn, or copy the same generated files manually. The Player and media remain package imports.
+      </P>
+      <RegistryInstall framework={framework} item={registryItem} />
+    </>
+  ) : null
+}
 
 <H2 id="customize-the-skin">Customize the skin</H2>
 

--- a/site/src/content/docs/concepts/overview.mdx
+++ b/site/src/content/docs/concepts/overview.mdx
@@ -108,7 +108,7 @@ If you want more control than a packaged skin offers, build your own UI from our
 ```
 </FrameworkCase>
 
-The easiest way to get started is to <DocsLink slug="how-to/customize-skins">install the closest skin's editable source</DocsLink> and use its pre-styled components as a foundation.
+The easiest way to get started is to <DocsLink slug="getting-started/shadcn">install the closest skin's editable source</DocsLink> and use its pre-styled components as a foundation.
 
 <DocsLinkCard slug="concepts/ui-components">Learn more about UI components</DocsLinkCard>
 <DocsLinkCard slug="how-to/build-your-own-component">Build your own component</DocsLinkCard>

--- a/site/src/content/docs/concepts/presets.mdx
+++ b/site/src/content/docs/concepts/presets.mdx
@@ -149,7 +149,7 @@ function Hero() {
 
 ### Own the skin source
 
-If a preset's skin is close but not quite right, <DocsLink slug="how-to/customize-skins">install its editable source</DocsLink> from the Video.js Shadcn registry and customize it in your project.
+If a preset's skin is close but not quite right, <DocsLink slug="getting-started/shadcn">install its editable source</DocsLink> from the Video.js Shadcn registry and customize it in your project.
 
 ### Swap the media element
 

--- a/site/src/content/docs/concepts/skins.mdx
+++ b/site/src/content/docs/concepts/skins.mdx
@@ -118,7 +118,7 @@ Either way the styles travel inside the skin's JavaScript and apply when the ele
 
 </FrameworkCase>
 
-To use Tailwind or change the underlying CSS, [install the skin source](../how-to/customize-skins#install-an-editable-skin) and edit its styles in your app.
+To use Tailwind or change the underlying CSS, <DocsLink slug="getting-started/shadcn">install the skin source</DocsLink> and edit its styles in your app.
 
 ### Shared limitations
 
@@ -127,7 +127,7 @@ To use Tailwind or change the underlying CSS, [install the skin source](../how-t
 
 ### Source-owned vanilla CSS
 
-- We use a [BEM](https://en.bem.info/methodology/quick-start/) classname structure and every component classname is scoped with a `media-` prefix.
+- Generated component and part classes use semantic `media-`-prefixed names so styles remain readable and locally scoped.
 
 ### Source-owned Tailwind
 

--- a/site/src/content/docs/how-to/build-your-own-component.mdx
+++ b/site/src/content/docs/how-to/build-your-own-component.mdx
@@ -17,12 +17,12 @@ Before building from scratch, check if an existing approach covers your use case
 <FrameworkCase frameworks={["react"]}>
 - **Change what a control renders**: use the `render` prop on any built-in component. See <DocsLink slug="concepts/ui-components">UI components</DocsLink>.
 - **Restyle a control**: use CSS custom properties and data attributes. See <DocsLink slug="concepts/ui-components">UI components</DocsLink>.
-- **Rearrange or remove controls**: install a skin's editable source and modify it. See <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>.
+- **Rearrange or remove controls**: <DocsLink slug="getting-started/shadcn">install a skin's editable source</DocsLink> and modify it.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
 - **Restyle a control**: use CSS custom properties and data attributes. See <DocsLink slug="concepts/ui-components">UI components</DocsLink>.
-- **Rearrange or remove controls**: install a skin's editable source and modify it. See <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>.
+- **Rearrange or remove controls**: <DocsLink slug="getting-started/shadcn">install a skin's editable source</DocsLink> and modify it.
 </FrameworkCase>
 
 Build a custom component when you need new behavior, a new state display, or integration with an external system.
@@ -448,7 +448,7 @@ Use CSS custom properties and data attributes. See <DocsLink slug="concepts/ui-c
 
 ### Rearrange or remove controls
 
-Eject a skin and modify it. See <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>.
+<DocsLink slug="getting-started/shadcn">Install a skin's source from the Shadcn registry</DocsLink> and modify it.
 
 ## Troubleshooting
 

--- a/site/src/content/docs/how-to/customize-skins.mdx
+++ b/site/src/content/docs/how-to/customize-skins.mdx
@@ -102,14 +102,14 @@ The hosted Video.js registry installs a complete skin and its dependencies into 
 
 The same item name works for React or HTML and Tailwind or CSS; the configured namespace URL chooses the catalog. Add `-minimal` for the Minimal layout, for example `@videojs/video-minimal`. Audio and live presets follow the same pattern.
 
-- <DocsLink slug="skins/default-video">VideoSkin</DocsLink>
-- <DocsLink slug="skins/minimal-video">MinimalVideoSkin</DocsLink>
-- <DocsLink slug="skins/default-audio">AudioSkin</DocsLink>
-- <DocsLink slug="skins/minimal-audio">MinimalAudioSkin</DocsLink>
-- <DocsLink slug="skins/default-live-video">LiveVideoSkin</DocsLink>
-- <DocsLink slug="skins/minimal-live-video">MinimalLiveVideoSkin</DocsLink>
-- <DocsLink slug="skins/default-live-audio">LiveAudioSkin</DocsLink>
-- <DocsLink slug="skins/minimal-live-audio">MinimalLiveAudioSkin</DocsLink>
+- <DocsLink slug="reference/video-skin">VideoSkin</DocsLink>
+- <DocsLink slug="reference/minimal-video-skin">MinimalVideoSkin</DocsLink>
+- <DocsLink slug="reference/audio-skin">AudioSkin</DocsLink>
+- <DocsLink slug="reference/minimal-audio-skin">MinimalAudioSkin</DocsLink>
+- <DocsLink slug="reference/live-video-skin">LiveVideoSkin</DocsLink>
+- <DocsLink slug="reference/minimal-live-video-skin">MinimalLiveVideoSkin</DocsLink>
+- <DocsLink slug="reference/live-audio-skin">LiveAudioSkin</DocsLink>
+- <DocsLink slug="reference/minimal-live-audio-skin">MinimalLiveAudioSkin</DocsLink>
 
 If none of the provided skins is a useful starting point, build a custom UI from the player, container, and individual <DocsLink slug="concepts/ui-components">UI components</DocsLink> instead.
 

--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -40,10 +40,10 @@ This guide has interactive examples tailored to the selected framework, preset, 
 </div>
 
 <FrameworkCase frameworks={["react"]}>
-If your user's requirements can't be met by a packaged preset or skin, [install its editable source](/docs/framework/react/how-to/customize-skins). As you develop with Video.js, rely heavily on [llms.txt](/docs/framework/react/llms.txt) to make sure you always have the latest information.
+If your user's requirements can't be met by a packaged preset or skin, [install its editable source](/docs/framework/react/getting-started/shadcn). As you develop with Video.js, rely heavily on [llms.txt](/docs/framework/react/llms.txt) to make sure you always have the latest information.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
-If your user's requirements can't be met by a packaged preset or skin, [install its editable source](/docs/framework/html/how-to/customize-skins). As you develop with Video.js, rely heavily on [llms.txt](/docs/framework/html/llms.txt) to make sure you always have the latest information.
+If your user's requirements can't be met by a packaged preset or skin, [install its editable source](/docs/framework/html/getting-started/shadcn). As you develop with Video.js, rely heavily on [llms.txt](/docs/framework/html/llms.txt) to make sure you always have the latest information.
 </FrameworkCase>
 </LLMCase>
 

--- a/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
+++ b/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
@@ -284,7 +284,7 @@ The packaged Video.js skins expose `--media-accent-color`, `--media-accent-text-
 
 ## Themes become skins
 
-Media Chrome's `<template>`-based themes (`media-theme`) become Video.js <DocsLink slug="concepts/skins">skins</DocsLink> and <DocsLink slug="concepts/presets">presets</DocsLink>. Start from a preset, then install and customize its source with <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>, rather than authoring a template.
+Media Chrome's `<template>`-based themes (`media-theme`) become Video.js <DocsLink slug="concepts/skins">skins</DocsLink> and <DocsLink slug="concepts/presets">presets</DocsLink>. Start from a preset, then <DocsLink slug="getting-started/shadcn">install its source from the Shadcn registry</DocsLink> and customize it, rather than authoring a template.
 
 <FrameworkCase frameworks={["html"]}>
 Ready-made HTML skins keep their controls inside Shadow DOM. Code outside the skin sees a click as coming from the skin, not the button inside it. Some control events also stay inside the skin. Do not use an outside listener to identify which built-in button was clicked.

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -426,7 +426,7 @@ Mux Player gives you attributes and documented CSS variables. Past that, you're 
 
 ### Level 1: pick a skin
 
-Two are packaged. The default skin is a modern, frosted look. The minimal skin is closer to a classic control bar. Both bring controls, tooltips, captions, keyboard shortcuts, touch gestures, and a settings menu that appears when there's something to put in it. See <DocsLink slug="concepts/skins">Skins</DocsLink>.
+Two are packaged. The <DocsLink slug="reference/video-skin">Default Video Skin</DocsLink> is a modern, frosted look. The <DocsLink slug="reference/minimal-video-skin">Minimal Video Skin</DocsLink> is closer to a classic control bar. Both bring controls, tooltips, captions, keyboard shortcuts, touch gestures, and a settings menu that appears when there's something to put in it. See <DocsLink slug="concepts/skins">Skins</DocsLink> for the underlying model.
 
 ### Level 2: restyle it
 
@@ -466,7 +466,7 @@ The skins use a different visual design, so you may not need to replace Mux Play
 
 ### Level 3: own the source
 
-Install the closest Player or skin block from the hosted Video.js Shadcn registry, then edit its ordinary application files. <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink> explains the available framework and styling variants.
+Install the closest Player or skin block from the hosted Video.js Shadcn registry, then edit its ordinary application files. <DocsLink slug="getting-started/shadcn">Install from the Shadcn registry</DocsLink> explains the available framework and styling variants.
 
 This is the level that per-control tweaks need, and it's a genuine step up in effort from a Mux Player attribute. `forward-seek-offset="30"` was one character. In Video.js, the skins bake their seek step into their keyboard shortcuts and gestures, so changing it means editing those lines:
 

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -9,14 +9,14 @@ import FrameworkCase from '@/components/docs/FrameworkCase.astro';
 
 Video.js v10 is not a drop-in replacement for Plyr. Plyr wraps one media element with a constructor and options object. Video.js composes a player, media component, and skin in markup, then exposes behavior through <DocsLink slug="concepts/features">player state</DocsLink>.
 
-Start with the Minimal skin, move media settings into markup, and replace calls to the Plyr instance with native media APIs or Video.js state actions.
+Start with the <DocsLink slug="reference/minimal-video-skin">Minimal Video Skin</DocsLink>, move media settings into markup, and replace calls to the Plyr instance with native media APIs or Video.js state actions.
 
 ## What changes
 
 - **The player becomes three pieces.** Player state, the media component, and the skin are separate, so you can replace one without wrapping or forking the others.
 - **Streaming behavior becomes player state.** HLS, DASH, and Mux integrations expose renditions, tracks, and live state to the UI instead of leaving that wiring to application code.
 - **React uses native components and hooks.** `@videojs/react` owns its lifecycle instead of wrapping an imperative constructor around framework-owned DOM.
-- **The UI is composable.** Buttons, sliders, menus, gestures, and hotkeys are individual accessible components. Start with the Minimal or Default skin, then [install its source](#install-the-skin-source) when you need to change the structure.
+- **The UI is composable.** Buttons, sliders, menus, gestures, and hotkeys are individual accessible components. Start with the <DocsLink slug="reference/minimal-video-skin">Minimal Video Skin</DocsLink> or <DocsLink slug="reference/video-skin">Default Video Skin</DocsLink>, then [install its source](#install-the-skin-source) when you need to change the structure.
 - **Remote playback is built in.** The video skins include AirPlay and Cast controls. Follow <DocsLink slug="how-to/cast-to-airplay-and-chromecast">Cast to AirPlay and Chromecast</DocsLink> to add the Google Cast integration.
 
 <Aside type="note">
@@ -46,7 +46,7 @@ const player = new Plyr('#player', {
 </script>
 ```
 
-The Minimal skin is the closest built-in starting point for this migration.
+The <DocsLink slug="reference/minimal-video-skin">Minimal Video Skin</DocsLink> is the closest built-in starting point for this migration.
 
 <FrameworkCase frameworks={["html"]}>
 
@@ -76,7 +76,7 @@ import '@videojs/html/video/minimal-skin';
 
 - The skin attaches its styles automatically to its shadow root.
 - The poster moves from `data-poster` on the media to `poster` on `<video-player>`. The skin reads that value and controls how the poster appears. For more advanced control (like supplying your own image element), see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink>.
-- There's also a default skin with a modern, frosted appearance that some may prefer. Try it by removing the `-minimal` suffix from the script `src` if you're using the CDN, or the `minimal-` prefix from the imports.
+- There's also a <DocsLink slug="reference/video-skin">Default Video Skin</DocsLink> with a modern, frosted appearance that some may prefer. Try it by removing the `-minimal` suffix from the script `src` if you're using the CDN, or the `minimal-` prefix from the imports.
 
 </FrameworkCase>
 
@@ -120,7 +120,7 @@ export function AppVideoPlayer({ origin }: AppVideoPlayerProps) {
 - The poster URL is metadata on `VideoPlayer`. The skin reads that metadata and controls how the poster appears. To replace the rendered image, pass `renderPoster` to the skin — see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink>.
 - This example assumes all your files for a given asset live in the same path, using consistent filenames. This will almost certainly need adjusting for your implementation.
 - If `origin` points somewhere other than your page's origin, add `crossOrigin="anonymous"` to `<Video>` and serve those files with CORS headers. A cross-origin thumbnail track only loads when the media element is CORS-enabled. See <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink>.
-- There's also a default skin with a modern, frosted appearance that some may prefer. Try it by switching the CSS import filename to `skin.css` and the `MinimalVideoSkin` import and usage to `VideoSkin`.
+- There's also a <DocsLink slug="reference/video-skin">Default Video Skin</DocsLink> with a modern, frosted appearance that some may prefer. Try it by switching the CSS import filename to `skin.css` and the `MinimalVideoSkin` import and usage to `VideoSkin`.
 
 </FrameworkCase>
 
@@ -470,7 +470,7 @@ video-player {
 
 ## Install the skin source
 
-If you need extra customization of layout, styles, or icons, install the closest Player or skin block from the hosted Video.js Shadcn registry. It resolves the complete component and style dependency graph, then writes ordinary files you can modify directly. See <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>.
+If you need extra customization of layout, styles, or icons, install the closest Player or skin block from the hosted Video.js Shadcn registry. It resolves the complete component and style dependency graph, then writes ordinary files you can modify directly. See <DocsLink slug="getting-started/shadcn">Install from the Shadcn registry</DocsLink>.
 
 ## Known gaps
 

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -106,7 +106,7 @@ Four differences worth understanding, because each one is a pattern you'll see a
 - **The poster is player metadata, not a media attribute.** Set `poster` on `<video-player>`, and the skin, not the browser, controls how it appears. For more advanced control (like supplying your own image element), see <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink>.
 - **Your `<track>` elements don't change.** Captions, subtitles, chapters, and thumbnails are all still tracks, and the skin shows the matching controls when it finds them.
 
-There's also a minimal skin, closer to v8's control bar if the default's frosted look is too much of a change. Swap `cdn/video.js` for `cdn/video-minimal.js`.
+There's also a <DocsLink slug="reference/minimal-video-skin">Minimal Video Skin</DocsLink>, closer to v8's control bar if the default's frosted look is too much of a change. Swap `cdn/video.js` for `cdn/video-minimal.js`.
 
 </FrameworkCase>
 
@@ -177,7 +177,7 @@ Three differences worth understanding, because each one is a pattern you'll see 
 - **No `controls` prop.** The skin *is* the controls. Rendering a skin is how you ask for them, which is also how you opt out.
 - **The poster is player metadata, not a media attribute.** Pass it to `VideoPlayer`, and the skin controls how it appears.
 
-The `'use client'` directive is there because the player owns browser state. There's also a minimal skin, closer to v8's control bar, if the default's frosted look is too much of a change.
+The `'use client'` directive is there because the player owns browser state. There's also a <DocsLink slug="reference/minimal-video-skin">Minimal Video Skin</DocsLink>, closer to v8's control bar, if the default's frosted look is too much of a change.
 
 </FrameworkCase>
 
@@ -325,7 +325,7 @@ In v8, customizing meant three different techniques depending on what you wanted
 
 ### Level 1: pick a skin
 
-The default skin is a modern, frosted look. The minimal skin is closer to v8's control bar. Both bring controls, tooltips, captions, keyboard shortcuts, touch gestures, and a settings menu that appears when there's something to put in it. See <DocsLink slug="concepts/skins">Skins</DocsLink>.
+The <DocsLink slug="reference/video-skin">Default Video Skin</DocsLink> is a modern, frosted look. The <DocsLink slug="reference/minimal-video-skin">Minimal Video Skin</DocsLink> is closer to v8's control bar. Both bring controls, tooltips, captions, keyboard shortcuts, touch gestures, and a settings menu that appears when there's something to put in it. See <DocsLink slug="concepts/skins">Skins</DocsLink> for the underlying model.
 
 Both also include AirPlay and Cast buttons, which v8 had no answer for. Follow <DocsLink slug="how-to/cast-to-airplay-and-chromecast">Cast to AirPlay and Chromecast</DocsLink> to add the Google Cast integration. Remote playback is a feature you compose in rather than a plugin you install.
 
@@ -349,7 +349,7 @@ video-player {
 
 ### Level 3: own the source
 
-Install the closest Player or skin block from the hosted Video.js Shadcn registry, then edit its ordinary application files. <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink> explains the available React and HTML, Tailwind and vanilla CSS variants.
+Install the closest Player or skin block from the hosted Video.js Shadcn registry, then edit its ordinary application files. <DocsLink slug="getting-started/shadcn">Install from the Shadcn registry</DocsLink> explains the available React and HTML, Tailwind and vanilla CSS variants.
 
 This is where v8's `controlBar` config and `addChild` calls end up, and honestly it's the better trade. Instead of `controlBar: { pictureInPictureToggle: false }`, you delete a line. Instead of subclassing a component to change its behavior, you edit the markup.
 

--- a/site/src/content/docs/how-to/play-live-streams.mdx
+++ b/site/src/content/docs/how-to/play-live-streams.mdx
@@ -104,7 +104,7 @@ LiveButton reads this state: it renders as an active "go to live" control while 
 
 ### DVR: let users scrub back
 
-For streams with a DVR window, give users a <DocsLink slug="reference/time-slider">TimeSlider</DocsLink>. The live preset skins don't include one, so add it to your own UI or <DocsLink slug="how-to/customize-skins">install the skin source</DocsLink>. The slider tracks the sliding window automatically because `duration` follows the live edge.
+For streams with a DVR window, give users a <DocsLink slug="reference/time-slider">TimeSlider</DocsLink>. The live preset skins don't include one, so add it to your own UI or <DocsLink slug="getting-started/shadcn">install the skin source</DocsLink>. The slider tracks the sliding window automatically because `duration` follows the live edge.
 
 ### Switch UI by stream type
 

--- a/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
+++ b/site/src/content/docs/how-to/use-videojs-with-svelte.mdx
@@ -61,7 +61,7 @@ If a style depends on a Video.js `data-*` state, Svelte may remove its selector 
 </style>
 ```
 
-`:defined` applies the state style only after the browser loads the element. These selectors matter when you own a skin's source or compose controls yourself. Styles cannot reach controls inside a packaged skin; use its CSS custom properties, or <DocsLink slug="how-to/customize-skins">install the skin source</DocsLink> to own its markup and CSS.
+`:defined` applies the state style only after the browser loads the element. These selectors matter when you own a skin's source or compose controls yourself. Styles cannot reach controls inside a packaged skin; use its CSS custom properties, or <DocsLink slug="getting-started/shadcn">install the skin source</DocsLink> to own its markup and CSS.
 
 ## Pass objects as properties
 

--- a/site/src/content/docs/how-to/use-videojs-with-vue.mdx
+++ b/site/src/content/docs/how-to/use-videojs-with-vue.mdx
@@ -106,7 +106,7 @@ video-skin:not(:defined) {
 </style>
 ```
 
-Scoped styles cannot reach controls inside a packaged skin. Use its CSS custom properties, or <DocsLink slug="how-to/customize-skins">install the skin source</DocsLink> to own its markup and CSS.
+Scoped styles cannot reach controls inside a packaged skin. Use its CSS custom properties, or <DocsLink slug="getting-started/shadcn">install the skin source</DocsLink> to own its markup and CSS.
 
 ## Pass objects as properties
 

--- a/site/src/content/docs/reference/audio-skin.mdx
+++ b/site/src/content/docs/reference/audio-skin.mdx
@@ -1,5 +1,7 @@
 ---
-title: Default audio skin
+title: AudioSkin
+frameworkTitle:
+  html: audio-skin
 description: Accessible audio controls for playback, seeking, volume, speed, and feedback
 ---
 

--- a/site/src/content/docs/reference/background-video-skin.mdx
+++ b/site/src/content/docs/reference/background-video-skin.mdx
@@ -1,5 +1,7 @@
 ---
-title: Background video preset
+title: BackgroundVideoSkin
+frameworkTitle:
+  html: background-video-skin
 description: Control-free decorative video layout with poster layering and object-fit support
 ---
 

--- a/site/src/content/docs/reference/live-audio-skin.mdx
+++ b/site/src/content/docs/reference/live-audio-skin.mdx
@@ -1,5 +1,7 @@
 ---
-title: Default live audio skin
+title: LiveAudioSkin
+frameworkTitle:
+  html: live-audio-skin
 description: Accessible live audio controls for playback, live-edge state, volume, and feedback
 ---
 

--- a/site/src/content/docs/reference/live-video-skin.mdx
+++ b/site/src/content/docs/reference/live-video-skin.mdx
@@ -1,5 +1,7 @@
 ---
-title: Default live video skin
+title: LiveVideoSkin
+frameworkTitle:
+  html: live-video-skin
 description: Full live video controls with live-edge state, captions, feedback, and remote playback
 ---
 

--- a/site/src/content/docs/reference/minimal-audio-skin.mdx
+++ b/site/src/content/docs/reference/minimal-audio-skin.mdx
@@ -1,5 +1,7 @@
 ---
-title: Minimal audio skin
+title: MinimalAudioSkin
+frameworkTitle:
+  html: audio-minimal-skin
 description: Compact responsive audio controls for playback, time, volume, speed, and feedback
 ---
 

--- a/site/src/content/docs/reference/minimal-live-audio-skin.mdx
+++ b/site/src/content/docs/reference/minimal-live-audio-skin.mdx
@@ -1,5 +1,7 @@
 ---
-title: Minimal live audio skin
+title: MinimalLiveAudioSkin
+frameworkTitle:
+  html: live-audio-minimal-skin
 description: Compact live audio controls for playback, live-edge state, volume, and feedback
 ---
 

--- a/site/src/content/docs/reference/minimal-live-video-skin.mdx
+++ b/site/src/content/docs/reference/minimal-live-video-skin.mdx
@@ -1,5 +1,7 @@
 ---
-title: Minimal live video skin
+title: MinimalLiveVideoSkin
+frameworkTitle:
+  html: live-video-minimal-skin
 description: Compact live video controls with live-edge state, captions, feedback, and input support
 ---
 

--- a/site/src/content/docs/reference/minimal-video-skin.mdx
+++ b/site/src/content/docs/reference/minimal-video-skin.mdx
@@ -1,5 +1,7 @@
 ---
-title: Minimal video skin
+title: MinimalVideoSkin
+frameworkTitle:
+  html: video-minimal-skin
 description: Compact responsive video controls with the complete on-demand feature set
 ---
 

--- a/site/src/content/docs/reference/time-slider.mdx
+++ b/site/src/content/docs/reference/time-slider.mdx
@@ -117,18 +117,20 @@ Use [CSS custom properties](#root-css-custom-properties) to style the fill, poin
 
 <FrameworkCase frameworks={["html"]}>
 ```css
-media-time-slider::before {
-  width: var(--media-slider-fill);
+media-slider-fill {
+  width: 100%;
+  clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0);
 }
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
-React renders a `<div>` element. Add a `className` to style it:
+Add a `className` to `TimeSlider.Fill`, which renders a `<div>` element:
 
 ```css
-.time-slider::before {
-  width: var(--media-slider-fill);
+.time-slider-fill {
+  width: 100%;
+  clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0);
 }
 ```
 </FrameworkCase>

--- a/site/src/content/docs/reference/video-skin.mdx
+++ b/site/src/content/docs/reference/video-skin.mdx
@@ -1,5 +1,7 @@
 ---
-title: Default video skin
+title: VideoSkin
+frameworkTitle:
+  html: video-skin
 description: Full responsive video controls with settings, feedback, gestures, and keyboard input
 ---
 

--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -66,18 +66,20 @@ Use [CSS custom properties](#root-css-custom-properties) to style the fill and p
 
 <FrameworkCase frameworks={["html"]}>
 ```css
-media-volume-slider::before {
-  width: var(--media-slider-fill);
+media-slider-fill {
+  width: 100%;
+  clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0);
 }
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
-React renders a `<div>` element. Add a `className` to style it:
+Add a `className` to `VolumeSlider.Fill`, which renders a `<div>` element:
 
 ```css
-.volume-slider::before {
-  width: var(--media-slider-fill);
+.volume-slider-fill {
+  width: 100%;
+  clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0);
 }
 ```
 </FrameworkCase>

--- a/site/src/content/docs/reference/write-references.mdx
+++ b/site/src/content/docs/reference/write-references.mdx
@@ -86,19 +86,21 @@ src/components/docs/demos/{name}/react/css/
 └── BasicUsage.css      # Styles
 ```
 
-### BEM naming
+### CSS scoping
 
-Use BEM class names for CSS scoping. The block name follows the pattern `{framework}-{component}-{variant}`:
+Give every demo a unique root class using `{framework}-{component}-{variant}`. Use flat, semantic names for any
+additional component or part hooks:
 
 ```css
 /* HTML demo */
-.html-play-button-basic__button { /* ... */ }
+.html-play-button-basic-button { /* ... */ }
 
 /* React demo */
-.react-play-button-basic__button { /* ... */ }
+.react-play-button-basic-button { /* ... */ }
 ```
 
-React and HTML demos for the same variant should use matching BEM structures.
+React and HTML demos for the same variant should use matching semantic hooks. Keep every selector specific to its demo
+so hidden examples cannot affect the visible one.
 
 ### Video and poster sources
 

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -63,22 +63,6 @@ export const sidebar: Sidebar = [
     ],
   },
   {
-    sidebarLabel: 'Skins',
-    llmsDescription:
-      'Packaged player skins, including previews, supported targets, usage, behavior, and customization.',
-    contents: [
-      { slug: 'skins/default-video' },
-      { slug: 'skins/minimal-video' },
-      { slug: 'skins/default-audio' },
-      { slug: 'skins/minimal-audio' },
-      { slug: 'skins/default-live-video' },
-      { slug: 'skins/minimal-live-video' },
-      { slug: 'skins/default-live-audio' },
-      { slug: 'skins/minimal-live-audio' },
-      { slug: 'skins/background-video' },
-    ],
-  },
-  {
     sidebarLabel: 'How to',
     llmsDescription:
       "Task-oriented guides that each answer one goal in the reader's words. Some cover custom player UI; others configure a preset, skin, media component, or integration. Guides lead with the recommended path, then the constraints and variations needed to apply it.",
@@ -117,6 +101,22 @@ export const sidebar: Sidebar = [
     llmsDescription:
       'Reference for every public export, grouped by what it is: UI components, media components, player features, and utilities.',
     contents: [
+      {
+        sidebarLabel: 'Skins',
+        defaultOpen: false,
+        llmsDescription: 'Packaged and source-owned player Skin API references.',
+        contents: [
+          { slug: 'reference/video-skin' },
+          { slug: 'reference/minimal-video-skin' },
+          { slug: 'reference/audio-skin' },
+          { slug: 'reference/minimal-audio-skin' },
+          { slug: 'reference/live-video-skin' },
+          { slug: 'reference/minimal-live-video-skin' },
+          { slug: 'reference/live-audio-skin' },
+          { slug: 'reference/minimal-live-audio-skin' },
+          { slug: 'reference/background-video-skin' },
+        ],
+      },
       {
         sidebarLabel: 'UI Components',
         defaultOpen: false,


### PR DESCRIPTION
Part of #2184.

## Summary

- add dedicated API reference pages for every packaged React and HTML skin plus the Background preset
- include runnable package-backed previews and exact packaged usage snippets
- reuse the registry-backed source explorer so readers can inspect the editable multi-file skin output
- document each skin's intended use and customization surface alongside the Shadcn and manual installation paths
- format skin names consistently with the rest of the UI API reference

## Verification

- `pnpm -F site test`
- `pnpm -C site astro check --minimumSeverity warning`
- `pnpm -F site check:anchors`
- `pnpm exec vp run site#build`

## Stack

- Depends on #2549.
- Final PR in the stack.