### PR TITLE
docs(site): clarify declarative media API stability

### DIFF
--- a/site/src/components/docs/api-reference/MediaApiStabilityNotice.astro
+++ b/site/src/components/docs/api-reference/MediaApiStabilityNotice.astro
@@ -1,0 +1,12 @@
+---
+import Aside from '@/components/Aside.astro';
+
+const interfaceName = Astro.params.framework === 'react' ? 'props' : 'attributes';
+---
+
+<Aside type="caution" title="Unstable declarative API">
+  <p>
+    Playback behavior may be stable, but this component's declarative API is not. Its {interfaceName} and how they
+    configure the media may change before the API becomes stable.
+  </p>
+</Aside>

--- a/site/src/components/docs/api-reference/MediaReference.astro
+++ b/site/src/components/docs/api-reference/MediaReference.astro
@@ -6,6 +6,7 @@ import type { MediaReference } from '@/types/media-reference';
 import { resolveReferenceSlug } from '@/utils/api-reference-overrides';
 import { createMediaReferenceModel } from '@/utils/mediaReferenceModel';
 import HtmlMediaReference from './HtmlMediaReference.astro';
+import MediaApiStabilityNotice from './MediaApiStabilityNotice.astro';
 import ReactMediaReference from './ReactMediaReference.astro';
 
 interface Props {
@@ -38,6 +39,7 @@ for (const engine of model.engines) {
 
 <ContentWidth>
   <H2 id={model.heading.id}>{model.heading.text}</H2>
+  <MediaApiStabilityNotice />
   {
     framework === "html" ? (
       <HtmlMediaReference

--- a/site/src/content/docs/reference/background-video.mdx
+++ b/site/src/content/docs/reference/background-video.mdx
@@ -9,6 +9,7 @@ import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
+import MediaApiStabilityNotice from "@/components/docs/api-reference/MediaApiStabilityNotice.astro";
 import MarkdownCode from "@/components/typography/MarkdownCode.astro";
 import Table from "@/components/typography/Table.astro";
 import Tbody from "@/components/typography/Tbody.astro";
@@ -70,6 +71,8 @@ An HLS URL only works where the browser has native HLS playback. See <DocsLink s
 <FrameworkCase frameworks={["html"]}>
 
 ## API Reference
+
+<MediaApiStabilityNotice />
 
 ### Attributes
 

--- a/site/src/content/docs/reference/hls-background-video.mdx
+++ b/site/src/content/docs/reference/hls-background-video.mdx
@@ -6,6 +6,7 @@ description: HLS background video without controls, audio, captions, or adaptive
 ---
 
 import DocsLink from '@/components/docs/DocsLink.astro';
+import MediaApiStabilityNotice from '@/components/docs/api-reference/MediaApiStabilityNotice.astro';
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
 
 HlsBackgroundVideo plays an HLS source through the SPF background engine. It is fixed to muted, autoplaying, inline, looped playback and omits controls, audio, text, DRM, and adaptive rendition switching.
@@ -52,6 +53,8 @@ import '@videojs/html/media/hls-background-video';
 There is no `source` object, `preload` mode, or opt-out for muted, autoplay, and loop. Assigning a new `src` restarts playback from scratch.
 
 ## API
+
+<MediaApiStabilityNotice />
 
 | Member | Platform | Description |
 | --- | --- | --- |

--- a/site/src/content/docs/reference/mux-background-video.mdx
+++ b/site/src/content/docs/reference/mux-background-video.mdx
@@ -6,6 +6,7 @@ description: Mux-specific name for the HLS background video component
 ---
 
 import DocsLink from '@/components/docs/DocsLink.astro';
+import MediaApiStabilityNotice from '@/components/docs/api-reference/MediaApiStabilityNotice.astro';
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
 
 MuxBackgroundVideo is the Mux-specific name for <DocsLink slug="reference/hls-background-video">HlsBackgroundVideo</DocsLink>. The two names use the same implementation and API.
@@ -51,5 +52,7 @@ Pass a complete Mux HLS URL through `src`. This component does not take a playba
 MuxBackgroundVideo does not create a poster or preview thumbnails, and it does not send analytics data. Keep the poster in your page and add analytics separately when you need them.
 
 ## API
+
+<MediaApiStabilityNotice />
 
 The source, error, fixed playback behavior, and CSS custom properties are identical to <DocsLink slug="reference/hls-background-video">HlsBackgroundVideo</DocsLink>.


### PR DESCRIPTION
## Summary

Clarify that stable playback behavior does not imply a stable declarative interface. Add a caution directly above every Video.js media API table, using `attributes` for HTML references and `props` for React references.

This is PR 2 of a two-PR stack and depends on #2513.

## Changes

- Add one shared framework-aware media API stability notice
- Include the notice in every generated media reference
- Include the notice in the manually authored background-video API sections
- Leave native audio and video references unchanged because they document browser-native APIs and have no Video.js API table

## Testing

- `pnpm -F site api-docs`
- `pnpm -F site astro check`
- `env CI=true pnpm -F site test`
- `pnpm check:workspace`
- `env -u SENTRY_AUTH_TOKEN CI=true pnpm build:site`
- Visually verified generated and manual media references in HTML and React modes