### PR TITLE
feat(packages): add explicit controls visibility

### DIFF
--- a/packages/core/src/core/ui/controls/controls-component.ts
+++ b/packages/core/src/core/ui/controls/controls-component.ts
@@ -1,12 +1,13 @@
 import { defineComponent } from 'vjsc/components';
 
+import type { ControlsProps } from './core';
 import { ControlsDataAttrs } from './data';
 
 export default defineComponent({
   name: 'Controls',
   root: 'Root',
   parts: {
-    Root: defineComponent(),
+    Root: defineComponent<ControlsProps>(),
     Backdrop: defineComponent(),
     Content: defineComponent(),
     Group: defineComponent(),

--- a/packages/core/src/core/ui/controls/core.ts
+++ b/packages/core/src/core/ui/controls/core.ts
@@ -1,27 +1,53 @@
 import type { MediaControlsState } from '@videojs/media';
+import { defaults } from '@videojs/utils/object';
+import type { NonNullableObject } from '@videojs/utils/types';
+
+export type ControlsVisibility = 'auto' | 'always';
+
+export interface ControlsProps {
+  /** Whether controls follow player visibility state or remain visible. */
+  visibility?: ControlsVisibility | undefined;
+}
 
 export interface ControlsState {
+  /** Whether the controls are visible. */
   visible: boolean;
+  /** Whether the user has recently interacted with the player. */
   userActive: boolean;
 }
 
 export class ControlsCore {
+  static readonly defaultProps: NonNullableObject<ControlsProps> = {
+    visibility: 'auto',
+  };
+
+  #props = { ...ControlsCore.defaultProps };
   #media: MediaControlsState | null = null;
 
-  setMedia(media: MediaControlsState): void {
+  constructor(props?: ControlsProps) {
+    if (props) this.setProps(props);
+  }
+
+  setProps(props: ControlsProps): void {
+    this.#props = defaults(props, ControlsCore.defaultProps);
+  }
+
+  setMedia(media: MediaControlsState | null): void {
     this.#media = media;
   }
 
-  getState(): ControlsState {
-    const media = this.#media!;
+  getState(): ControlsState | null {
+    const media = this.#media;
+    if (!media) return this.#props.visibility === 'always' ? { visible: true, userActive: true } : null;
 
     return {
-      visible: media.controlsVisible,
+      visible: this.#props.visibility === 'always' || media.controlsVisible,
       userActive: media.userActive,
     };
   }
 }
 
 export namespace ControlsCore {
+  export type Props = ControlsProps;
   export type State = ControlsState;
 }

--- a/packages/core/src/core/ui/controls/tests/core.test.ts
+++ b/packages/core/src/core/ui/controls/tests/core.test.ts
@@ -4,7 +4,24 @@ import { describe, expect, it } from 'vite-plus/test';
 import { ControlsCore } from '../core';
 
 describe('ControlsCore', () => {
+  describe('defaultProps', () => {
+    it('follows player visibility by default', () => {
+      expect(ControlsCore.defaultProps).toEqual({ visibility: 'auto' });
+    });
+  });
+
   describe('getState', () => {
+    it('returns null without controls state in auto mode', () => {
+      expect(new ControlsCore().getState()).toBeNull();
+    });
+
+    it('stays visible without controls state in always mode', () => {
+      expect(new ControlsCore({ visibility: 'always' }).getState()).toEqual({
+        visible: true,
+        userActive: true,
+      });
+    });
+
     it('returns visible: true when controlsVisible is true', () => {
       const core = new ControlsCore();
       const media = createControlsState({ controlsVisible: true });
@@ -26,6 +43,14 @@ describe('ControlsCore', () => {
       const media = createControlsState({ userActive: false });
 
       core.setMedia(media);
+      expect(core.getState()).toEqual({ visible: true, userActive: false });
+    });
+
+    it('keeps controls visible without overriding user activity in always mode', () => {
+      const core = new ControlsCore({ visibility: 'always' });
+
+      core.setMedia(createControlsState({ controlsVisible: false, userActive: false }));
+
       expect(core.getState()).toEqual({ visible: true, userActive: false });
     });
 
@@ -62,7 +87,7 @@ describe('ControlsCore', () => {
       const core = new ControlsCore();
 
       core.setMedia(createControlsState());
-      const state = core.getState();
+      const state = core.getState()!;
 
       const functionKeys = Object.entries(state).filter(([, value]) => typeof value === 'function');
 

--- a/packages/core/src/core/ui/tests/jsx-runtime.test-d.tsx
+++ b/packages/core/src/core/ui/tests/jsx-runtime.test-d.tsx
@@ -21,7 +21,7 @@ import { Slot, Text } from 'vjsc/components';
 describe('constrained JSX', () => {
   it('accepts typed components and nested compound parts', () => {
     void (
-      <Controls.Root>
+      <Controls.Root visibility="auto">
         <Controls.Content className="controls">
           <Tooltip.Provider delay={300}>
             <Controls.Group>

--- a/packages/html/src/ui/controls/controls-element.ts
+++ b/packages/html/src/ui/controls/controls-element.ts
@@ -1,6 +1,6 @@
-import { ControlsCore, ControlsDataAttrs, POPUP_HOST_SELECTOR } from '@videojs/core';
+import { ControlsCore, ControlsDataAttrs, type ControlsVisibility, POPUP_HOST_SELECTOR } from '@videojs/core';
 import { applyStateDataAttrs, logMissingFeature, selectControls } from '@videojs/core/dom';
-import type { PropertyValues } from '@videojs/element';
+import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextProvider } from '@videojs/element/context';
 import { isFunction } from '@videojs/utils/predicate';
 
@@ -12,6 +12,12 @@ import { controlsContext } from './context';
 export class ControlsElement extends UIElement {
   static readonly tagName = 'media-controls';
 
+  static override properties = {
+    visibility: { type: String },
+  } satisfies PropertyDeclarationMap<'visibility'>;
+
+  visibility: ControlsVisibility = ControlsCore.defaultProps.visibility;
+
   readonly #core = new ControlsCore();
   readonly #mediaState = new PlayerController(this, playerContext, selectControls);
   readonly #provider = new ContextProvider(this, { context: controlsContext });
@@ -20,7 +26,7 @@ export class ControlsElement extends UIElement {
   override connectedCallback(): void {
     super.connectedCallback();
 
-    if (__DEV__ && !this.#mediaState.value && this.#mediaState.displayName) {
+    if (__DEV__ && this.visibility === 'auto' && !this.#mediaState.value && this.#mediaState.displayName) {
       logMissingFeature(this.localName, this.#mediaState.displayName);
     }
   }
@@ -28,11 +34,11 @@ export class ControlsElement extends UIElement {
   protected override update(_changed: PropertyValues): void {
     super.update(_changed);
 
-    const media = this.#mediaState.value;
-    if (!media) return;
+    this.#core.setProps({ visibility: this.visibility });
+    this.#core.setMedia(this.#mediaState.value ?? null);
 
-    this.#core.setMedia(media);
     const state = this.#core.getState();
+    if (!state) return;
 
     applyStateDataAttrs(this, state, ControlsDataAttrs);
 

--- a/packages/html/src/ui/controls/tests/controls-element.test.ts
+++ b/packages/html/src/ui/controls/tests/controls-element.test.ts
@@ -101,6 +101,40 @@ afterEach(() => {
 });
 
 describe('ControlsElement', () => {
+  it('keeps controls visible without controls state when requested', async () => {
+    const controls = createDefinedElement(ControlsElement);
+    const content = createDefinedElement(ControlsContentElement);
+
+    controls.visibility = 'always';
+    controls.append(content);
+    document.body.append(controls);
+
+    await controls.updateComplete;
+
+    expect(content.hasAttribute('data-visible')).toBe(true);
+    expect(content.hasAttribute('data-user-active')).toBe(true);
+  });
+
+  it('keeps controls visible while preserving user activity when requested', async () => {
+    const provider = document.createElement('test-controls-player-provider') as TestPlayerProviderElement;
+    const controls = createDefinedElement(ControlsElement);
+    const content = createDefinedElement(ControlsContentElement);
+
+    controls.visibility = 'always';
+    controls.append(content);
+    document.body.append(provider);
+    provider.append(controls);
+
+    await controls.updateComplete;
+
+    provider.setVisible(false);
+
+    await waitForAssertion(() => {
+      expect(content.hasAttribute('data-visible')).toBe(true);
+      expect(content.hasAttribute('data-user-active')).toBe(false);
+    });
+  });
+
   it('keeps interactivity on the content rather than the context host', async () => {
     const provider = document.createElement('test-controls-player-provider') as TestPlayerProviderElement;
     const controls = createDefinedElement(ControlsElement);

--- a/packages/react/src/ui/controls/controls-root.tsx
+++ b/packages/react/src/ui/controls/controls-root.tsx
@@ -1,4 +1,4 @@
-import { ControlsCore, ControlsDataAttrs } from '@videojs/core';
+import { ControlsCore, ControlsDataAttrs, type ControlsProps } from '@videojs/core';
 import { logMissingFeature, selectControls } from '@videojs/core/dom';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
@@ -6,23 +6,28 @@ import { useState } from 'react';
 import { usePlayer } from '../../player/context';
 import { ControlsContextProvider } from './context';
 
-export interface ControlsRootProps {
+export interface ControlsRootProps extends ControlsProps {
   children?: ReactNode | undefined;
 }
 
 /** Manages controls state and provides it to the compound parts. Does not render an element. */
-export function ControlsRoot({ children }: ControlsRootProps): ReactNode {
+export function ControlsRoot({
+  children,
+  visibility = ControlsCore.defaultProps.visibility,
+}: ControlsRootProps): ReactNode {
   const controls = usePlayer(selectControls);
   const [core] = useState(() => new ControlsCore());
 
-  if (!controls) {
+  core.setProps({ visibility });
+  core.setMedia(controls ?? null);
+
+  const state = core.getState();
+
+  if (!state) {
     if (__DEV__) logMissingFeature('Controls.Root', 'controls');
 
     return null;
   }
-
-  core.setMedia(controls);
-  const state = core.getState();
 
   return (
     <ControlsContextProvider value={{ state, stateAttrMap: ControlsDataAttrs }}>{children}</ControlsContextProvider>

--- a/packages/react/src/ui/controls/tests/controls.test.tsx
+++ b/packages/react/src/ui/controls/tests/controls.test.tsx
@@ -1,9 +1,11 @@
-import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vite-plus/test';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
 
 import { createPlayerWrapper } from '../../../testing/mocks';
 import { ControlsContent } from '../controls-content';
 import { ControlsRoot } from '../controls-root';
+
+afterEach(cleanup);
 
 describe('ControlsRoot', () => {
   it('renders no wrapper element', () => {
@@ -20,6 +22,32 @@ describe('ControlsRoot', () => {
 
     expect(container.children).toHaveLength(1);
     expect(container.firstElementChild?.localName).toBe('span');
+  });
+
+  it('keeps controls visible without controls state when requested', () => {
+    const { Wrapper } = createPlayerWrapper();
+    const { getByTestId } = render(
+      <ControlsRoot visibility="always">
+        <ControlsContent data-testid="controls" />
+      </ControlsRoot>,
+      { wrapper: Wrapper }
+    );
+
+    expect(getByTestId('controls').hasAttribute('data-visible')).toBe(true);
+    expect(getByTestId('controls').hasAttribute('data-user-active')).toBe(true);
+  });
+
+  it('keeps controls visible while preserving user activity when requested', () => {
+    const { Wrapper } = createPlayerWrapper({ controlsVisible: false, userActive: false });
+    const { getByTestId } = render(
+      <ControlsRoot visibility="always">
+        <ControlsContent data-testid="controls" />
+      </ControlsRoot>,
+      { wrapper: Wrapper }
+    );
+
+    expect(getByTestId('controls').hasAttribute('data-visible')).toBe(true);
+    expect(getByTestId('controls').hasAttribute('data-user-active')).toBe(false);
   });
 });
 

--- a/packages/skins/vjsc/target/react.tsx
+++ b/packages/skins/vjsc/target/react.tsx
@@ -52,7 +52,7 @@ export const reactComponentTarget: ComponentTarget<CoreSchema> = defineComponent
     },
     components: {
       Controls: {
-        Root: ({ children }) => <target.Controls.Root>{children}</target.Controls.Root>,
+        Root: ({ props, children }) => <target.Controls.Root {...props}>{children}</target.Controls.Root>,
       },
       ErrorDialog: {
         Root: ({ children }) => <target.ErrorDialog.Root>{children}</target.ErrorDialog.Root>,


### PR DESCRIPTION
Refs #1055

## Summary

Add an explicit Controls visibility mode so audio skins can remain visible without treating missing player state as an implicit media type.

## Changes

- Add `visibility="auto" | "always"` across Core, React, HTML, and VJSC
- Preserve real user activity while forcing controls visibility
- Use a visible fallback only when `always` is explicitly requested without controls state

## Testing

- `pnpm -F @videojs/core test src/core/ui/controls/tests/core.test.ts`
- `pnpm -F @videojs/html test src/ui/controls/tests/controls-element.test.ts`
- `pnpm -F @videojs/react test src/ui/controls/tests/controls.test.tsx`
- `pnpm exec vp run @videojs/skins#build`
- `pnpm typecheck`