### PR TITLE
fix(packages): stabilize slider keyboard input

### DIFF
--- a/apps/e2e/shared/fixtures/volume-slider.ts
+++ b/apps/e2e/shared/fixtures/volume-slider.ts
@@ -1,0 +1,89 @@
+import type { Locator, Page } from '@playwright/test';
+
+interface VolumeKeyResult {
+  beforeRelease: number;
+  frames: number[];
+  gaps: number[];
+  release: number[];
+}
+
+function getThumbPercent(slider: Locator): Promise<number> {
+  return slider.evaluate((element) => {
+    const thumb = element.querySelector<HTMLElement>('.media-slider__thumb, media-slider-thumb, [role="slider"]')!;
+    const sliderRect = element.getBoundingClientRect();
+    const thumbRect = thumb.getBoundingClientRect();
+
+    return 100 - ((thumbRect.top + thumbRect.height / 2 - sliderRect.top) / sliderRect.height) * 100;
+  });
+}
+
+export async function holdVolumeKey(
+  page: Page,
+  slider: Locator,
+  key: 'ArrowDown' | 'ArrowUp'
+): Promise<VolumeKeyResult> {
+  await slider.evaluate((element) => {
+    const frames: number[] = [];
+    const gaps: number[] = [];
+    const record = () => {
+      const thumb = element.querySelector<HTMLElement>('.media-slider__thumb, media-slider-thumb, [role="slider"]')!;
+      const sliderRect = element.getBoundingClientRect();
+      const thumbRect = thumb.getBoundingClientRect();
+
+      frames.push(100 - ((thumbRect.top + thumbRect.height / 2 - sliderRect.top) / sliderRect.height) * 100);
+      gaps.push(Math.min(thumbRect.top - sliderRect.top, sliderRect.bottom - thumbRect.bottom));
+      window.volumeSliderFrame = requestAnimationFrame(record);
+    };
+
+    window.volumeSliderFrames = frames;
+    window.volumeSliderGaps = gaps;
+    record();
+  });
+
+  await page.keyboard.down(key);
+  await page.waitForTimeout(500);
+
+  for (let i = 1; i < 24; i++) {
+    await page.keyboard.down(key);
+    await page.waitForTimeout(17);
+  }
+
+  const beforeRelease = await getThumbPercent(slider);
+
+  await page.keyboard.up(key);
+  const release: number[] = [];
+
+  for (const wait of [0, 16, 100]) {
+    await page.waitForTimeout(wait);
+    release.push(await getThumbPercent(slider));
+  }
+
+  const { frames, gaps } = await page.evaluate(() => {
+    cancelAnimationFrame(window.volumeSliderFrame);
+
+    return {
+      frames: window.volumeSliderFrames,
+      gaps: window.volumeSliderGaps,
+    };
+  });
+
+  return { beforeRelease, frames, gaps, release };
+}
+
+export function neverReverses(values: number[], direction: 'down' | 'up'): boolean {
+  const sign = direction === 'up' ? 1 : -1;
+
+  return values.slice(1).every((value, index) => (value - values[index]!) * sign >= -0.01);
+}
+
+export function stays(values: number[], expected: number): boolean {
+  return values.every((value) => Math.abs(value - expected) < 0.01);
+}
+
+declare global {
+  interface Window {
+    volumeSliderFrame: number;
+    volumeSliderFrames: number[];
+    volumeSliderGaps: number[];
+  }
+}

--- a/apps/e2e/suites/player/tests/slider-keyboard.spec.ts
+++ b/apps/e2e/suites/player/tests/slider-keyboard.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+
+import { VIDEO_PAGES } from '../../../shared/fixtures/media';
+import { DATA_ATTRS } from '../../../shared/fixtures/selectors';
+import { holdVolumeKey, neverReverses, stays } from '../../../shared/fixtures/volume-slider';
+import { PlayerPage } from '../../../shared/page-objects/player';
+
+for (const { name, path } of VIDEO_PAGES.filter(({ resource }) => resource === 'mp4')) {
+  test.describe(`Slider keyboard input — ${name}`, () => {
+    test('keeps repeated volume keys within range', async ({ page }) => {
+      await page.addInitScript(() => {
+        const forwarded = new WeakSet<Event>();
+
+        document.addEventListener(
+          'volumechange',
+          (event) => {
+            if (forwarded.has(event)) return;
+
+            event.stopImmediatePropagation();
+
+            setTimeout(() => {
+              const next = new Event('volumechange');
+
+              forwarded.add(next);
+              event.target?.dispatchEvent(next);
+            }, 100);
+          },
+          true
+        );
+      });
+
+      const player = new PlayerPage(page);
+
+      await page.goto(path);
+      await player.waitForMediaReady({ muted: false });
+      await player.muteButton.hover();
+      await player.volumeSliderThumb.focus();
+      await page.waitForTimeout(300);
+
+      for (const [key, value] of [
+        ['ArrowDown', 0],
+        ['ArrowUp', 100],
+      ] as const) {
+        const result = await holdVolumeKey(page, player.volumeSlider, key);
+        const direction = key === 'ArrowUp' ? 'up' : 'down';
+
+        await expect(player.volumeSliderThumb).toHaveAttribute('aria-valuenow', String(value));
+        expect(neverReverses(result.frames, direction), JSON.stringify(result.frames)).toBe(true);
+        expect(Math.min(...result.frames)).toBeGreaterThanOrEqual(-0.01);
+        expect(Math.max(...result.frames)).toBeLessThanOrEqual(100.01);
+        expect(Math.min(...result.gaps), JSON.stringify(result.gaps)).toBeGreaterThanOrEqual(-0.02);
+        expect(stays(result.release, result.beforeRelease), JSON.stringify(result.release)).toBe(true);
+      }
+    });
+
+    test('keeps controls visible while a volume key is held', async ({ page }) => {
+      const player = new PlayerPage(page);
+
+      await page.goto(path);
+      await player.waitForMediaReady();
+      await player.play();
+      await player.muteButton.hover();
+      await player.volumeSliderThumb.focus();
+      await expect(player.volumeSliderThumb).toBeFocused();
+      await page.keyboard.down('ArrowDown');
+
+      try {
+        for (let index = 0; index < 8; index++) {
+          await page.waitForTimeout(500);
+          await page.keyboard.down('ArrowDown');
+        }
+
+        await expect(player.controls).toHaveAttribute(DATA_ATTRS.visible, '');
+      } finally {
+        await page.keyboard.up('ArrowDown');
+      }
+    });
+  });
+}

--- a/packages/core/src/dom/store/features/controls.ts
+++ b/packages/core/src/dom/store/features/controls.ts
@@ -217,6 +217,7 @@ export const controlsFeature = definePlayerFeature({
     listen(container, 'pointermove', onPointerMove, { signal });
     listen(container, 'pointerdown', onPointerDown, { signal });
     listen(container, 'pointerup', onPointerUp, { signal });
+    listen(container, 'keydown', setActive, { signal });
     listen(container, 'keyup', setActive, { signal });
     listen(
       container,

--- a/packages/core/src/dom/store/features/tests/controls.test.ts
+++ b/packages/core/src/dom/store/features/tests/controls.test.ts
@@ -93,6 +93,26 @@ describe('controlsFeature', () => {
       expect(store.state.controlsVisible).toBe(true);
     });
 
+    it('keeps controls active while keydown repeats', () => {
+      const video = createMockVideo({ paused: false });
+      const { store, container } = createPlayerStore(video);
+
+      for (let index = 0; index < 3; index++) {
+        vi.advanceTimersByTime(IDLE_DELAY - 500);
+        container!.dispatchEvent(new Event('keydown'));
+        flush();
+      }
+
+      expect(store.state.userActive).toBe(true);
+      expect(store.state.controlsVisible).toBe(true);
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
+
+      expect(store.state.userActive).toBe(false);
+      expect(store.state.controlsVisible).toBe(false);
+    });
+
     it('reactivates on pointermove after idle', () => {
       const video = createMockVideo({ paused: false });
       const { store, container } = createPlayerStore(video);

--- a/packages/core/src/dom/store/features/tests/volume.test.ts
+++ b/packages/core/src/dom/store/features/tests/volume.test.ts
@@ -35,10 +35,17 @@ describe('volumeFeature', () => {
     it('reports mute available on media that has no volume level', () => {
       // An embed that takes a mute command but offers no way to set a level.
       // Reading one availability for both would hide a mute button that works.
-      const media = { muted: false, addEventListener() {}, removeEventListener() {} };
+      const media = {
+        muted: false,
+        addEventListener() {},
+        removeEventListener() {},
+      };
       const store = createStore<PlayerTarget>()(volumeFeature);
 
-      store.attach({ media: media as unknown as HTMLVideoElement, container: null });
+      store.attach({
+        media: media as unknown as HTMLVideoElement,
+        container: null,
+      });
 
       expect(store.state.mutedAvailability).toBe('available');
       expect(store.state.volumeAvailability).toBe('unavailable');
@@ -49,7 +56,10 @@ describe('volumeFeature', () => {
       const media = { addEventListener() {}, removeEventListener() {} };
       const store = createStore<PlayerTarget>()(volumeFeature);
 
-      store.attach({ media: media as unknown as HTMLVideoElement, container: null });
+      store.attach({
+        media: media as unknown as HTMLVideoElement,
+        container: null,
+      });
 
       expect(store.state.mutedAvailability).toBe('unavailable');
       expect(store.state.volumeAvailability).toBe('unavailable');
@@ -85,6 +95,7 @@ describe('volumeFeature', () => {
         const result = await store.setVolume(0.7);
 
         expect(video.volume).toBe(0.7);
+        expect(store.state.volume).toBe(0.7);
         expect(result).toBe(0.7);
       });
 
@@ -120,6 +131,7 @@ describe('volumeFeature', () => {
 
         expect(video.volume).toBe(0.7);
         expect(video.muted).toBe(false);
+        expect(store.state.muted).toBe(false);
       });
 
       it('does not unmute when setting volume to 0', async () => {

--- a/packages/core/src/dom/store/features/volume.ts
+++ b/packages/core/src/dom/store/features/volume.ts
@@ -9,7 +9,7 @@ const UNMUTE_VOLUME = 0.25;
 
 export const volumeFeature = definePlayerFeature({
   name: 'volume',
-  state: ({ target }): MediaVolumeState => ({
+  state: ({ target, set }): MediaVolumeState => ({
     volume: 1,
     muted: false,
     volumeAvailability: 'unavailable',
@@ -26,6 +26,11 @@ export const volumeFeature = definePlayerFeature({
       }
 
       media.volume = clamped;
+
+      // `volumechange` can be asynchronous. Sync immediately so controlled sliders do not render a stale value
+      // between keyboard repeats.
+      set({ volume: media.volume, muted: media.muted });
+
       return media.volume;
     },
 

--- a/packages/core/src/dom/ui/event.ts
+++ b/packages/core/src/dom/ui/event.ts
@@ -7,6 +7,7 @@ export interface UIEvent {
 
 export interface UIKeyboardEvent extends UIEvent {
   key: string;
+  repeat?: boolean;
   shiftKey: boolean;
   ctrlKey: boolean;
   altKey: boolean;

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -103,6 +103,7 @@ export function createSlider(options: SliderOptions): SliderApi {
     pointerDownX = 0,
     pointerDownY = 0,
     lastDragPercent = 0,
+    lastKeyPercent: number | null = null,
     committedOnRelease = false,
     pointingOnRelease = false;
 
@@ -194,8 +195,15 @@ export function createSlider(options: SliderOptions): SliderApi {
       pointerDownX = event.clientX;
       pointerDownY = event.clientY;
       lastDragPercent = percent;
-      input.patch({ pointing: true, pointerPercent: percent, dragPercent: percent });
+      lastKeyPercent = percent;
+      input.patch({
+        pointing: true,
+        pointerPercent: percent,
+        dragPercent: percent,
+      });
+
       options.onPressStart?.();
+
       options.onValueChange?.(percent);
 
       // Focus the thumb for keyboard follow-up and screen reader tracking.
@@ -225,7 +233,12 @@ export function createSlider(options: SliderOptions): SliderApi {
         }
 
         lastDragPercent = percent;
-        input.patch({ dragging: true, dragPercent: percent, pointerPercent: percent });
+        lastKeyPercent = percent;
+        input.patch({
+          dragging: true,
+          dragPercent: percent,
+          pointerPercent: percent,
+        });
 
         if (startingDrag) options.onDragStart?.();
 
@@ -291,7 +304,7 @@ export function createSlider(options: SliderOptions): SliderApi {
 
       const stepPercent = options.getStepPercent();
       const largeStepPercent = options.getLargeStepPercent();
-      const currentPercent = options.getPercent();
+      const currentPercent = event.repeat && !isNull(lastKeyPercent) ? lastKeyPercent : options.getPercent();
 
       // Round to nearest step before stepping to prevent drift from pointer drags.
       const rounded = roundToStep(currentPercent, stepPercent, 0);
@@ -329,8 +342,14 @@ export function createSlider(options: SliderOptions): SliderApi {
 
       if (newPercent !== null) {
         event.preventDefault();
+
         newPercent = clamp(newPercent, 0, 100);
-        input.patch({ pointerPercent: newPercent, dragPercent: newPercent, pointing: false });
+        lastKeyPercent = newPercent;
+        input.patch({
+          pointerPercent: newPercent,
+          dragPercent: newPercent,
+          pointing: false,
+        });
         options.onValueChange?.(newPercent);
         options.onValueCommit?.(newPercent);
       }
@@ -371,7 +390,10 @@ export function createSlider(options: SliderOptions): SliderApi {
     stopObservingResize = observeResize(options.getElement(), () => options.onResize!());
   }
 
-  const rootStyle: SliderRootStyle = { touchAction: 'none', userSelect: 'none' };
+  const rootStyle: SliderRootStyle = {
+    touchAction: 'none',
+    userSelect: 'none',
+  };
 
   return {
     input,
@@ -385,6 +407,7 @@ export function createSlider(options: SliderOptions): SliderApi {
       abort.abort();
       stopObservingResize?.();
       releaseCapture();
+
       cleanup();
     },
   };

--- a/packages/core/src/dom/ui/tests/slider.test.ts
+++ b/packages/core/src/dom/ui/tests/slider.test.ts
@@ -254,7 +254,14 @@ describe('createSlider', () => {
       const onPressEnd = vi.fn();
       const onDragStart = vi.fn();
       const el = createMockElement({ left: 0, width: 200 });
-      const slider = createSlider(createOptions({ getElement: () => el, onPressStart, onPressEnd, onDragStart }));
+      const slider = createSlider(
+        createOptions({
+          getElement: () => el,
+          onPressStart,
+          onPressEnd,
+          onDragStart,
+        })
+      );
 
       slider.rootProps.onPointerDown(pointerEvent({ clientX: 50 }));
       flush();
@@ -447,7 +454,11 @@ describe('createSlider', () => {
       expect(slider.input.current.dragging).toBe(true);
 
       // Stale: buttons = 0, mouse pointer
-      firePointerMove(slider, { clientX: 100, buttons: 0, pointerType: 'mouse' });
+      firePointerMove(slider, {
+        clientX: 100,
+        buttons: 0,
+        pointerType: 'mouse',
+      });
       flush();
 
       expect(slider.input.current.dragging).toBe(false);
@@ -469,7 +480,11 @@ describe('createSlider', () => {
       expect(slider.input.current.dragging).toBe(true);
 
       // Touch with buttons=0 should NOT trigger stale drag detection
-      firePointerMove(slider, { clientX: 100, buttons: 0, pointerType: 'touch' });
+      firePointerMove(slider, {
+        clientX: 100,
+        buttons: 0,
+        pointerType: 'touch',
+      });
       flush();
 
       expect(slider.input.current.dragging).toBe(true);
@@ -553,7 +568,13 @@ describe('createSlider', () => {
 
     it('ArrowLeft decrements by step', () => {
       const onValueChange = vi.fn();
-      const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 1, onValueChange }));
+      const slider = createSlider(
+        createOptions({
+          getPercent: () => 50,
+          getStepPercent: () => 1,
+          onValueChange,
+        })
+      );
 
       slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowLeft'));
 
@@ -564,7 +585,13 @@ describe('createSlider', () => {
 
     it('ArrowUp increments by step', () => {
       const onValueChange = vi.fn();
-      const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 5, onValueChange }));
+      const slider = createSlider(
+        createOptions({
+          getPercent: () => 50,
+          getStepPercent: () => 5,
+          onValueChange,
+        })
+      );
 
       slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowUp'));
 
@@ -575,7 +602,13 @@ describe('createSlider', () => {
 
     it('ArrowDown decrements by step', () => {
       const onValueChange = vi.fn();
-      const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 5, onValueChange }));
+      const slider = createSlider(
+        createOptions({
+          getPercent: () => 50,
+          getStepPercent: () => 5,
+          onValueChange,
+        })
+      );
 
       slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowDown'));
 
@@ -605,7 +638,11 @@ describe('createSlider', () => {
     it('PageUp increments by large step', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(
-        createOptions({ getPercent: () => 50, getLargeStepPercent: () => 10, onValueChange })
+        createOptions({
+          getPercent: () => 50,
+          getLargeStepPercent: () => 10,
+          onValueChange,
+        })
       );
 
       slider.thumbProps.onKeyDownCapture(keyboardEvent('PageUp'));
@@ -618,7 +655,11 @@ describe('createSlider', () => {
     it('PageDown decrements by large step', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(
-        createOptions({ getPercent: () => 50, getLargeStepPercent: () => 10, onValueChange })
+        createOptions({
+          getPercent: () => 50,
+          getLargeStepPercent: () => 10,
+          onValueChange,
+        })
       );
 
       slider.thumbProps.onKeyDownCapture(keyboardEvent('PageDown'));
@@ -652,12 +693,62 @@ describe('createSlider', () => {
 
     it('clamps to 0-100 range', () => {
       const onValueChange = vi.fn();
-      const slider = createSlider(createOptions({ getPercent: () => 99, getStepPercent: () => 5, onValueChange }));
+      const slider = createSlider(
+        createOptions({
+          getPercent: () => 99,
+          getStepPercent: () => 5,
+          onValueChange,
+        })
+      );
 
       slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
 
       expect(onValueChange).toHaveBeenCalledWith(100);
 
+      slider.destroy();
+    });
+
+    it('steps from the last value while a key repeats', () => {
+      const onValueChange = vi.fn();
+      const slider = createSlider(
+        createOptions({
+          getPercent: () => 80,
+          getStepPercent: () => 5,
+          onValueChange,
+        })
+      );
+
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight', { repeat: true }));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight', { repeat: true }));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight', { repeat: true }));
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight', { repeat: true }));
+
+      expect(onValueChange.mock.calls.map(([percent]) => percent)).toEqual([85, 90, 95, 100, 100]);
+
+      slider.destroy();
+    });
+
+    it('steps from the latest pointer value while a key repeats', () => {
+      const onValueChange = vi.fn();
+      const el = createMockElement({ left: 0, width: 200 });
+      const slider = createSlider(
+        createOptions({
+          getElement: () => el,
+          getPercent: () => 50,
+          getStepPercent: () => 5,
+          onValueChange,
+        })
+      );
+
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
+      slider.rootProps.onPointerDown(pointerEvent({ clientX: 160 }));
+      firePointerMove(slider, { clientX: 120 });
+      slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight', { repeat: true }));
+
+      expect(onValueChange.mock.calls.map(([percent]) => percent)).toEqual([55, 80, 60, 65]);
+
+      firePointerUp(slider, { clientX: 120 });
       slider.destroy();
     });
 
@@ -721,7 +812,13 @@ describe('createSlider', () => {
     it('rounds before stepping to prevent drift', () => {
       const onValueChange = vi.fn();
       // Simulate a value between steps (e.g., from a drag that landed at 47.3)
-      const slider = createSlider(createOptions({ getPercent: () => 47.3, getStepPercent: () => 5, onValueChange }));
+      const slider = createSlider(
+        createOptions({
+          getPercent: () => 47.3,
+          getStepPercent: () => 5,
+          onValueChange,
+        })
+      );
 
       slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
 
@@ -737,7 +834,13 @@ describe('createSlider', () => {
       const onValueChange = vi.fn();
 
       document.documentElement.dir = 'rtl';
-      const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 1, onValueChange }));
+      const slider = createSlider(
+        createOptions({
+          getPercent: () => 50,
+          getStepPercent: () => 1,
+          onValueChange,
+        })
+      );
 
       slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
 
@@ -750,7 +853,13 @@ describe('createSlider', () => {
       const onValueChange = vi.fn();
 
       document.documentElement.dir = 'rtl';
-      const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 1, onValueChange }));
+      const slider = createSlider(
+        createOptions({
+          getPercent: () => 50,
+          getStepPercent: () => 1,
+          onValueChange,
+        })
+      );
 
       slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowLeft'));
 
@@ -838,7 +947,12 @@ describe('createSlider', () => {
   describe('orientation', () => {
     it('computes percent from Y axis for vertical orientation', () => {
       const el = createMockElement({ top: 0, height: 100 });
-      const slider = createSlider(createOptions({ getElement: () => el, getOrientation: () => 'vertical' }));
+      const slider = createSlider(
+        createOptions({
+          getElement: () => el,
+          getOrientation: () => 'vertical',
+        })
+      );
 
       // vertical: 0% at bottom (y=100), 100% at top (y=0)
       slider.rootProps.onPointerDown(pointerEvent({ clientY: 25 }));
@@ -851,7 +965,12 @@ describe('createSlider', () => {
 
     it('computes percent from X axis for horizontal orientation', () => {
       const el = createMockElement({ left: 0, width: 200 });
-      const slider = createSlider(createOptions({ getElement: () => el, getOrientation: () => 'horizontal' }));
+      const slider = createSlider(
+        createOptions({
+          getElement: () => el,
+          getOrientation: () => 'horizontal',
+        })
+      );
 
       slider.rootProps.onPointerDown(pointerEvent({ clientX: 50 }));
       flush();
@@ -954,7 +1073,11 @@ describe('createSlider', () => {
       onValueCommit.mockClear();
 
       // Stale drag: buttons = 0, mouse pointer
-      firePointerMove(slider, { clientX: 100, buttons: 0, pointerType: 'mouse' });
+      firePointerMove(slider, {
+        clientX: 100,
+        buttons: 0,
+        pointerType: 'mouse',
+      });
 
       expect(onValueCommit).toHaveBeenCalledOnce();
       // Last drag percent was 40% (80/200) — the stale move doesn't update it.
@@ -1027,7 +1150,13 @@ describe('createSlider', () => {
 
       const onValueChange = vi.fn();
       const el = createMockElement({ left: 0, width: 200 });
-      const slider = createSlider(createOptions({ getElement: () => el, onValueChange, changeThrottle: 100 }));
+      const slider = createSlider(
+        createOptions({
+          getElement: () => el,
+          onValueChange,
+          changeThrottle: 100,
+        })
+      );
 
       slider.rootProps.onPointerDown(pointerEvent({ clientX: 50 }));
       onValueChange.mockClear();
@@ -1051,7 +1180,13 @@ describe('createSlider', () => {
 
       const onValueChange = vi.fn();
       const el = createMockElement({ left: 0, width: 200 });
-      const slider = createSlider(createOptions({ getElement: () => el, onValueChange, changeThrottle: 100 }));
+      const slider = createSlider(
+        createOptions({
+          getElement: () => el,
+          onValueChange,
+          changeThrottle: 100,
+        })
+      );
 
       slider.rootProps.onPointerDown(pointerEvent({ clientX: 50 }));
       onValueChange.mockClear();
@@ -1080,7 +1215,13 @@ describe('createSlider', () => {
     it('does not throttle onValueChange when changeThrottle is 0', () => {
       const onValueChange = vi.fn();
       const el = createMockElement({ left: 0, width: 200 });
-      const slider = createSlider(createOptions({ getElement: () => el, onValueChange, changeThrottle: 0 }));
+      const slider = createSlider(
+        createOptions({
+          getElement: () => el,
+          onValueChange,
+          changeThrottle: 0,
+        })
+      );
 
       slider.rootProps.onPointerDown(pointerEvent({ clientX: 50 }));
       onValueChange.mockClear();
@@ -1100,7 +1241,13 @@ describe('createSlider', () => {
 
       const onValueChange = vi.fn();
       const el = createMockElement({ left: 0, width: 200 });
-      const slider = createSlider(createOptions({ getElement: () => el, onValueChange, changeThrottle: 100 }));
+      const slider = createSlider(
+        createOptions({
+          getElement: () => el,
+          onValueChange,
+          changeThrottle: 100,
+        })
+      );
 
       slider.rootProps.onPointerDown(pointerEvent({ clientX: 50 }));
       onValueChange.mockClear();
@@ -1130,7 +1277,13 @@ describe('createSlider', () => {
 
       const onValueChange = vi.fn();
       const el = createMockElement({ left: 0, width: 200 });
-      const slider = createSlider(createOptions({ getElement: () => el, onValueChange, changeThrottle: 100 }));
+      const slider = createSlider(
+        createOptions({
+          getElement: () => el,
+          onValueChange,
+          changeThrottle: 100,
+        })
+      );
 
       slider.rootProps.onPointerDown(pointerEvent({ clientX: 50 }));
       onValueChange.mockClear();
@@ -1151,7 +1304,13 @@ describe('createSlider', () => {
 
     it('does not throttle keyboard changes', () => {
       const onValueChange = vi.fn();
-      const slider = createSlider(createOptions({ getPercent: () => 50, onValueChange, changeThrottle: 100 }));
+      const slider = createSlider(
+        createOptions({
+          getPercent: () => 50,
+          onValueChange,
+          changeThrottle: 100,
+        })
+      );
 
       slider.thumbProps.onKeyDownCapture(keyboardEvent('ArrowRight'));
 

--- a/packages/react/src/ui/hooks/use-slider.ts
+++ b/packages/react/src/ui/hooks/use-slider.ts
@@ -134,6 +134,11 @@ export function useSlider<State extends SliderState = SliderState>(
     (element = rootElementRef.current) => {
       if (!element) return;
 
+      const { dragging, pointing } = slider.input.current;
+      // Keyboard values come from the controlled state. Applying them here would
+      // briefly write the previous value before the caller handles the key.
+      if (!dragging && !pointing) return;
+
       const next = optionsRef.current.computeState(slider.input.current);
 
       applyStyles(element, optionsRef.current.getCSSVars(slider.adjustForAlignment(next)));

--- a/packages/skins/src/styles/sliders/slider.styles.ts
+++ b/packages/skins/src/styles/sliders/slider.styles.ts
@@ -3,7 +3,7 @@ import { styles } from 'vjsc/styles';
 const trackLayer = [
   'pointer-events-none absolute rounded-[inherit]',
   'transition-[clip-path] duration-media-slider ease-out',
-  'group-data-dragging/slider:duration-0 group-data-seeking/slider:duration-0',
+  'group-data-dragging/slider:duration-0 group-data-seeking/slider:duration-0 group-focus-within/slider:duration-0',
 ] as const;
 
 export default styles({
@@ -51,6 +51,7 @@ export default styles({
         'absolute z-10 top-1/2 left-(--media-slider-fill) size-3 -translate-x-1/2 -translate-y-1/2 rounded-media-control bg-current',
         'select-none transition-[opacity,height,width,outline-offset,left,top,scale] duration-media-slider ease-out',
         'group-data-dragging/slider:transition-[opacity,height,width,outline-offset,scale]',
+        'group-focus-within/slider:transition-[opacity,height,width,outline-offset,scale]',
         'group-data-dragging/slider:scale-90',
         'data-[orientation=vertical]:top-[calc(100%-var(--media-slider-fill))] data-[orientation=vertical]:left-1/2',
         'group-data-dragging/slider:data-[orientation=horizontal]:left-(--media-slider-pointer)',


### PR DESCRIPTION
## Summary

Fix shared slider keyboard interaction so held keys advance monotonically, remain within range, settle on release, and keep player controls visible for the full press. The volume slider is the browser regression because delayed `volumechange` events exposed the general controlled-slider timing problem.

## Changes

- Track in-flight keyboard percentages and rebase them when pointer input takes over.
- Treat a held key as one slider press, releasing the controls lock on key-up or blur.
- Prevent React pointer-only style synchronization from overwriting keyboard-driven values.
- Disable position transitions while sliders are focused across the Default, Minimal, Tailwind, and VJSC skins.
- Synchronize the volume adapter immediately because `volumechange` can be asynchronous; the shared slider remains media-agnostic.
- Add browser coverage for uninterrupted boundary holds, release stability, overflow, and controls visibility.

## Testing

- `pnpm build:packages`
- `pnpm typecheck`
- `pnpm -F @videojs/core test src/dom/ui/tests/slider.test.ts src/dom/store/features/tests/volume.test.ts`
- `pnpm -F @videojs/html test src/ui/time-slider/tests/time-slider-element.test.ts`
- `pnpm -F @videojs/react test src/ui/slider/tests/slider.test.tsx src/ui/volume-slider/tests/volume-slider.test.tsx`
- `pnpm -F @videojs/skins test`
- `pnpm lint`
- Chromium sandbox E2E: repeated slider keys and held-key controls visibility (2 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core slider input, React style sync, and volume state timing—high user-visible surface area but scoped changes with broad test coverage.
> 
> **Overview**
> Fixes **held arrow-key** interaction on sliders (especially volume) so values step monotonically, stay in range, and don’t visually bounce when media state updates lag behind the UI.
> 
> The shared DOM slider now tracks **`lastKeyPercent`** and uses it for **`event.repeat`** steps instead of re-reading a stale controlled percent; pointer drags refresh that baseline. **`UIKeyboardEvent`** gains an optional **`repeat`** flag. React **`useSlider`** only applies pointer-driven CSS var sync while **dragging/pointing**, so keyboard steps aren’t overwritten by the previous value. Skins disable slider position transitions under **`group-focus-within/slider`** so keyboard moves aren’t animated into the wrong place.
> 
> **Volume** **`setVolume`** immediately **`set`s** store volume/muted because **`volumechange`** can arrive late. **Controls** treat **`keydown`** on the container like activity (not just **`keyup`**), so auto-hide doesn’t fire mid key-repeat.
> 
> Adds **Playwright** coverage (held keys, boundaries, release stability, delayed **`volumechange`**, controls stay visible) plus unit tests for repeat stepping and controls idle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b870a37738d9bf24c44e007815e0be97ac931291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->