### PR TITLE
fix(core): avoid Turbopack circular dependency

### DIFF
--- a/packages/core/src/dom/gesture/action-value.ts
+++ b/packages/core/src/dom/gesture/action-value.ts
@@ -1,7 +1,7 @@
 import { isUndefined } from '@videojs/utils/predicate';
 
 import { DEFAULT_SEEK_STEP } from '../../core/ui/constants';
-import { getMediaInputActionValue } from '../media-actions';
+import { getMediaInputActionValue } from '../media-action-value';
 import type { GestureRegion } from './gesture';
 
 /** Resolves the effective value for a gesture action from its explicit value and region. */

--- a/packages/core/src/dom/hotkey/hotkey.ts
+++ b/packages/core/src/dom/hotkey/hotkey.ts
@@ -1,7 +1,7 @@
 import { isMacOS } from '@videojs/utils/dom';
 
 import type { HotkeyProps } from '../../core/ui/hotkey/core';
-import { getMediaInputActionValue } from '../media-actions';
+import { getMediaInputActionValue } from '../media-action-value';
 import { HotkeyCoordinator } from './coordinator';
 
 export type HotkeyModifierKey = 'shift' | 'ctrl' | 'alt' | 'meta';

--- a/packages/core/src/dom/media-action-value.ts
+++ b/packages/core/src/dom/media-action-value.ts
@@ -1,0 +1,25 @@
+import { isUndefined } from '@videojs/utils/predicate';
+
+import { DEFAULT_SEEK_STEP, DEFAULT_VOLUME_STEP } from '../core/ui/constants';
+
+export function getMediaInputActionValue(
+  action: string,
+  key: string | undefined,
+  value?: number | undefined
+): number | undefined {
+  if (!isUndefined(value)) return value;
+
+  const normalizedKey = key?.toLowerCase();
+
+  if (action === 'seekStep') {
+    return normalizedKey === 'arrowleft' || normalizedKey === 'j' ? -DEFAULT_SEEK_STEP : DEFAULT_SEEK_STEP;
+  }
+
+  if (action === 'volumeStep') {
+    const step = DEFAULT_VOLUME_STEP / 100;
+
+    return normalizedKey === 'arrowdown' ? -step : step;
+  }
+
+  return undefined;
+}

--- a/packages/core/src/dom/media-actions.ts
+++ b/packages/core/src/dom/media-actions.ts
@@ -1,8 +1,8 @@
-import { isUndefined } from '@videojs/utils/predicate';
-
-import { DEFAULT_SEEK_STEP, DEFAULT_VOLUME_STEP } from '../core/ui/constants';
+import { getMediaInputActionValue } from './media-action-value';
 import type { AnyPlayerStore } from './player';
 import { selectPlaybackRate, selectTime, selectVolume } from './store/selectors';
+
+export { getMediaInputActionValue } from './media-action-value';
 
 export type MediaInputActionName = 'seekStep' | 'volumeStep' | 'speedUp' | 'speedDown';
 
@@ -13,28 +13,6 @@ export interface MediaInputActionContext {
 }
 
 export type MediaInputActionResolver = (context: MediaInputActionContext) => void;
-
-export function getMediaInputActionValue(
-  action: string,
-  key: string | undefined,
-  value?: number | undefined
-): number | undefined {
-  if (!isUndefined(value)) return value;
-
-  const normalizedKey = key?.toLowerCase();
-
-  if (action === 'seekStep') {
-    return normalizedKey === 'arrowleft' || normalizedKey === 'j' ? -DEFAULT_SEEK_STEP : DEFAULT_SEEK_STEP;
-  }
-
-  if (action === 'volumeStep') {
-    const step = DEFAULT_VOLUME_STEP / 100;
-
-    return normalizedKey === 'arrowdown' ? -step : step;
-  }
-
-  return undefined;
-}
 
 export const MEDIA_INPUT_ACTION_OVERRIDES: Record<MediaInputActionName, MediaInputActionResolver> = {
   seekStep({ store, value, key }) {


### PR DESCRIPTION
## Summary

- Split media input value resolution from selector-dependent action handlers
- Break the Core module cycle exposed by Turbopack during client module evaluation
- Preserve the existing `getMediaInputActionValue` re-export

## Testing

- `pnpm -F @videojs/core test` (102 test files, 1,488 tests)
- Repository-native formatting and lint checks on the changed files
- Direct ESM import of the built selectors module
- Next.js 16.3.2 Turbopack dev server using the locally linked React package (`GET /` returned 200)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only module split with a preserved public re-export; no change to seek/volume step logic or handler behavior.
> 
> **Overview**
> **Splits `getMediaInputActionValue` into `media-action-value.ts`** so seek/volume step defaults no longer live alongside store-backed action handlers.
> 
> Gesture and hotkey modules now import the resolver from **`media-action-value`** instead of **`media-actions`**, avoiding a module cycle Turbopack hit during client evaluation. **`media-actions`** still **re-exports** `getMediaInputActionValue` and owns `MEDIA_INPUT_ACTION_OVERRIDES` unchanged in behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0567514a6b7cebd6a4801af2e546a0db4ee1568b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->