### PR TITLE
fix: scale seek-bar thumbnails to fill their box

### DIFF
--- a/apps/e2e/tests/sandbox-skin-styling.spec.ts
+++ b/apps/e2e/tests/sandbox-skin-styling.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+import { DATA_ATTRS } from '../fixtures/selectors';
+
 const SANDBOX_BASE = process.env.SANDBOX_URL ?? 'http://localhost:5299';
 
 const CASES = [
@@ -75,6 +77,77 @@ for (const { platform, skin, styling } of CASES) {
       fillUsesAccent: true,
       videoBorderRadius: '18px',
     });
+  });
+
+  test(`${platform} ${skin} ${styling} scales thumbnails in fullscreen`, async ({ page }) => {
+    await page.setViewportSize({ width: 1920, height: 1080 });
+
+    const query = new URLSearchParams({
+      styling,
+      skin,
+      source: 'hls-1',
+      autoplay: '0',
+      muted: '1',
+      loop: '0',
+      preload: 'metadata',
+    });
+
+    await page.goto(`${SANDBOX_BASE}/${platform}-video/?${query}`, { waitUntil: 'domcontentloaded' });
+
+    const root = page.getByRole('group', { name: 'Media player' }).first();
+    const slider = page.getByRole('slider', { name: 'Seek' }).first().locator('..');
+    // The preview is `aria-hidden`, so `role=img` is the only hook the CSS and Tailwind skins share.
+    const thumbnail = root.locator('[role="img"]').first();
+
+    await expect(root).toBeVisible({ timeout: 15_000 });
+    await slider.hover();
+    await expect(thumbnail).toBeAttached({ timeout: 15_000 });
+    await expect(thumbnail).not.toHaveAttribute(DATA_ATTRS.loading, { timeout: 15_000 });
+
+    // Layout sizes, not bounding rects: the preview scales in over 150ms and a transform would skew the comparison.
+    const measure = () =>
+      thumbnail.evaluate((element) => {
+        const image = element.shadowRoot?.querySelector('img') ?? element.querySelector('img');
+        const rect = element.getBoundingClientRect();
+        const imageRect = image!.getBoundingClientRect();
+        const host = element as HTMLElement;
+
+        return {
+          width: host.offsetWidth,
+          height: host.offsetHeight,
+          maxWidth: parseFloat(getComputedStyle(element).maxWidth),
+          rightGap: rect.right - imageRect.right,
+          bottomGap: rect.bottom - imageRect.bottom,
+        };
+      });
+
+    const before = await measure();
+
+    const fullscreenButton = root.getByRole('button', { name: /full ?screen/i }).first();
+
+    await fullscreenButton.click();
+    await expect(fullscreenButton).toHaveAttribute(DATA_ATTRS.fullscreen, '');
+    await slider.hover();
+
+    // Fullscreen widens the preview through a container query, and the tile has to grow to fill it — less the 1px
+    // anti-fringe inset on each edge.
+    await expect.poll(async () => (await measure()).maxWidth).toBeGreaterThan(before.maxWidth);
+    await expect
+      .poll(async () => {
+        const box = await measure();
+
+        return box.maxWidth - box.width;
+      })
+      .toBeLessThanOrEqual(2);
+
+    const after = await measure();
+
+    expect(after.width).toBeGreaterThan(before.width);
+    // Aspect ratio survives the resize, so the tile is neither cropped nor letterboxed.
+    expect(Math.abs(after.width / after.height - before.width / before.height)).toBeLessThan(0.02);
+    // The sprite still covers the container that clips it.
+    expect(after.rightGap).toBeLessThanOrEqual(0);
+    expect(after.bottomGap).toBeLessThanOrEqual(0);
   });
 }
 

--- a/packages/core/src/core/ui/thumbnail/core.ts
+++ b/packages/core/src/core/ui/thumbnail/core.ts
@@ -69,12 +69,13 @@ export class ThumbnailCore {
   }
 
   /**
-   * Calculate a uniform scale factor that fits `tileWidth × tileHeight` within the given CSS min/max constraints while
+   * Calculate a uniform scale factor that sizes `tileWidth × tileHeight` to the given CSS min/max constraints while
    * preserving aspect ratio.
    *
-   * - Scales down when the tile exceeds max constraints.
-   * - Scales up when the tile is smaller than min constraints.
-   * - Returns `1` when no scaling is needed.
+   * - Fills the max constraints, scaling the tile up as readily as down. A box that grows — entering fullscreen widens it
+   *   through a container query — has to take the tile with it rather than leave it at its native size.
+   * - Raises that to meet min constraints, which win over max as they do in CSS.
+   * - Returns `1` when unconstrained.
    */
   calculateScale(tileWidth: number, tileHeight: number, constraints: ThumbnailConstraints): number {
     const { minWidth, maxWidth, minHeight, maxHeight } = constraints;
@@ -82,18 +83,13 @@ export class ThumbnailCore {
     const maxRatio = Math.min(maxWidth / tileWidth, maxHeight / tileHeight);
     const minRatio = Math.max(minWidth / tileWidth, minHeight / tileHeight);
 
-    // Scale down if exceeding max constraints.
-    if (Number.isFinite(maxRatio) && maxRatio < 1) return maxRatio;
+    const scale = Number.isFinite(maxRatio) ? maxRatio : 1;
 
-    // Scale up if below min constraints.
-    if (Number.isFinite(minRatio) && minRatio > 1) return minRatio;
-
-    return 1;
+    return Number.isFinite(minRatio) && minRatio > scale ? minRatio : scale;
   }
 
   /**
-   * Compute container and image dimensions for the current thumbnail, scaled to fit within the element's CSS min/max
-   * constraints.
+   * Compute container and image dimensions for the current thumbnail, scaled to the element's CSS min/max constraints.
    *
    * The container clips the sprite sheet via `overflow: hidden`, and the image is positioned with `transform:
    * translate()` to show the correct tile.

--- a/packages/core/src/core/ui/thumbnail/tests/core.test.ts
+++ b/packages/core/src/core/ui/thumbnail/tests/core.test.ts
@@ -169,7 +169,7 @@ describe('ThumbnailCore', () => {
       expect(scale).toBe(2);
     });
 
-    it('does not scale when tile already fits within constraints', () => {
+    it('scales up to fill the max box', () => {
       const core = new ThumbnailCore();
 
       const scale = core.calculateScale(256, 160, {
@@ -179,7 +179,21 @@ describe('ThumbnailCore', () => {
         maxHeight: 320,
       });
 
-      expect(scale).toBe(1);
+      expect(scale).toBe(2);
+    });
+
+    it('lets min constraints win over max', () => {
+      const core = new ThumbnailCore();
+
+      const scale = core.calculateScale(100, 50, {
+        minWidth: 400,
+        maxWidth: 200,
+        minHeight: 0,
+        maxHeight: Infinity,
+      });
+
+      // Filling max-width alone gives 200/100 = 2; min-width raises it to 400/100 = 4.
+      expect(scale).toBe(4);
     });
   });
 

--- a/packages/core/src/dom/ui/tests/thumbnail.test.ts
+++ b/packages/core/src/dom/ui/tests/thumbnail.test.ts
@@ -208,6 +208,47 @@ describe('createThumbnail', () => {
       handle.destroy();
     });
 
+    it('returns to a failed sheet without restarting loading', () => {
+      const img = createMockImg();
+      const handle = createThumbnail(createOptions({ getImg: () => img }));
+
+      handle.updateSrc('bad.jpg');
+      img.dispatchEvent(new Event('error'));
+
+      // Scrubbing across the sheet boundary and back.
+      handle.updateSrc('good.jpg');
+      handle.updateSrc('bad.jpg');
+
+      expect(handle.loading).toBe(false);
+      expect(handle.error).toBe(true);
+
+      handle.destroy();
+    });
+
+    it('clears a failed sheet once it loads', () => {
+      const img = createMockImg();
+      const handle = createThumbnail(createOptions({ getImg: () => img }));
+
+      handle.updateSrc('flaky.jpg');
+      img.dispatchEvent(new Event('error'));
+
+      handle.updateSrc('good.jpg');
+      handle.updateSrc('flaky.jpg');
+      expect(handle.error).toBe(true);
+
+      // The renderer assigns the src regardless, so a retry that succeeds recovers.
+      img.dispatchEvent(new Event('load'));
+      expect(handle.error).toBe(false);
+
+      handle.updateSrc('good.jpg');
+      handle.updateSrc('flaky.jpg');
+
+      expect(handle.loading).toBe(true);
+      expect(handle.error).toBe(false);
+
+      handle.destroy();
+    });
+
     it('stops listening to img events after destroy', () => {
       const img = createMockImg();
       const onStateChange = vi.fn();
@@ -278,6 +319,30 @@ describe('createThumbnail', () => {
       // ResizeObserver should now be set up.
       expect(ResizeObserverStub.instances).toHaveLength(1);
       expect(ResizeObserverStub.instances[0]!.observe).toHaveBeenCalledWith(container);
+
+      handle.destroy();
+    });
+
+    it('notifies on container resize so constraints are re-read', () => {
+      const container = createMockContainer();
+      const onStateChange = vi.fn();
+
+      const handle = createThumbnail(
+        createOptions({
+          getContainer: () => container,
+          onStateChange,
+        })
+      );
+
+      handle.connect();
+      onStateChange.mockClear();
+
+      const observer = ResizeObserverStub.instances[0]!;
+
+      // SAFETY: The stub is what `new ResizeObserver()` returns here, and the callback ignores this argument.
+      observer.callback([], observer as unknown as ResizeObserver);
+
+      expect(onStateChange).toHaveBeenCalledOnce();
 
       handle.destroy();
     });
@@ -415,6 +480,18 @@ describe('createThumbnail', () => {
 
       handle.destroy();
       handle.destroy();
+    });
+
+    it('stops observing resizes', () => {
+      const handle = createThumbnail(createOptions());
+
+      handle.connect();
+
+      const observer = ResizeObserverStub.instances[0]!;
+
+      handle.destroy();
+
+      expect(observer.disconnect).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/core/src/dom/ui/thumbnail.ts
+++ b/packages/core/src/dom/ui/thumbnail.ts
@@ -34,6 +34,9 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
   let imgBound = false;
   let stopObservingResize: (() => void) | null = null;
 
+  // Sprite sheets that have already failed, so re-entering one does not restart the loading state.
+  const failedSrcs = new Set<string>();
+
   // --- img event listeners ---
 
   function onImgLoad() {
@@ -44,14 +47,22 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
       naturalHeight = img.naturalHeight;
     }
 
+    // A sheet that succeeds on a later attempt stops counting as failed.
+    failedSrcs.delete(lastSrc);
+
     loading = false;
     error = false;
     onStateChange();
   }
 
-  function onImgError() {
+  function markFailed(): void {
+    failedSrcs.add(lastSrc);
     loading = false;
     error = true;
+  }
+
+  function onImgError() {
+    markFailed();
     onStateChange();
   }
 
@@ -92,8 +103,13 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
     lastSrc = src;
 
     if (src) {
-      loading = true;
-      error = false;
+      // Returning to a sheet already known to fail goes straight back to the error state. Restarting the loading
+      // state would flash the skin's spinner shell under the pointer every time scrubbing crosses that boundary. The
+      // renderer assigns the src either way, so a sheet that recovers still clears itself on load.
+      const failed = failedSrcs.has(src);
+
+      loading = !failed;
+      error = failed;
     } else {
       loading = false;
       error = false;
@@ -118,8 +134,7 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
         loading = false;
         error = false;
       } else {
-        loading = false;
-        error = true;
+        markFailed();
       }
 
       onStateChange();

--- a/site/src/content/docs/reference/thumbnail.mdx
+++ b/site/src/content/docs/reference/thumbnail.mdx
@@ -102,7 +102,7 @@ Supported source formats:
 
 In React, text-track mode needs `Player` because it reads track state from the player store. JSON modes (`thumbnails` prop) work without a player.
 
-The component picks the latest thumbnail whose `startTime` is less than or equal to the current `time`, then scales/clips sprite tiles to fit CSS min/max constraints while preserving aspect ratio.
+The component picks the latest thumbnail whose `startTime` is less than or equal to the current `time`, then scales/clips sprite tiles to fill CSS min/max constraints while preserving aspect ratio. Tiles scale up as well as down, so a preview whose `max-width` grows — a container query widening it in fullscreen, say — grows with it.
 
 ### Cross-origin images
 


### PR DESCRIPTION
## What

Seek-bar thumbnail previews stayed at their native tile size when the player entered fullscreen. Two related fixes to the preview:

1. **Scale to fill (the reported bug).** `ThumbnailCore.calculateScale` returned early on `maxRatio < 1`, so it only ever scaled a sprite tile *down*. Constraints were already re-read on every update, so when a container query widened the preview in fullscreen the new `max-width` was seen and then ignored. It now fills the max constraints in either direction, and min constraints win over max as they do in CSS — that branch was previously unreachable whenever a max constraint was finite.

2. **No spinner flash on a failed sheet.** `updateSrc` cleared `error` on every URL change, so scrubbing back and forth across a sheet boundary restarted the loading state for a sheet already known to 404, flashing the skin's spinner shell under the pointer on each crossing. Failed sheet URLs are now remembered. It stays recoverable rather than permanently sticky: the renderer assigns the `src` either way, so a sheet that failed on a network blip and succeeds later clears itself on load.

## Why this shape

The first version of this branch reworked sizing onto `width: 100%` + `aspect-ratio` + a `ResizeObserver`. That was more machinery than the bug needed and introduced three regressions of its own: non-16:9 tiles were cover-fitted and cropped (~44% of a 9:16 tile, since every skin clamps the preview with `max-height`), a failed sprite rendered a full-size empty black box instead of collapsing, and the element silently required a wrapper with a definite width — breaking third-party skins built on the previous shrink-wrap pattern. That approach is reverted here; the element sizes itself intrinsically from its CSS constraints as before.

## Verification

Measured in Chromium: the thumbnail grows from **190px → 334px** on entering fullscreen (against a 192px → 336px `max-width`), wrapper hugging it, aspect ratio held at 1.79 throughout.

- e2e `sandbox-skin-styling.spec.ts`: 30 passed, including a new fullscreen scaling test across all 8 skin/renderer combinations (html/react × default/minimal × css/tailwind).
- Unit: core 1475, skins 25, html 447, react 536.
- `pnpm typecheck`, `pnpm lint`, `pnpm check:workspace`.

## Reviewer notes

- The new e2e assertions use `offsetWidth`, not `getBoundingClientRect()`: the preview scales in over 150ms, so a bounding rect is transform-skewed mid-animation.
- No ARIA changes. The preview host is already `aria-hidden="true"`, so an accessibility review confirmed no naming or status-message requirement in any state, and that a live region here would race the seek slider's own `aria-valuetext` during a scrub.
- **Forced colors is deliberately out of scope and will follow separately.** Worth knowing what's there: forced-colors mode drops every `box-shadow`, and the preview's only edge comes from one — the surface shadow in the default skin, the `::after` ring in the minimal skin — so it renders as an unbounded `Canvas` rectangle over the video. The same trap makes the vjsc skin's existing forced-colors borders no-ops (`surface.styles.ts` builds them from `ring-*` and inset shadows), leaving every vjsc menu, tooltip, and feedback popup borderless in High Contrast mode. Its e2e test doesn't catch it because it only diffs CSS against Tailwind output, and two equally-empty outputs match. The fix in both cases is `outline`, which survives forced colors and follows `border-radius`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core thumbnail sizing math and load/error state during scrubbing, which affects every skin’s seek preview; risk is mitigated by broad e2e and unit coverage.
> 
> **Overview**
> Seek-bar thumbnail previews no longer stay at native tile size when fullscreen widens their CSS `max-width` via container queries. **`ThumbnailCore.calculateScale`** now sizes tiles to **fill** the max constraint box (scaling up as well as down) while letting min constraints override max, matching prior “fit only when too large” behavior.
> 
> The DOM thumbnail controller **remembers failed sprite sheet URLs** so scrubbing back onto a known-bad sheet keeps `error` without toggling `loading` (no spinner flash); a later successful `load` clears the failure cache.
> 
> **Playwright** adds a per-skin/renderer test that hovers the seek bar, enters fullscreen, and asserts larger layout size, stable aspect ratio, and sprite coverage. **Unit tests** cover the new scale math, failed-sheet revisits, resize observer notifications, and observer teardown. **Docs** describe fill-up scaling for growing preview boxes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44402e487194891b29bd4fa88e38058e4cbfb556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->