### PR TITLE
docs(site): explain CDN build layout

### DIFF
--- a/site/src/components/docs/api-reference/ComponentImports.astro
+++ b/site/src/components/docs/api-reference/ComponentImports.astro
@@ -3,6 +3,7 @@ import type { BundledLanguage } from 'shiki';
 
 import ServerCode from '@/components/Code/ServerCode.astro';
 import CodeFrame from '@/components/typography/CodeFrame.astro';
+import DocsLink from '../DocsLink.astro';
 import FrameworkCase from '../FrameworkCase.astro';
 
 interface Props {
@@ -35,3 +36,10 @@ const imports: Array<{ code: string; framework: 'react' | 'html'; lang: BundledL
     </FrameworkCase>
   ))
 }
+
+<FrameworkCase frameworks={['html']}>
+  <p>
+    CDN presets register the UI elements their skins use; individual UI components do not have CDN entry files. See
+    <DocsLink slug="concepts/cdn-builds"> CDN builds</DocsLink>.
+  </p>
+</FrameworkCase>

--- a/site/src/content/docs/concepts/cdn-builds.mdx
+++ b/site/src/content/docs/concepts/cdn-builds.mdx
@@ -1,0 +1,69 @@
+---
+title: CDN builds
+description: How Video.js packages presets, media elements, shared modules, and styles for direct browser use
+---
+
+import Aside from '@/components/Aside.astro';
+import DocsLink from '@/components/docs/DocsLink.astro';
+
+`@videojs/html` publishes two layouts from the same source. Package-manager imports expose small modules for a bundler to combine. The CDN layout is a browser-ready ES module graph organized around complete players and media elements.
+
+## Entry files start the module graph
+
+A CDN URL points to an **entry file**. For example, the default video entry registers `<video-player>`, `<video-skin>`, and the UI elements used by that skin:
+
+```html
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/video.js"></script>
+```
+
+The entry can import shared chunks beside it. The browser follows those imports, downloads each module once, and reuses it when another entry needs the same module. This keeps combinations such as a player preset and an HLS media element from downloading duplicate framework code.
+
+<Aside type="caution" title="Pin one version">
+Use the same exact `@videojs/html` version for every CDN URL on a page. Entry files share version-specific chunks and module state, including the internationalization registry.
+</Aside>
+
+## The layout follows player composition
+
+The first path segment describes the role of an entry:
+
+| Path | What it provides |
+| --- | --- |
+| `video.js`, `audio.js`, `live-video.js`, `live-audio.js` | A player, the default skin, and the UI that skin uses |
+| `*-minimal.js` | The same player with its minimal skin and UI |
+| `*-player.js` | A player without a skin or UI registrations |
+| `background.js` | The background player, skin, and media element |
+| `media/<name>.js` | One additional media element, such as `<hls-video>` or `<mux-video>` |
+| `locales/<tag>.js` | One locale registered as a side effect |
+| `i18n.js` | Internationalization functions for a custom module |
+| `*.css` | Optional copies of preset styles for pre-upgrade or declarative shadow DOM rendering |
+
+Most players therefore start with one preset entry. A source that needs a custom media element adds one media entry:
+
+```html
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/video.js"></script>
+<script type="module" src="{{VJS10_HTML_CDN_BASE}}/media/hls-video.js"></script>
+
+<video-player>
+  <video-skin>
+    <hls-video src="https://example.com/video.m3u8"></hls-video>
+  </video-skin>
+</video-player>
+```
+
+The <DocsLink slug="how-to/installation">installation builder</DocsLink> chooses this combination from the player, skin, and media source you select.
+
+## CDN entries and package imports have different boundaries
+
+A package import can register one HTML component:
+
+```ts
+import '@videojs/html/ui/play-button';
+```
+
+The CDN does not publish a matching `ui/play-button.js` entry. Its preset entries register the set of UI elements used by a complete skin. Use the package-manager layout with a bundler when you want component-level imports or a custom feature bundle. Use the CDN layout when its preset- and media-level boundaries fit your player.
+
+## Treat the version directory as one unit
+
+CDN JavaScript entries inline their templates and styles, so a running player does not need a stylesheet link. The separate CSS files cover styles that must apply before a custom element upgrades or inside declarative shadow DOM.
+
+Because entries depend on sibling chunks, copying one JavaScript file is not enough to host it elsewhere. Mirror the whole `cdn/` directory without changing its structure. See <DocsLink slug="how-to/self-host-the-player">Self-host the player</DocsLink> for bundling, release archives, and CDN mirroring.

--- a/site/src/content/docs/reference/write-references.mdx
+++ b/site/src/content/docs/reference/write-references.mdx
@@ -188,7 +188,7 @@ import basicUsageHtmlTs from "@/components/docs/demos/{name}/html/css/BasicUsage
 
 After imports, the page follows this order:
 
-1. **Import** — render the public React export and HTML registration module with `<ComponentImports>`.
+1. **Import** — render the public React export, HTML registration module, and HTML CDN boundary with `<ComponentImports>`.
 2. **Anatomy** — show part nesting with self-closing placeholders for each framework using `<FrameworkCase>`, following the [Base UI anatomy convention](https://base-ui.com/react/overview/quick-start). No hooks, state, handlers, or option mapping — working code belongs in Examples.
 3. **Prose sections** (optional, as needed):
    - **Behavior** — state transitions, timing, interaction logic
@@ -205,6 +205,8 @@ After imports, the page follows this order:
 ```
 
 `component` is the named export from `@videojs/react`. `html` is the suffix of the side-effect registration import from `@videojs/html/ui/`.
+
+The component also links HTML readers to the CDN builds concept. CDN presets register the UI their skins use; they do not publish one CDN entry per UI component.
 
 ```mdx
 <ComponentReference component="PlayButton" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -53,6 +53,7 @@ export const sidebar: Sidebar = [
       { slug: 'concepts/features' },
       { slug: 'concepts/skins' },
       { slug: 'concepts/presets' },
+      { slug: 'concepts/cdn-builds', frameworks: ['html'] },
       { slug: 'concepts/ui-components' },
       { slug: 'concepts/accessibility' },
       { slug: 'concepts/media-sources' },


### PR DESCRIPTION
## Summary

Explain how the `@videojs/html` CDN output is organized and why its entry points differ from package-manager imports. This gives HTML readers a reusable mental model without duplicating component-level API reference.

## Changes

- Add an HTML-only CDN builds concept covering presets, media entries, shared chunks, styles, version pinning, and self-hosting
- Clarify in UI component import blocks that CDN presets register their skin dependencies instead of publishing one URL per component
- Keep the reference-authoring guidance aligned with the shared import component

## Testing

- `CI=true pnpm -F site test src/utils/docs/__tests__/component-reference-imports.test.ts src/utils/docs/__tests__/sidebar.test.ts src/utils/tests/satteriCdnVersion.test.ts` (40 tests)
- `CI=true pnpm -F site astro check` (0 errors)
- `env -u SENTRY_AUTH_TOKEN CI=true pnpm build:site`
- Rendered the CDN concept and representative HTML and React component references locally