### PR TITLE
fix(spf): probe codec support through ManagedMediaSource where classic MSE is absent

### DIFF
--- a/packages/spf/src/media/dom/mse/mediasource-setup.ts
+++ b/packages/spf/src/media/dom/mse/mediasource-setup.ts
@@ -237,11 +237,15 @@ export function buildMimeCodec(track: { mimeType: string; codecs?: string[] }): 
  * @returns True if the codec is supported
  */
 export function isCodecSupported(mimeCodec: string): boolean {
-  if (!supportsMediaSource()) {
-    return false;
+  if (supportsMediaSource()) {
+    return MediaSource.isTypeSupported(mimeCodec);
   }
 
-  return MediaSource.isTypeSupported(mimeCodec);
+  if (supportsManagedMediaSource()) {
+    return ManagedMediaSource!.isTypeSupported(mimeCodec);
+  }
+
+  return false;
 }
 
 /**

--- a/packages/spf/src/media/dom/mse/tests/mediasource-setup.test.ts
+++ b/packages/spf/src/media/dom/mse/tests/mediasource-setup.test.ts
@@ -278,6 +278,32 @@ describe('isCodecSupported', () => {
     // Test with unlikely/unsupported codec
     expect(isCodecSupported('video/invalid; codecs="fake"')).toBe(false);
   });
+
+  it('falls back to ManagedMediaSource.isTypeSupported when classic MediaSource is absent — the iPhone shape', () => {
+    const isTypeSupported = vi.fn((type: string) => type.includes('avc1'));
+
+    vi.stubGlobal('MediaSource', undefined);
+    vi.stubGlobal('ManagedMediaSource', { isTypeSupported });
+
+    try {
+      expect(isCodecSupported('video/mp4; codecs="avc1.42E01E"')).toBe(true);
+      expect(isCodecSupported('video/mp4; codecs="hvc1.2.4.L123.B0"')).toBe(false);
+      expect(isTypeSupported).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('returns false when neither MediaSource API exists', () => {
+    vi.stubGlobal('MediaSource', undefined);
+    vi.stubGlobal('ManagedMediaSource', undefined);
+
+    try {
+      expect(isCodecSupported('video/mp4; codecs="avc1.42E01E"')).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 describe('waitForMediaSourceOpen', () => {


### PR DESCRIPTION
## Summary

SPF could not play anything on iPhone: the codec capability probe consulted classic `MediaSource.isTypeSupported` only, and iPhone Safari ships `ManagedMediaSource` exclusively (iOS 17.1+). Every codec reported unsupported, selection pruned every rendition, and every source failed with a 2011 (no playable video track) verdict before playback was attempted. The probe now falls back to `ManagedMediaSource.isTypeSupported` when classic MSE is absent.

## Changes

- `isCodecSupported` consults `ManagedMediaSource.isTypeSupported` when classic `MediaSource` does not exist; behavior is unchanged wherever classic MSE is present (every other platform)
- Returns `false` only when neither API exists

## Deliberately minimal — follow-up planned

This is the smallest change that unbreaks iPhone, and it deliberately leaves a latent inconsistency in place: `setupMediaSource` attaches with `createMediaSource({ preferManaged: true })`, so on dual-API Safari (macOS) the engine attaches **ManagedMediaSource** while this probe still asks **classic MediaSource**. The two front the same media engine and no divergence in their `isTypeSupported` answers is known, so aligning them here would be an unforced behavior change on our most-verified platform inside an outage fix.

The follow-up is the by-construction fix: the composition owns a single MediaSource constructor that feeds both `createMediaSource` and the `canPlayTrack` probe (with `preferManaged` promoted from the behavior call site into composition config, and the probe's memoization keyed accordingly). That change touches the engine config surface, so it gets its own PR.

## Testing

- Two new unit tests pin the iPhone shape (classic MSE absent → MMS consulted) and the neither-API case; `pnpm -F @videojs/spf test` green with clean `tsbuildinfo` (1567 passed)
- Device-verified on a physical iPhone (2026-08-31): clear HLS and FairPlay-over-MMS sources that previously reported 2011 all play

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rendition/track selection on MMS-only Safari; behavior is unchanged where classic MediaSource exists, with a known follow-up to align probing with `preferManaged` on dual-API Safari.
> 
> **Overview**
> Fixes **iPhone Safari playback** where every rendition was dropped because codec probing only called classic `MediaSource.isTypeSupported`, while iOS 17.1+ exposes **ManagedMediaSource** without classic MSE.
> 
> **`isCodecSupported`** now uses `MediaSource.isTypeSupported` when classic MSE exists (unchanged elsewhere), otherwise **`ManagedMediaSource.isTypeSupported`**, and returns **`false`** only when neither API is present. **`createSourceBuffer`** and DOM track capability checks (`canPlayTrack` via `capabilities.ts`) inherit the fix.
> 
> Two unit tests cover the MMS-only “iPhone shape” and the no-API case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06341b40ee8eaa19f8b4ff0887c8ea33f37c4d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->