### PR TITLE
fix(spf): never adopt the UA-default preload on attach

### DIFF
--- a/packages/spf/src/media/types/index.ts
+++ b/packages/spf/src/media/types/index.ts
@@ -41,6 +41,13 @@ export interface AddressableObject {
  */
 export interface MediaElementLike {
   preload: string;
+  /**
+   * DOM attribute-reflection surface, present on real elements. Where it exists, reflected IDL properties like
+   * `preload` report a browser-dependent UA default even when no attribute was authored — so consumers that need author
+   * intent must gate property reads on attribute presence. A non-DOM implementation may omit it; its properties carry
+   * no UA defaults and are authored by construction.
+   */
+  hasAttribute?(qualifiedName: string): boolean;
 }
 
 // =============================================================================

--- a/packages/spf/src/media/utils/preload.ts
+++ b/packages/spf/src/media/utils/preload.ts
@@ -10,7 +10,8 @@ export function isStandardPreload(value: unknown): value is StandardPreload {
 
 /**
  * Default `preload` value used as the fallback across behaviors (`syncPreload`, `resolvePresentation`,
- * `isBlockingPreload`). Matches the `<video>`/`<audio>` element's implicit default.
+ * `isBlockingPreload`). SPF's own default, deliberately independent of the `<video>`/`<audio>` element's implicit
+ * default — that one is UA policy and browser-dependent (`'metadata'` Chromium, `'auto'` WebKit), never a source.
  */
 export const DEFAULT_PRELOAD = 'metadata';
 

--- a/packages/spf/src/playback/adapters/hls-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/hls-video/tests/adapter.test.ts
@@ -413,6 +413,45 @@ describe('HlsVideoMediaElement', () => {
       expect(media.engine.state.preload.get()).toBe('none');
     });
 
+    // Regression (#2532): the engine's DOM→state read must never adopt the
+    // attached element's UA-default preload. A shadow-style <video> carries no
+    // preload attribute, and its `preload` IDL property then reports a
+    // browser-dependent UA default ('metadata' Chromium, 'auto' WebKit).
+    it('keeps an explicit preload across attach of an element with no preload attribute (UA default is not a source)', async () => {
+      const media = new HlsVideoMediaElement();
+      const el = document.createElement('video');
+
+      // 'none' differs from every measured UA default, so a clobber from the
+      // attach-time read fails this on any browser.
+      media.preload = 'none';
+      media.attach(el);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(media.engine.state.preload.get()).toBe('none');
+    });
+
+    it("keeps SPF's 'metadata' default (not the UA default) when attaching with no preload set anywhere", async () => {
+      const media = new HlsVideoMediaElement();
+      const el = document.createElement('video');
+
+      media.attach(el);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(media.engine.state.preload.get()).toBe('metadata');
+    });
+
+    it('adopts an authored preload attribute from a newly attached element (most-recent-wins on attach)', async () => {
+      const media = new HlsVideoMediaElement();
+      const el = document.createElement('video');
+
+      el.setAttribute('preload', 'auto');
+      media.preload = 'none';
+      media.attach(el);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(media.engine.state.preload.get()).toBe('auto');
+    });
+
     it('keeps explicit preload in engine state across src changes', () => {
       const media = new HlsVideoMediaElement();
       const el = document.createElement('video');

--- a/packages/spf/src/playback/behaviors/sync-preload.ts
+++ b/packages/spf/src/playback/behaviors/sync-preload.ts
@@ -3,10 +3,13 @@
  *
  * Two effects:
  *
- * - **Read (DOM → state)** — on `context.mediaElement` swap or `state.presentation.url` change, copies
- *   `mediaElement.preload` into `state.preload` if it's a W3C value and `state.preload` isn't holding an extended
- *   (non-W3C) value. When the DOM has no W3C opinion and `state.preload` is undefined, backfills from
- *   `config.defaultPreload` (default-default `'metadata'`) so `state.preload` is never undefined in steady state.
+ * - **Read (DOM → state)** — on `context.mediaElement` swap or `state.presentation.url` change, copies the media
+ *   element's _authored_ preload into `state.preload` if it's a W3C value and `state.preload` isn't holding an extended
+ *   (non-W3C) value. Author intent only: on a DOM element the `preload` IDL property reports a browser-dependent UA
+ *   default even when no attribute was set (`'metadata'` Chromium, `'auto'` WebKit), so the property is consulted only
+ *   when the element carries a `preload` content attribute — a UA default is never a source. When the element has no
+ *   authored W3C opinion and `state.preload` is undefined, backfills from `config.defaultPreload` (default-default
+ *   `'metadata'`) so `state.preload` is never undefined in steady state.
  * - **Write (state → DOM)** — on `state.preload` change or `context.mediaElement` swap, writes `state.preload` back to
  *   `mediaElement.preload` if the value is W3C.
  *
@@ -63,12 +66,21 @@ function syncPreloadSetup({
     // Extended sticky: leave non-W3C values (e.g. 'canplay') alone.
     if (current !== undefined && !isStandardPreload(current)) return;
 
-    const target: StandardPreload | undefined =
-      mediaElement && isStandardPreload(mediaElement.preload)
+    // Author intent only: a DOM element's `preload` property reports a UA
+    // default when no attribute was authored (the shadow <video> under an SPF
+    // Media never carries one), so gate the property read on attribute
+    // presence. An element without attribute reflection has no UA defaults —
+    // its property is authored by construction.
+    const authoredPreload =
+      mediaElement && (!mediaElement.hasAttribute || mediaElement.hasAttribute('preload'))
         ? mediaElement.preload
-        : current === undefined
-          ? defaultPreload
-          : undefined;
+        : undefined;
+
+    const target: StandardPreload | undefined = isStandardPreload(authoredPreload)
+      ? authoredPreload
+      : current === undefined
+        ? defaultPreload
+        : undefined;
     if (target === undefined || target === current) return;
 
     state.preload.set(target);

--- a/packages/spf/src/playback/behaviors/tests/sync-preload.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/sync-preload.test.ts
@@ -92,6 +92,68 @@ describe('syncPreload', () => {
       cleanup();
     });
 
+    // DOM-reflected elements (#2532): the `preload` IDL property reports a
+    // browser-dependent UA default even when no attribute was authored, so the
+    // read gates on `hasAttribute` when the element exposes it. Fakes below
+    // model a real element: property always populated, attribute optional.
+    describe('authored attribute gate (UA default is never a source)', () => {
+      it('ignores the preload property when the element carries no preload attribute', () => {
+        const state = makeState();
+        // A bare shadow <video>: no attribute, property reports the UA default.
+        const context = makeContext({ mediaElement: { preload: 'auto', hasAttribute: () => false } });
+
+        const cleanup = syncPreload.setup({ state, context });
+
+        // SPF's own default, not the element's UA default.
+        expect(state.preload.get()).toBe('metadata');
+
+        cleanup();
+      });
+
+      it('does not clobber a prior state.preload when an attribute-less element attaches', async () => {
+        const state = makeState({ preload: 'none' });
+        const context = makeContext();
+
+        const cleanup = syncPreload.setup({ state, context });
+
+        context.mediaElement.set({ preload: 'auto', hasAttribute: () => false });
+        await Promise.resolve();
+
+        expect(state.preload.get()).toBe('none');
+
+        cleanup();
+      });
+
+      it('does not clobber state.preload on presentation.url change when the element has no preload attribute', async () => {
+        const state = makeState({ preload: 'none', presentation: { url: 'a.m3u8' } });
+        const context = makeContext({ mediaElement: { preload: 'auto', hasAttribute: () => false } });
+
+        const cleanup = syncPreload.setup({ state, context });
+
+        state.presentation.set({ url: 'b.m3u8' });
+        await Promise.resolve();
+
+        expect(state.preload.get()).toBe('none');
+
+        cleanup();
+      });
+
+      it('adopts the preload property when the element carries a preload attribute (most-recent-wins on attach)', async () => {
+        const state = makeState({ preload: 'none' });
+        const context = makeContext();
+
+        const cleanup = syncPreload.setup({ state, context });
+
+        context.mediaElement.set({ preload: 'auto', hasAttribute: (name) => name === 'preload' });
+
+        await vi.waitFor(() => {
+          expect(state.preload.get()).toBe('auto');
+        });
+
+        cleanup();
+      });
+    });
+
     it('does not clear state.preload when mediaElement is removed', () => {
       const state = makeState({ preload: 'auto' });
       const context = makeContext();


### PR DESCRIPTION
Fixes #2532

## Summary

`syncPreload`'s attach-time DOM→state read consulted the `preload` IDL property, which reports a browser-dependent UA default (`'metadata'` Chromium, `'auto'` WebKit) even when no attribute was authored. The SPF Medias attach a shadow `<video>` that never carries the host's `preload` attribute, so the read clobbered author intent with UA policy — on WebKit a paused `<hls-video preload="metadata">` buffered the full stream. Chromium's default coincidentally matching SPF's masked the bug there.

## Changes

- The DOM→state read now consults the `preload` property only when the element actually carries a `preload` content attribute, so a UA default is never adopted as author intent.
- Absent author intent, `state.preload` stays on SPF's own `'metadata'` default; its doc no longer claims to match the element's implicit (UA-defined) default.
- `MediaElementLike` gains an optional `hasAttribute` for the reflection surface; a plain `MediaElementLike` without attribute reflection keeps its property authority (it has no UA to inject a default).
- Regression coverage in `sync-preload.test.ts` (authored-attribute gate, attach/swap/url-change paths) and `adapter.test.ts` (author value forwarded via the adapter survives attach).

<details>
<summary>Design choice: constrain the read vs drop the sync</summary>

The recorded direction on #2532 ruled out deferring to the UA default and left two shapes open: drop `syncPreload`'s DOM→state read entirely, or keep it constrained. This PR constrains it to authored intent: attribute-present reads keep the IDL property's spec normalization, and most-recent-wins on attach still holds for authored elements. Dropping the bidirectional sync altogether remains on the table if the attribute gate isn't worth its edge cases.

</details>

## Testing

- `pnpm -F @videojs/spf test src/playback/behaviors/tests/sync-preload.test.ts src/playback/adapters/hls-video/tests/adapter.test.ts` — 91 pass, no type errors (this branch is based on `main`, which has no WebKit unit tier; the divergence itself was diagnosed and measured in #2532).
- Manual cross-browser check: paused `<hls-video preload="metadata">` on WebKit should no longer buffer the stream; behavior now matches Chromium.

## Review context

This diff was produced end-to-end by a context-free agent session working from the recorded direction on #2532, as rehearsal 2 of the SPF automation proving-out plan (`internal/design/spf/automation/proving-out.md`). Review is deliberately of the cold diff; the embedded design choice above is one of the graded touchpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core playback loading behavior on media attach and URL changes; wrong gating could still mis-sync preload vs author intent, but scope is limited to sync-preload and the fix is well-tested.
> 
> **Overview**
> Fixes **#2532**: attach-time DOM→state preload sync no longer treats the shadow `<video>`’s browser-dependent `preload` IDL default as author intent (notably WebKit `'auto'` overriding `<hls-video preload="metadata">` and over-buffering).
> 
> **`syncPreload`** now reads `mediaElement.preload` only when the element has a `preload` content attribute (via optional **`hasAttribute`** on **`MediaElementLike`**); without an authored attribute it keeps existing **`state.preload`** or backfills SPF’s **`'metadata'`** default. Authored attributes still win on attach (most-recent-wins). **`DEFAULT_PRELOAD`** documentation is updated to state it is SPF policy, not the element’s UA implicit default.
> 
> Regression tests cover the attribute gate in **`sync-preload.test.ts`** and attach paths in **`adapter.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3caa1ed3e32a8aeaf6605a307ad02abdf24f630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->