### PR TITLE
docs(site): include Mux Data by default in Mux installation examples

### DIFF
--- a/packages/cli/src/commands/tests/docs.test.ts
+++ b/packages/cli/src/commands/tests/docs.test.ts
@@ -307,6 +307,8 @@ describe('handleDocs', () => {
 
         expect(out).toContain('<mux-video src=');
         expect(out).toContain("import '@videojs/html/media/mux-video'");
+        expect(out).toContain('<mux-data></mux-data>');
+        expect(out).toContain("import '@videojs/html/media/mux-data'");
       });
 
       it('generates Vimeo media variant via npm', async () => {
@@ -339,6 +341,7 @@ describe('handleDocs', () => {
 
         expect(out).toContain('<script');
         expect(out).toContain('media/mux-video.js');
+        expect(out).toContain('media/mux-data.js');
       });
 
       it('errors when requesting CDN for a renderer without a CDN build (vimeo)', async () => {

--- a/packages/cli/src/utils/tests/fixtures/cdn-media.json
+++ b/packages/cli/src/utils/tests/fixtures/cdn-media.json
@@ -2,6 +2,7 @@
   { "id": "dash-video" },
   { "id": "hlsjs-video" },
   { "id": "mux-audio" },
+  { "id": "mux-data" },
   { "id": "mux-video" },
   { "id": "native-hls-video" },
   { "id": "hls-audio" },

--- a/site/src/utils/installation/__tests__/cdn-code.test.ts
+++ b/site/src/utils/installation/__tests__/cdn-code.test.ts
@@ -7,8 +7,9 @@ import { generateCdnCode, rendererSupportsCdn } from '../cdn-code';
 
 describe('generateCdnCode', () => {
   // Media subpaths that ship a CDN build. The media script is emitted only for
-  // renderers whose subpath is in this set.
-  const manifest = ['hlsjs-video', 'dash-video', 'mux-video', 'mux-audio'];
+  // renderers whose subpath is in this set. Mux media also register the separate
+  // Mux Data component, so its subpath ships a build too.
+  const manifest = ['hlsjs-video', 'dash-video', 'mux-video', 'mux-audio', 'mux-data'];
 
   it('pins generated URLs to the current @videojs/html package version', () => {
     expect(VJS10_HTML_CDN_BASE).toBe(`https://cdn.jsdelivr.net/npm/@videojs/html@${htmlPackage.version}/cdn`);
@@ -34,11 +35,23 @@ describe('generateCdnCode', () => {
     );
   });
 
-  it('includes the mux media bundle when renderer is mux-video', () => {
+  it('includes the mux media bundle and the Mux Data bundle when renderer is mux-video', () => {
     expect(generateCdnCode('default-video', 'video', 'mux-video', manifest)).toEqual(
+      `<script type="module" src="${VJS10_HTML_CDN_BASE}/video.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-video.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-data.js"></script>`
+    );
+  });
+
+  it('omits the Mux Data script when the manifest has no Mux Data build', () => {
+    expect(generateCdnCode('default-video', 'video', 'mux-video', ['mux-video'])).toEqual(
       `<script type="module" src="${VJS10_HTML_CDN_BASE}/video.js"></script>
 <script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-video.js"></script>`
     );
+  });
+
+  it('does not add a Mux Data script for non-Mux media', () => {
+    expect(generateCdnCode('default-video', 'video', 'dash', manifest)).not.toContain('mux-data');
   });
 
   it('omits the media script for a media renderer absent from the manifest', () => {
@@ -75,7 +88,8 @@ describe('generateCdnCode', () => {
   it('generates the minimal live video CDN tag', () => {
     expect(generateCdnCode('live-video', 'minimal-video', 'mux-video', manifest)).toEqual(
       `<script type="module" src="${VJS10_HTML_CDN_BASE}/live-video-minimal.js"></script>
-<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-video.js"></script>`
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-video.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-data.js"></script>`
     );
   });
 
@@ -89,7 +103,8 @@ describe('generateCdnCode', () => {
   it('generates live audio CDN tags for each skin variant', () => {
     expect(generateCdnCode('live-audio', 'audio', 'mux-audio', manifest)).toEqual(
       `<script type="module" src="${VJS10_HTML_CDN_BASE}/live-audio.js"></script>
-<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-audio.js"></script>`
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-audio.js"></script>
+<script type="module" src="${VJS10_HTML_CDN_BASE}/media/mux-data.js"></script>`
     );
     expect(generateCdnCode('live-audio', 'minimal-audio', 'mux-audio', manifest)).toContain(
       'cdn/live-audio-minimal.js'

--- a/site/src/utils/installation/__tests__/codegen.test.ts
+++ b/site/src/utils/installation/__tests__/codegen.test.ts
@@ -58,7 +58,7 @@ describe('validateInstallationOptions', () => {
 });
 
 describe('generateHTMLInstallCode', () => {
-  const manifest = ['hlsjs-video', 'dash-video', 'mux-video', 'mux-audio'];
+  const manifest = ['hlsjs-video', 'dash-video', 'mux-video', 'mux-audio', 'mux-data'];
 
   it('returns install commands for all methods', () => {
     const result = generateHTMLInstallCode(baseHTML, manifest);
@@ -80,6 +80,13 @@ describe('generateHTMLInstallCode', () => {
     const result = generateHTMLInstallCode({ ...baseHTML, renderer: 'hls' }, manifest);
 
     expect(result.cdn).toContain('media/hlsjs-video.js');
+  });
+
+  it('includes the Mux Data media script alongside Mux media in CDN output', () => {
+    const result = generateHTMLInstallCode({ ...baseHTML, renderer: 'mux-video' }, manifest);
+
+    expect(result.cdn).toContain('media/mux-video.js');
+    expect(result.cdn).toContain('media/mux-data.js');
   });
 });
 
@@ -168,6 +175,21 @@ describe('generateHTMLUsageCode', () => {
     expect(result.imports).toContain("import '@videojs/html/media/mux-video'");
   });
 
+  it('adds the Mux Data component and import alongside Mux video by default', () => {
+    const result = generateHTMLUsageCode({ ...baseHTML, renderer: 'mux-video' });
+
+    expect(result.html).toContain('<mux-data></mux-data>');
+    expect(result.html).toContain('Mux Data monitors playback quality');
+    expect(result.imports).toContain("import '@videojs/html/media/mux-data'");
+  });
+
+  it('does not add Mux Data for non-Mux media', () => {
+    const result = generateHTMLUsageCode({ ...baseHTML, renderer: 'hls' });
+
+    expect(result.html).not.toContain('mux-data');
+    expect(result.imports).not.toContain('mux-data');
+  });
+
   it('uses the vimeo-video tag and media import, without playsinline (iframe)', () => {
     const result = generateHTMLUsageCode({ ...baseHTML, renderer: 'vimeo' });
 
@@ -220,6 +242,8 @@ describe('generateHTMLUsageCode', () => {
     expect(result.html).toContain('<mux-audio src=');
     expect(result.html).not.toContain('playsinline');
     expect(result.imports).toContain("import '@videojs/html/media/mux-audio'");
+    expect(result.html).toContain('<mux-data></mux-data>');
+    expect(result.imports).toContain("import '@videojs/html/media/mux-data'");
   });
 
   it('uses minimal skin tag', () => {
@@ -298,6 +322,8 @@ describe('generateHTMLUsageCode', () => {
     expect(result.imports).toContain("import '@videojs/html/live-audio/player'");
     expect(result.imports).toContain("import '@videojs/html/live-audio/skin'");
     expect(result.imports).toContain("import '@videojs/html/media/mux-audio'");
+    expect(result.html).toContain('<mux-data></mux-data>');
+    expect(result.imports).toContain("import '@videojs/html/media/mux-data'");
   });
 
   it('defaults live use cases to a live source URL', () => {
@@ -350,6 +376,21 @@ describe('generateReactCreateCode', () => {
 
     expect(code).toContain("import { MuxVideo } from '@videojs/react/media/mux-video'");
     expect(code).toContain('<MuxVideo src={src} playsInline />');
+  });
+
+  it('renders and imports the Mux Data component alongside Mux video by default', () => {
+    const code = generateReactCreateCode({ ...baseReact, renderer: 'mux-video' })['MyPlayer.tsx'];
+
+    expect(code).toContain("import { MuxData } from '@videojs/react/media/mux-data'");
+    expect(code).toContain('<MuxData />');
+    expect(code).toContain('Mux Data monitors playback quality');
+  });
+
+  it('does not add Mux Data for non-Mux media', () => {
+    const code = generateReactCreateCode({ ...baseReact, renderer: 'hls' })['MyPlayer.tsx'];
+
+    expect(code).not.toContain('MuxData');
+    expect(code).not.toContain('mux-data');
   });
 
   it('uses separate media import for Vimeo without playsInline (iframe)', () => {
@@ -476,6 +517,8 @@ describe('generateReactCreateCode', () => {
     expect(code).toContain("import { MuxAudio } from '@videojs/react/media/mux-audio'");
     expect(code).toContain("import '@videojs/react/live-audio/skin.css'");
     expect(code).not.toContain('playsInline');
+    expect(code).toContain("import { MuxData } from '@videojs/react/media/mux-data'");
+    expect(code).toContain('<MuxData />');
   });
 
   it('uses the minimal live audio skin component', () => {

--- a/site/src/utils/installation/cdn-code.ts
+++ b/site/src/utils/installation/cdn-code.ts
@@ -2,6 +2,8 @@ import { VJS10_HTML_CDN_BASE } from '@/consts';
 import {
   getInstallationPreset,
   getMediaSubpath,
+  isMuxRenderer,
+  MUX_DATA_MEDIA_SUBPATH,
   RENDERERS,
   type Renderer,
   type Skin,
@@ -57,6 +59,13 @@ export function generateCdnCode(
   // this starts emitting automatically — no code change needed.
   if (mediaSubpath !== null && cdnMediaSubpaths.includes(mediaSubpath)) {
     scriptLines.push(`<script type="module" src="${VJS10_HTML_CDN_BASE}/media/${mediaSubpath}.js"></script>`);
+  }
+
+  // Mux media default to the separate Mux Data component, so register its script
+  // too. Gated on the manifest like any other media build, so it drops out
+  // automatically if Mux Data ever stops shipping a CDN bundle.
+  if (isMuxRenderer(renderer) && cdnMediaSubpaths.includes(MUX_DATA_MEDIA_SUBPATH)) {
+    scriptLines.push(`<script type="module" src="${VJS10_HTML_CDN_BASE}/media/${MUX_DATA_MEDIA_SUBPATH}.js"></script>`);
   }
 
   return scriptLines.join('\n');

--- a/site/src/utils/installation/codegen.ts
+++ b/site/src/utils/installation/codegen.ts
@@ -14,6 +14,8 @@ import {
   getInstallationPreset,
   getMediaSubpath,
   type InstallMethod,
+  isMuxRenderer,
+  MUX_DATA_MEDIA_SUBPATH,
   type Renderer,
   type Skin,
   type UseCase,
@@ -171,6 +173,29 @@ function getSkinTag(useCase: UseCase, skin: Exclude<Skin, 'none'>): string {
   return getSkinFile(skin) === 'minimal-skin' ? `${prefix}-minimal-skin` : `${prefix}-skin`;
 }
 
+// The media element line, plus the Mux Data component for Mux media. Mux Data is
+// a separate, opt-in component included here by default for Mux-hosted playback —
+// no environment key required — placed as a sibling of the media element.
+function generateMediaMarkup(
+  tag: string,
+  src: string,
+  playsInline: string,
+  renderer: Renderer,
+  indent: string
+): string {
+  const mediaEl = `${indent}<${tag} src="${src}"${playsInline}></${tag}>`;
+
+  if (!isMuxRenderer(renderer)) return mediaEl;
+
+  return `${mediaEl}
+${indent}<!--
+${indent}    Mux Data monitors playback quality. It is a separate,
+${indent}    opt-in component, included here by default for Mux-hosted
+${indent}    playback — no environment key required.
+${indent}  -->
+${indent}<mux-data></mux-data>`;
+}
+
 function generateHTMLMarkup(useCase: UseCase, skin: Skin, renderer: Renderer, url: string): string {
   const playerTag = getPlayerTag(useCase);
   const tag = getRendererTag(renderer);
@@ -198,7 +223,7 @@ function generateHTMLMarkup(useCase: UseCase, skin: Skin, renderer: Renderer, ur
     return `${playerComment}
 <${playerTag}>
 ${mediaComment}
-  <${tag} src="${src}"${playsInline}></${tag}>
+${generateMediaMarkup(tag, src, playsInline, renderer, '  ')}
 </${playerTag}>`;
   }
 
@@ -213,7 +238,7 @@ ${mediaComment}
    -->
   <${skinTag}>
 ${skinMediaComment}
-    <${tag} src="${src}"${playsInline}></${tag}>
+${generateMediaMarkup(tag, src, playsInline, renderer, '    ')}
   </${skinTag}>
 </${playerTag}>`;
 }
@@ -232,12 +257,16 @@ import '@videojs/html/background/video';${mediaImport}`;
   const mediaSubpath = getMediaSubpath(renderer);
   const mediaImport = mediaSubpath ? `\nimport '@videojs/html/media/${mediaSubpath}';` : '';
 
+  // Mux media pair with the separate Mux Data component by default; register it
+  // alongside the Mux media import.
+  const muxDataImport = isMuxRenderer(renderer) ? `\nimport '@videojs/html/media/${MUX_DATA_MEDIA_SUBPATH}';` : '';
+
   if (skin === 'none') {
-    return `import '@videojs/html/${group}/player';${mediaImport}`;
+    return `import '@videojs/html/${group}/player';${mediaImport}${muxDataImport}`;
   }
 
   return `import '@videojs/html/${group}/player';
-import '@videojs/html/${group}/${getSkinFile(skin)}';${mediaImport}`;
+import '@videojs/html/${group}/${getSkinFile(skin)}';${mediaImport}${muxDataImport}`;
 }
 
 export function generateHTMLUsageCode(
@@ -288,6 +317,19 @@ function isPresetRenderer(renderer: Renderer): boolean {
   return renderer === 'html5-video' || renderer === 'html5-audio' || renderer === 'background-video';
 }
 
+// The media JSX, plus the Mux Data component for Mux media. Mux Data is a
+// separate, opt-in component rendered here by default for Mux-hosted playback —
+// no environment key required — as a sibling of the media component.
+function generateReactMediaJsx(rendererJsx: string, renderer: Renderer, indent: string): string {
+  if (!isMuxRenderer(renderer)) return rendererJsx;
+
+  return `${rendererJsx}
+${indent}{/* Mux Data monitors playback quality. It is a separate, opt-in
+${indent}    component, rendered here by default for Mux-hosted playback —
+${indent}    no environment key required. */}
+${indent}<MuxData />`;
+}
+
 export function generateReactCreateCode(
   opts: Pick<InstallationOptions, 'useCase' | 'skin' | 'renderer'>
 ): Record<'MyPlayer.tsx', string> {
@@ -330,20 +372,27 @@ export function generateReactCreateCode(
     }
   }
 
+  // Mux media pair with the separate Mux Data component by default; render it
+  // alongside the Mux media and import it beside the media import.
+  const muxDataImport = isMuxRenderer(renderer)
+    ? `import { MuxData } from '@videojs/react/media/${MUX_DATA_MEDIA_SUBPATH}';`
+    : null;
+
   const playerJsx = skinComponent
     ? `    <${playerComponent}>
       <${skinComponent}>
-        ${rendererJsx}
+        ${generateReactMediaJsx(rendererJsx, renderer, '        ')}
       </${skinComponent}>
     </${playerComponent}>`
     : `    <${playerComponent}>
-      ${rendererJsx}
+      ${generateReactMediaJsx(rendererJsx, renderer, '      ')}
     </${playerComponent}>`;
 
   const imports = [
     ...(skinCssImport ? [`import '${skinCssImport}';`] : []),
     presetImport,
     ...(mediaImport ? [mediaImport] : []),
+    ...(muxDataImport ? [muxDataImport] : []),
   ].join('\n');
 
   return {

--- a/site/src/utils/installation/codegen.ts
+++ b/site/src/utils/installation/codegen.ts
@@ -190,8 +190,7 @@ function generateMediaMarkup(
   return `${mediaEl}
 ${indent}<!--
 ${indent}    Mux Data monitors playback quality. It is a separate,
-${indent}    opt-in component, included here by default for Mux-hosted
-${indent}    playback — no environment key required.
+${indent}    opt-in component, included by default for Mux-hosted playback.
 ${indent}  -->
 ${indent}<mux-data></mux-data>`;
 }

--- a/site/src/utils/installation/codegen.ts
+++ b/site/src/utils/installation/codegen.ts
@@ -324,8 +324,7 @@ function generateReactMediaJsx(rendererJsx: string, renderer: Renderer, indent: 
 
   return `${rendererJsx}
 ${indent}{/* Mux Data monitors playback quality. It is a separate, opt-in
-${indent}    component, rendered here by default for Mux-hosted playback —
-${indent}    no environment key required. */}
+${indent}    component, rendered by default for Mux-hosted playback. */}
 ${indent}<MuxData />`;
 }
 

--- a/site/src/utils/installation/types.ts
+++ b/site/src/utils/installation/types.ts
@@ -104,6 +104,17 @@ export function getInstallationPreset(useCase: UseCase): InstallationPreset {
   return INSTALLATION_PRESETS[useCase];
 }
 
+// The Mux Data media subpath. Mux Data is a separate media component the
+// installation examples pair with Mux media by default, so it is imported and
+// registered alongside the Mux media rather than merged into it.
+export const MUX_DATA_MEDIA_SUBPATH = 'mux-data';
+
+// Whether a renderer plays Mux-hosted media. The installation examples add the
+// Mux Data monitoring component by default for these, as a sibling of the media.
+export function isMuxRenderer(renderer: Renderer): boolean {
+  return renderer === 'mux-video' || renderer === 'mux-audio';
+}
+
 // Renderer → media subpath name, independent of whether a CDN build exists.
 // Preset renderers (html5-video/audio, background-video) are covered by their
 // preset bundle and have no separate media script, so they map to null.


### PR DESCRIPTION
## Summary

Mux-hosted installation examples (`mux-video` and `mux-audio`) now include the separate Mux Data extension by default, across HTML and React and every install method. This mirrors the sandbox templates and the `concepts/mux-data` guide, keeping playback and monitoring as separate, swappable pieces. Both the site code blocks and `@videojs/cli docs how-to/installation` consume the same generators, so web and CLI users get the same output.

## Changes

- **Install commands** (npm/pnpm/yarn/bun) add `@videojs/mux-data` next to the Mux adapter package, e.g. `npm install @videojs/html @videojs/mux-video @videojs/mux-data`.
- **HTML** registers `@videojs/html/extensions/mux-data` and places a sibling `<mux-data></mux-data>` after the Mux media element, with a short comment explaining it is a separate, default-included component that needs no environment key for Mux-hosted playback.
- **React** imports `MuxData` from `@videojs/react/extensions/mux-data` and renders `<MuxData />` beside the Mux media component, with the same comment.
- **CDN** (HTML) emits `extensions/mux-data.js` alongside the Mux media script.
- Non-Mux examples (HTML5, HLS, DASH, Vimeo, YouTube, Cloudflare, TikTok, Twitch, Spotify, background video) are unchanged.

<details>
<summary>Implementation details</summary>

- `isMuxRenderer()`, `MUX_DATA_EXTENSION_SUBPATH`, and `MUX_DATA_PACKAGE` live in `site/src/utils/installation/types.ts` and are shared by `codegen.ts` and `cdn-code.ts`.
- The CDN Mux Data script is **not** gated on the CDN media manifest. That manifest is built by scanning `packages/cdn/media/` only, so extensions never appear in it; `@videojs/cdn` always ships `extensions/mux-data.js`, so the script is emitted for every Mux renderer.
- Mux Data stays a separate extension; no combined preset was added.

</details>

## Testing

- `pnpm -F site test run src/utils/installation` — 145 passed
- `pnpm -F @videojs/cli test` — 70 passed (includes HTML Mux npm and CDN docs generation)
- `pnpm typecheck` — clean
- `pnpm lint:fix:file` on changed files — 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example codegen only; no runtime player or auth changes. Copy/install snippets change for Mux paths only.
> 
> **Overview**
> Mux-hosted installation examples (`mux-video` / `mux-audio`) now **include the Mux Data extension by default** in the shared installation generators used by the site and `@videojs/cli docs`.
> 
> **Install commands** add `@videojs/mux-data` next to the Mux adapter for npm/pnpm/yarn/bun (HTML and React). **HTML** samples add `<mux-data></mux-data>`, the `@videojs/html/extensions/mux-data` import, and a short comment that it is separate from playback. **React** samples import and render `<MuxData />` beside the Mux media component. **CDN** output adds `extensions/mux-data.js` for Mux renderers (not gated on the media CDN manifest).
> 
> Shared helpers `isMuxRenderer()`, `MUX_DATA_EXTENSION_SUBPATH`, and `MUX_DATA_PACKAGE` live in `types.ts`. Non-Mux renderers are unchanged. Tests cover codegen, CDN generation, and CLI installation docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c67ce67d569a4eda80144317a5ea7ebd1eb2f06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

