### PR TITLE
fix(skins): improve generated skin parity

### DIFF
--- a/packages/core/src/core/ui/menu/core.ts
+++ b/packages/core/src/core/ui/menu/core.ts
@@ -1,7 +1,7 @@
 import { defaults } from '@videojs/utils/object';
 import type { NonNullableObject } from '@videojs/utils/types';
 
-import type { PopoverAlign, PopoverSide } from '../popover/core';
+import type { PopoverAlign, PopoverBoundary, PopoverSide } from '../popover/core';
 import type { TransitionFlags, TransitionState, TransitionStatus } from '../transition';
 import { getTransitionFlags } from '../transition';
 
@@ -12,6 +12,8 @@ export interface MenuProps {
   side?: PopoverSide | undefined;
   /** Alignment along the trigger's edge. Root menus only. */
   align?: PopoverAlign | undefined;
+  /** Boundary used to constrain the root menu popup. */
+  boundary?: PopoverBoundary | undefined;
   /** Controlled open state. */
   open?: boolean | undefined;
   /** Initial open state (uncontrolled). */
@@ -21,6 +23,8 @@ export interface MenuProps {
   /** Close the menu when clicking outside. Root menus only. */
   closeOnOutsideClick?: boolean | undefined;
 }
+
+type MenuCoreProps = Omit<MenuProps, 'boundary'>;
 
 export interface MenuTriggerProps {
   disabled?: boolean | undefined;
@@ -91,7 +95,7 @@ export interface MenuState extends TransitionFlags {
 
 /** Base menu logic: ARIA attributes and open/close state computation. */
 export class MenuCore {
-  static readonly defaultProps: NonNullableObject<MenuProps> = {
+  static readonly defaultProps: NonNullableObject<MenuCoreProps> = {
     side: 'bottom',
     align: 'start',
     open: false,
@@ -103,15 +107,15 @@ export class MenuCore {
   #props = { ...MenuCore.defaultProps };
   #input: MenuInput | null = null;
 
-  get props(): Readonly<NonNullableObject<MenuProps>> {
+  get props(): Readonly<NonNullableObject<MenuCoreProps>> {
     return this.#props;
   }
 
-  constructor(props?: MenuProps) {
+  constructor(props?: MenuCoreProps) {
     if (props) this.setProps(props);
   }
 
-  setProps(props: MenuProps): void {
+  setProps(props: MenuCoreProps): void {
     this.#props = defaults(props, MenuCore.defaultProps);
   }
 
@@ -155,7 +159,7 @@ export class MenuCore {
 }
 
 export namespace MenuCore {
-  export type Props = MenuProps;
+  export type Props = MenuCoreProps;
   export type State = MenuState;
   export type Input = MenuInput;
 }

--- a/packages/core/src/core/ui/menu/menu-component.ts
+++ b/packages/core/src/core/ui/menu/menu-component.ts
@@ -3,16 +3,11 @@ import { defineComponent } from 'vjsc/components';
 import type { MenuItemIndicatorProps, MenuItemProps, MenuPopupProps, MenuProps, MenuTriggerProps } from './core';
 import { MenuDataAttrs } from './data';
 
-interface MenuRootProps extends MenuProps {
-  /** Boundary used to constrain the root menu popup size. */
-  boundary?: 'viewport' | 'container' | (string & {}) | undefined;
-}
-
 export default defineComponent({
   name: 'Menu',
   root: 'Root',
   parts: {
-    Root: defineComponent<MenuRootProps>(),
+    Root: defineComponent<MenuProps>(),
     Trigger: defineComponent<MenuTriggerProps>(),
     Popup: defineComponent<MenuPopupProps>(),
     Content: defineComponent(),

--- a/packages/core/src/core/ui/popover/core.ts
+++ b/packages/core/src/core/ui/popover/core.ts
@@ -8,11 +8,15 @@ export type PopoverSide = 'top' | 'bottom' | 'left' | 'right';
 
 export type PopoverAlign = 'start' | 'center' | 'end';
 
+export type PopoverBoundary = 'viewport' | 'container' | (string & {});
+
 export interface PopoverProps {
   /** Preferred side of the trigger for the popup. */
   side?: PopoverSide | undefined;
   /** Alignment of the popup along the trigger's edge. */
   align?: PopoverAlign | undefined;
+  /** Boundary used to constrain the popup position. */
+  boundary?: PopoverBoundary | undefined;
   /**
    * - `false` (default): non-modal; background content remains interactive.
    * - `true`: modal; sets `aria-modal="true"` on the popup.
@@ -35,6 +39,8 @@ export interface PopoverProps {
   closeDelay?: number | undefined;
 }
 
+type PopoverCoreProps = Omit<PopoverProps, 'boundary'>;
+
 /**
  * The raw transition state managed by `createTransition`. Uses `active` (not `open`) to distinguish the generic
  * transition state machine from the domain-specific `PopoverState.open`.
@@ -51,7 +57,7 @@ export interface PopoverState extends TransitionFlags {
 }
 
 export class PopoverCore {
-  static readonly defaultProps: NonNullableObject<PopoverProps> = {
+  static readonly defaultProps: NonNullableObject<PopoverCoreProps> = {
     side: 'top',
     align: 'center',
     modal: false,
@@ -66,11 +72,11 @@ export class PopoverCore {
 
   #props = { ...PopoverCore.defaultProps };
 
-  constructor(props?: PopoverProps) {
+  constructor(props?: PopoverCoreProps) {
     if (props) this.setProps(props);
   }
 
-  setProps(props: PopoverProps): void {
+  setProps(props: PopoverCoreProps): void {
     this.#props = defaults(props, PopoverCore.defaultProps);
   }
 
@@ -111,7 +117,7 @@ export class PopoverCore {
 }
 
 export namespace PopoverCore {
-  export type Props = PopoverProps;
+  export type Props = PopoverCoreProps;
   export type State = PopoverState;
   export type Input = PopoverInput;
 }

--- a/packages/core/src/core/ui/tooltip/core.ts
+++ b/packages/core/src/core/ui/tooltip/core.ts
@@ -1,7 +1,7 @@
 import { defaults } from '@videojs/utils/object';
 import type { NonNullableObject } from '@videojs/utils/types';
 
-import type { PopoverAlign, PopoverSide } from '../popover/core';
+import type { PopoverAlign, PopoverBoundary, PopoverSide } from '../popover/core';
 import type { TransitionFlags, TransitionState, TransitionStatus } from '../transition';
 import { getTransitionFlags } from '../transition';
 
@@ -10,6 +10,8 @@ export interface TooltipProps {
   side?: PopoverSide | undefined;
   /** Alignment of the tooltip along the trigger's edge. */
   align?: PopoverAlign | undefined;
+  /** Boundary used to constrain the tooltip position. */
+  boundary?: PopoverBoundary | undefined;
   /** Controlled open state. */
   open?: boolean | undefined;
   /** Initial open state for uncontrolled usage. */
@@ -26,6 +28,8 @@ export interface TooltipProps {
   sticky?: boolean | undefined;
 }
 
+type TooltipCoreProps = Omit<TooltipProps, 'boundary'>;
+
 export interface TooltipInput extends TransitionState {}
 
 export interface TooltipState extends TransitionFlags {
@@ -40,7 +44,7 @@ export interface TooltipState extends TransitionFlags {
 }
 
 export class TooltipCore {
-  static readonly defaultProps: NonNullableObject<TooltipProps> = {
+  static readonly defaultProps: NonNullableObject<TooltipCoreProps> = {
     side: 'top',
     align: 'center',
     open: false,
@@ -54,11 +58,11 @@ export class TooltipCore {
 
   #props = { ...TooltipCore.defaultProps };
 
-  constructor(props?: TooltipProps) {
+  constructor(props?: TooltipCoreProps) {
     if (props) this.setProps(props);
   }
 
-  setProps(props: TooltipProps): void {
+  setProps(props: TooltipCoreProps): void {
     this.#props = defaults(props, TooltipCore.defaultProps);
   }
 
@@ -89,7 +93,7 @@ export class TooltipCore {
 }
 
 export namespace TooltipCore {
-  export type Props = TooltipProps;
+  export type Props = TooltipCoreProps;
   export type State = TooltipState;
   export type Input = TooltipInput;
 }

--- a/packages/core/src/core/ui/volume-popover/core.ts
+++ b/packages/core/src/core/ui/volume-popover/core.ts
@@ -33,6 +33,6 @@ export class VolumePopoverCore extends PopoverCore {
 }
 
 export namespace VolumePopoverCore {
-  export type Props = VolumePopoverProps;
+  export type Props = PopoverCore.Props;
   export type State = VolumePopoverState;
 }

--- a/packages/core/src/dom/ui/menu/menu-popup.ts
+++ b/packages/core/src/dom/ui/menu/menu-popup.ts
@@ -95,6 +95,16 @@ export function createMenuPopup(): MenuPopupApi {
     );
   }
 
+  function getVerticalScrollbarWidth(content: HTMLElement): number {
+    if (content.scrollHeight <= content.clientHeight) return 0;
+
+    const style = getComputedStyle(content);
+    const inlineBorder =
+      (Number.parseFloat(style.borderInlineStartWidth) || 0) + (Number.parseFloat(style.borderInlineEndWidth) || 0);
+
+    return Math.max(0, content.offsetWidth - content.clientWidth - inlineBorder);
+  }
+
   function measureContent(content: HTMLElement, availableWidth: number | null) {
     const children = getElementChildren(
       content,
@@ -157,8 +167,15 @@ export function createMenuPopup(): MenuPopupApi {
     const contentAvailableWidth = availableWidth === null ? null : Math.max(0, availableWidth - inlinePadding);
     const size = measureContent(current.element, contentAvailableWidth);
 
-    element.style.setProperty(MenuCSSVars.width, `${Math.ceil(size.width + inlinePadding)}px`);
-    element.style.setProperty(MenuCSSVars.height, `${Math.ceil(size.height + blockPadding)}px`);
+    const width = Math.ceil(size.width + inlinePadding);
+    const height = Math.ceil(size.height + blockPadding);
+
+    element.style.setProperty(MenuCSSVars.width, `${width}px`);
+    element.style.setProperty(MenuCSSVars.height, `${height}px`);
+
+    const scrollbarWidth = getVerticalScrollbarWidth(current.element);
+
+    if (scrollbarWidth > 0) element.style.setProperty(MenuCSSVars.width, `${width + scrollbarWidth}px`);
   }
 
   function setElement(next: HTMLElement | null): void {

--- a/packages/core/src/dom/ui/menu/tests/menu-popup.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/menu-popup.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { MenuCSSVars } from '../../../../core/ui/menu/vars';
+import { createMenuPopup } from '../menu-popup';
+import { createTestMenu } from './create-menu-helpers';
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe('createMenuPopup', () => {
+  it('includes the vertical scrollbar when sizing the popup', () => {
+    const popupElement = document.createElement('div');
+    const content = document.createElement('div');
+    const item = document.createElement('div');
+    const { menu } = createTestMenu();
+    const popup = createMenuPopup();
+
+    popupElement.style.paddingInlineStart = '4px';
+    popupElement.style.paddingInlineEnd = '4px';
+    popupElement.style.paddingBlockStart = '4px';
+    popupElement.style.paddingBlockEnd = '4px';
+    content.append(item);
+    popupElement.append(content);
+    document.body.append(popupElement);
+
+    vi.spyOn(item, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 60, 266));
+    Object.defineProperties(item, {
+      scrollWidth: { configurable: true, value: 60 },
+      scrollHeight: { configurable: true, value: 266 },
+    });
+    Object.defineProperties(content, {
+      offsetWidth: { configurable: true, value: 64 },
+      clientWidth: { configurable: true, value: 49 },
+      scrollHeight: { configurable: true, value: 266 },
+      clientHeight: { configurable: true, value: 209 },
+    });
+
+    popup.setElement(popupElement);
+    popup.registerContent({ menu, parent: null, element: content });
+    popup.sync();
+
+    expect(popupElement.style.getPropertyValue(MenuCSSVars.width)).toBe('83px');
+    expect(popupElement.style.getPropertyValue(MenuCSSVars.height)).toBe('274px');
+
+    popup.destroy();
+    menu.destroy();
+  });
+});

--- a/packages/core/src/dom/ui/popover/popover.ts
+++ b/packages/core/src/dom/ui/popover/popover.ts
@@ -181,6 +181,7 @@ export function createPopover(options: PopoverOptions): PopoverApi {
     const opening = layer.open(() => popupEl);
     if (!opening) return;
 
+    tryShowPopover(popupEl);
     options.group?.()?.open(groupMember);
 
     opening.then(() => {

--- a/packages/core/src/dom/ui/popover/tests/popover.test.ts
+++ b/packages/core/src/dom/ui/popover/tests/popover.test.ts
@@ -38,6 +38,21 @@ describe('createPopover', () => {
       expect(popover.input.current).toEqual({ active: true, status: 'ending' });
     });
 
+    it('shows an already-mounted popup when a deferred open is committed', () => {
+      const { popover } = createTestPopover({ deferOpenChanges: true });
+      const popup = document.createElement('div');
+      const showPopover = vi.fn();
+
+      Object.defineProperty(popup, 'showPopover', { value: showPopover });
+      popover.setPopupElement(popup);
+
+      popover.open();
+      expect(showPopover).not.toHaveBeenCalled();
+
+      popover.syncOpen(true);
+      expect(showPopover).toHaveBeenCalledOnce();
+    });
+
     it('updates input state and calls onOpenChange when opening', () => {
       const { popover, onOpenChange } = createTestPopover();
 

--- a/packages/react/src/ui/menu/menu-root.tsx
+++ b/packages/react/src/ui/menu/menu-root.tsx
@@ -19,7 +19,7 @@ import { useOptionalControlsContext } from '../controls/context';
 import { usePositionedState } from '../hooks/use-positioned-state';
 import { MenuContextProvider, useOptionalMenuContext } from './context';
 
-export interface MenuRootProps extends MenuCore.Props {
+export interface MenuRootProps extends Omit<MenuCore.Props, 'boundary'> {
   /** Boundary used to constrain the root menu popup size. */
   boundary?: PositioningBoundary;
   /** Called when the menu open state changes (fires immediately, before animations). */

--- a/packages/react/src/ui/menu/tests/menu.test.tsx
+++ b/packages/react/src/ui/menu/tests/menu.test.tsx
@@ -717,8 +717,11 @@ describe('MenuContent', () => {
     expect(submenu.hasAttribute('data-ending-style')).toBe(true);
     expect(submenu.hasAttribute('data-open')).toBe(true);
     expect(screen.getByTestId('submenu-trigger').getAttribute('aria-expanded')).toBe('false');
-    expect(screen.getByTestId('root-content').hasAttribute('data-child-open')).toBe(false);
-    expect(submenu.hasAttribute('inert')).toBe(true);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('root-content').hasAttribute('data-child-open')).toBe(false);
+      expect(submenu.hasAttribute('inert')).toBe(true);
+    });
   });
 
   it('portals submenu content into the popup', async () => {
@@ -1036,7 +1039,6 @@ describe('MenuContent', () => {
     fireEvent.click(screen.getByTestId('submenu-back'));
 
     expect(screen.getByTestId('submenu-content').hasAttribute('data-ending-style')).toBe(true);
-    expect(screen.getByTestId('root-content').hasAttribute('inert')).toBe(false);
 
     await waitFor(() => {
       expect(screen.queryByTestId('submenu-content')).toBeNull();

--- a/packages/react/src/ui/popover/popover-root.tsx
+++ b/packages/react/src/ui/popover/popover-root.tsx
@@ -19,7 +19,7 @@ import { useOptionalControlsContext } from '../controls/context';
 import { usePositionedState } from '../hooks/use-positioned-state';
 import { PopoverContextProvider } from './context';
 
-export interface PopoverRootProps extends CorePopoverProps {
+export interface PopoverRootProps extends Omit<CorePopoverProps, 'boundary'> {
   /** Boundary used to constrain the popup size. */
   boundary?: PositioningBoundary;
   /** Called when the popover open state changes (fires immediately, before animations). */

--- a/packages/react/src/ui/tooltip/tooltip-root.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-root.tsx
@@ -20,7 +20,7 @@ import { usePositionedState } from '../hooks/use-positioned-state';
 import { type TooltipContent, TooltipContextProvider } from './context';
 import { useTooltipGroup } from './group-context';
 
-export interface TooltipRootProps extends CoreTooltipProps {
+export interface TooltipRootProps extends Omit<CoreTooltipProps, 'boundary'> {
   /** Boundary used to constrain the popup size. */
   boundary?: PositioningBoundary;
   /** Called when the tooltip open state changes (fires immediately, before animations). */

--- a/packages/react/src/utils/tests/use-render.test.tsx
+++ b/packages/react/src/utils/tests/use-render.test.tsx
@@ -265,6 +265,17 @@ describe('renderElement', () => {
       expect(ref.current).toBeInstanceOf(HTMLDivElement);
     });
 
+    it('keeps a single callback ref attached across renders', () => {
+      const ref = vi.fn();
+      const { rerender } = render(<TestComponent ref={ref} />);
+      const element = ref.mock.calls[0]![0];
+
+      rerender(<TestComponent ref={ref} active />);
+
+      expect(ref).toHaveBeenCalledTimes(1);
+      expect(ref).toHaveBeenCalledWith(element);
+    });
+
     it('forwards array of refs', () => {
       const ref1 = createRef<HTMLDivElement>();
       const ref2 = createRef<HTMLDivElement>();

--- a/packages/react/src/utils/use-render.tsx
+++ b/packages/react/src/utils/use-render.tsx
@@ -43,6 +43,15 @@ function getElementRef(element: ReactElement): Ref<unknown> | undefined {
   return elementAny.ref ?? elementAny.props?.ref;
 }
 
+function mergeRefs<T>(...refs: (Ref<T> | Ref<T>[] | undefined)[]): Ref<T> | undefined {
+  const flatRefs = refs.flat().filter((ref): ref is Ref<T> => ref !== null && ref !== undefined);
+  if (flatRefs.length === 0) return undefined;
+
+  if (flatRefs.length === 1) return flatRefs[0];
+
+  return composeRefs(...flatRefs);
+}
+
 /**
  * Render a UI component element.
  *
@@ -95,7 +104,7 @@ export function renderElement<
 
   if (isFunction(render)) {
     // Render function: call with props and state
-    const mergedRef = composeRefs(ref, mergedProps.ref);
+    const mergedRef = mergeRefs(ref, mergedProps.ref);
 
     return render({ ...mergedProps, ref: mergedRef } as HTMLProps, state);
   }
@@ -103,7 +112,7 @@ export function renderElement<
   if (isValidElement(render)) {
     const elementRef = getElementRef(render);
 
-    const mergedRef = composeRefs(ref, mergedProps.ref, elementRef);
+    const mergedRef = mergeRefs(ref, mergedProps.ref, elementRef);
 
     const elementProps = mergeProps(mergedProps, render.props as Record<string, unknown>);
 
@@ -113,7 +122,7 @@ export function renderElement<
   }
 
   // Default tag
-  const mergedRef = composeRefs(ref, mergedProps.ref);
+  const mergedRef = mergeRefs(ref, mergedProps.ref);
 
   mergedProps.ref = mergedRef;
 

--- a/packages/skins/build/packages/react.ts
+++ b/packages/skins/build/packages/react.ts
@@ -198,8 +198,6 @@ function reactSkinWrapper(options: {
 }): string {
   const props = `${options.component}Props`;
   const base = options.video ? 'BaseVideoSkinProps' : 'BaseSkinProps';
-  const parameters = options.video ? `{ renderPoster, ...props }: ${props}` : `props: ${props}`;
-  const forwarded = options.video ? 'poster={renderPoster} {...props}' : '{...props}';
 
   return `'use client';
 
@@ -209,8 +207,8 @@ import type { ${base} } from '../types';
 
 export interface ${props} extends ${base} {}
 
-export function ${options.component}(${parameters}) {
-  return <Skin ${forwarded} />;
+export function ${options.component}(props: ${props}) {
+  return <Skin {...props} />;
 }
 `;
 }

--- a/packages/skins/build/packages/tests/react.test.ts
+++ b/packages/skins/build/packages/tests/react.test.ts
@@ -20,7 +20,7 @@ describe('createReactPackageSkins', () => {
     );
 
     expect(files.get('packages/react/src/presets/video/skin.tsx')).toContain('export interface VideoSkinProps');
-    expect(files.get('packages/react/src/presets/video/skin.tsx')).toContain('poster={renderPoster}');
+    expect(files.get('packages/react/src/presets/video/skin.tsx')).toContain('<Skin {...props} />');
     expect(files.get('packages/react/src/internal/skins/default-video/skin.tsx')).toContain(
       "from '../shared/components/button'"
     );

--- a/packages/skins/build/target/html.tsx
+++ b/packages/skins/build/target/html.tsx
@@ -190,12 +190,14 @@ export const htmlComponentTarget: ComponentTarget<CoreSchema> = defineComponentT
           const controlledId = id(popup ? 'popup' : 'content');
 
           if (popup) {
-            const playbackRateButtonProps = renderTargetProps(trigger.props, 'PlaybackRateButton');
+            const componentProps =
+              renderTargetProps(trigger.props, 'CaptionsButton') ??
+              renderTargetProps(trigger.props, 'PlaybackRateButton');
 
             return [
               trigger.replaceWith(
-                playbackRateButtonProps ? (
-                  <Host commandfor={controlledId} {...playbackRateButtonProps}>
+                componentProps ? (
+                  <Host commandfor={controlledId} {...componentProps}>
                     {trigger.children}
                   </Host>
                 ) : (
@@ -309,6 +311,7 @@ export const htmlComponentTarget: ComponentTarget<CoreSchema> = defineComponentT
         target: () => htmlComponentTarget,
         targets: {
           Button: { element: Button },
+          CaptionsButton: { element: htmlElementTarget('CaptionsButton', element), kind: 'component' },
           PlaybackRateButton: { element: PlaybackRateButton, kind: 'component' },
           SliderBuffer: { element: Div },
           SliderFill: { element: Div },

--- a/packages/skins/build/target/react.tsx
+++ b/packages/skins/build/target/react.tsx
@@ -151,6 +151,7 @@ export const reactComponentTarget: ComponentTarget<CoreSchema> = defineComponent
         target: () => reactComponentTarget,
         targets: {
           Button: { element: Button },
+          CaptionsButton: { element: Button, kind: 'component' },
           PlaybackRateButton: { element: Button, kind: 'component' },
           SliderBuffer: { element: Div },
           SliderFill: { element: Div },

--- a/packages/skins/build/tests/vite.test.ts
+++ b/packages/skins/build/tests/vite.test.ts
@@ -12,6 +12,9 @@ const defaultControlsUrl = `/../src/skins/default-video/controls.tsx${reactTarge
 const htmlContainerUrl = '/../src/components/layout/container.tsx?style=tailwind&target=html&skin=minimal-video';
 const playButtonUrl = `/../src/components/buttons/play-button.tsx${reactTarget}`;
 const settingsMenuUrl = `/../src/components/menus/settings-menu.tsx${reactTarget}`;
+const reactCaptionsMenuUrl =
+  '/../src/components/menus/captions-menu.tsx?style=css&target=react&skin=default-live-video';
+const htmlCaptionsMenuUrl = '/../src/components/menus/captions-menu.tsx?style=css&target=html&skin=default-live-video';
 const htmlAudioSettingsMenuUrl = '/../src/skins/audio/settings-menu.tsx?style=css&target=html&skin=default-audio';
 const volumePopoverUrl = `/../src/components/controls/volume-popover.tsx${reactTarget}`;
 const htmlPosterUrl = '/../src/components/layout/poster.tsx?style=tailwind&target=html&skin=default-video';
@@ -132,6 +135,7 @@ describe('Skins Vite workflow', () => {
     expect(settingsMenu?.code).toContain('children: /* @__PURE__ */ _jsxDEV(Menu.Trigger');
     expect(settingsMenu?.code).toContain('render: /* @__PURE__ */ _jsxDEV(Button');
     expect(settingsMenu?.code).toContain('resolveClassName(className, state)');
+    expect(settingsMenu?.code).toContain('media-menu-resizable-popup');
     expect(volumePopover?.code).toContain(
       'VolumePopoverPrimitive.Trigger, { render: /* @__PURE__ */ _jsxDEV(MuteButton'
     );
@@ -143,7 +147,18 @@ describe('Skins Vite workflow', () => {
     const code = settingsMenu?.code ?? '';
 
     expect(code).toContain('/components/buttons/playback-rate-button.tsx?skin=default-audio&style=css&target=html');
-    expect(code).toMatch(/_jsxDEV\(PlaybackRateButton, \{\s+commandfor:[\s\S]*?class: className/);
+    expect(code).toMatch(/_jsxDEV\(PlaybackRateButton, \{\s+commandfor:[\s\S]*?className/);
+    expect(code).not.toContain('media-menu-resizable-popup');
+  }, 30_000);
+
+  it('uses the captions button itself as the menu trigger', async () => {
+    const react = await server.transformRequest(reactCaptionsMenuUrl);
+    const html = await server.transformRequest(htmlCaptionsMenuUrl);
+
+    expect(react?.code).toMatch(/_jsxDEV\(MenuPrimitive\.Trigger, \{\s+render: .*_jsxDEV\(CaptionsButton/);
+    expect(react?.code).not.toContain('ButtonTooltip');
+    expect(html?.code).toMatch(/_jsxDEV\(CaptionsButton, \{\s+commandfor:[\s\S]*?className/);
+    expect(html?.code).not.toContain('data-vjsc-render-captions-button');
   }, 30_000);
 
   it('emits base visibility styles for stateful button icons', async () => {

--- a/packages/skins/build/transform.ts
+++ b/packages/skins/build/transform.ts
@@ -30,6 +30,7 @@ export function resolveSkinStyles(module: TransformModule): StyleTransformOption
 export function validateSkinConfig(parameters: URLSearchParams): SkinTransformConfig | null {
   const target = parameters.get('target');
   const skin = parameters.get('skin');
+
   const style = parameters.get('style');
   if ((target !== 'react' && target !== 'html') || (style !== 'tailwind' && style !== 'css')) return null;
 

--- a/packages/skins/dev/controls.ts
+++ b/packages/skins/dev/controls.ts
@@ -40,6 +40,10 @@ function createOptions(preview: PreviewOptions): HTMLFormElement {
       ['css', 'CSS'],
       ['tailwind', 'Tailwind'],
     ]),
+    createSelect('scheme', 'Color scheme', preview.colorScheme, [
+      ['dark', 'Dark'],
+      ['light', 'Light'],
+    ]),
     createSelect(
       'media',
       'Media',
@@ -136,6 +140,7 @@ function createCopyButton(preview: PreviewOptions): HTMLButtonElement {
       `framework=${preview.framework}`,
       `skin=${preview.skin}`,
       `style=${preview.styleMode}`,
+      `scheme=${preview.colorScheme}`,
       `media=${preview.mediaId} (${preview.media.label})`,
       `captions=${preview.captionsMode}`,
       `width=${width}px (${formatRem(width)})`,

--- a/packages/skins/dev/main.tsx
+++ b/packages/skins/dev/main.tsx
@@ -14,6 +14,9 @@ import './styles.css';
 
 const captions = new URL('./captions.vtt', import.meta.url).href;
 const preview = readPreviewOptions();
+
+document.documentElement.dataset.colorScheme = preview.colorScheme;
+
 const Skin = await loadSkin(preview);
 
 if (preview.styleMode === 'tailwind') await import('../src/styles/tailwind.compiler.css');

--- a/packages/skins/dev/options.ts
+++ b/packages/skins/dev/options.ts
@@ -27,6 +27,7 @@ export const errorSource = {
 export const mediaIds = [...SOURCE_IDS, 'error'] as const;
 
 export type CaptionsMode = 'multiple' | 'single';
+export type ColorScheme = 'dark' | 'light';
 export type Framework = 'html' | 'react';
 export type MediaId = (typeof mediaIds)[number];
 export type SkinName =
@@ -42,6 +43,7 @@ export type StyleMode = 'css' | 'tailwind';
 
 export interface PreviewOptions {
   readonly captionsMode: CaptionsMode;
+  readonly colorScheme: ColorScheme;
   readonly framework: Framework;
   readonly isAudio: boolean;
   readonly isLive: boolean;
@@ -64,6 +66,7 @@ export function readPreviewOptions(search = location.search): PreviewOptions {
   const isLive = skin.includes('-live-');
   const styleMode = params.get('style') === 'tailwind' ? 'tailwind' : 'css';
   const captionsMode = params.get('captions') === 'multiple' ? 'multiple' : 'single';
+  const colorScheme = params.get('scheme') === 'light' ? 'light' : 'dark';
   const requestedMedia = params.get('media');
   const mediaId = isMediaId(requestedMedia) ? requestedMedia : isLive ? 'hls-live' : 'mp4-1';
   const requestedWidth = Number.parseInt(params.get('width') ?? '', 10);
@@ -75,6 +78,7 @@ export function readPreviewOptions(search = location.search): PreviewOptions {
 
   return {
     captionsMode,
+    colorScheme,
     framework,
     isAudio,
     isLive,

--- a/packages/skins/dev/styles.css
+++ b/packages/skins/dev/styles.css
@@ -4,10 +4,18 @@ body,
   min-height: 100%;
 }
 
+:root {
+  color-scheme: dark;
+}
+
+:root[data-color-scheme="light"] {
+  color-scheme: light;
+}
+
 body {
   margin: 0;
-  background: #111;
-  color: white;
+  background: light-dark(#f5f5f5, #111);
+  color: light-dark(#111, white);
   font-family: Inter, ui-sans-serif, system-ui, sans-serif;
 }
 
@@ -23,6 +31,10 @@ body {
   aspect-ratio: 16 / 9;
 }
 
+#root[data-media-kind="audio"] {
+  margin-top: 10rem;
+}
+
 #root[data-media-kind="audio"] .preview-player {
   aspect-ratio: auto;
 }
@@ -35,15 +47,15 @@ body {
   align-items: end;
   width: 100%;
   padding: 1rem;
-  border-bottom: 1px solid rgb(255 255 255 / 15%);
-  background: #181818;
+  border-bottom: 1px solid light-dark(rgb(0 0 0 / 15%), rgb(255 255 255 / 15%));
+  background: light-dark(#fff, #181818);
 }
 
 .preview-control {
   display: grid;
   gap: 0.25rem;
   min-width: 8rem;
-  color: rgb(255 255 255 / 70%);
+  color: light-dark(rgb(0 0 0 / 70%), rgb(255 255 255 / 70%));
   font-size: 0.75rem;
   font-weight: 600;
 }
@@ -55,13 +67,12 @@ body {
 .preview-control select {
   min-height: 2.25rem;
   padding: 0.375rem 2rem 0.375rem 0.625rem;
-  color-scheme: dark;
-  color: white;
+  color: light-dark(#111, white);
   font: inherit;
   font-size: 0.875rem;
-  border: 1px solid rgb(255 255 255 / 20%);
+  border: 1px solid light-dark(rgb(0 0 0 / 20%), rgb(255 255 255 / 20%));
   border-radius: 0.375rem;
-  background: #272727;
+  background: light-dark(#f5f5f5, #272727);
 }
 
 .preview-control select:focus-visible {
@@ -88,7 +99,7 @@ body {
 }
 
 .preview-copy:focus-visible {
-  outline: 2px solid white;
+  outline: 2px solid light-dark(#111, white);
   outline-offset: 2px;
 }
 
@@ -97,11 +108,11 @@ body {
   display: grid;
   gap: 0.625rem;
   width: min(60rem, calc(100% - 2rem));
-  margin: 1rem auto 0;
+  margin: 1rem auto;
   padding: 0.75rem 1rem;
-  border: 1px solid rgb(255 255 255 / 15%);
+  border: 1px solid light-dark(rgb(0 0 0 / 15%), rgb(255 255 255 / 15%));
   border-radius: 0.5rem;
-  background: #181818;
+  background: light-dark(#fff, #181818);
 }
 
 .preview-width-header {
@@ -114,7 +125,7 @@ body {
 }
 
 .preview-width-header output {
-  color: rgb(255 255 255 / 70%);
+  color: light-dark(rgb(0 0 0 / 70%), rgb(255 255 255 / 70%));
   font-variant-numeric: tabular-nums;
 }
 
@@ -137,12 +148,12 @@ body {
 
 .preview-width-presets button {
   padding: 0.25rem 0.5rem;
-  color: rgb(255 255 255 / 75%);
+  color: light-dark(rgb(0 0 0 / 75%), rgb(255 255 255 / 75%));
   font: inherit;
   font-size: 0.75rem;
-  border: 1px solid rgb(255 255 255 / 15%);
+  border: 1px solid light-dark(rgb(0 0 0 / 15%), rgb(255 255 255 / 15%));
   border-radius: 0.375rem;
-  background: #272727;
+  background: light-dark(#f5f5f5, #272727);
   cursor: pointer;
 }
 
@@ -154,6 +165,6 @@ body {
 }
 
 .preview-width-presets button:focus-visible {
-  outline: 2px solid white;
+  outline: 2px solid light-dark(#111, white);
   outline-offset: 2px;
 }

--- a/packages/skins/src/components/buttons/airplay-button.tsx
+++ b/packages/skins/src/components/buttons/airplay-button.tsx
@@ -7,16 +7,13 @@ import type { SkinComponentMeta } from '../../meta';
 import styles from '../../styles/buttons/airplay-button.styles';
 import buttonStyles from '../../styles/buttons/button.styles';
 import { Button } from './button';
-import { ButtonTooltip } from './button-tooltip';
 
 export function AirPlayButton({ className, ...props }: Props<CoreProps> = {}) {
   return (
-    <ButtonTooltip side="top">
-      <$.AirPlayButton $render={Button} className={[styles.root, className]} {...props}>
-        <AirPlayEnterIcon className={[buttonStyles.icon, styles.enterIcon]} />
-        <AirPlayExitIcon className={[buttonStyles.icon, styles.exitIcon]} />
-      </$.AirPlayButton>
-    </ButtonTooltip>
+    <$.AirPlayButton $render={Button} className={[styles.root, className]} {...props}>
+      <AirPlayEnterIcon className={[buttonStyles.icon, styles.enterIcon]} />
+      <AirPlayExitIcon className={[buttonStyles.icon, styles.exitIcon]} />
+    </$.AirPlayButton>
   );
 }
 

--- a/packages/skins/src/components/buttons/button-tooltip.tsx
+++ b/packages/skins/src/components/buttons/button-tooltip.tsx
@@ -15,7 +15,9 @@ export function ButtonTooltip({ children, label, ...props }: PropsWithChildren<B
   return (
     <$.Tooltip.Root {...props}>
       <$.Tooltip.Trigger>{children}</$.Tooltip.Trigger>
-      <$.Tooltip.Popup className={[popupStyles.popup, popupStyles.transition, popupStyles.surface, styles.popup]}>
+      <$.Tooltip.Popup
+        className={[popupStyles.popup, popupStyles.safeArea, popupStyles.transition, popupStyles.surface, styles.popup]}
+      >
         {label ?? <$.Tooltip.Label />}
         {!label && <$.Tooltip.Shortcut className={styles.shortcut} />}
       </$.Tooltip.Popup>

--- a/packages/skins/src/components/buttons/captions-button.tsx
+++ b/packages/skins/src/components/buttons/captions-button.tsx
@@ -7,16 +7,13 @@ import type { SkinComponentMeta } from '../../meta';
 import buttonStyles from '../../styles/buttons/button.styles';
 import styles from '../../styles/buttons/captions-button.styles';
 import { Button } from './button';
-import { ButtonTooltip } from './button-tooltip';
 
 export function CaptionsButton({ className, ...props }: Props<CoreProps> = {}) {
   return (
-    <ButtonTooltip side="top">
-      <$.CaptionsButton $render={Button} className={[styles.root, className]} {...props}>
-        <CaptionsOffIcon className={[buttonStyles.icon, styles.offIcon]} />
-        <CaptionsOnIcon className={[buttonStyles.icon, styles.onIcon]} />
-      </$.CaptionsButton>
-    </ButtonTooltip>
+    <$.CaptionsButton $render={Button} className={[styles.root, className]} {...props}>
+      <CaptionsOffIcon className={[buttonStyles.icon, styles.offIcon]} />
+      <CaptionsOnIcon className={[buttonStyles.icon, styles.onIcon]} />
+    </$.CaptionsButton>
   );
 }
 

--- a/packages/skins/src/components/buttons/cast-button.tsx
+++ b/packages/skins/src/components/buttons/cast-button.tsx
@@ -7,16 +7,13 @@ import type { SkinComponentMeta } from '../../meta';
 import buttonStyles from '../../styles/buttons/button.styles';
 import styles from '../../styles/buttons/cast-button.styles';
 import { Button } from './button';
-import { ButtonTooltip } from './button-tooltip';
 
 export function CastButton({ className, ...props }: Props<CoreProps> = {}) {
   return (
-    <ButtonTooltip side="top">
-      <$.CastButton $render={Button} className={[styles.root, className]} {...props}>
-        <CastEnterIcon className={[buttonStyles.icon, styles.enterIcon]} />
-        <CastExitIcon className={[buttonStyles.icon, styles.exitIcon]} />
-      </$.CastButton>
-    </ButtonTooltip>
+    <$.CastButton $render={Button} className={[styles.root, className]} {...props}>
+      <CastEnterIcon className={[buttonStyles.icon, styles.enterIcon]} />
+      <CastExitIcon className={[buttonStyles.icon, styles.exitIcon]} />
+    </$.CastButton>
   );
 }
 

--- a/packages/skins/src/components/buttons/fullscreen-button.tsx
+++ b/packages/skins/src/components/buttons/fullscreen-button.tsx
@@ -7,16 +7,13 @@ import type { SkinComponentMeta } from '../../meta';
 import buttonStyles from '../../styles/buttons/button.styles';
 import styles from '../../styles/buttons/fullscreen-button.styles';
 import { Button } from './button';
-import { ButtonTooltip } from './button-tooltip';
 
 export function FullscreenButton({ className, ...props }: Props<CoreProps> = {}) {
   return (
-    <ButtonTooltip side="top">
-      <$.FullscreenButton $render={Button} className={[styles.root, className]} {...props}>
-        <FullscreenEnterIcon className={[buttonStyles.icon, styles.enterIcon]} />
-        <FullscreenExitIcon className={[buttonStyles.icon, styles.exitIcon]} />
-      </$.FullscreenButton>
-    </ButtonTooltip>
+    <$.FullscreenButton $render={Button} className={[styles.root, className]} {...props}>
+      <FullscreenEnterIcon className={[buttonStyles.icon, styles.enterIcon]} />
+      <FullscreenExitIcon className={[buttonStyles.icon, styles.exitIcon]} />
+    </$.FullscreenButton>
   );
 }
 
@@ -24,5 +21,5 @@ export const meta = {
   name: 'fullscreen-button',
   type: 'component',
   title: 'Fullscreen Button',
-  description: 'A button that enters and exits fullscreen with state-aware icons and an accessible tooltip.',
+  description: 'A button that enters and exits fullscreen with state-aware icons.',
 } as const satisfies SkinComponentMeta;

--- a/packages/skins/src/components/buttons/pip-button.tsx
+++ b/packages/skins/src/components/buttons/pip-button.tsx
@@ -7,16 +7,13 @@ import type { SkinComponentMeta } from '../../meta';
 import buttonStyles from '../../styles/buttons/button.styles';
 import styles from '../../styles/buttons/pip-button.styles';
 import { Button } from './button';
-import { ButtonTooltip } from './button-tooltip';
 
 export function PiPButton({ className, ...props }: Props<CoreProps> = {}) {
   return (
-    <ButtonTooltip side="top">
-      <$.PiPButton $render={Button} className={[styles.root, className]} {...props}>
-        <PipEnterIcon className={[buttonStyles.icon, styles.enterIcon]} />
-        <PipExitIcon className={[buttonStyles.icon, styles.exitIcon]} />
-      </$.PiPButton>
-    </ButtonTooltip>
+    <$.PiPButton $render={Button} className={[styles.root, className]} {...props}>
+      <PipEnterIcon className={[buttonStyles.icon, styles.enterIcon]} />
+      <PipExitIcon className={[buttonStyles.icon, styles.exitIcon]} />
+    </$.PiPButton>
   );
 }
 

--- a/packages/skins/src/components/buttons/play-button.tsx
+++ b/packages/skins/src/components/buttons/play-button.tsx
@@ -7,17 +7,14 @@ import type { SkinComponentMeta } from '../../meta';
 import buttonStyles from '../../styles/buttons/button.styles';
 import styles from '../../styles/buttons/play-button.styles';
 import { Button } from './button';
-import { ButtonTooltip } from './button-tooltip';
 
 export function PlayButton({ className, ...props }: Props<CoreProps> = {}) {
   return (
-    <ButtonTooltip side="top">
-      <$.PlayButton $render={Button} className={[styles.root, className]} {...props}>
-        <RestartIcon className={[buttonStyles.icon, styles.restartIcon]} />
-        <PlayIcon className={[buttonStyles.icon, styles.playIcon]} />
-        <PauseIcon className={[buttonStyles.icon, styles.pauseIcon]} />
-      </$.PlayButton>
-    </ButtonTooltip>
+    <$.PlayButton $render={Button} className={[styles.root, className]} {...props}>
+      <RestartIcon className={[buttonStyles.icon, styles.restartIcon]} />
+      <PlayIcon className={[buttonStyles.icon, styles.playIcon]} />
+      <PauseIcon className={[buttonStyles.icon, styles.pauseIcon]} />
+    </$.PlayButton>
   );
 }
 
@@ -25,6 +22,5 @@ export const meta = {
   name: 'play-button',
   type: 'component',
   title: 'Play Button',
-  description:
-    'A three-state button that plays, pauses, or restarts media with matching icons and an accessible tooltip.',
+  description: 'A three-state button that plays, pauses, or restarts media with matching icons.',
 } as const satisfies SkinComponentMeta;

--- a/packages/skins/src/components/buttons/seek-button.tsx
+++ b/packages/skins/src/components/buttons/seek-button.tsx
@@ -1,24 +1,23 @@
 import type { SeekButtonProps as CoreProps } from '@videojs/core';
 import * as $ from '@videojs/core/vjsc';
 import { SeekIcon } from '@videojs/icons/vjsc';
-import { type Props, Text } from 'vjsc/components';
+import { Box, type Props, Text } from 'vjsc/components';
 
 import type { SkinComponentMeta } from '../../meta';
 import buttonStyles from '../../styles/buttons/button.styles';
 import styles from '../../styles/buttons/seek-button.styles';
 import { Button } from './button';
-import { ButtonTooltip } from './button-tooltip';
 
 export function SeekButton({ className, seconds = 10, ...props }: Props<CoreProps> = {}) {
   return (
-    <ButtonTooltip side="top">
-      <$.SeekButton $render={Button} className={[styles.root, className]} seconds={seconds} {...props}>
+    <$.SeekButton $render={Button} className={[styles.root, className]} seconds={seconds} {...props}>
+      <Box className={styles.content}>
         <SeekIcon className={[buttonStyles.icon, seconds < 0 && styles.backwardIcon]} />
         <Text className={[styles.label, seconds < 0 ? styles.backwardLabel : styles.forwardLabel]}>
           {Math.abs(seconds)}
         </Text>
-      </$.SeekButton>
-    </ButtonTooltip>
+      </Box>
+    </$.SeekButton>
   );
 }
 
@@ -26,6 +25,5 @@ export const meta = {
   name: 'seek-button',
   type: 'component',
   title: 'Seek Button',
-  description:
-    'A button that skips playback forward or backward by a configurable number of seconds, with a direction-aware icon and accessible tooltip.',
+  description: 'A button that skips playback forward or backward with a direction-aware icon and value.',
 } as const satisfies SkinComponentMeta;

--- a/packages/skins/src/components/controls/volume-popover.tsx
+++ b/packages/skins/src/components/controls/volume-popover.tsx
@@ -29,7 +29,9 @@ export function VolumePopover({
           <MuteButton className={[className]} />
         </$.VolumePopover.Trigger>
       </ButtonTooltip>
-      <$.VolumePopover.Popup className={[popupStyles.popup, popupStyles.transition, popupStyles.surface, styles.popup]}>
+      <$.VolumePopover.Popup
+        className={[popupStyles.popup, popupStyles.safeArea, popupStyles.transition, popupStyles.surface, styles.popup]}
+      >
         <VolumeSlider orientation={orientation} />
       </$.VolumePopover.Popup>
     </$.VolumePopover.Root>

--- a/packages/skins/src/components/menus/captions-menu.tsx
+++ b/packages/skins/src/components/menus/captions-menu.tsx
@@ -1,35 +1,22 @@
 import type { MenuProps } from '@videojs/core';
 import * as $ from '@videojs/core/vjsc';
-import { CaptionsOffIcon, CaptionsOnIcon } from '@videojs/icons/vjsc';
-import { type ClassNameValue, type Props, Template } from 'vjsc/components';
+import { type Props, type PropsOf, Template } from 'vjsc/components';
 
 import type { SkinComponentMeta } from '../../meta';
-import buttonStyles from '../../styles/buttons/button.styles';
-import captionsButtonStyles from '../../styles/buttons/captions-button.styles';
 import styles from '../../styles/menus/menu.styles';
 import popupStyles from '../../styles/popups/popup.styles';
-import { Button } from '../buttons/button';
-import { ButtonTooltip } from '../buttons/button-tooltip';
+import { CaptionsButton } from '../buttons/captions-button';
 import { RadioItem } from './radio-item';
 
 export interface CaptionsMenuProps extends MenuProps {
-  className?: ClassNameValue;
+  className?: PropsOf<typeof $.Menu.Trigger>['className'];
 }
 
 export function CaptionsMenu({ className, ...props }: Props<CaptionsMenuProps> = {}) {
   return (
     <$.Menu.Root side="top" align="center" boundary="viewport" {...props}>
       <$.CaptionsRadioGroup.Root>
-        <ButtonTooltip side="top">
-          <$.Menu.Trigger
-            $render={Button}
-            aria-label="Enable captions"
-            className={[captionsButtonStyles.root, className]}
-          >
-            <CaptionsOffIcon className={[buttonStyles.icon, captionsButtonStyles.offIcon]} />
-            <CaptionsOnIcon className={[buttonStyles.icon, captionsButtonStyles.onIcon]} />
-          </$.Menu.Trigger>
-        </ButtonTooltip>
+        <$.Menu.Trigger $render={CaptionsButton} className={className} />
         <$.Menu.Popup className={[popupStyles.popup, popupStyles.surface, styles.popup]}>
           <$.Menu.Content className={styles.content}>
             <$.CaptionsRadioGroup.Options className={styles.radioGroup}>

--- a/packages/skins/src/components/menus/settings-menu.tsx
+++ b/packages/skins/src/components/menus/settings-menu.tsx
@@ -26,7 +26,10 @@ export function SettingsMenu({ children, className, ...props }: PropsWithChildre
           </Text>
         </$.Menu.Trigger>
       </ButtonTooltip>
-      <$.Menu.Popup keepMounted className={[popupStyles.popup, popupStyles.surface, styles.popup]}>
+      <$.Menu.Popup
+        keepMounted
+        className={[popupStyles.popup, popupStyles.surface, styles.popup, styles.resizablePopup]}
+      >
         <$.Menu.Content className={styles.content}>{children}</$.Menu.Content>
       </$.Menu.Popup>
     </$.Menu.Root>

--- a/packages/skins/src/skins/audio/error-dialog.styles.ts
+++ b/packages/skins/src/skins/audio/error-dialog.styles.ts
@@ -34,7 +34,7 @@ export default styles({
     },
     title: {
       className: 'audio-dialog-title',
-      utilities: 'm-0 text-media-lg font-semibold leading-tight',
+      utilities: 'm-0 text-media font-semibold leading-tight',
     },
     description: {
       className: 'audio-dialog-description',
@@ -46,7 +46,7 @@ export default styles({
     },
     close: {
       className: 'audio-dialog-close',
-      utilities: 'h-media-control w-auto flex-none bg-media-accent px-3 font-medium text-media-accent-text',
+      utilities: 'h-media-control w-auto flex-none bg-media-primary! px-3 font-medium text-media-primary-foreground!',
     },
   },
 });

--- a/packages/skins/src/skins/audio/play-button.tsx
+++ b/packages/skins/src/skins/audio/play-button.tsx
@@ -1,5 +1,6 @@
 import { Box, type Props } from 'vjsc/components';
 
+import { ButtonTooltip } from '../../components/buttons/button-tooltip';
 import { PlayButton } from '../../components/buttons/play-button';
 import { BufferingIndicator } from '../../components/feedback/buffering-indicator';
 import styles from './play-button.styles';
@@ -8,7 +9,9 @@ export function AudioPlayButton({ className, ...props }: Props = {}) {
   return (
     <Box className={[styles.root, className]} {...props}>
       <BufferingIndicator className={styles.bufferingIndicator} />
-      <PlayButton />
+      <ButtonTooltip boundary="viewport" side="top">
+        <PlayButton />
+      </ButtonTooltip>
     </Box>
   );
 }

--- a/packages/skins/src/skins/audio/settings-menu.tsx
+++ b/packages/skins/src/skins/audio/settings-menu.tsx
@@ -1,7 +1,6 @@
 import type { MenuProps } from '@videojs/core';
-import { speedText } from '@videojs/core/i18n/text/menu';
 import * as $ from '@videojs/core/vjsc';
-import { type Props, type PropsOf, Template, Text } from 'vjsc/components';
+import { type Props, type PropsOf, Template } from 'vjsc/components';
 
 import { ButtonTooltip } from '../../components/buttons/button-tooltip';
 import { PlaybackRateButton } from '../../components/buttons/playback-rate-button';
@@ -17,7 +16,7 @@ export function AudioSettingsMenu({
   return (
     <$.Menu.Root side="top" align="center" boundary="viewport" {...props}>
       <$.PlaybackRateRadioGroup.Root>
-        <ButtonTooltip label={<Text token={speedText.key}>{speedText.text}</Text>} side="top">
+        <ButtonTooltip boundary="viewport" side="top">
           <$.Menu.Trigger $render={PlaybackRateButton} className={className} />
         </ButtonTooltip>
         <$.Menu.Popup className={[popupStyles.popup, popupStyles.surface, styles.popup, audioSettingsMenuStyles.popup]}>

--- a/packages/skins/src/skins/audio/time-slider.styles.ts
+++ b/packages/skins/src/skins/audio/time-slider.styles.ts
@@ -14,13 +14,10 @@ export default styles({
     },
     previewContent: {
       className: 'audio-time-slider-preview-content',
-      utilities: ['bottom-[calc(100%+--spacing(10))] rounded-media-control px-2.5 py-1 tabular-nums', 'text-media'],
+      utilities: 'bottom-[calc(100%+--spacing(10))] tabular-nums',
       variants: {
         default: 'left-1/2',
-        minimal: [
-          '[left:var(--media-preview-left,var(--media-slider-pointer))]',
-          'rounded-[--spacing(2)] px-2 after:hidden',
-        ],
+        minimal: ['[left:var(--media-preview-left,var(--media-slider-pointer))]', 'after:hidden'],
       },
     },
     value: {

--- a/packages/skins/src/skins/audio/time-slider.tsx
+++ b/packages/skins/src/skins/audio/time-slider.tsx
@@ -4,6 +4,7 @@ import { Box, type Props } from 'vjsc/components';
 
 import { SliderBuffer, SliderFill, SliderThumb, SliderTrack } from '../../components/sliders/slider';
 import popupStyles from '../../styles/popups/popup.styles';
+import tooltipStyles from '../../styles/popups/tooltip.styles';
 import sliderStyles from '../../styles/sliders/slider.styles';
 import styles from './time-slider.styles';
 
@@ -20,7 +21,7 @@ export function AudioTimeSlider({
       </$.TimeSlider.Track>
       <$.TimeSlider.Thumb $render={SliderThumb} className={styles.thumb} />
       <$.TimeSlider.Preview className={sliderStyles.preview} overflow={previewOverflow}>
-        <Box className={[sliderStyles.previewContent, popupStyles.surface, styles.previewContent]}>
+        <Box className={[sliderStyles.previewContent, popupStyles.surface, tooltipStyles.popup, styles.previewContent]}>
           <$.TimeSlider.Value className={styles.value} type="pointer" />
         </Box>
       </$.TimeSlider.Preview>

--- a/packages/skins/src/skins/default-audio/controls.tsx
+++ b/packages/skins/src/skins/default-audio/controls.tsx
@@ -1,5 +1,6 @@
 import * as $ from '@videojs/core/vjsc';
 
+import { ButtonTooltip } from '../../components/buttons/button-tooltip';
 import { SeekButton } from '../../components/buttons/seek-button';
 import { VolumePopover } from '../../components/controls/volume-popover';
 import audioControlsStyles from '../../styles/layout/audio-controls.styles';
@@ -16,8 +17,12 @@ export function DefaultAudioControls() {
         <$.Tooltip.Provider>
           <$.Controls.Group className={styles.start}>
             <AudioPlayButton />
-            <SeekButton className={styles.seekButton} seconds={-10} />
-            <SeekButton className={styles.seekButton} seconds={10} />
+            <ButtonTooltip boundary="viewport" side="top">
+              <SeekButton className={styles.seekButton} seconds={-10} />
+            </ButtonTooltip>
+            <ButtonTooltip boundary="viewport" side="top">
+              <SeekButton className={styles.seekButton} seconds={10} />
+            </ButtonTooltip>
           </$.Controls.Group>
 
           <$.Controls.Group className={styles.timeSliderGroup}>
@@ -28,7 +33,7 @@ export function DefaultAudioControls() {
 
           <$.Controls.Group className={styles.end}>
             <AudioSettingsMenu />
-            <VolumePopover />
+            <VolumePopover boundary="viewport" />
           </$.Controls.Group>
         </$.Tooltip.Provider>
       </$.Controls.Content>

--- a/packages/skins/src/skins/default-live-audio/controls.tsx
+++ b/packages/skins/src/skins/default-live-audio/controls.tsx
@@ -21,7 +21,7 @@ export function DefaultLiveAudioControls() {
           <Box aria-hidden="true" className={styles.spacer} />
 
           <$.Controls.Group className={styles.end}>
-            <VolumePopover />
+            <VolumePopover boundary="viewport" />
           </$.Controls.Group>
         </$.Tooltip.Provider>
       </$.Controls.Content>

--- a/packages/skins/src/skins/default-live-video/controls.tsx
+++ b/packages/skins/src/skins/default-live-video/controls.tsx
@@ -2,6 +2,7 @@ import * as $ from '@videojs/core/vjsc';
 import { Box } from 'vjsc/components';
 
 import { AirPlayButton } from '../../components/buttons/airplay-button';
+import { ButtonTooltip } from '../../components/buttons/button-tooltip';
 import { CastButton } from '../../components/buttons/cast-button';
 import { FullscreenButton } from '../../components/buttons/fullscreen-button';
 import { LiveButton } from '../../components/buttons/live-button';
@@ -20,15 +21,25 @@ export function DefaultLiveVideoControls() {
       <$.Controls.Content className={[controlsStyles.root, controlsStyles.surface, styles.content]}>
         <$.Tooltip.Provider>
           <$.Controls.Group className={[popupStyles.surface, styles.primary]}>
-            <PlayButton />
+            <ButtonTooltip side="top">
+              <PlayButton />
+            </ButtonTooltip>
             <LiveButton />
             <Box aria-hidden="true" className={styles.spacer} />
             <VolumePopover />
             <CaptionsMenu className={styles.captionsMenu} />
-            <CastButton />
-            <AirPlayButton />
-            <PiPButton />
-            <FullscreenButton />
+            <ButtonTooltip side="top">
+              <CastButton />
+            </ButtonTooltip>
+            <ButtonTooltip side="top">
+              <AirPlayButton />
+            </ButtonTooltip>
+            <ButtonTooltip side="top">
+              <PiPButton />
+            </ButtonTooltip>
+            <ButtonTooltip side="top">
+              <FullscreenButton />
+            </ButtonTooltip>
           </$.Controls.Group>
         </$.Tooltip.Provider>
       </$.Controls.Content>

--- a/packages/skins/src/skins/default-live-video/skin.tsx
+++ b/packages/skins/src/skins/default-live-video/skin.tsx
@@ -8,20 +8,19 @@ import type { SkinMeta } from '../../meta';
 import { LiveVideoGestures } from '../live-video/gestures';
 import { LiveVideoHotkeys } from '../live-video/hotkeys';
 import { LiveVideoStatusIndicators } from '../live-video/status-indicators';
+import videoSkinStyles from '../video/skin.styles';
 import { DefaultLiveVideoControls } from './controls';
 
 export interface DefaultLiveVideoSkinProps extends Omit<PropsOf<typeof Container>, 'children'> {
   children?: VjscNode;
-  poster?: string | PropsOf<typeof Poster>['children'];
+  renderPoster?: PropsOf<typeof Poster>['children'];
 }
 
-export function DefaultLiveVideoSkin({ children, className, poster, ...props }: DefaultLiveVideoSkinProps = {}) {
-  const isPosterString = typeof poster === 'string';
-
+export function DefaultLiveVideoSkin({ children, className, renderPoster, ...props }: DefaultLiveVideoSkinProps = {}) {
   return (
-    <Container className={className} data-theme="default" data-preset="live-video" {...props}>
+    <Container className={[videoSkinStyles.root, className]} data-theme="default" data-preset="live-video" {...props}>
       <Slot>{children}</Slot>
-      <Poster src={isPosterString ? poster : undefined}>{isPosterString ? undefined : poster}</Poster>
+      <Poster>{renderPoster}</Poster>
       <BufferingIndicator />
       <ErrorDialog />
       <DefaultLiveVideoControls />

--- a/packages/skins/src/skins/default-video/controls.tsx
+++ b/packages/skins/src/skins/default-video/controls.tsx
@@ -1,6 +1,7 @@
 import * as $ from '@videojs/core/vjsc';
 
 import { AirPlayButton } from '../../components/buttons/airplay-button';
+import { ButtonTooltip } from '../../components/buttons/button-tooltip';
 import { CaptionsButton } from '../../components/buttons/captions-button';
 import { CastButton } from '../../components/buttons/cast-button';
 import { FullscreenButton } from '../../components/buttons/fullscreen-button';
@@ -20,7 +21,9 @@ export function DefaultVideoControls() {
       <$.Controls.Content className={[controlsStyles.root, controlsStyles.surface, styles.content]}>
         <$.Tooltip.Provider>
           <$.Controls.Group className={[popupStyles.surface, styles.primary]}>
-            <PlayButton />
+            <ButtonTooltip side="top">
+              <PlayButton />
+            </ButtonTooltip>
             <VolumePopover className={styles.volumeButton} />
 
             <$.Controls.Group className={styles.timeSliderGroup}>
@@ -29,15 +32,25 @@ export function DefaultVideoControls() {
               <$.Time.Value className={styles.remainingValue} type="remaining" toggle />
             </$.Controls.Group>
 
-            <CaptionsButton className={styles.captionsButton} />
+            <ButtonTooltip side="top">
+              <CaptionsButton className={styles.captionsButton} />
+            </ButtonTooltip>
             <VideoSettingsMenu className={styles.settingsButton} />
           </$.Controls.Group>
 
           <$.Controls.Group className={[popupStyles.surface, styles.secondary]}>
-            <CastButton />
-            <AirPlayButton />
-            <PiPButton />
-            <FullscreenButton />
+            <ButtonTooltip side="top">
+              <CastButton />
+            </ButtonTooltip>
+            <ButtonTooltip side="top">
+              <AirPlayButton />
+            </ButtonTooltip>
+            <ButtonTooltip side="top">
+              <PiPButton />
+            </ButtonTooltip>
+            <ButtonTooltip side="top">
+              <FullscreenButton />
+            </ButtonTooltip>
           </$.Controls.Group>
         </$.Tooltip.Provider>
       </$.Controls.Content>

--- a/packages/skins/src/skins/default-video/skin.tsx
+++ b/packages/skins/src/skins/default-video/skin.tsx
@@ -7,21 +7,20 @@ import { Poster } from '../../components/layout/poster';
 import type { SkinMeta } from '../../meta';
 import { VideoGestures } from '../video/gestures';
 import { VideoHotkeys } from '../video/hotkeys';
+import videoSkinStyles from '../video/skin.styles';
 import { VideoStatusIndicators } from '../video/status-indicators';
 import { DefaultVideoControls } from './controls';
 
 export interface DefaultVideoSkinProps extends Omit<PropsOf<typeof Container>, 'children'> {
   children?: VjscNode;
-  poster?: string | PropsOf<typeof Poster>['children'];
+  renderPoster?: PropsOf<typeof Poster>['children'];
 }
 
-export function DefaultVideoSkin({ children, className, poster, ...props }: DefaultVideoSkinProps = {}) {
-  const isPosterString = typeof poster === 'string';
-
+export function DefaultVideoSkin({ children, className, renderPoster, ...props }: DefaultVideoSkinProps = {}) {
   return (
-    <Container className={className} data-theme="default" data-preset="video" {...props}>
+    <Container className={[videoSkinStyles.root, className]} data-theme="default" data-preset="video" {...props}>
       <Slot>{children}</Slot>
-      <Poster src={isPosterString ? poster : undefined}>{isPosterString ? undefined : poster}</Poster>
+      <Poster>{renderPoster}</Poster>
       <BufferingIndicator />
       <ErrorDialog />
 

--- a/packages/skins/src/skins/minimal-audio/controls.styles.ts
+++ b/packages/skins/src/skins/minimal-audio/controls.styles.ts
@@ -15,6 +15,7 @@ export default styles({
       utilities: [
         'after:hidden!',
         'relative z-20 flex items-center gap-2 rounded-[--spacing(3.5)] bg-media-controls p-1 text-media-controls-foreground',
+        'shadow-[0_0_0_1px_var(--media-border)]',
         'text-shadow-media',
         '[--media-popover-side-offset:--spacing(3)] [--media-tooltip-side-offset:var(--media-popover-side-offset)]',
         '[--media-popover-boundary-offset:--spacing(3)] [--media-tooltip-boundary-offset:var(--media-popover-boundary-offset)]',

--- a/packages/skins/src/skins/minimal-audio/controls.tsx
+++ b/packages/skins/src/skins/minimal-audio/controls.tsx
@@ -1,9 +1,9 @@
 import * as $ from '@videojs/core/vjsc';
 
+import { ButtonTooltip } from '../../components/buttons/button-tooltip';
 import { SeekButton } from '../../components/buttons/seek-button';
 import { VolumePopover } from '../../components/controls/volume-popover';
 import audioControlsStyles from '../../styles/layout/audio-controls.styles';
-import popupStyles from '../../styles/popups/popup.styles';
 import { AudioPlayButton } from '../audio/play-button';
 import { AudioSettingsMenu } from '../audio/settings-menu';
 import { AudioTimeSlider } from '../audio/time-slider';
@@ -12,12 +12,16 @@ import styles from './controls.styles';
 export function MinimalAudioControls() {
   return (
     <$.Controls.Root visibility="always">
-      <$.Controls.Content className={[audioControlsStyles.root, popupStyles.surface, styles.content]}>
+      <$.Controls.Content className={[audioControlsStyles.root, styles.content]}>
         <$.Tooltip.Provider>
           <$.Controls.Group className={styles.start}>
             <AudioPlayButton />
-            <SeekButton seconds={-10} />
-            <SeekButton seconds={10} />
+            <ButtonTooltip boundary="viewport" side="top">
+              <SeekButton seconds={-10} />
+            </ButtonTooltip>
+            <ButtonTooltip boundary="viewport" side="top">
+              <SeekButton seconds={10} />
+            </ButtonTooltip>
           </$.Controls.Group>
 
           <$.Controls.Group className={styles.timeSliderGroup}>
@@ -30,7 +34,7 @@ export function MinimalAudioControls() {
           </$.Controls.Group>
 
           <$.Controls.Group className={styles.end}>
-            <VolumePopover showTooltip side="left" orientation="horizontal" />
+            <VolumePopover boundary="viewport" showTooltip side="left" orientation="horizontal" />
             <AudioSettingsMenu />
           </$.Controls.Group>
         </$.Tooltip.Provider>

--- a/packages/skins/src/skins/minimal-live-audio/controls.styles.ts
+++ b/packages/skins/src/skins/minimal-live-audio/controls.styles.ts
@@ -8,6 +8,7 @@ export default styles({
       utilities: [
         'after:hidden!',
         'relative z-20 flex items-center gap-2 rounded-[--spacing(3.5)] bg-media-controls p-1 text-media-controls-foreground',
+        'shadow-[0_0_0_1px_var(--media-border)]',
         'text-shadow-media',
         '[--media-popover-side-offset:--spacing(3)] [--media-tooltip-side-offset:var(--media-popover-side-offset)]',
         '[--media-popover-boundary-offset:--spacing(3)] [--media-tooltip-boundary-offset:var(--media-popover-boundary-offset)]',

--- a/packages/skins/src/skins/minimal-live-audio/controls.tsx
+++ b/packages/skins/src/skins/minimal-live-audio/controls.tsx
@@ -4,14 +4,13 @@ import { Box } from 'vjsc/components';
 import { LiveButton } from '../../components/buttons/live-button';
 import { VolumePopover } from '../../components/controls/volume-popover';
 import audioControlsStyles from '../../styles/layout/audio-controls.styles';
-import popupStyles from '../../styles/popups/popup.styles';
 import { AudioPlayButton } from '../audio/play-button';
 import styles from './controls.styles';
 
 export function MinimalLiveAudioControls() {
   return (
     <$.Controls.Root visibility="always">
-      <$.Controls.Content className={[audioControlsStyles.root, popupStyles.surface, styles.content]}>
+      <$.Controls.Content className={[audioControlsStyles.root, styles.content]}>
         <$.Tooltip.Provider>
           <$.Controls.Group className={styles.start}>
             <AudioPlayButton />
@@ -21,7 +20,7 @@ export function MinimalLiveAudioControls() {
           <Box aria-hidden="true" className={styles.spacer} />
 
           <$.Controls.Group className={styles.end}>
-            <VolumePopover showTooltip side="left" orientation="horizontal" />
+            <VolumePopover boundary="viewport" showTooltip side="left" orientation="horizontal" />
           </$.Controls.Group>
         </$.Tooltip.Provider>
       </$.Controls.Content>

--- a/packages/skins/src/skins/minimal-live-video/controls.tsx
+++ b/packages/skins/src/skins/minimal-live-video/controls.tsx
@@ -2,6 +2,7 @@ import * as $ from '@videojs/core/vjsc';
 import { Box } from 'vjsc/components';
 
 import { AirPlayButton } from '../../components/buttons/airplay-button';
+import { ButtonTooltip } from '../../components/buttons/button-tooltip';
 import { CastButton } from '../../components/buttons/cast-button';
 import { FullscreenButton } from '../../components/buttons/fullscreen-button';
 import { LiveButton } from '../../components/buttons/live-button';
@@ -19,7 +20,9 @@ export function MinimalLiveVideoControls() {
       <$.Controls.Content className={[controlsStyles.root, styles.content]}>
         <$.Tooltip.Provider>
           <$.Controls.Group className={styles.start}>
-            <PlayButton />
+            <ButtonTooltip side="top">
+              <PlayButton />
+            </ButtonTooltip>
             <LiveButton />
             <VolumePopover showTooltip side="right" orientation="horizontal" />
           </$.Controls.Group>
@@ -28,10 +31,18 @@ export function MinimalLiveVideoControls() {
 
           <$.Controls.Group className={styles.end}>
             <CaptionsMenu />
-            <CastButton />
-            <AirPlayButton />
-            <PiPButton />
-            <FullscreenButton />
+            <ButtonTooltip side="top">
+              <CastButton />
+            </ButtonTooltip>
+            <ButtonTooltip side="top">
+              <AirPlayButton />
+            </ButtonTooltip>
+            <ButtonTooltip side="top">
+              <PiPButton />
+            </ButtonTooltip>
+            <ButtonTooltip side="top">
+              <FullscreenButton />
+            </ButtonTooltip>
           </$.Controls.Group>
         </$.Tooltip.Provider>
       </$.Controls.Content>

--- a/packages/skins/src/skins/minimal-live-video/skin.tsx
+++ b/packages/skins/src/skins/minimal-live-video/skin.tsx
@@ -8,20 +8,19 @@ import type { SkinMeta } from '../../meta';
 import { LiveVideoGestures } from '../live-video/gestures';
 import { LiveVideoHotkeys } from '../live-video/hotkeys';
 import { LiveVideoStatusIndicators } from '../live-video/status-indicators';
+import videoSkinStyles from '../video/skin.styles';
 import { MinimalLiveVideoControls } from './controls';
 
 export interface MinimalLiveVideoSkinProps extends Omit<PropsOf<typeof Container>, 'children'> {
   children?: VjscNode;
-  poster?: string | PropsOf<typeof Poster>['children'];
+  renderPoster?: PropsOf<typeof Poster>['children'];
 }
 
-export function MinimalLiveVideoSkin({ children, className, poster, ...props }: MinimalLiveVideoSkinProps = {}) {
-  const isPosterString = typeof poster === 'string';
-
+export function MinimalLiveVideoSkin({ children, className, renderPoster, ...props }: MinimalLiveVideoSkinProps = {}) {
   return (
-    <Container className={className} data-theme="minimal" data-preset="live-video" {...props}>
+    <Container className={[videoSkinStyles.root, className]} data-theme="minimal" data-preset="live-video" {...props}>
       <Slot>{children}</Slot>
-      <Poster src={isPosterString ? poster : undefined}>{isPosterString ? undefined : poster}</Poster>
+      <Poster>{renderPoster}</Poster>
       <BufferingIndicator />
       <ErrorDialog />
       <MinimalLiveVideoControls />

--- a/packages/skins/src/skins/minimal-video/controls.tsx
+++ b/packages/skins/src/skins/minimal-video/controls.tsx
@@ -1,6 +1,7 @@
 import * as $ from '@videojs/core/vjsc';
 
 import { AirPlayButton } from '../../components/buttons/airplay-button';
+import { ButtonTooltip } from '../../components/buttons/button-tooltip';
 import { CaptionsButton } from '../../components/buttons/captions-button';
 import { CastButton } from '../../components/buttons/cast-button';
 import { FullscreenButton } from '../../components/buttons/fullscreen-button';
@@ -19,7 +20,9 @@ export function MinimalVideoControls() {
       <$.Controls.Content className={[controlsStyles.root, styles.content]}>
         <$.Tooltip.Provider>
           <$.Controls.Group className={styles.start}>
-            <PlayButton />
+            <ButtonTooltip side="top">
+              <PlayButton />
+            </ButtonTooltip>
             <VolumePopover showTooltip side="right" orientation="horizontal" />
           </$.Controls.Group>
 
@@ -33,13 +36,23 @@ export function MinimalVideoControls() {
           </$.Controls.Group>
 
           <$.Controls.Group className={styles.end}>
-            <CaptionsButton />
+            <ButtonTooltip side="top">
+              <CaptionsButton />
+            </ButtonTooltip>
             <VideoSettingsMenu />
             <$.Controls.Group className={styles.trailing}>
-              <CastButton />
-              <AirPlayButton />
-              <PiPButton />
-              <FullscreenButton />
+              <ButtonTooltip side="top">
+                <CastButton />
+              </ButtonTooltip>
+              <ButtonTooltip side="top">
+                <AirPlayButton />
+              </ButtonTooltip>
+              <ButtonTooltip side="top">
+                <PiPButton />
+              </ButtonTooltip>
+              <ButtonTooltip side="top">
+                <FullscreenButton />
+              </ButtonTooltip>
             </$.Controls.Group>
           </$.Controls.Group>
         </$.Tooltip.Provider>

--- a/packages/skins/src/skins/minimal-video/skin.tsx
+++ b/packages/skins/src/skins/minimal-video/skin.tsx
@@ -7,21 +7,20 @@ import { Poster } from '../../components/layout/poster';
 import type { SkinMeta } from '../../meta';
 import { VideoGestures } from '../video/gestures';
 import { VideoHotkeys } from '../video/hotkeys';
+import videoSkinStyles from '../video/skin.styles';
 import { VideoStatusIndicators } from '../video/status-indicators';
 import { MinimalVideoControls } from './controls';
 
 export interface MinimalVideoSkinProps extends Omit<PropsOf<typeof Container>, 'children'> {
   children?: VjscNode;
-  poster?: string | PropsOf<typeof Poster>['children'];
+  renderPoster?: PropsOf<typeof Poster>['children'];
 }
 
-export function MinimalVideoSkin({ children, className, poster, ...props }: MinimalVideoSkinProps = {}) {
-  const isPosterString = typeof poster === 'string';
-
+export function MinimalVideoSkin({ children, className, renderPoster, ...props }: MinimalVideoSkinProps = {}) {
   return (
-    <Container className={className} data-theme="minimal" data-preset="video" {...props}>
+    <Container className={[videoSkinStyles.root, className]} data-theme="minimal" data-preset="video" {...props}>
       <Slot>{children}</Slot>
-      <Poster src={isPosterString ? poster : undefined}>{isPosterString ? undefined : poster}</Poster>
+      <Poster>{renderPoster}</Poster>
       <BufferingIndicator />
       <ErrorDialog />
 

--- a/packages/skins/src/skins/shared/live-playback-hotkeys.tsx
+++ b/packages/skins/src/skins/shared/live-playback-hotkeys.tsx
@@ -10,8 +10,8 @@ export function LivePlaybackHotkeys({ disabled = false }: LivePlaybackHotkeysPro
       <$.Hotkey disabled={disabled} keys="Space" action="togglePaused" />
       <$.Hotkey disabled={disabled} keys="k" action="togglePaused" />
       <$.Hotkey disabled={disabled} keys="m" action="toggleMuted" />
-      <$.Hotkey disabled={disabled} keys="ArrowUp" action="volumeStep" value={0.05} />
-      <$.Hotkey disabled={disabled} keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <$.Hotkey disabled={disabled} keys="ArrowUp" action="volumeStep" />
+      <$.Hotkey disabled={disabled} keys="ArrowDown" action="volumeStep" />
     </>
   );
 }

--- a/packages/skins/src/skins/shared/playback-hotkeys.tsx
+++ b/packages/skins/src/skins/shared/playback-hotkeys.tsx
@@ -10,12 +10,12 @@ export function PlaybackHotkeys({ disabled = false }: PlaybackHotkeysProps = {})
       <$.Hotkey disabled={disabled} keys="Space" action="togglePaused" />
       <$.Hotkey disabled={disabled} keys="k" action="togglePaused" />
       <$.Hotkey disabled={disabled} keys="m" action="toggleMuted" />
-      <$.Hotkey disabled={disabled} keys="ArrowRight" action="seekStep" value={5} />
-      <$.Hotkey disabled={disabled} keys="ArrowLeft" action="seekStep" value={-5} />
-      <$.Hotkey disabled={disabled} keys="l" action="seekStep" value={10} />
-      <$.Hotkey disabled={disabled} keys="j" action="seekStep" value={-10} />
-      <$.Hotkey disabled={disabled} keys="ArrowUp" action="volumeStep" value={0.05} />
-      <$.Hotkey disabled={disabled} keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <$.Hotkey disabled={disabled} keys="ArrowRight" action="seekStep" />
+      <$.Hotkey disabled={disabled} keys="ArrowLeft" action="seekStep" />
+      <$.Hotkey disabled={disabled} keys="l" action="seekStep" />
+      <$.Hotkey disabled={disabled} keys="j" action="seekStep" />
+      <$.Hotkey disabled={disabled} keys="ArrowUp" action="volumeStep" />
+      <$.Hotkey disabled={disabled} keys="ArrowDown" action="volumeStep" />
       <$.Hotkey disabled={disabled} keys="0-9" action="seekToPercent" />
       <$.Hotkey disabled={disabled} keys="Home" action="seekToPercent" value={0} />
       <$.Hotkey disabled={disabled} keys="End" action="seekToPercent" value={100} />

--- a/packages/skins/src/skins/video/gestures.tsx
+++ b/packages/skins/src/skins/video/gestures.tsx
@@ -9,9 +9,9 @@ export function VideoGestures({ disabled = false }: VideoGesturesProps = {}) {
     <>
       <$.Gesture disabled={disabled} type="tap" action="togglePaused" pointer="mouse" region="center" />
       <$.Gesture disabled={disabled} type="tap" action="toggleControls" pointer="touch" />
-      <$.Gesture disabled={disabled} type="doubletap" action="seekStep" value={-10} region="left" />
+      <$.Gesture disabled={disabled} type="doubletap" action="seekStep" region="left" />
       <$.Gesture disabled={disabled} type="doubletap" action="toggleFullscreen" region="center" />
-      <$.Gesture disabled={disabled} type="doubletap" action="seekStep" value={10} region="right" />
+      <$.Gesture disabled={disabled} type="doubletap" action="seekStep" region="right" />
     </>
   );
 }

--- a/packages/skins/src/skins/video/skin.styles.ts
+++ b/packages/skins/src/skins/video/skin.styles.ts
@@ -1,0 +1,11 @@
+import { styles } from 'vjsc/styles';
+
+export default styles({
+  file: 'video/skin.css',
+  rules: {
+    root: {
+      className: 'video-skin',
+      utilities: 'pointer-fine:not-data-controls-visible:cursor-none',
+    },
+  },
+});

--- a/packages/skins/src/styles/buttons/button.styles.ts
+++ b/packages/skins/src/styles/buttons/button.styles.ts
@@ -17,6 +17,9 @@ export default styles({
         'motion-reduce:scale-100 motion-reduce:will-change-auto motion-reduce:[transition-property:background-color,color]',
         'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
       ],
+      variants: {
+        minimal: 'supports-[corner-shape:squircle]:rounded-2xl',
+      },
     },
     icon: {
       className: 'media-button-icon',

--- a/packages/skins/src/styles/buttons/seek-button.styles.ts
+++ b/packages/skins/src/styles/buttons/seek-button.styles.ts
@@ -7,6 +7,10 @@ export default styles({
       className: 'media-seek-button',
       utilities: [],
     },
+    content: {
+      className: 'media-seek-button-content',
+      utilities: 'relative grid',
+    },
     backwardIcon: {
       className: 'media-seek-button-backward-icon',
       utilities: '-scale-x-100',

--- a/packages/skins/src/styles/feedback/status-indicator.styles.ts
+++ b/packages/skins/src/styles/feedback/status-indicator.styles.ts
@@ -20,7 +20,7 @@ export default styles({
       variants: {
         default: [
           'bg-media-popover text-media-popover-foreground backdrop-blur-lg backdrop-saturate-150',
-          'ring-1 ring-media-border shadow-media-sm',
+          'shadow-media-sm',
           'after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]',
           'after:shadow-media-surface-inset',
           'opaque:bg-media-background opaque:backdrop-filter-none',

--- a/packages/skins/src/styles/feedback/volume-indicator.styles.ts
+++ b/packages/skins/src/styles/feedback/volume-indicator.styles.ts
@@ -18,7 +18,7 @@ export default styles({
       variants: {
         default: [
           'bg-media-popover text-media-popover-foreground backdrop-blur-lg backdrop-saturate-150',
-          'ring-1 ring-media-border shadow-media-sm',
+          'shadow-media-sm',
           'after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]',
           'after:shadow-media-surface-inset',
           'opaque:bg-media-background opaque:backdrop-filter-none',

--- a/packages/skins/src/styles/layout/container.styles.ts
+++ b/packages/skins/src/styles/layout/container.styles.ts
@@ -17,7 +17,6 @@ export default styles({
         '[--media-shadow-subtle-current-color:oklch(from_var(--media-shadow-current-color)_l_c_h/calc(alpha*0.4))]',
         'outline-2 -outline-offset-4 outline-transparent transition-[outline-offset,outline-color] duration-100 ease-out motion-reduce:duration-50',
         'focus-visible:outline-[var(--media-focus-ring-color,light-dark(rgb(0_0_0),rgb(255_255_255)))] focus-visible:outline-offset-2 forced-colors:focus-visible:outline-[CanvasText]',
-        'pointer-fine:not-data-controls-visible:cursor-none',
         'after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]',
         'forced-colors:after:shadow-[inset_0_0_0_1px_CanvasText] [&:fullscreen]:after:hidden',
         '[&:fullscreen]:[--media-video-border-radius:0] [&:fullscreen]:[--media-object-fit:contain]',

--- a/packages/skins/src/styles/layout/controls.styles.ts
+++ b/packages/skins/src/styles/layout/controls.styles.ts
@@ -12,7 +12,7 @@ export default styles({
       utilities: [
         '@lg/media-root:bg-media-popover @lg/media-root:text-media-popover-foreground',
         '@lg/media-root:backdrop-blur-lg @lg/media-root:backdrop-saturate-150',
-        '@lg/media-root:ring-1 @lg/media-root:ring-media-border @lg/media-root:shadow-media-sm',
+        '@lg/media-root:shadow-media-sm',
         '@lg/media-root:after:pointer-events-none @lg/media-root:after:absolute @lg/media-root:after:inset-0',
         '@lg/media-root:after:z-10 @lg/media-root:after:rounded-[inherit]',
         '@lg/media-root:after:shadow-media-surface-inset',

--- a/packages/skins/src/styles/menus/menu.styles.ts
+++ b/packages/skins/src/styles/menus/menu.styles.ts
@@ -48,8 +48,8 @@ export default styles({
         'max-h-[min(var(--media-menu-available-height,--spacing(56)),--spacing(56))] overscroll-none',
         'h-(--media-menu-height) w-(--media-menu-width)',
         'motion-reduce:[--media-menu-transition-duration:0ms]',
-        '[transition-property:opacity,filter,transform,scale,width,height]',
-        '[transition-duration:100ms,100ms,100ms,100ms,250ms,250ms] ease-out',
+        '[transition-property:opacity,filter,transform,scale]',
+        '[transition-duration:100ms] ease-out',
         'data-starting-style:[transition-duration:100ms] data-starting-style:[transition-property:opacity,filter,transform,scale]',
         'data-ending-style:[transition-duration:100ms] data-ending-style:[transition-property:opacity,filter,transform,scale]',
         'motion-reduce:[transition-duration:0ms]!',
@@ -58,6 +58,13 @@ export default styles({
         default: 'rounded-[--spacing(3)]',
         minimal: 'rounded-[--spacing(2.5)]',
       },
+    },
+    resizablePopup: {
+      className: 'media-menu-resizable-popup',
+      utilities: [
+        '[transition-property:opacity,filter,transform,scale,width,height]',
+        '[transition-duration:100ms,100ms,100ms,100ms,var(--media-menu-transition-duration),var(--media-menu-transition-duration)]',
+      ],
     },
     content: {
       className: 'media-menu-content',

--- a/packages/skins/src/styles/popups/dialog.styles.ts
+++ b/packages/skins/src/styles/popups/dialog.styles.ts
@@ -32,7 +32,7 @@ export default styles({
       variants: {
         default: [
           'bg-media-popover text-media-popover-foreground backdrop-blur-lg backdrop-saturate-150',
-          'ring-1 ring-media-border shadow-media-sm',
+          'shadow-media-sm',
           'after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]',
           'after:shadow-media-surface-inset',
           'opaque:bg-media-background opaque:backdrop-filter-none',
@@ -67,7 +67,7 @@ export default styles({
     },
     close: {
       className: 'media-dialog-close',
-      utilities: 'h-media-control w-full flex-1 bg-media-accent! px-4 py-2 font-medium text-media-accent-text!',
+      utilities: 'h-media-control w-full flex-1 bg-media-primary! px-4 py-2 font-medium text-media-primary-foreground!',
     },
   },
 });

--- a/packages/skins/src/styles/popups/popup.styles.ts
+++ b/packages/skins/src/styles/popups/popup.styles.ts
@@ -19,6 +19,14 @@ export default styles({
         'data-[side=bottom]:[--media-popup-translate-y-distance:calc(var(--media-popup-translate-distance)*-1)]',
         'data-[side=left]:[--media-popup-translate-x-distance:var(--media-popup-translate-distance)]',
         'data-[side=right]:[--media-popup-translate-x-distance:calc(var(--media-popup-translate-distance)*-1)]',
+      ],
+      variants: {
+        minimal: 'data-starting-style:filter-none',
+      },
+    },
+    safeArea: {
+      className: 'media-popup-safe-area',
+      utilities: [
         'before:pointer-events-auto before:absolute',
         'data-[side=top]:before:inset-x-0 data-[side=top]:before:top-full',
         'data-[side=bottom]:before:inset-x-0 data-[side=bottom]:before:bottom-full',
@@ -27,9 +35,6 @@ export default styles({
         'data-[side=top]:before:h-(--media-popup-side-offset) data-[side=bottom]:before:h-(--media-popup-side-offset)',
         'data-[side=left]:before:w-(--media-popup-side-offset) data-[side=right]:before:w-(--media-popup-side-offset)',
       ],
-      variants: {
-        minimal: 'data-starting-style:filter-none',
-      },
     },
     transition: {
       className: 'media-popup-transition',
@@ -42,7 +47,7 @@ export default styles({
       className: 'media-popup-surface',
       utilities: [
         'bg-media-popover text-media-popover-foreground backdrop-blur-lg backdrop-saturate-150',
-        'ring-1 ring-media-border shadow-media-sm',
+        'shadow-media-sm',
         'after:pointer-events-none after:absolute after:inset-0 after:z-10 after:rounded-[inherit]',
         'after:shadow-media-surface-inset',
         'opaque:bg-media-background opaque:backdrop-filter-none',

--- a/packages/skins/src/styles/popups/tooltip.styles.ts
+++ b/packages/skins/src/styles/popups/tooltip.styles.ts
@@ -11,7 +11,10 @@ export default styles({
       ],
       variants: {
         default: 'rounded-[9999px] px-2.5',
-        minimal: 'rounded-[--spacing(2)] px-2',
+        minimal: [
+          'rounded-[--spacing(2)] px-2',
+          'shadow-[0_0_0_1px_var(--media-border),0_4px_6px_-1px_oklch(0_0_0/0.2),0_2px_4px_-2px_oklch(0_0_0/0.2)]!',
+        ],
       },
     },
     shortcut: {

--- a/packages/skins/src/styles/sliders/slider.styles.ts
+++ b/packages/skins/src/styles/sliders/slider.styles.ts
@@ -52,7 +52,7 @@ export default styles({
     thumb: {
       className: 'media-slider-thumb',
       utilities: [
-        'absolute z-10 top-1/2 left-(--media-slider-fill) -translate-x-1/2 -translate-y-1/2 rounded-media-control bg-current',
+        'absolute z-10 top-1/2 left-(--media-slider-fill) size-3 -translate-x-1/2 -translate-y-1/2 rounded-media-control bg-current',
         'select-none transition-none motion-safe:transition-[opacity,height,width,outline-offset,left,top,scale] motion-safe:duration-100 motion-safe:ease-out',
         'group-data-dragging/slider:motion-safe:transition-[opacity,height,width,outline-offset,scale]',
         'group-data-dragging/slider:scale-90',

--- a/packages/skins/src/styles/sliders/time-slider.styles.ts
+++ b/packages/skins/src/styles/sliders/time-slider.styles.ts
@@ -34,7 +34,7 @@ export default styles({
     thumb: {
       className: 'media-time-slider-thumb',
       utilities: [
-        'size-3 opacity-0 data-interactive:opacity-100 focus-visible:opacity-100',
+        'opacity-0 data-interactive:opacity-100 focus-visible:opacity-100',
         'pointer-fine:group-hover/slider:scale-100 pointer-fine:group-hover/slider:opacity-100',
       ],
       variants: { default: 'scale-80', minimal: 'scale-70 data-interactive:scale-100' },

--- a/packages/skins/src/styles/sliders/volume-slider.styles.ts
+++ b/packages/skins/src/styles/sliders/volume-slider.styles.ts
@@ -9,7 +9,7 @@ export default styles({
     },
     thumb: {
       className: 'media-volume-slider-thumb',
-      utilities: 'size-3 scale-100 opacity-100',
+      utilities: 'scale-100 opacity-100',
     },
   },
 });

--- a/packages/skins/src/styles/tailwind.shared.css
+++ b/packages/skins/src/styles/tailwind.shared.css
@@ -42,5 +42,7 @@
 }
 
 @utility shadow-media-sm {
-  box-shadow: var(--media-shadow-sm);
+  box-shadow:
+    0 0 0 1px var(--media-surface-border, var(--media-border)),
+    var(--media-shadow-sm);
 }

--- a/packages/skins/src/styles/themes/audio.css
+++ b/packages/skins/src/styles/themes/audio.css
@@ -6,6 +6,7 @@
     --media-controls-foreground: var(--media-foreground);
     --media-popover: var(--media-controls);
     --media-popover-foreground: var(--media-foreground);
+    --media-surface-border: oklch(0 0 0 / 0.05);
     --media-primary: var(--media-accent-color, var(--media-foreground));
     --media-primary-foreground: var(--media-accent-text-color, contrast-color(var(--media-primary)));
     --media-border: light-dark(oklch(0 0 0 / 0.1), oklch(1 0 0 / 0.1));
@@ -24,6 +25,7 @@
     .media-skin:is([data-preset="audio"], [data-preset="live-audio"]) {
       --media-controls: var(--media-background);
       --media-popover: var(--media-background);
+      --media-surface-border: light-dark(oklch(0 0 0 / 0.05), transparent);
     }
   }
 }

--- a/packages/skins/src/styles/themes/theme.css
+++ b/packages/skins/src/styles/themes/theme.css
@@ -20,7 +20,7 @@
     --media-muted-foreground: oklch(1 0 0 / 0.65);
     --media-border: oklch(0 0 0 / 0.1);
     --media-ring: var(--media-focus-ring-color, oklch(1 0 0));
-    --media-shadow-sm: 0 1px 2px oklch(0 0 0 / 0.15);
+    --media-shadow-sm: 0 1px 3px 0 oklch(0 0 0 / 0.15), 0 1px 2px -1px oklch(0 0 0 / 0.15);
 
     --media-caption-controls-y: calc(var(--media-spacing) * -14);
     --media-control-corner-shape: round;

--- a/packages/skins/src/styles/vars.ts
+++ b/packages/skins/src/styles/vars.ts
@@ -120,6 +120,10 @@ export const vars = {
     kind: 'internal',
     description: 'Scoped small surface shadow.',
   },
+  '--media-surface-border': {
+    kind: 'internal',
+    description: 'Scoped surface hairline color.',
+  },
   '--media-caption-controls-y': {
     kind: 'internal',
     description: 'Caption offset while controls are visible.',

--- a/packages/vjsc/src/plugins/html-runtime.ts
+++ b/packages/vjsc/src/plugins/html-runtime.ts
@@ -58,7 +58,21 @@ export function Host(props) {
   }
 
   const current = child[element];
-  return htmlElement(current.type, { ...current.attributes, ...attributes }, current.children);
+  return htmlElement(current.type, mergeHostAttributes(current.attributes, attributes), current.children);
+}
+
+function mergeHostAttributes(current, forwarded) {
+  const attributes = { ...current, ...forwarded };
+  const className = [current.class, current.className, forwarded.class, forwarded.className]
+    .flat(Infinity)
+    .filter(Boolean);
+
+  delete attributes.className;
+
+  if (className.length > 0) attributes.class = className;
+  else delete attributes.class;
+
+  return attributes;
 }
 
 function renderAttributes(attributes, context) {

--- a/packages/vjsc/src/plugins/tests/component-target.test.ts
+++ b/packages/vjsc/src/plugins/tests/component-target.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vite-plus/test';
 
 import { defineComponent, defineSchema } from '../../components/definition';
 import { defineComponentTarget } from '../../target/definition';
-import { jsx } from '../../target/jsx-runtime';
+import { Host, jsx } from '../../target/jsx-runtime';
 import { readComponentSource } from '../component-meta';
 import { componentSourcePlugin } from '../component-source';
 import { type ComponentTargetSelection, componentTargetPlugin } from '../component-target';
@@ -99,6 +99,7 @@ const htmlTarget = defineComponentTarget<typeof schema>()(({ target, element, un
         }),
       rules: {
         OptionGroup: { Root: unwrap() },
+        Poster: ({ props, children }) => jsx(Host, { ...props, className: 'poster', children }),
         PlayButton: () =>
           jsx(Svg, {
             viewBox: '0 0 18 18',
@@ -272,6 +273,20 @@ describe('componentTargetPlugin', () => {
     expect(source).toContain(
       '<svg viewBox="0 0 18 18" preserveAspectRatio="xMidYMid meet" stroke-width={2} xlink:href="#icon" />'
     );
+  });
+
+  it('preserves component prop names when forwarding HTML host props', async () => {
+    const source = await transform(
+      `
+        import * as $ from '@fixture/components';
+        const CustomPoster = (props) => <img {...props} />;
+        export const poster = <$.Poster src="poster.jpg"><CustomPoster /></$.Poster>;
+      `,
+      { targets: [htmlTarget] }
+    );
+
+    expect(source).toMatch(/<CustomPoster\s+className="poster"\s+src="poster\.jpg"\s*\/>/);
+    expect(source).not.toContain('class="poster"');
   });
 
   it('lowers canonical components retained by an outer rewrite', async () => {

--- a/packages/vjsc/src/plugins/tests/html-runtime.test.ts
+++ b/packages/vjsc/src/plugins/tests/html-runtime.test.ts
@@ -30,11 +30,12 @@ describe('htmlRuntimePlugin', () => {
   it('forwards host attributes to one dynamic element child', async () => {
     const runtime = await loadRuntime();
     const output = runtime.jsx(runtime.Host, {
+      class: ['trigger', 'active'],
       id: 'trigger',
-      children: runtime.jsx('button', { className: ['button', 'active'] }),
+      children: runtime.jsx('button', { className: 'button' }),
     });
 
-    expect(String(output)).toBe('<button class="button active" id="trigger"></button>');
+    expect(String(output)).toBe('<button class="button trigger active" id="trigger"></button>');
   });
 
   it('flattens class arrays after HTML attribute normalization', async () => {

--- a/packages/vjsc/src/target/render.ts
+++ b/packages/vjsc/src/target/render.ts
@@ -82,6 +82,14 @@ function renderTargetNode(node: TargetNode, context: TargetRenderContext): strin
 }
 
 export function renderTargetAttributes(node: TargetNode, context: TargetRenderContext): string[] {
+  return renderAttributesFor(node, context, context.target.jsx.attributes);
+}
+
+function renderAttributesFor(
+  node: TargetNode,
+  context: TargetRenderContext,
+  attributeMode: ComponentTarget['jsx']['attributes']
+): string[] {
   const attributes: string[] = [];
   const props = node.props as Readonly<Record<PropertyKey, unknown>>;
 
@@ -93,7 +101,7 @@ export function renderTargetAttributes(node: TargetNode, context: TargetRenderCo
     const value = props[property];
 
     if (property === SOURCE_PROPS) {
-      if (isSourcePropsToken(value)) attributes.push(...renderSourceProps(value, context.target.jsx.attributes));
+      if (isSourcePropsToken(value)) attributes.push(...renderSourceProps(value, attributeMode));
 
       continue;
     }
@@ -108,7 +116,7 @@ export function renderTargetAttributes(node: TargetNode, context: TargetRenderCo
 
     if (typeof property !== 'string' || value === undefined) continue;
 
-    const attribute = renderAttribute(property, value, context);
+    const attribute = renderAttribute(property, value, context, attributeMode);
 
     if (attribute) attributes.push(attribute);
   }
@@ -150,8 +158,13 @@ function renderTargetReplacement(replacement: TargetReplacement, context: Target
   return renderSourceRange(source, replacement.branchStart, replacement.branchEnd).value;
 }
 
-function renderAttribute(name: string, value: unknown, context: TargetRenderContext): string | undefined {
-  const targetName = targetAttributeName(name, context.target.jsx.attributes);
+function renderAttribute(
+  name: string,
+  value: unknown,
+  context: TargetRenderContext,
+  attributeMode: ComponentTarget['jsx']['attributes']
+): string | undefined {
+  const targetName = targetAttributeName(name, attributeMode);
 
   if (isSourcePropToken(value)) return renderSourcePropAttribute(targetName, value);
 
@@ -263,7 +276,11 @@ function renderWithProps(
 
   const attributes = isExpressionNode(props)
     ? [`{...${renderTargetExpression(props, context)}}`]
-    : renderTargetAttributes({ [TARGET_NODE]: true, type: TARGET_HOST, props: { ...props }, key: null }, context);
+    : renderAttributesFor(
+        { [TARGET_NODE]: true, type: TARGET_HOST, props: { ...props }, key: null },
+        context,
+        children.rootComponent ? 'react' : context.target.jsx.attributes
+      );
 
   if (children.rootOpeningEnd === undefined) {
     const host = context.target.jsx.host;

--- a/packages/vjsc/src/target/source.ts
+++ b/packages/vjsc/src/target/source.ts
@@ -1,4 +1,4 @@
-import type { JSXAttribute, JSXElement, JSXOpeningElement } from '@oxc-project/types';
+import type { JSXAttribute, JSXElement, JSXElementName, JSXOpeningElement } from '@oxc-project/types';
 
 import { createSourceText, renderSourceRange, type SourceText } from '../ast';
 import { type SourceProps, type TargetOutput, type TargetReplacement, TARGET_REPLACEMENT } from './definition';
@@ -27,6 +27,8 @@ export interface SourceChildrenToken {
   readonly value: string;
   /** Opening-tag offset when the children contain exactly one JSX element. */
   readonly rootOpeningEnd?: number | undefined;
+  /** Whether the single root is a component invocation rather than an intrinsic element. */
+  readonly rootComponent?: boolean | undefined;
 }
 
 export function singleJsxElementChild(node: JSXElement): JSXElement | undefined {
@@ -115,7 +117,14 @@ export function createSourceChildren(
     source: normalized,
     value: rendered.value,
     ...(rootOpeningEnd !== undefined ? { rootOpeningEnd } : {}),
+    ...(rootOpening ? { rootComponent: isComponentName(rootOpening.name) } : {}),
   };
+}
+
+function isComponentName(name: JSXElementName): boolean {
+  if (name.type === 'JSXIdentifier') return /^[A-Z]/.test(name.name);
+
+  return name.type === 'JSXMemberExpression';
 }
 
 export function isSourcePropsToken(value: unknown): value is SourcePropsToken {


### PR DESCRIPTION
Refs #1055

Stacked on #2576.

## Summary

Restore generated skin behavior and visual parity discovered while exercising the new Shadcn consumers and skin preview across React, HTML, Tailwind, and CSS. The supporting runtime changes preserve authored component props and make popup interactions stable.

## Changes

- preserve authored host props through VJSC React and HTML render targets
- expose popup boundaries through the shared component contracts without leaking DOM types into core
- prevent deferred popovers, menu sizing, and composed refs from causing broken opens or render loops
- align audio and video controls, sliders, menus, tooltips, dialogs, posters, and playback feedback with legacy skins
- improve the skin preview with color-scheme controls and clearer audio layout spacing

## Testing

- `pnpm -F @videojs/core test` — 1498 passed
- `pnpm -F @videojs/react test` — 543 passed
- `pnpm -F vjsc test` — 105 passed
- `pnpm -F @videojs/skins test` — 34 passed
- `pnpm typecheck`
- manual React/CSS and React/Tailwind error-dialog verification in the skin preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches popover open timing, menu measurement, ref composition, and broad skin/control markup—user-visible UI with moderate regression surface but well-covered by tests.
> 
> **Overview**
> Restores **generated skin behavior and visuals** across React, HTML, CSS, and Tailwind while tightening popup/menu runtime behavior discovered in preview and Shadcn-style consumers.
> 
> **Runtime & contracts:** Adds shared **`PopoverBoundary`** on menu, popover, and tooltip public props (kept out of core state machines). **Deferred popover opens** now call **`showPopover` on commit** when the popup is already mounted. **Menu popup sizing** accounts for **vertical scrollbar width**. **`use-render`** merges refs so a **single callback ref is not re-invoked every render** (avoids loops). **VJSC** forwards **React `className` on component children** in HTML targets and merges classes on **`Host`**.
> 
> **Skins & UX:** Moves **tooltips to control layouts** (`ButtonTooltip`) instead of wrapping every primitive button; **captions menu** uses **`CaptionsButton` as the menu trigger** (no nested tooltip). Video presets use **`renderPoster`** instead of a `poster` string prop; generated React skin wrappers pass **`{...props}`** only. **Settings menus** get **resizable popup** transition classes; **popup safe-area** and **theme/surface** tweaks (hairline via `shadow-media-sm`, primary dialog buttons, slider thumb sizing). **Skin preview** adds **light/dark scheme** and layout polish. **Hotkeys/gestures** drop redundant step `value` props where defaults apply.
> 
> **Tests** cover scrollbar menu width, deferred popover show, ref stability, and async submenu assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dfdc2d368ef5b81b0a966dfb98f282134901013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->