### PR TITLE
docs(site): document chrome's muted audio autoplay block

### DIFF
--- a/site/src/content/docs/how-to/autoplay.mdx
+++ b/site/src/content/docs/how-to/autoplay.mdx
@@ -70,11 +70,12 @@ Calling `play()` from player state returns the native promise from the media ele
 ## Availability and constraints
 
 - Autoplay can fail. Browsers decide per page load based on audio state, whether the user has interacted with your site before, browser settings, and platform policy.
-- Muted autoplay is broadly allowed. Unmuted autoplay is blocked on first visit in most browsers; do not rely on it.
+- Muted autoplay is broadly allowed for video. Unmuted autoplay is blocked on first visit in most browsers; do not rely on it.
+- Chrome grants the muted exemption to video elements only. Muted autoplay on an audio element works in Firefox and macOS Safari, but Chrome and other Chromium browsers block it until the user interacts with the page, and nothing retries the attempt afterward. Start audio components (Audio, HlsAudio, MuxAudio, and the like) from a user action instead.
 - Without inline playback, iPhone Safari opens the video in fullscreen when playback starts.
 - Low-power mode and data-saver settings can block even muted autoplay. This is why the recommended approach keeps a manual play control.
 - Programmatic volume control is unsupported on some platforms. The <DocsLink slug="reference/feature-volume">volume feature</DocsLink> exposes this as `volumeAvailability: 'available' | 'unavailable' | 'unsupported'`; iOS Safari reports `'unsupported'`, and `'unavailable'` means the feature hasn't attached to a media element yet.
-- This guide applies to media components that render a video element (Video, HlsJsVideo, DashVideo, MuxVideo, and the like). Embed components (YouTube, Vimeo, TikTok, Twitch) forward autoplay to the third-party player, which applies its own autoplay rules; muted and inline behavior varies by provider.
+- The recommended approach above targets media components that render a video element (Video, HlsJsVideo, DashVideo, MuxVideo, and the like). Embed components (YouTube, Vimeo, TikTok, Twitch) forward autoplay to the third-party player, which applies its own autoplay rules; muted and inline behavior varies by provider.
 
 ## Common variations
 

--- a/site/src/content/docs/reference/audio.mdx
+++ b/site/src/content/docs/reference/audio.mdx
@@ -81,6 +81,12 @@ Video.js does not replace the native audio API. Use `src` for one URL or add chi
 
 See MDN for the complete [`<audio>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/audio), [`HTMLAudioElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement), and shared [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) APIs.
 
+## Autoplay
+
+Muting does not enable autoplay for audio. Chrome grants the muted-autoplay exemption to video elements only, so an audio element stays blocked until the user interacts with the page, and the attempt is not retried once they do. Firefox and macOS Safari decide on audibility instead, and allow it.
+
+Start audio playback from a user action when it needs to be reliable. See <DocsLink slug="how-to/autoplay">Autoplay</DocsLink>.
+
 ## Examples
 
 ### Basic Usage


### PR DESCRIPTION
## Summary

Chrome blocks muted autoplay on audio elements, and our autoplay guide told readers the opposite. This corrects the claim and documents the behavior where people hit it.

## Changes

- Scope the existing "muted autoplay is broadly allowed" claim to video.
- Add a constraint bullet covering audio elements, including the part that makes this confusing to debug: the blocked attempt is never retried, so interacting with the page afterward does not start playback.
- Reword the closing bullet so the guide no longer says it applies only to video-rendering components while carrying an audio constraint.
- Add an Autoplay section to the Audio reference, linking back to the guide.

<details>
<summary>Why Chrome differs</summary>

Blink gates the muted exemption on element type in `AutoplayPolicy::IsEligibleForAutoplayMuted`:

```cpp
bool AutoplayPolicy::IsEligibleForAutoplayMuted() const {
  if (!IsA<HTMLVideoElement>(element_.Get()))
    return false;
  ...
}
```

`IsGestureNeededForPlayback()` returns `!IsEligibleForAutoplayMuted()`, so a muted `<audio>` is treated exactly like unmuted autoplay and needs user activation.

Gecko and WebKit both key on audibility rather than element type, so they allow it:

- Firefox `IsMediaElementInaudible()` returns true for `Volume() == 0.0 || Muted()` with no element-type check.
- WebKit `MediaElementSession::playbackStateChangePermitted` denies only when `!element->muted() && element->volume()`. Its video-specific restrictions (low power mode, thermal mitigation) are `isVideo()`-gated, so muted audio is actually *less* restricted than muted video there.

iOS Safari is unverified. `RequiresUserGestureForAudioPlayback` defaults true on iOS and `autoplayPermittedWhileInvisible()` returns false for muted elements, so it may block for a different reason. The docs say "macOS Safari" rather than "Safari" for that reason.

</details>

## Testing

- `pnpm -F site test` — 33 files, 577 tests passing.
- Compiled both files with the @mdx-js/mdx 3.1.1 to confirm they parse.

Prose-only change; no runtime behavior is affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only prose updates; no runtime or API behavior changes.
> 
> **Overview**
> **Fixes incorrect autoplay guidance** that implied muted autoplay works the same for all media. The how-to now limits “muted autoplay is broadly allowed” to **video**, adds a bullet on **Chrome/Chromium**: the muted exemption applies only to `<video>`, so muted `<audio>` stays blocked until user activation and **is not retried** after interaction, and recommends starting **Audio**-family components from a user gesture. The closing constraints bullet is reworded so the guide’s recommended pattern is framed as targeting video-rendering components without contradicting the new audio rule.
> 
> The **Audio** reference gains an **Autoplay** section with the same Chrome vs Firefox/macOS Safari distinction and a link to the autoplay guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d9dbddaee8ce142b54f83a18de7c3177ac9a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->