### PR TITLE
fix(packages): restore ejected player registration and slider press locking

### DIFF
--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -427,7 +427,10 @@ video.innerHTML = \`<track kind="metadata" label="thumbnails" src="\${MEDIA.${re
 poster.src = MEDIA.${resource}.poster;
 poster.alt = 'Video poster';
 
-await import('@videojs/html/video/skin');
+// Ejected layouts have no <video-skin>, so register the player (context owner)
+// before the light DOM UI elements that consume it.
+await import('@videojs/html/video/player');
+await import('@videojs/html/video/ui');
 `;
 }
 

--- a/apps/e2e/tests/sandbox-html-i18n.spec.ts
+++ b/apps/e2e/tests/sandbox-html-i18n.spec.ts
@@ -207,19 +207,23 @@ test.describe('Sandbox RTL playback control order', () => {
       source: 'hls-1',
       width: 1280,
     },
+    // The audio sandbox pages hand their source to a native media element, and
+    // Chromium's HLS demuxer crashes the renderer on the audio-only CMAF asset
+    // (reproducible with a bare `<audio src>`, no player involved). The MPEG-TS
+    // audio-only asset gives the same audio-player coverage without the crash.
     {
       name: 'HTML Default CSS audio',
       path: 'html-audio',
       skin: 'default',
       styling: 'css',
-      source: 'hls-audio-only-cmaf',
+      source: 'hls-audio-only-ts',
     },
     {
       name: 'React Minimal Tailwind audio',
       path: 'react-audio',
       skin: 'minimal',
       styling: 'tailwind',
-      source: 'hls-audio-only-cmaf',
+      source: 'hls-audio-only-ts',
     },
   ] as const;
 

--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -194,7 +194,9 @@ for (const { name, path } of UI_VIDEO_PAGES) {
       await expect(player.settingsSpeedItem).toBeVisible();
     });
 
-    test('controls remain visible during a stationary time slider drag', async ({ page }) => {
+    // A stationary press never crosses the drag threshold, so the slider stays
+    // interactive without becoming `data-dragging`. Controls must still stay up.
+    test('controls remain visible during a stationary time slider press', async ({ page }) => {
       await player.play();
       await player.showControls();
 
@@ -203,6 +205,30 @@ for (const { name, path } of UI_VIDEO_PAGES) {
 
       await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
       await page.mouse.down();
+
+      try {
+        await expect(player.timeSlider).toHaveAttribute(DATA_ATTRS.interactive, '');
+        await page.waitForTimeout(2_500);
+
+        await expect(player.controls).toHaveAttribute(DATA_ATTRS.visible, '');
+        await expect(player.timeSlider).toHaveAttribute(DATA_ATTRS.interactive, '');
+      } finally {
+        await page.mouse.up();
+      }
+    });
+
+    test('controls remain visible while dragging the time slider', async ({ page }) => {
+      await player.play();
+      await player.showControls();
+
+      const box = await player.timeSlider.boundingBox();
+      if (!box) throw new Error('Time slider not visible');
+
+      const y = box.y + box.height / 2;
+
+      await page.mouse.move(box.x + box.width / 2, y);
+      await page.mouse.down();
+      await page.mouse.move(box.x + box.width * 0.6, y);
 
       try {
         await expect(player.timeSlider).toHaveAttribute(DATA_ATTRS.dragging, '');

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -39,6 +39,14 @@ export interface SliderOptions {
   onValueChange?: ((percent: number) => void) | undefined;
   /** Fires once when the user commits the value (pointer release, keyboard step). */
   onValueCommit?: ((percent: number) => void) | undefined;
+  /**
+   * Fires on pointer down, before the drag threshold is crossed. Use for work that must span the whole press, such as
+   * holding controls visible while the pointer rests on the slider.
+   */
+  onPressStart?: (() => void) | undefined;
+  /** Fires when the press ends, whether or not it became a drag. */
+  onPressEnd?: (() => void) | undefined;
+  /** Fires once the pointer moves past the drag threshold. */
   onDragStart?: (() => void) | undefined;
   onDragEnd?: (() => void) | undefined;
   /** Called when the root element resizes (e.g. gains layout inside a popover). */
@@ -142,6 +150,8 @@ export function createSlider(options: SliderOptions): SliderApi {
 
     if (wasDragging) options.onDragEnd?.();
 
+    options.onPressEnd?.();
+
     committedOnRelease = false;
     pointingOnRelease = false;
     cleanup();
@@ -185,6 +195,7 @@ export function createSlider(options: SliderOptions): SliderApi {
       pointerDownY = event.clientY;
       lastDragPercent = percent;
       input.patch({ pointing: true, pointerPercent: percent, dragPercent: percent });
+      options.onPressStart?.();
       options.onValueChange?.(percent);
 
       // Focus the thumb for keyboard follow-up and screen reader tracking.

--- a/packages/core/src/dom/ui/tests/slider.test.ts
+++ b/packages/core/src/dom/ui/tests/slider.test.ts
@@ -249,6 +249,30 @@ describe('createSlider', () => {
       slider.destroy();
     });
 
+    it('brackets a stationary press with onPressStart and onPressEnd', () => {
+      const onPressStart = vi.fn();
+      const onPressEnd = vi.fn();
+      const onDragStart = vi.fn();
+      const el = createMockElement({ left: 0, width: 200 });
+      const slider = createSlider(createOptions({ getElement: () => el, onPressStart, onPressEnd, onDragStart }));
+
+      slider.rootProps.onPointerDown(pointerEvent({ clientX: 50 }));
+      flush();
+
+      expect(onPressStart).toHaveBeenCalledOnce();
+      expect(onDragStart).not.toHaveBeenCalled();
+      expect(onPressEnd).not.toHaveBeenCalled();
+
+      slider.rootProps.onPointerUp(pointerEvent({ clientX: 50 }));
+      slider.rootProps.onLostPointerCapture();
+      flush();
+
+      expect(onPressEnd).toHaveBeenCalledOnce();
+      expect(onDragStart).not.toHaveBeenCalled();
+
+      slider.destroy();
+    });
+
     it('calls onValueChange on every pointermove during drag', () => {
       const onValueChange = vi.fn();
       const el = createMockElement({ left: 0, width: 200 });

--- a/packages/html/src/ui/slider/slider-element.ts
+++ b/packages/html/src/ui/slider/slider-element.ts
@@ -83,12 +83,14 @@ export class SliderElement extends UIElement {
         this.value = this.#core.valueFromPercent(percent);
         this.dispatchEvent(new CustomEvent('value-commit', { detail: { value: this.value }, bubbles: true }));
       },
-      onDragStart: () => {
+      onPressStart: () => {
         this.#releaseControlsLock ??= this.#controlsState.value?.requestControlsLock() ?? null;
+      },
+      onPressEnd: () => this.#releaseControlsVisibilityLock(),
+      onDragStart: () => {
         this.dispatchEvent(new CustomEvent('drag-start', { bubbles: true }));
       },
       onDragEnd: () => {
-        this.#releaseControlsVisibilityLock();
         this.dispatchEvent(new CustomEvent('drag-end', { bubbles: true }));
       },
       adjustPercent: (raw, thumbSize, trackSize) => this.#core.adjustPercentForAlignment(raw, thumbSize, trackSize),

--- a/packages/html/src/ui/slider/tests/slider-element.test.ts
+++ b/packages/html/src/ui/slider/tests/slider-element.test.ts
@@ -187,6 +187,28 @@ describe('SliderElement', () => {
     expect(provider.releaseControlsLock).toHaveBeenCalledTimes(1);
   });
 
+  it('holds a controls visibility lock while the pointer rests without dragging', async () => {
+    const provider = createElement(TestPlayerProviderElement);
+    const slider = createElement(SliderElement);
+
+    provider.append(slider);
+    document.body.append(provider);
+    await slider.updateComplete;
+
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+
+    slider.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientX: 50 }));
+
+    expect(provider.requestControlsLock).toHaveBeenCalledTimes(1);
+    expect(provider.releaseControlsLock).not.toHaveBeenCalled();
+
+    slider.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1, clientX: 50 }));
+    slider.dispatchEvent(new PointerEvent('lostpointercapture', { bubbles: true, pointerId: 1 }));
+
+    expect(provider.releaseControlsLock).toHaveBeenCalledTimes(1);
+  });
+
   it('supports vertical orientation', async () => {
     const slider = createElement(SliderElement);
 

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -90,13 +90,15 @@ export class TimeSliderElement extends UIElement {
         if (media) media.seek(this.#core.rawValueFromPercent(percent));
       },
       changeThrottle: this.changeThrottle,
-      onDragStart: () => {
+      onPressStart: () => {
         this.#releaseControlsLock ??= this.#controlsState.value?.requestControlsLock() ?? null;
+      },
+      onPressEnd: () => this.#releaseControlsVisibilityLock(),
+      onDragStart: () => {
         this.#core.startDrag(this.#playbackState.value);
         this.dispatchEvent(new CustomEvent('drag-start', { bubbles: true }));
       },
       onDragEnd: () => {
-        this.#releaseControlsVisibilityLock();
         this.#core.endDrag(this.#playbackState.value);
         this.dispatchEvent(new CustomEvent('drag-end', { bubbles: true }));
       },

--- a/packages/html/src/ui/volume-slider/volume-slider-element.ts
+++ b/packages/html/src/ui/volume-slider/volume-slider-element.ts
@@ -85,12 +85,14 @@ export class VolumeSliderElement extends UIElement {
       getLargeStepPercent: () => this.#core.getLargeStepPercent(),
       onValueChange: setVolume,
       onValueCommit: setVolume,
-      onDragStart: () => {
+      onPressStart: () => {
         this.#releaseControlsLock ??= this.#controlsState.value?.requestControlsLock() ?? null;
+      },
+      onPressEnd: () => this.#releaseControlsVisibilityLock(),
+      onDragStart: () => {
         this.dispatchEvent(new CustomEvent('drag-start', { bubbles: true }));
       },
       onDragEnd: () => {
-        this.#releaseControlsVisibilityLock();
         this.dispatchEvent(new CustomEvent('drag-end', { bubbles: true }));
       },
       adjustPercent: (raw, thumbSize, trackSize) => this.#core.adjustPercentForAlignment(raw, thumbSize, trackSize),

--- a/packages/react/src/ui/hooks/use-slider.ts
+++ b/packages/react/src/ui/hooks/use-slider.ts
@@ -25,6 +25,8 @@ export interface UseSliderOptions<State extends SliderState = SliderState> exten
   | 'changeThrottle'
   | 'onValueChange'
   | 'onValueCommit'
+  | 'onPressStart'
+  | 'onPressEnd'
   | 'onDragStart'
   | 'onDragEnd'
 > {
@@ -88,14 +90,16 @@ export function useSlider<State extends SliderState = SliderState>(
       adjustPercent: optionsRef.current.adjustPercent,
       onValueChange: (percent) => optionsRef.current.onValueChange?.(percent),
       onValueCommit: (percent) => optionsRef.current.onValueCommit?.(percent),
-      onDragStart: () => {
+      onPressStart: () => {
         releaseControlsLockRef.current ??= requestControlsLock?.() ?? null;
-        optionsRef.current.onDragStart?.();
+        optionsRef.current.onPressStart?.();
       },
-      onDragEnd: () => {
+      onPressEnd: () => {
         releaseControlsLock();
-        optionsRef.current.onDragEnd?.();
+        optionsRef.current.onPressEnd?.();
       },
+      onDragStart: () => optionsRef.current.onDragStart?.(),
+      onDragEnd: () => optionsRef.current.onDragEnd?.(),
     };
 
     return createSlider(stableOptions);

--- a/packages/react/src/ui/slider/tests/slider.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider.test.tsx
@@ -14,6 +14,8 @@ const { mockSliderApi, sliderOptionsRef } = vi.hoisted(() => {
   const sliderOptionsRef: {
     current:
       | {
+          onPressStart?: () => void;
+          onPressEnd?: () => void;
           onDragStart?: () => void;
           onDragEnd?: () => void;
         }
@@ -26,6 +28,8 @@ const { mockSliderApi, sliderOptionsRef } = vi.hoisted(() => {
       getElement?: () => HTMLElement;
       getThumbElement?: () => HTMLElement | null;
       adjustPercent?: (raw: number, thumb: number, track: number) => number;
+      onPressStart?: () => void;
+      onPressEnd?: () => void;
       onDragStart?: () => void;
       onDragEnd?: () => void;
     }) => {
@@ -131,7 +135,7 @@ describe('SliderRoot', () => {
     expect(el.style.getPropertyValue('--media-slider-pointer')).toBeTruthy();
   });
 
-  it('holds a controls visibility lock for the duration of a drag', () => {
+  it('holds a controls visibility lock for the duration of a press', () => {
     const releaseControlsLock = vi.fn();
     const requestControlsLock = vi.fn(() => releaseControlsLock);
     const { Wrapper } = createPlayerWrapper({
@@ -143,11 +147,11 @@ describe('SliderRoot', () => {
 
     render(<SliderRoot />, { wrapper: Wrapper });
 
-    sliderOptionsRef.current?.onDragStart?.();
+    sliderOptionsRef.current?.onPressStart?.();
     expect(requestControlsLock).toHaveBeenCalledTimes(1);
     expect(releaseControlsLock).not.toHaveBeenCalled();
 
-    sliderOptionsRef.current?.onDragEnd?.();
+    sliderOptionsRef.current?.onPressEnd?.();
     expect(releaseControlsLock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the two regressions behind the failing [E2E (chromium) run on `main`](https://github.com/videojs/v10/actions/runs/33043418887/job/98421910646). Neither came from the commit the run was attributed to.

## Changes

**Ejected HTML players never initialized.** #2247 moved `video-player` registration out of `@videojs/html/video/ui` into `@videojs/html/video/player`, and in the same change pointed the generated ejected E2E page at `@videojs/html/video/skin`. Neither entry defines `video-player`, so the ejected layout never upgraded its player element — no store, no features, no state attributes, and controls stuck at `opacity: 0; pointer-events: none` (hence Playwright's `<video> intercepts pointer events`). The ejected page now registers the player entry before the light DOM UI entry.

**Controls auto-hid during a stationary slider press.** #2437 added a 3px drag threshold, so `dragging` only becomes true after movement — but the controls visibility lock was acquired in `onDragStart`. Pressing and holding a slider without moving took no lock, and the 2s idle timer hid the controls mid-interaction. This is a real user-facing bug, not just a test assumption.

<details>
<summary>Implementation details</summary>

`createSlider` gains `onPressStart` / `onPressEnd`, fired on pointer down and when the press ends regardless of whether it crossed the drag threshold. The HTML slider elements and the React `useSlider` hook move the controls lock onto those callbacks. `onDragStart` / `onDragEnd` keep drag-only responsibilities: pause-on-drag for the time slider, and the public `drag-start` / `drag-end` events.

The E2E case is split in two — one for a stationary press (asserts `data-interactive`) and one for a real drag (asserts `data-dragging`) — so both paths keep the controls up.

</details>

## Testing

- `pnpm -F @videojs/core test`, `pnpm -F @videojs/html test`, `pnpm -F @videojs/react test`
- `pnpm --dir apps/e2e exec playwright test --project=vite-chromium` — 266 passed, 4 skipped (was 11 failed)
- `pnpm --dir apps/e2e test:sandbox` — 40 passed
- `pnpm typecheck`, `pnpm exec vp lint --quiet`, `pnpm check:workspace`

Manual: press and hold the time slider without moving during playback — controls stay visible instead of fading after 2s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared slider interaction and controls-visibility locking across core, HTML, and React, plus ejected player load order—user-visible playback UI with broad test coverage but no auth or data paths.
> 
> **Overview**
> Fixes two regressions: ejected HTML E2E pages no longer initialize the player, and controls can auto-hide while the user is holding a slider without moving.
> 
> **Ejected pages** now import `@videojs/html/video/player` before `@videojs/html/video/ui` so `video-player` registers as the context owner before light-DOM UI consumes it (replacing the `skin` entry that never defined the custom element).
> 
> **Sliders** gain `onPressStart` / `onPressEnd` in core `createSlider`, wired through HTML slider/time/volume elements and React `useSlider`. The controls visibility lock is taken on press start and released on press end; drag callbacks keep drag-only behavior (seek pause, `drag-start` / `drag-end` events). E2E splits stationary press vs drag scenarios; sandbox audio cases switch to `hls-audio-only-ts` to avoid a Chromium renderer crash on the CMAF audio asset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73eb6118d65a2cfbad91dedd3a85b0b547291b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->