### PR TITLE
fix(media): keep one Mux Data view per viewing across loadstarts

### DIFF
--- a/internal/decisions/README.md
+++ b/internal/decisions/README.md
@@ -41,6 +41,7 @@ Add alternatives, consequences, or source links only when they materially explai
 
 | Area | Decisions |
 | --- | --- |
+| `media/` | Media contracts, hosts, and third-party integrations such as Mux Data |
 | `player/` | Provider, container, media discovery, and player composition |
 | `spf/` | Stream-processing ownership and coordination |
 | `store/` | State-management contracts |

--- a/internal/decisions/media/mux-data-monitor-lifecycle.md
+++ b/internal/decisions/media/mux-data-monitor-lifecycle.md
@@ -1,0 +1,28 @@
+---
+status: decided
+date: 2026-09-01
+---
+
+# Mux Data Keeps One Monitor Per Target
+
+## Decision
+
+`MuxData` starts one `mux-embed` monitor per target and keeps it alive for the target's lifetime. A source change is reported to the live monitor as `videochange`, and an engine swap re-hooks engine telemetry on the live monitor. The monitor is destroyed and re-created only when the target changes or when an option baked into `monitor()` itself changes (SDK, beacon domain, debug, cookies).
+
+## Why
+
+Destroying and re-running `monitor()` per source, the shape Mux Player's `playback-core` uses, is the outlier among Mux integrations and the cause of #2562. mux-embed's documented contract for playing several videos in one player is `videochange`: the SDK ends the current view, resets every `video_*` and `view_*` field, and arms `viewstart` on the next `play`. Every Mux-maintained integration (the Video.js plugin, THEOplayer, Kaltura, Akamai, React Native Video) follows it. A fresh `monitor()` per source instead re-runs first-view setup, so each fragment of one viewing lands as a separate player and view and can never be grouped back together. `playback-core` rediscovered this the hard way: its FairPlay retry has to force `muxDataKeepSession` and re-hook hls.js on the live monitor to avoid duplicate views, which is the same mechanism this decision makes the default.
+
+Three properties of the contract shaped the details:
+
+- The reset is complete, so `videochange` carries the full video metadata every time, not a diff.
+- `viewstart` waits for `play`. That is safe on `HTMLMediaElement` hosts because the load algorithm sets `paused` on every `load()`, so a source change always yields a fresh `play`. Integrations whose pipeline can swap sources without a paused transition (THEOplayer) synthesize `play` themselves. An SPF media (#1845) must either preserve that transition or do the same.
+- A cleared source is not a video change. mux-embed's element monitor does not listen to `emptied` or `abort`; the load algorithm's `pause` simply idles the view. So a cleared source is neither reported nor tracked, and the next real source is compared against the last video the monitor was told about.
+
+## Sources
+
+- Mux Data, Monitor HTML5 Video Element, "Changing the video": https://www.mux.com/docs/guides/monitor-html5-video-element
+- mux-embed SDK behavior (`videochange` resets the view and arms `viewstart` on `play`; the element monitor's event list), as shipped in the `mux-embed` npm package: https://www.npmjs.com/package/mux-embed
+- `playback-core` destroy-per-source and its `muxDataKeepSession` workaround: https://github.com/muxinc/elements/blob/e1a32eb3fb147fcbd42f810ecf54101f4582f868/packages/playback-core/src/index.ts#L671-L679 and https://github.com/muxinc/elements/blob/e1a32eb3fb147fcbd42f810ecf54101f4582f868/packages/playback-core/src/index.ts#L697-L740
+- Bug and fix: https://github.com/videojs/v10/issues/2562, https://github.com/videojs/v10/pull/2565. Inheriting work: https://github.com/videojs/v10/issues/1845
+- Implementation: [`mux-data.ts`](/packages/media/src/dom/mux/mux-data.ts), [`mux-data.test.ts`](/packages/media/src/dom/mux/tests/mux-data.test.ts)

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -1,7 +1,7 @@
 import Mux from 'mux-embed';
 
 import { getPlayerVersion } from './env';
-import { toMuxDataEngineOptions } from './mux-data-engine';
+import { type MuxDataEngineOptions, toMuxDataEngineOptions } from './mux-data-engine';
 import type { MuxDataOptions, MuxDataSdk } from './types';
 
 export interface MuxDataProps {
@@ -280,19 +280,23 @@ export class MuxData implements MuxDataProps {
   #syncEngineHook(mux: LiveMuxMonitor, engine: MuxDataMedia['engine']) {
     if (engine === this.#monitoredEngine) return;
 
-    const options = toMuxDataEngineOptions(engine);
-    const hook = options.hlsjs ? 'hlsjs' : options.dashjs ? 'dashjs' : null;
-
     if (this.#engineHook === 'hlsjs') mux.removeHLSJS();
 
     if (this.#engineHook === 'dashjs') mux.removeDashJS();
+
+    const options = toMuxDataEngineOptions(engine);
 
     if (options.hlsjs) mux.addHLSJS({ hlsjs: options.hlsjs, Hls: options.Hls });
 
     if (options.dashjs) mux.addDashJS({ dashjs: options.dashjs });
 
+    this.#trackEngine(engine, options);
+  }
+
+  /** Record which engine the monitor reflects and which telemetry hook carries it. */
+  #trackEngine(engine: MuxDataMedia['engine'], options: MuxDataEngineOptions) {
     this.#monitoredEngine = engine ?? null;
-    this.#engineHook = hook;
+    this.#engineHook = options.hlsjs ? 'hlsjs' : options.dashjs ? 'dashjs' : null;
   }
 
   #monitor(target: HTMLVideoElement, media: MuxDataMedia) {
@@ -309,8 +313,7 @@ export class MuxData implements MuxDataProps {
     const engineOptions = toMuxDataEngineOptions(media.engine);
 
     this.#monitoredSrc = media.src;
-    this.#monitoredEngine = media.engine ?? null;
-    this.#engineHook = engineOptions.hlsjs ? 'hlsjs' : engineOptions.dashjs ? 'dashjs' : null;
+    this.#trackEngine(media.engine, engineOptions);
 
     this.MuxDataSdk?.monitor(target, {
       debug,

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -286,7 +286,7 @@ export class MuxData implements MuxDataProps {
 
     const options = toMuxDataEngineOptions(engine);
 
-    if (options.hlsjs) mux.addHLSJS({ hlsjs: options.hlsjs, Hls: options.Hls });
+    if (options.hlsjs && options.Hls) mux.addHLSJS({ hlsjs: options.hlsjs, Hls: options.Hls });
 
     if (options.dashjs) mux.addDashJS({ dashjs: options.dashjs });
 

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -287,12 +287,11 @@ export class MuxData implements MuxDataProps {
 
     if (this.#engineHook === 'dashjs') mux.removeDashJS();
 
-    if (options.hlsjs)
-      mux.addHLSJS(options.Hls ? { hlsjs: options.hlsjs, Hls: options.Hls } : { hlsjs: options.hlsjs });
+    if (options.hlsjs) mux.addHLSJS({ hlsjs: options.hlsjs, Hls: options.Hls });
 
     if (options.dashjs) mux.addDashJS({ dashjs: options.dashjs });
 
-    this.#monitoredEngine = engine;
+    this.#monitoredEngine = engine ?? null;
     this.#engineHook = hook;
   }
 

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -36,11 +36,8 @@ type LiveMuxMonitor = Extract<NonNullable<HTMLVideoElement['mux']>, { deleted: f
 
 /**
  * What Mux Data needs from the media it monitors: the source being played, a `loadstart` hinting that the source or
- * engine may have changed, and — for engine-backed playback — the engine itself.
- *
- * `loadstart` is a hint, not a command: medias fire it for same-video reasons too (remote playback engaging, engine
- * rebuilds, MediaSource re-attachment), and how often varies by media. Mux Data reads the current `src` and `engine` on
- * each hint and reacts only to what actually changed, so redundant hints are free.
+ * engine may have changed, and — for engine-backed playback — the engine itself. Redundant hints are free — Mux Data
+ * reacts only to what actually changed — so medias can fire `loadstart` as often as their flavor requires.
  *
  * `engine` is deliberately untyped. Every engine-backed media host exposes one, but they are unrelated types (an hls.js
  * instance, a dash.js player, an SPF composition), and which of them Mux Data can hook is decided by
@@ -262,12 +259,13 @@ export class MuxData implements MuxDataProps {
     const src = media.src;
     if (src === this.#monitoredSrc) return;
 
+    // A cleared source isn't a new video (the element's own events wind the view down), and it isn't tracked: the
+    // video that loads next is still compared against the last video the monitor was told about.
+    if (!src) return;
+
     const isFirstSource = !this.#monitoredSrc;
 
     this.#monitoredSrc = src;
-
-    // A cleared source isn't a new video; the element's own events wind the view down.
-    if (!src) return;
 
     // A monitor started before the first source has its pending view: name the video rather than change it.
     if (isFirstSource) {

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -31,9 +31,16 @@ export const muxDataDefaultProps: MuxDataProps = {
 
 const MUX_VIDEO_DOMAIN = 'mux.com';
 
+/** The SDK's monitor handle on a video element, narrowed to a live (non-destroyed) one. */
+type LiveMuxMonitor = Extract<NonNullable<HTMLVideoElement['mux']>, { deleted: false }>;
+
 /**
- * What Mux Data needs from the media it monitors: the source being played, a `loadstart` to re-monitor on, and — for
- * engine-backed playback — the engine itself.
+ * What Mux Data needs from the media it monitors: the source being played, a `loadstart` hinting that the source or
+ * engine may have changed, and — for engine-backed playback — the engine itself.
+ *
+ * `loadstart` is a hint, not a command: medias fire it for same-video reasons too (remote playback engaging, engine
+ * rebuilds, MediaSource re-attachment), and how often varies by media. Mux Data reads the current `src` and `engine` on
+ * each hint and reacts only to what actually changed, so redundant hints are free.
  *
  * `engine` is deliberately untyped. Every engine-backed media host exposes one, but they are unrelated types (an hls.js
  * instance, a dash.js player, an SPF composition), and which of them Mux Data can hook is decided by
@@ -46,7 +53,7 @@ export interface MuxDataMedia extends EventTarget {
 
 export class MuxData implements MuxDataProps {
   #MuxDataSdk: MuxDataSdk | undefined = muxDataDefaultProps.MuxDataSdk;
-  #pendingInitialize: Promise<void> | null = null;
+  #pendingSync: Promise<void> | null = null;
   #beaconCollectionDomain: string | undefined = muxDataDefaultProps.beaconCollectionDomain;
   #debug = muxDataDefaultProps.debug;
   #disableCookies = muxDataDefaultProps.disableCookies;
@@ -57,6 +64,12 @@ export class MuxData implements MuxDataProps {
   #playerInitTime: number | undefined = this.#generatePlayerInitTime();
   #media: MuxDataMedia | null = null;
   #target: HTMLVideoElement | null = null;
+  // What the live monitor currently reflects, so a sync can react only to what changed.
+  #monitoredSrc: string | null = null;
+  #monitoredEngine: MuxDataMedia['engine'] = null;
+  #engineHook: 'hlsjs' | 'dashjs' | null = null;
+  // Generated once per instance, so the views of one player group into one session.
+  #viewSessionId: string | undefined;
 
   constructor(props: Partial<MuxDataProps> = {}) {
     Object.assign(this, props);
@@ -65,28 +78,29 @@ export class MuxData implements MuxDataProps {
   setMedia(media: MuxDataMedia) {
     if (this.#media === media) return;
 
-    this.#media?.removeEventListener('loadstart', this.#reinitialize);
+    this.#media?.removeEventListener('loadstart', this.#syncMonitor);
     this.#media = media;
-    this.#media.addEventListener('loadstart', this.#reinitialize);
+    this.#media.addEventListener('loadstart', this.#syncMonitor);
+
+    this.#syncMonitor();
   }
 
   attach(target: HTMLVideoElement) {
+    if (this.#target === target) return;
+
+    this.#destroyMonitor();
     this.#target = target;
-    this.#reinitialize();
+    this.#syncMonitor();
   }
 
   detach() {
-    if (this.#target?.mux) {
-      this.#target.mux.destroy();
-      delete this.#target.mux;
-    }
-
+    this.#destroyMonitor();
     this.#target = null;
   }
 
   destroy() {
     this.detach();
-    this.#media?.removeEventListener('loadstart', this.#reinitialize);
+    this.#media?.removeEventListener('loadstart', this.#syncMonitor);
     this.#media = null;
   }
 
@@ -194,26 +208,97 @@ export class MuxData implements MuxDataProps {
     this.#target?.mux?.updateData(value ? { ...value } : {});
   }
 
-  #reinitialize = () => {
+  #destroyMonitor() {
     if (this.#target?.mux) {
       this.#target.mux.destroy();
       delete this.#target.mux;
     }
 
-    this.#initialize();
+    this.#monitoredSrc = null;
+    this.#monitoredEngine = null;
+    this.#engineHook = null;
+  }
+
+  /**
+   * Full re-monitor, reserved for options that are baked into `monitor()` itself (the SDK, beacon routing, debug,
+   * cookies). Source and engine changes go through {@link #syncMonitor} instead, which keeps the monitor — and its view
+   * — alive.
+   */
+  #reinitialize = () => {
+    this.#destroyMonitor();
+    this.#syncMonitor();
   };
 
-  async #initialize() {
-    // Defer to ensure all properties are set before the Mux Data SDK is initialized.
-    if (this.#pendingInitialize) return;
+  /**
+   * Reconcile the monitor with the media's current state. Called on every `loadstart`, but the event is only a hint:
+   * the media's `src` and `engine` are compared against what the monitor already reflects, so a same-video `load()`
+   * (remote playback engaging, an engine rebuild, a MediaSource re-attach) is a no-op, a video change becomes a
+   * `videochange` on the live monitor, and only a missing monitor starts a new one.
+   */
+  #syncMonitor = () => {
+    void this.#sync();
+  };
 
-    await (this.#pendingInitialize = Promise.resolve());
-    this.#pendingInitialize = null;
+  async #sync() {
+    // Defer to coalesce bursts and to ensure all properties are set before the Mux Data SDK is initialized.
+    if (this.#pendingSync) return;
+
+    await (this.#pendingSync = Promise.resolve());
+    this.#pendingSync = null;
 
     const target = this.#target;
     const media = this.#media;
-    if (!this.MuxDataSdk || !target || !media || (target.mux && !target.mux.deleted)) return;
+    if (!this.MuxDataSdk || !target || !media) return;
 
+    const mux = target.mux;
+
+    if (!mux || mux.deleted) {
+      this.#monitor(target, media);
+      return;
+    }
+
+    this.#syncEngineHook(mux, media.engine);
+
+    const src = media.src;
+    if (src === this.#monitoredSrc) return;
+
+    const isFirstSource = !this.#monitoredSrc;
+
+    this.#monitoredSrc = src;
+
+    // A cleared source isn't a new video; the element's own events wind the view down.
+    if (!src) return;
+
+    // A monitor started before the first source has its pending view: name the video rather than change it.
+    if (isFirstSource) {
+      mux.updateData(this.#videoData(media));
+      return;
+    }
+
+    mux.emit('videochange', this.#videoData(media));
+  }
+
+  /** Keep engine telemetry hooked to the engine actually playing, without restarting the monitor. */
+  #syncEngineHook(mux: LiveMuxMonitor, engine: MuxDataMedia['engine']) {
+    if (engine === this.#monitoredEngine) return;
+
+    const options = toMuxDataEngineOptions(engine);
+    const hook = options.hlsjs ? 'hlsjs' : options.dashjs ? 'dashjs' : null;
+
+    if (this.#engineHook === 'hlsjs') mux.removeHLSJS();
+
+    if (this.#engineHook === 'dashjs') mux.removeDashJS();
+
+    if (options.hlsjs)
+      mux.addHLSJS(options.Hls ? { hlsjs: options.hlsjs, Hls: options.Hls } : { hlsjs: options.hlsjs });
+
+    if (options.dashjs) mux.addDashJS({ dashjs: options.dashjs });
+
+    this.#monitoredEngine = engine;
+    this.#engineHook = hook;
+  }
+
+  #monitor(target: HTMLVideoElement, media: MuxDataMedia) {
     const {
       debug,
       beaconCollectionDomain,
@@ -222,21 +307,19 @@ export class MuxData implements MuxDataProps {
       playerSoftwareName: player_software_name,
       playerSoftwareVersion: player_software_version,
       playerInitTime: player_init_time,
-      metadata = {},
     } = this;
 
-    const { view_session_id = this.MuxDataSdk?.utils.generateUUID() } = metadata;
-    const video_id = toVideoId({ metadata, src: media.src });
+    const engineOptions = toMuxDataEngineOptions(media.engine);
 
-    metadata.view_session_id = view_session_id;
-
-    if (video_id) metadata.video_id = video_id;
+    this.#monitoredSrc = media.src;
+    this.#monitoredEngine = media.engine ?? null;
+    this.#engineHook = engineOptions.hlsjs ? 'hlsjs' : engineOptions.dashjs ? 'dashjs' : null;
 
     this.MuxDataSdk?.monitor(target, {
       debug,
       ...(beaconCollectionDomain ? { beaconCollectionDomain } : {}),
       ...(disableCookies ? { disableCookies } : {}),
-      ...toMuxDataEngineOptions(media.engine),
+      ...engineOptions,
       data: {
         ...(env_key ? { env_key } : {}),
         ...(player_software_name ? { player_software_name } : {}),
@@ -245,10 +328,28 @@ export class MuxData implements MuxDataProps {
         ...(player_software_name ? { player_software: player_software_name } : {}),
         ...(player_software_version ? { player_software_version } : {}),
         ...(player_init_time ? { player_init_time } : {}),
-        // Use any metadata passed in programmatically (which may override the defaults above)
-        ...metadata,
+        ...this.#videoData(media),
       },
     });
+  }
+
+  /**
+   * The video-scoped beacon data: the session id, the derived `video_id`, and the caller's metadata, which may override
+   * both. Built fresh per use — the caller's `metadata` object is never mutated.
+   */
+  #videoData(media: MuxDataMedia) {
+    const metadata = this.metadata ?? {};
+    const view_session_id = metadata.view_session_id ?? (this.#viewSessionId ??= this.MuxDataSdk?.utils.generateUUID());
+    const video_id = toVideoId({ metadata, src: media.src });
+
+    const derived: NonNullable<MuxDataOptions['data']> = {};
+
+    if (view_session_id) derived.view_session_id = view_session_id;
+
+    if (video_id) derived.video_id = video_id;
+
+    // Any metadata passed in programmatically may override the derived defaults above.
+    return { ...derived, ...metadata };
   }
 
   #generatePlayerInitTime() {

--- a/packages/media/src/dom/mux/tests/mux-data.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data.test.ts
@@ -169,6 +169,32 @@ describe('MuxData', () => {
     expect(updateData).toHaveBeenCalledWith(expect.objectContaining({ video_id: 'abc123' }));
   });
 
+  it('emits videochange for a new video loaded after the source was cleared', async () => {
+    const { sdk, monitor, emit } = createSdk();
+    const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
+    const video = document.createElement('video');
+    const media = new FakeMedia();
+
+    media.src = 'https://stream.mux.com/abc123.m3u8';
+
+    data.setMedia(media);
+    data.attach(video);
+    await settle();
+
+    media.src = '';
+    media.dispatchEvent(new Event('loadstart'));
+    await settle();
+
+    expect(emit).not.toHaveBeenCalled();
+
+    media.src = 'https://stream.mux.com/def456.m3u8';
+    media.dispatchEvent(new Event('loadstart'));
+    await settle();
+
+    expect(monitor).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith('videochange', expect.objectContaining({ video_id: 'def456' }));
+  });
+
   it('hooks a new engine into the live monitor instead of re-monitoring', async () => {
     const { sdk, monitor, addHLSJS, removeHLSJS, destroy } = createSdk();
     const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });

--- a/packages/media/src/dom/mux/tests/mux-data.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data.test.ts
@@ -4,13 +4,29 @@ import { MuxData } from '..';
 import type { MuxDataSdk } from '../types';
 
 function createSdk() {
-  const monitor = vi.fn();
+  const emit = vi.fn();
+  const updateData = vi.fn();
+  const addHLSJS = vi.fn();
+  const removeHLSJS = vi.fn();
+  const addDashJS = vi.fn();
+  const removeDashJS = vi.fn();
+  const destroy = vi.fn();
+  let uuid = 0;
+
+  // Like the real SDK, `monitor` installs a live handle on the element.
+  const monitor = vi.fn((target: HTMLVideoElement, _options?: any) => {
+    destroy.mockImplementation(() => {
+      delete target.mux;
+    });
+    target.mux = { deleted: false, emit, updateData, addHLSJS, removeHLSJS, addDashJS, removeDashJS, destroy } as any;
+  });
+
   const sdk = {
     monitor,
-    utils: { now: () => 0, generateUUID: () => 'uuid' },
+    utils: { now: () => 0, generateUUID: () => `uuid-${++uuid}` },
   } as unknown as MuxDataSdk;
 
-  return { sdk, monitor };
+  return { sdk, monitor, emit, updateData, addHLSJS, removeHLSJS, addDashJS, removeDashJS, destroy };
 }
 
 class FakeMedia extends EventTarget {
@@ -40,7 +56,7 @@ class FakeDashJsEngine {
   off() {}
 }
 
-// Initialization is deferred by a microtask so all props settle first.
+// Syncing is deferred by a microtask so all props settle first.
 async function settle() {
   await Promise.resolve();
   await Promise.resolve();
@@ -71,7 +87,7 @@ describe('MuxData', () => {
     expect(monitor).toHaveBeenCalledWith(
       video,
       expect.objectContaining({
-        data: expect.objectContaining({ env_key: 'key', player_software_name: 'mux-video' }),
+        data: expect.objectContaining({ env_key: 'key', player_software_name: 'mux-video', video_id: 'abc123' }),
       })
     );
   });
@@ -90,36 +106,100 @@ describe('MuxData', () => {
     expect(monitor).not.toHaveBeenCalled();
   });
 
-  it('re-monitors with the new engine when the media fires loadstart', async () => {
-    const { sdk, monitor } = createSdk();
+  it('keeps the monitor across a same-source loadstart', async () => {
+    const { sdk, monitor, emit, destroy } = createSdk();
+    const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
+    const video = document.createElement('video');
+    const media = new FakeMedia();
+
+    media.src = 'https://stream.mux.com/abc123.m3u8';
+
+    data.setMedia(media);
+    data.attach(video);
+    await settle();
+
+    // e.g. remote playback engaging or a MediaSource re-attach reruns `load()`.
+    media.dispatchEvent(new Event('loadstart'));
+    await settle();
+
+    expect(monitor).toHaveBeenCalledTimes(1);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('emits videochange on the live monitor when the source changes', async () => {
+    const { sdk, monitor, emit, destroy } = createSdk();
+    const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
+    const video = document.createElement('video');
+    const media = new FakeMedia();
+
+    media.src = 'https://stream.mux.com/abc123.m3u8';
+
+    data.setMedia(media);
+    data.attach(video);
+    await settle();
+
+    media.src = 'https://stream.mux.com/def456.m3u8';
+    media.dispatchEvent(new Event('loadstart'));
+    await settle();
+
+    expect(monitor).toHaveBeenCalledTimes(1);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledWith('videochange', expect.objectContaining({ video_id: 'def456' }));
+  });
+
+  it('names the pending view instead of changing videos when the first source arrives', async () => {
+    const { sdk, monitor, emit, updateData } = createSdk();
     const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
     const video = document.createElement('video');
     const media = new FakeMedia();
 
     data.setMedia(media);
     data.attach(video);
-
     await settle();
 
     expect(monitor).toHaveBeenCalledTimes(1);
 
+    media.src = 'https://stream.mux.com/abc123.m3u8';
+    media.dispatchEvent(new Event('loadstart'));
+    await settle();
+
+    expect(monitor).toHaveBeenCalledTimes(1);
+    expect(emit).not.toHaveBeenCalled();
+    expect(updateData).toHaveBeenCalledWith(expect.objectContaining({ video_id: 'abc123' }));
+  });
+
+  it('hooks a new engine into the live monitor instead of re-monitoring', async () => {
+    const { sdk, monitor, addHLSJS, removeHLSJS, destroy } = createSdk();
+    const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
+    const video = document.createElement('video');
+    const media = new FakeMedia();
+
+    media.src = 'https://stream.mux.com/abc123.m3u8';
+
+    data.setMedia(media);
+    data.attach(video);
+    await settle();
+
+    // An engine rebuild with the same source reruns `load()` with a new instance.
     const engine = new FakeHlsJsEngine();
 
     media.engine = engine;
-    media.src = 'https://stream.mux.com/abc123.m3u8';
     media.dispatchEvent(new Event('loadstart'));
-
     await settle();
 
-    expect(monitor).toHaveBeenCalledTimes(2);
-    expect(monitor).toHaveBeenLastCalledWith(
-      video,
-      expect.objectContaining({
-        hlsjs: engine,
-        Hls: FakeHlsJsEngine,
-        data: expect.objectContaining({ video_id: 'abc123' }),
-      })
-    );
+    expect(monitor).toHaveBeenCalledTimes(1);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(addHLSJS).toHaveBeenCalledWith({ hlsjs: engine, Hls: FakeHlsJsEngine });
+
+    const rebuilt = new FakeHlsJsEngine();
+
+    media.engine = rebuilt;
+    media.dispatchEvent(new Event('loadstart'));
+    await settle();
+
+    expect(removeHLSJS).toHaveBeenCalledTimes(1);
+    expect(addHLSJS).toHaveBeenLastCalledWith({ hlsjs: rebuilt, Hls: FakeHlsJsEngine });
   });
 
   it('monitors a dash.js engine through the dash.js integration', async () => {
@@ -163,25 +243,112 @@ describe('MuxData', () => {
     expect(options).not.toHaveProperty('dashjs');
   });
 
-  it('moves its media listener when registered with another host', async () => {
+  it('keeps one view session id across video changes', async () => {
+    const { sdk, monitor, emit } = createSdk();
+    const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
+    const video = document.createElement('video');
+    const media = new FakeMedia();
+
+    media.src = 'https://stream.mux.com/abc123.m3u8';
+
+    data.setMedia(media);
+    data.attach(video);
+    await settle();
+
+    const [, options] = monitor.mock.lastCall!;
+    const { view_session_id } = options.data;
+
+    expect(view_session_id).toBeTruthy();
+
+    media.src = 'https://stream.mux.com/def456.m3u8';
+    media.dispatchEvent(new Event('loadstart'));
+    await settle();
+
+    expect(emit).toHaveBeenCalledWith('videochange', expect.objectContaining({ view_session_id }));
+  });
+
+  it('honors a caller-supplied view session id and never mutates caller metadata', async () => {
     const { sdk, monitor } = createSdk();
+    const metadata = { view_session_id: 'caller-session', video_title: 'Some Title' };
+    const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key', metadata });
+    const video = document.createElement('video');
+    const media = new FakeMedia();
+
+    media.src = 'https://stream.mux.com/abc123.m3u8';
+
+    data.setMedia(media);
+    data.attach(video);
+    await settle();
+
+    const [, options] = monitor.mock.lastCall!;
+
+    expect(options.data).toEqual(expect.objectContaining({ view_session_id: 'caller-session' }));
+    expect(metadata).toEqual({ view_session_id: 'caller-session', video_title: 'Some Title' });
+  });
+
+  it('does not write a generated view session id into caller metadata', async () => {
+    const { sdk } = createSdk();
+    const metadata = { video_title: 'Some Title' };
+    const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key', metadata });
+    const video = document.createElement('video');
+    const media = new FakeMedia();
+
+    media.src = 'https://stream.mux.com/abc123.m3u8';
+
+    data.setMedia(media);
+    data.attach(video);
+    await settle();
+
+    expect(metadata).toEqual({ video_title: 'Some Title' });
+  });
+
+  it('destroys the old target monitor when attached to a new target', async () => {
+    const { sdk, monitor, destroy } = createSdk();
+    const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
+    const first = document.createElement('video');
+    const second = document.createElement('video');
+    const media = new FakeMedia();
+
+    media.src = 'https://stream.mux.com/abc123.m3u8';
+
+    data.setMedia(media);
+    data.attach(first);
+    await settle();
+
+    data.attach(second);
+    await settle();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(first.mux).toBeUndefined();
+    expect(monitor).toHaveBeenCalledTimes(2);
+    expect(monitor).toHaveBeenLastCalledWith(second, expect.anything());
+  });
+
+  it('follows the media when registered with another host', async () => {
+    const { sdk, monitor, emit } = createSdk();
     const data = new MuxData({ MuxDataSdk: sdk });
     const video = document.createElement('video');
     const first = new FakeMedia();
     const second = new FakeMedia();
+
+    first.src = 'https://stream.mux.com/abc123.m3u8';
+    second.src = 'https://stream.mux.com/def456.m3u8';
 
     data.setMedia(first);
     data.attach(video);
     await settle();
 
     data.setMedia(second);
+    await settle();
+
+    expect(monitor).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith('videochange', expect.objectContaining({ video_id: 'def456' }));
+
+    emit.mockClear();
     first.dispatchEvent(new Event('loadstart'));
     await settle();
-    expect(monitor).toHaveBeenCalledTimes(1);
 
-    second.dispatchEvent(new Event('loadstart'));
-    await settle();
-    expect(monitor).toHaveBeenCalledTimes(2);
+    expect(emit).not.toHaveBeenCalled();
   });
 
   it('destroys active monitoring on destroy', () => {
@@ -198,8 +365,8 @@ describe('MuxData', () => {
     expect(video.mux).toBeUndefined();
   });
 
-  it('stops re-monitoring after destroy', async () => {
-    const { sdk, monitor } = createSdk();
+  it('stops syncing after destroy', async () => {
+    const { sdk, monitor, emit } = createSdk();
     const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
     const video = document.createElement('video');
     const media = new FakeMedia();
@@ -214,10 +381,12 @@ describe('MuxData', () => {
     expect(monitor).toHaveBeenCalledTimes(1);
 
     data.destroy();
+    media.src = 'https://stream.mux.com/def456.m3u8';
     media.dispatchEvent(new Event('loadstart'));
 
     await settle();
 
     expect(monitor).toHaveBeenCalledTimes(1);
+    expect(emit).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #2562
Refs #1845

## Why

A single continuous viewing shows up in Mux Data as several unrelated players and views. Medias fire `loadstart` for many same-video reasons — remote playback engaging, an engine rebuild, a MediaSource re-attach — and the integration destroyed and re-created its `mux-embed` monitor on every one. Each fragment became its own view under a freshly generated `view_session_id`, so startup time, rebuffering, watch time, and errors are attributed to views that never logically existed and can never be grouped back into one session. When a caller supplied a `metadata` object, the generated id was also written into it as a side effect. The SPF integration (#1845) would have inherited all of this.

## What changed

`loadstart` is now a hint: the media's current `src` and `engine` are compared against what the monitor already reflects, and only real changes get a reaction.

- A same-video `loadstart` is a no-op; the monitor and its view stay alive.
- A video change emits `videochange` on the live monitor instead of destroy + re-`monitor()`, per the SDK's own contract (`viewinit` is first-view-only).
- A cleared source is ignored without being tracked, so a video loaded after it still emits `videochange` (and re-setting the same video stays a no-op).
- An engine swap re-hooks telemetry on the live monitor (`addHLSJS`/`removeHLSJS`/`addDashJS`/`removeDashJS`) rather than restarting it.
- A monitor started before the first source names its pending view via `updateData` rather than emitting a spurious `videochange`.
- `view_session_id` is generated once per component so a player's views group into one session; a caller-supplied id always wins, and caller metadata is never mutated.
- `attach()` destroys the old target's monitor before switching targets, closing a latent leak where a live monitor kept beaconing on an abandoned target.
- Full destroy + re-monitor remains only for options baked into `monitor()` itself (SDK, beacon domain, debug, cookies).

The rationale for the live-monitor model, with links to the SDK contract and prior art, is recorded in [`internal/decisions/media/mux-data-monitor-lifecycle.md`](https://github.com/videojs/v10/blob/fix/mux-data-view-continuity/internal/decisions/media/mux-data-monitor-lifecycle.md).

<details>
<summary>Implementation details</summary>

Syncing follows the media-state pattern (cf. `sourceFeature`): events trigger a deferred reconcile that reads current state and cross-compares against tracked identity, so redundant hints are free. This also makes the fix robust to how often a media fires `loadstart`, which varies by flavor — the hls.js-backed media synthesizes one per `load()`, while shadow-video medias forward every native `loadstart` raw. Identity compares use the facade `src` (the element's `currentSrc` is a `blob:` URL under MSE).

</details>

## Testing

`pnpm -F @videojs/media test` (1141 passing, including 17 rewritten/new `MuxData` cases covering same-src loads, `videochange` — including after a cleared source — engine re-hooking, first-source naming, session-id stability, caller-metadata immutability, and target swaps). The html and react `mux-data` suites pass. `pnpm typecheck` is clean for `packages/media`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production Mux Data view/session attribution and beacon lifecycle; behavior should align with the SDK contract but analytics dashboards may shift compared to the prior split-view bug.
> 
> **Overview**
> Fixes **#2562** by changing how `MuxData` talks to `mux-embed`: instead of tearing down and calling `monitor()` on every `loadstart`, it keeps **one monitor per video target** and reconciles media state when `loadstart` fires.
> 
> **Same `src` / engine rebuilds** (remote playback, MediaSource re-attach, etc.) are no-ops. **Real source changes** emit `videochange` on the live monitor. **Engine swaps** re-hook hls.js/dash.js via `addHLSJS`/`removeHLSJS` (and dash equivalents) without restarting the monitor. **Cleared sources** are ignored for tracking so the next real load still compares against the last known video. **First source after attach** uses `updateData` instead of a spurious `videochange`. **`view_session_id`** is generated once per `MuxData` instance (caller metadata is no longer mutated). **`attach()`** to a new target destroys the previous element’s monitor.
> 
> Full destroy + re-`monitor()` remains only when monitor-level options change (SDK, beacon domain, debug, cookies) or the target changes. Rationale is recorded in `internal/decisions/media/mux-data-monitor-lifecycle.md`, with tests expanded for the new sync behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04dbd69e3c8cf5c1e494dd76574560514a9f04d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->