### PR TITLE
docs(site): mention lightweight HLS option

### DIFF
--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -116,6 +116,10 @@ Video.js supports a wide range of file types and hosting services. It's easy to 
   <RendererPicker client:idle />
 </ContentWidth>
 
+<Aside type="tip" title="Want a smaller HLS bundle?">
+This guide uses <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink> for broad compatibility. To experiment with our lightweight HLS engine and reduce your bundle size, try <DocsLink slug="reference/hls-video">HlsVideo</DocsLink>.
+</Aside>
+
 </HumanCase>
 
 <div data-cli-replace="installation" class="contents">


### PR DESCRIPTION
## Summary

Point HLS users to the smaller experimental HLS engine without changing the installation guide's broadly compatible hls.js default.

## Changes

- Add a tip beside the media-source picker that keeps `HlsJsVideo` as the broad-compatibility choice
- Link `HlsVideo` as the lightweight engine readers can experiment with for a smaller bundle

## Testing

- `CI=true pnpm -F site test`
- `CI=true pnpm -F site astro check`
- `env -u SENTRY_AUTH_TOKEN CI=true pnpm build:site`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and links on the installation page; no runtime or API changes.
> 
> **Overview**
> Adds a **tip** on the installation guide immediately after the media-source picker so readers know the walkthrough still defaults to **`HlsJsVideo`** for broad compatibility, while **`HlsVideo`** is available if they want to try the lighter experimental HLS engine for a smaller bundle.
> 
> The aside links to the existing reference pages for both components; it does not change install steps or swap the guide’s default renderer choice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f91b7d07b567dd17b3144fd1dcfc6f75700f2bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->