### PR TITLE
fix(core): stop waiting from latching when readyState never recovers

### DIFF
--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -293,6 +293,25 @@ const SOURCE_MAP = {
     drm: true,
     poster: `https://image.mux.com/${DRM_PLAYBACK_ID}/thumbnail.webp?token=${DRM_TOKENS.thumbnail}`,
   },
+  'hls-drm-ezdrm': {
+    // EZDRM's FairPlay demo. No custom header — the asset is identified by the
+    // license URL path — and the SPC goes up as a raw octet-stream body, the same
+    // convention Mux uses. Its `skd://` carries the content id after a `;`, where
+    // Mux and Axinom each delimit differently.
+    label: 'HLS - DRM FairPlay (EZDRM)',
+    type: 'hls',
+    subType: 'mp4',
+    drm: true,
+    source: {
+      src: 'https://na-fps.ezdrm.com/demo/ezdrm/master.m3u8',
+      drm: {
+        'com.apple.fps': {
+          licenseUrl: 'https://fps.ezdrm.com/api/licenses/b99ed9e5-c641-49d1-bfa8-43692b686ddb',
+          serverCertificateUrl: 'https://fps.ezdrm.com/demo/video/eleisure.cer',
+        },
+      },
+    },
+  },
   'mp4-1': {
     label: 'MP4 - Dancing Dude',
     url: 'https://stream.mux.com/lhnU49l1VGi3zrTAZhDm9LUUxSjpaPW9BL4jY25Kwo4/highest.mp4',

--- a/packages/core/src/dom/store/features/playback.ts
+++ b/packages/core/src/dom/store/features/playback.ts
@@ -37,22 +37,44 @@ export const playbackFeature = definePlayerFeature({
     const { media } = target;
     if (!isMediaPauseCapable(media) || !isMediaSeekCapable(media) || !isMediaSourceCapable(media)) return;
 
-    const sync = () =>
+    // `currentTime` when playback last ran short of data, or `null` when it did
+    // not. Safari reports `HAVE_CURRENT_DATA` for the whole of some MSE streams
+    // while decoding and presenting normally, so `readyState` never climbs back
+    // over `HAVE_FUTURE_DATA` and `playing` never fires. A frame presented since
+    // then is proof the browser had future data after all.
+    let starvedAt: number | null = null;
+
+    const sync = () => {
+      const starved = media.readyState < HTMLMediaElement.HAVE_FUTURE_DATA && !media.paused;
+      if (!starved) starvedAt = null;
+      else starvedAt ??= media.currentTime;
+
       set({
         paused: media.paused,
         ended: media.ended,
         started: !media.paused || media.currentTime > 0,
-        waiting: media.readyState < HTMLMediaElement.HAVE_FUTURE_DATA && !media.paused,
+        waiting: starved && starvedAt === media.currentTime,
       });
+    };
+
+    // The browser reports running short of data; only an advancing `currentTime`
+    // reports recovering from it.
+    const starve = () => {
+      starvedAt = media.currentTime;
+      sync();
+    };
 
     sync();
 
-    listen(media, 'emptied', sync, { signal });
-    listen(media, 'play', sync, { signal });
+    listen(media, 'emptied', starve, { signal });
+    listen(media, 'play', starve, { signal });
     listen(media, 'pause', sync, { signal });
     listen(media, 'ended', sync, { signal });
     listen(media, 'playing', sync, { signal });
-    listen(media, 'waiting', sync, { signal });
+    listen(media, 'waiting', starve, { signal });
+    listen(media, 'seeking', starve, { signal });
     listen(media, 'seeked', sync, { signal });
+    listen(media, 'canplay', sync, { signal });
+    listen(media, 'timeupdate', sync, { signal });
   },
 });

--- a/packages/core/src/dom/store/features/playback.ts
+++ b/packages/core/src/dom/store/features/playback.ts
@@ -46,6 +46,7 @@ export const playbackFeature = definePlayerFeature({
 
     const sync = () => {
       const starved = media.readyState < HTMLMediaElement.HAVE_FUTURE_DATA && !media.paused;
+
       if (!starved) starvedAt = null;
       else starvedAt ??= media.currentTime;
 

--- a/packages/core/src/dom/store/features/tests/playback.test.ts
+++ b/packages/core/src/dom/store/features/tests/playback.test.ts
@@ -38,6 +38,63 @@ describe('playbackFeature', () => {
       expect(store.state.waiting).toBe(true);
     });
 
+    it('clears waiting once currentTime advances below HAVE_FUTURE_DATA', () => {
+      const video = createMockVideo({
+        paused: false,
+        readyState: HTMLMediaElement.HAVE_CURRENT_DATA,
+        currentTime: 0,
+      });
+
+      const store = createStore<PlayerTarget>()(playbackFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.waiting).toBe(true);
+
+      // Safari holds HAVE_CURRENT_DATA for the whole of some MSE streams, so a
+      // presented frame is the only evidence that playback ever recovered.
+      video.currentTime = 0.5;
+      video.dispatchEvent(new Event('timeupdate'));
+
+      expect(store.state.waiting).toBe(false);
+    });
+
+    it('keeps waiting while currentTime does not advance', () => {
+      const video = createMockVideo({
+        paused: false,
+        readyState: HTMLMediaElement.HAVE_CURRENT_DATA,
+        currentTime: 4,
+      });
+
+      const store = createStore<PlayerTarget>()(playbackFeature);
+      store.attach({ media: video, container: null });
+
+      video.dispatchEvent(new Event('timeupdate'));
+
+      expect(store.state.waiting).toBe(true);
+    });
+
+    it('restores waiting when the browser reports starvation again', () => {
+      const video = createMockVideo({
+        paused: false,
+        readyState: HTMLMediaElement.HAVE_CURRENT_DATA,
+        currentTime: 0,
+      });
+
+      const store = createStore<PlayerTarget>()(playbackFeature);
+      store.attach({ media: video, container: null });
+
+      video.currentTime = 12;
+      video.dispatchEvent(new Event('timeupdate'));
+      expect(store.state.waiting).toBe(false);
+
+      video.dispatchEvent(new Event('waiting'));
+      expect(store.state.waiting).toBe(true);
+
+      video.currentTime = 12.25;
+      video.dispatchEvent(new Event('timeupdate'));
+      expect(store.state.waiting).toBe(false);
+    });
+
     it('detects started from currentTime', () => {
       const video = createMockVideo({
         paused: true,

--- a/packages/core/src/dom/store/features/tests/playback.test.ts
+++ b/packages/core/src/dom/store/features/tests/playback.test.ts
@@ -46,6 +46,7 @@ describe('playbackFeature', () => {
       });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
+
       store.attach({ media: video, container: null });
 
       expect(store.state.waiting).toBe(true);
@@ -66,6 +67,7 @@ describe('playbackFeature', () => {
       });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
+
       store.attach({ media: video, container: null });
 
       video.dispatchEvent(new Event('timeupdate'));
@@ -81,6 +83,7 @@ describe('playbackFeature', () => {
       });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
+
       store.attach({ media: video, container: null });
 
       video.currentTime = 12;


### PR DESCRIPTION
## Summary

In Safari, playback of some DRM-protected streams latches the player's buffering UI on forever over video that is visibly playing.

**When it happens:** with DRM-protected content where **both** the audio and video tracks are encrypted (measured with FairPlay over MSE). It reproduces identically through SPF and through hls.js, so it is not an engine bug — and sources that encrypt video only, with clear audio (like Mux's), do not trigger it.

**The WebKit bug:** during startup Safari drops `readyState` to `HAVE_CURRENT_DATA` (2) and never raises it again, even after playback begins and runs normally — measured with ~25s of contiguous buffer ahead of an advancing playhead, which per MSE's SourceBuffer Monitoring rules mandates at least `HAVE_FUTURE_DATA`. Because `playing` is spec'd to fire on exactly that readyState crossing, it never fires either. A seek sometimes corrects the state, but not reliably.

**What users see:** the UI is stuck in its loading state for the entire stream — the buffering spinner and the skin scrim it gates stay up over visibly-playing video — because the store derived `waiting` from `readyState` alone, and every event that could have cleared it is welded to the same broken value.

**The fix:** stop trusting `readyState` for recovery. `waiting` clears once `currentTime` moves off the position where starvation was reported — a presented frame is proof the browser had future data, whatever `readyState` claims. The derivation lives in the store, so both engines are fixed at once.

## Changes

- `waiting` now records `currentTime` when the browser reports running short of data and stays true only while playback has not moved off that position — a presented frame is proof the browser had future data, whatever `readyState` claims. Video.js clears its waiting class the same way, and for the same reason.
- `canplay` and `timeupdate` join the sync listeners; `seeking` latches starvation so a seek into unbuffered territory still shows the indicator (a case the old derivation handled and this one must not regress).
- The sandbox gains the EZDRM FairPlay demo source (`hls-drm-ezdrm`), the known-bad case below.

## Seeing it in Safari

> [!NOTE]
> The EZDRM test stream is FairPlay-only, so it plays **only in Safari**. Loading it in Chrome, Edge, or Firefox is expected to fail with a playback error — those browsers' key systems have no license configuration on this source.

Open https://v10-sandbox-git-fix-core-waiting-readystate-mux.vercel.app/html-hlsjs-video/?source=hls-drm-ezdrm (this branch's sandbox preview) and play. This build carries the fix, so the spinner and scrim clear shortly after playback starts — while the browser bug is still live underneath, which the console shows:

```js
document.querySelector('hlsjs-video').readyState // 2 throughout normal playback
```

Without this fix, that pinned `readyState` kept `waiting` latched, so the spinner and scrim stayed up for the whole visibly-playing stream. There is deliberately no deployed build that shows the latched state — this branch is the first to carry the triggering source, and it carries the fix — but it takes one pasted block to see it locally:

<details>
<summary>Reproducing the latched state locally on <code>main</code></summary>

On `main` (no fix), paste this entry anywhere in `SOURCE_MAP` in `apps/sandbox/app/shared/sources.ts`:

```ts
'hls-drm-ezdrm': {
  label: 'HLS - DRM FairPlay (EZDRM)',
  type: 'hls',
  subType: 'mp4',
  drm: true,
  source: {
    src: 'https://na-fps.ezdrm.com/demo/ezdrm/master.m3u8',
    drm: {
      'com.apple.fps': {
        licenseUrl: 'https://fps.ezdrm.com/api/licenses/b99ed9e5-c641-49d1-bfa8-43692b686ddb',
        serverCertificateUrl: 'https://fps.ezdrm.com/demo/video/eleisure.cer',
      },
    },
  },
},
```

Run `pnpm -F @videojs/sandbox dev:https` (FairPlay needs a secure context; accept the self-signed certificate) and open the URL Vite prints plus `html-hlsjs-video/?source=hls-drm-ezdrm` — by default:

```
https://localhost:5173/html-hlsjs-video/?source=hls-drm-ezdrm
```

Press play in Safari. The video visibly plays while the buffering spinner and the scrim over it never clear, and `document.querySelector('hlsjs-video').readyState` stays at 2 the whole time. A seek sometimes unlatches it; nothing else does. On this branch, the same URL plays with the spinner clearing normally.

</details>

The trigger needs both tracks encrypted, which is why the sandbox's existing Mux DRM source does not show it: EZDRM encrypts audio and video, while the Mux asset encrypts video only with clear audio and keeps a healthy `readyState` (measured on the same stack). The demo uses the hls.js-backed element because it exercises MSE + EME on today's `main`; the failure was first found and fixed against SPF playback, where it presents identically.

## Testing

- Three new tests in `playback.test.ts` pin the recovery-by-advancing-time behavior, the still-stalled case, and re-starvation after recovery; mutation-verified (reverting to the plain `readyState` reading fails the two that matter). `pnpm -F @videojs/core test` green.
- Verified in Safari on this source: spinner and scrim clear shortly after playback starts while `readyState` still reads 2, a scrub into unbuffered territory still shows the spinner, and the cold-load startup spinner is intact. A clear-source control run reads `readyState` 4, so the pin is specific to encrypted content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core playback-state derivation used by the buffering indicator across engines; behavior is narrowed with tests but still affects all MSE playback paths, not only DRM.
> 
> **Overview**
> Fixes the buffering UI staying on over visibly playing video in Safari when **fully encrypted** FairPlay + MSE streams leave `readyState` stuck at `HAVE_CURRENT_DATA` and never fire `playing`.
> 
> **`playback` store:** `waiting` no longer equals “low `readyState` while unpaused.” It now latches at the `currentTime` where starvation was reported and clears when the playhead moves past that point (via `timeupdate`), treating an advancing clock as proof playback recovered regardless of `readyState`. `seeking` / `waiting` / `play` / `emptied` re-latch starvation; `canplay` and `timeupdate` participate in sync.
> 
> **Sandbox:** adds **`hls-drm-ezdrm`**, an EZDRM FairPlay demo that reproduces the Safari case (both tracks encrypted, unlike the existing Mux DRM sample).
> 
> **Tests:** three cases cover recovery on time advance, stalled time with low `readyState`, and re-buffering after recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02fc294e9be93a1b0f09ea9e919edca14708701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->