### PR TITLE
fix(store): match slice selectors by identity

### DIFF
--- a/packages/html/src/skin/tests/video-menu-composition.test.ts
+++ b/packages/html/src/skin/tests/video-menu-composition.test.ts
@@ -1,4 +1,5 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { audioTrackFeature, playbackRateFeature, qualityFeature, textTrackFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type {
   MediaAudioTrackState,
@@ -6,10 +7,10 @@ import type {
   MediaQualityState,
   MediaTextTrackState,
 } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { playerContext } from '../../player/context';
+import { createTestPlayerStore } from '../../testing/create-test-player-store';
 import { AudioTrackRadioGroupElement } from '../../ui/audio-track-radio-group/audio-track-radio-group-element';
 import { CaptionsRadioGroupElement } from '../../ui/captions-radio-group/captions-radio-group-element';
 import { MenuContentElement } from '../../ui/menu/menu-content-element';
@@ -28,37 +29,30 @@ function defineElement(tagName: string, Base: CustomElementConstructor): void {
 }
 
 function createMenuStore(overrides: Partial<MenuMediaState> = {}): AnyPlayerStore {
-  return createStore<unknown>()<MenuMediaState>({
-    name: 'videoMenuComposition',
-    state: () => ({
-      audioTrackList: [
-        { id: '0', kind: 'main', label: 'English', language: 'en', enabled: false },
-        { id: '1', kind: 'alternative', label: 'Spanish', language: 'es', enabled: true },
-      ],
-      selectAudioTrack: vi.fn(),
-      playbackRates: [0.5, 1, 1.5, 2],
-      playbackRate: 1.5,
-      setPlaybackRate: vi.fn(),
-      videoRenditionList: [
-        { id: '0', height: 1080, selected: false },
-        { id: '1', height: 720, selected: true },
-      ],
-      activeVideoRendition: null,
-      selectVideoRendition: vi.fn(),
-      chaptersCues: [],
-      thumbnailCues: [],
-      thumbnailTrackSrc: null,
-      thumbnailTrackCrossOrigin: null,
-      textTrackList: [
-        { kind: 'captions', label: 'English', language: 'en', mode: 'showing' },
-        { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
-      ],
-      subtitlesShowing: true,
-      toggleSubtitles: vi.fn(),
-      selectSubtitlesTrack: vi.fn(),
-      ...overrides,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([audioTrackFeature, playbackRateFeature, qualityFeature, textTrackFeature], {
+    audioTrackList: [
+      { id: '0', kind: 'main', label: 'English', language: 'en', enabled: false },
+      { id: '1', kind: 'alternative', label: 'Spanish', language: 'es', enabled: true },
+    ],
+    selectAudioTrack: vi.fn(),
+    playbackRates: [0.5, 1, 1.5, 2],
+    playbackRate: 1.5,
+    setPlaybackRate: vi.fn(),
+    videoRenditionList: [
+      { id: '0', height: 1080, selected: false },
+      { id: '1', height: 720, selected: true },
+    ],
+    activeVideoRendition: null,
+    selectVideoRendition: vi.fn(),
+    textTrackList: [
+      { kind: 'captions', label: 'English', language: 'en', mode: 'showing' },
+      { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
+    ],
+    subtitlesShowing: true,
+    toggleSubtitles: vi.fn(),
+    selectSubtitlesTrack: vi.fn(),
+    ...overrides,
+  });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/testing/create-test-player-store.ts
+++ b/packages/html/src/testing/create-test-player-store.ts
@@ -1,0 +1,42 @@
+import type { AnyPlayerFeature, AnyPlayerStore, PlayerTarget } from '@videojs/core/dom';
+import type { AnySlice, StateContext, Store, UnionSliceState } from '@videojs/store';
+import { combine, createStore } from '@videojs/store';
+
+const SET_TEST_STATE = Symbol('setTestPlayerState');
+
+interface TestStateAction<State extends object> {
+  [SET_TEST_STATE](partial: Partial<State>): void;
+}
+
+export type TestPlayerStore<State extends object> = AnyPlayerStore & {
+  setState(partial: Partial<State>): void;
+};
+
+/**
+ * Creates a player store for component tests from the real feature definitions.
+ *
+ * Selectors match slices by identity, so fixtures must build stores from the same feature objects the components
+ * select. `initialState` and `setState` override any published value, including actions.
+ */
+export function createTestPlayerStore<const Features extends readonly AnyPlayerFeature[]>(
+  features: Features,
+  initialState: Partial<UnionSliceState<Features>> = {}
+): TestPlayerStore<UnionSliceState<Features>> {
+  type State = UnionSliceState<Features>;
+
+  // A symbol-keyed action reaches the store's `set` without becoming public state.
+  const testStateFeature = {
+    state: ({ set }: StateContext<PlayerTarget>): TestStateAction<State> => ({
+      [SET_TEST_STATE]: (partial) => set(partial),
+    }),
+  };
+  const store = createStore<PlayerTarget>()(
+    combine(...features, testStateFeature) as AnySlice<PlayerTarget>
+  ) as unknown as Store<PlayerTarget, State> & TestStateAction<State>;
+
+  store[SET_TEST_STATE](initialState);
+
+  return Object.assign(store, {
+    setState: (partial: Partial<State>) => store[SET_TEST_STATE](partial),
+  }) as unknown as TestPlayerStore<State>;
+}

--- a/packages/html/src/ui/audio-track-radio-group/tests/audio-track-radio-group-element.test.ts
+++ b/packages/html/src/ui/audio-track-radio-group/tests/audio-track-radio-group-element.test.ts
@@ -1,12 +1,13 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { audioTrackFeature } from '@videojs/core/dom';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaAudioTrackState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { MediaI18nProviderElement } from '../../../i18n/provider-element';
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MenuElement } from '../../menu/menu-element';
 import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../../menu/menu-radio-group-element';
@@ -63,13 +64,7 @@ function createAudioTrackStore({
   audioTrackList?: MediaAudioTrackState['audioTrackList'] | undefined;
   selectAudioTrack?: MediaAudioTrackState['selectAudioTrack'] | undefined;
 } = {}): AnyPlayerStore {
-  return createStore<unknown>()<MediaAudioTrackState>({
-    name: 'audioTrack',
-    state: () => ({
-      audioTrackList,
-      selectAudioTrack,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([audioTrackFeature], { audioTrackList, selectAudioTrack });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/captions-button/tests/captions-button-element.test.ts
+++ b/packages/html/src/ui/captions-button/tests/captions-button-element.test.ts
@@ -1,10 +1,11 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { textTrackFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaTextTrackState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { UIElement } from '../../ui-element';
 import { CaptionsButtonElement } from '../captions-button-element';
 
@@ -35,19 +36,12 @@ async function waitForAssertion(assertion: () => void): Promise<void> {
 }
 
 function createTextTrackStore(textTrackList: MediaTextTrackState['textTrackList']): AnyPlayerStore {
-  return createStore<unknown>()<MediaTextTrackState>({
-    name: 'textTrack',
-    state: () => ({
-      chaptersCues: [],
-      thumbnailCues: [],
-      thumbnailTrackSrc: null,
-      thumbnailTrackCrossOrigin: null,
-      textTrackList,
-      subtitlesShowing: false,
-      toggleSubtitles: vi.fn(),
-      selectSubtitlesTrack: vi.fn(),
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([textTrackFeature], {
+    textTrackList,
+    subtitlesShowing: false,
+    toggleSubtitles: vi.fn(),
+    selectSubtitlesTrack: vi.fn(),
+  });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/captions-radio-group/tests/captions-radio-group-element.test.ts
+++ b/packages/html/src/ui/captions-radio-group/tests/captions-radio-group-element.test.ts
@@ -1,12 +1,13 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { textTrackFeature } from '@videojs/core/dom';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaTextTrackState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { MediaI18nProviderElement } from '../../../i18n/provider-element';
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MenuElement } from '../../menu/menu-element';
 import { MenuRadioItemElement } from '../../menu/menu-radio-item-element';
 import { UIElement } from '../../ui-element';
@@ -47,19 +48,12 @@ function createTextTrackStore({
   subtitlesShowing?: boolean | undefined;
   selectSubtitlesTrack?: MediaTextTrackState['selectSubtitlesTrack'] | undefined;
 } = {}): AnyPlayerStore {
-  return createStore<unknown>()<MediaTextTrackState>({
-    name: 'textTrack',
-    state: () => ({
-      chaptersCues: [],
-      thumbnailCues: [],
-      thumbnailTrackSrc: null,
-      thumbnailTrackCrossOrigin: null,
-      textTrackList,
-      subtitlesShowing,
-      toggleSubtitles: vi.fn(),
-      selectSubtitlesTrack,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([textTrackFeature], {
+    textTrackList,
+    subtitlesShowing,
+    toggleSubtitles: vi.fn(),
+    selectSubtitlesTrack,
+  });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/container/tests/container-element.test.ts
+++ b/packages/html/src/ui/container/tests/container-element.test.ts
@@ -1,12 +1,14 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { controlsFeature } from '@videojs/core/dom';
 import { registerI18n } from '@videojs/core/i18n';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaControlsState } from '@videojs/media';
-import { createStore, flush } from '@videojs/store';
+import { flush } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { MediaI18nProviderElement } from '../../../i18n/provider-element';
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { UIElement } from '../../ui-element';
 import { ContainerElement } from '../container-element';
 
@@ -20,20 +22,7 @@ function createElement<Element extends HTMLElement>(Base: abstract new () => Ele
 }
 
 function createControlsStore(): AnyPlayerStore {
-  return createStore<unknown>()<MediaControlsState>({
-    name: 'controls',
-    state: ({ get, set }) => ({
-      userActive: true,
-      controlsVisible: true,
-      requestControlsLock: () => () => {},
-      toggleControls() {
-        const visible = !(get().controlsVisible as boolean);
-
-        set({ userActive: visible, controlsVisible: visible });
-        return visible;
-      },
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([controlsFeature]);
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/controls/tests/controls-element.test.ts
+++ b/packages/html/src/ui/controls/tests/controls-element.test.ts
@@ -1,11 +1,13 @@
 import { POPUP_HOST_ATTR } from '@videojs/core';
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { controlsFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaControlsState } from '@videojs/media';
-import { createStore, flush } from '@videojs/store';
+import { flush } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MenuElement } from '../../menu/menu-element';
 import { PopoverElement } from '../../popover/popover-element';
 import { TooltipElement } from '../../tooltip/tooltip-element';
@@ -36,23 +38,7 @@ function defineElement(tagName: string, Base: CustomElementConstructor): void {
 }
 
 function createControlsStore(): AnyPlayerStore {
-  return createStore<unknown>()<MediaControlsState>({
-    name: 'controls',
-    state: ({ get, set }) => {
-      return {
-        userActive: true,
-        controlsVisible: true,
-        requestControlsLock: () => () => {},
-        toggleControls() {
-          const visible = !(get().controlsVisible as boolean);
-
-          set({ userActive: visible, controlsVisible: visible });
-
-          return visible;
-        },
-      };
-    },
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([controlsFeature]);
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/fullscreen-button/tests/fullscreen-button-element.test.ts
+++ b/packages/html/src/ui/fullscreen-button/tests/fullscreen-button-element.test.ts
@@ -1,25 +1,22 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { fullscreenFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
-import type { MediaFullscreenState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
 
 import { containerContext, playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { UIElement } from '../../ui-element';
 import { FullscreenButtonElement } from '../fullscreen-button-element';
 
 class TestFullscreenProvider extends UIElement {
   readonly requestFullscreen = vi.fn();
-  readonly store = createStore<unknown>()<MediaFullscreenState>({
-    name: 'fullscreen',
-    state: () => ({
-      fullscreen: false,
-      fullscreenAvailability: 'available',
-      requestFullscreen: this.requestFullscreen,
-      exitFullscreen: vi.fn(),
-      toggleFullscreen: vi.fn(),
-    }),
-  }) as unknown as AnyPlayerStore;
+  readonly store: AnyPlayerStore = createTestPlayerStore([fullscreenFeature], {
+    fullscreen: false,
+    fullscreenAvailability: 'available',
+    requestFullscreen: this.requestFullscreen,
+    exitFullscreen: vi.fn(),
+    toggleFullscreen: vi.fn(),
+  });
   readonly containerProvider: ContextProvider<typeof containerContext> = new ContextProvider(this, {
     context: containerContext,
     initialValue: { container: this, registerContainer: () => () => {} },

--- a/packages/html/src/ui/menu/tests/menu-element.test.ts
+++ b/packages/html/src/ui/menu/tests/menu-element.test.ts
@@ -1,10 +1,11 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { controlsFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
-import type { MediaControlsState } from '@videojs/media';
-import { createStore, flush } from '@videojs/store';
+import { flush } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { ControlsElement } from '../../controls/controls-element';
 import { UIElement } from '../../ui-element';
 import { MenuContentElement } from '../menu-content-element';
@@ -368,15 +369,9 @@ describe('MenuElement', () => {
     class TestPlayerProviderElement extends UIElement {
       readonly releaseControlsLock = vi.fn();
       readonly requestControlsLock = vi.fn(() => this.releaseControlsLock);
-      readonly store = createStore<unknown>()<MediaControlsState>({
-        name: 'controls',
-        state: () => ({
-          userActive: true,
-          controlsVisible: true,
-          requestControlsLock: this.requestControlsLock,
-          toggleControls: () => true,
-        }),
-      }) as unknown as AnyPlayerStore;
+      readonly store: AnyPlayerStore = createTestPlayerStore([controlsFeature], {
+        requestControlsLock: this.requestControlsLock,
+      });
       readonly provider = new ContextProvider(this, { context: playerContext, initialValue: this.store });
 
       override connectedCallback(): void {

--- a/packages/html/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group-element.test.ts
+++ b/packages/html/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group-element.test.ts
@@ -1,10 +1,11 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { playbackRateFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaPlaybackRateState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MenuElement } from '../../menu/menu-element';
 import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../../menu/menu-radio-group-element';
@@ -61,16 +62,7 @@ function createPlaybackRateStore({
   playbackRate?: number | undefined;
   setPlaybackRate?: ((rate: number) => void) | undefined;
 } = {}): AnyPlayerStore {
-  return createStore<unknown>()<MediaPlaybackRateState>({
-    name: 'playbackRate',
-    state: () => {
-      return {
-        playbackRates,
-        playbackRate,
-        setPlaybackRate,
-      };
-    },
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([playbackRateFeature], { playbackRates, playbackRate, setPlaybackRate });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/quality-radio-group/tests/quality-radio-group-element.test.ts
+++ b/packages/html/src/ui/quality-radio-group/tests/quality-radio-group-element.test.ts
@@ -1,12 +1,13 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { qualityFeature } from '@videojs/core/dom';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaQualityState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { MediaI18nProviderElement } from '../../../i18n/provider-element';
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MenuElement } from '../../menu/menu-element';
 import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../../menu/menu-radio-group-element';
@@ -65,14 +66,7 @@ function createQualityStore({
   activeVideoRendition?: MediaQualityState['activeVideoRendition'] | undefined;
   selectVideoRendition?: MediaQualityState['selectVideoRendition'] | undefined;
 } = {}): AnyPlayerStore {
-  return createStore<unknown>()<MediaQualityState>({
-    name: 'quality',
-    state: () => ({
-      videoRenditionList,
-      activeVideoRendition,
-      selectVideoRendition,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([qualityFeature], { videoRenditionList, activeVideoRendition, selectVideoRendition });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/slider/tests/slider-element.test.ts
+++ b/packages/html/src/ui/slider/tests/slider-element.test.ts
@@ -1,10 +1,11 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { controlsFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaControlsState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { UIElement } from '../../ui-element';
 import { SliderBufferElement } from '../slider-buffer-element';
 import { SliderElement } from '../slider-element';
@@ -28,15 +29,7 @@ function createElement<Element extends HTMLElement>(Base: abstract new () => Ele
 }
 
 function createControlsStore(requestControlsLock: MediaControlsState['requestControlsLock']): AnyPlayerStore {
-  return createStore<unknown>()<MediaControlsState>({
-    name: 'controls',
-    state: () => ({
-      userActive: true,
-      controlsVisible: true,
-      requestControlsLock,
-      toggleControls: () => true,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([controlsFeature], { requestControlsLock });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/thumbnail/tests/thumbnail-element.test.ts
+++ b/packages/html/src/ui/thumbnail/tests/thumbnail-element.test.ts
@@ -1,29 +1,18 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { textTrackFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaTextTrackState } from '@videojs/media';
-import { createStore } from '@videojs/store';
-import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { UIElement } from '../../ui-element';
 import { ThumbnailElement } from '../thumbnail-element';
 
 function createTextTrackStore(
   thumbnailTrackCrossOrigin: MediaTextTrackState['thumbnailTrackCrossOrigin']
 ): AnyPlayerStore {
-  return createStore<unknown>()<MediaTextTrackState>({
-    name: 'textTrack',
-    state: () => ({
-      chaptersCues: [],
-      thumbnailCues: [],
-      thumbnailTrackSrc: null,
-      thumbnailTrackCrossOrigin,
-      textTrackList: [],
-      subtitlesShowing: false,
-      toggleSubtitles: vi.fn(),
-      selectSubtitlesTrack: vi.fn(),
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([textTrackFeature], { thumbnailTrackCrossOrigin });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/time/tests/time-element.test.ts
+++ b/packages/html/src/ui/time/tests/time-element.test.ts
@@ -1,13 +1,14 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { timeFeature } from '@videojs/core/dom';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaTimeState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { formatTimeAsPhrase } from '@videojs/utils/time';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { MediaI18nProviderElement } from '../../../i18n';
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { UIElement } from '../../ui-element';
 import { TimeElement } from '../time-element';
 
@@ -51,16 +52,13 @@ async function waitForAssertion(assertion: () => void): Promise<void> {
 }
 
 function createTimeStore(overrides: Partial<MediaTimeState> = {}): AnyPlayerStore {
-  return createStore<unknown>()<MediaTimeState>({
-    name: 'time',
-    state: () => ({
-      currentTime: 90,
-      duration: 300,
-      seeking: false,
-      seek: vi.fn(),
-      ...overrides,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([timeFeature], {
+    currentTime: 90,
+    duration: 300,
+    seeking: false,
+    seek: vi.fn(),
+    ...overrides,
+  });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/volume-popover/tests/volume-popover-element.test.ts
+++ b/packages/html/src/ui/volume-popover/tests/volume-popover-element.test.ts
@@ -1,27 +1,25 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { volumeFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaVolumeState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { UIElement } from '../../ui-element';
 import { VolumePopoverElement } from '../volume-popover-element';
 
 let tagCounter = 0;
 
 function createVolumeStore(volumeAvailability: MediaVolumeState['volumeAvailability']): AnyPlayerStore {
-  return createStore<unknown>()<MediaVolumeState>({
-    name: 'volume',
-    state: () => ({
-      volume: 1,
-      muted: false,
-      volumeAvailability,
-      mutedAvailability: 'available',
-      setVolume: vi.fn(),
-      toggleMuted: vi.fn(),
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([volumeFeature], {
+    volume: 1,
+    muted: false,
+    volumeAvailability,
+    mutedAvailability: 'available',
+    setVolume: vi.fn(),
+    toggleMuted: vi.fn(),
+  });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
+++ b/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
@@ -1,10 +1,11 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { volumeFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaVolumeState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { SliderThumbElement } from '../../slider/slider-thumb-element';
 import { UIElement } from '../../ui-element';
 import { VolumeSliderElement } from '../volume-slider-element';
@@ -23,19 +24,16 @@ function createElement<Element extends HTMLElement>(Base: abstract new () => Ele
 }
 
 function createVolumeStore(volumeAvailability: MediaVolumeState['volumeAvailability']): AnyPlayerStore {
-  return createStore<unknown>()<MediaVolumeState>({
-    name: 'volume',
-    state: () => ({
-      volume: 1,
-      muted: false,
-      volumeAvailability,
-      // Mute has an availability of its own, and this slider reads the level's;
-      // these tests vary that one and leave the mute available throughout.
-      mutedAvailability: 'available',
-      setVolume: vi.fn(),
-      toggleMuted: vi.fn(),
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([volumeFeature], {
+    volume: 1,
+    muted: false,
+    volumeAvailability,
+    // Mute has an availability of its own, and this slider reads the level's;
+    // these tests vary that one and leave the mute available throughout.
+    mutedAvailability: 'available',
+    setVolume: vi.fn(),
+    toggleMuted: vi.fn(),
+  });
 }
 
 class TestPlayerProviderElement extends UIElement {

--- a/packages/store/src/core/combine.ts
+++ b/packages/store/src/core/combine.ts
@@ -15,6 +15,8 @@ type CombinedTarget<Slices extends readonly AnySlice[]> = Slices extends readonl
   ? unknown
   : UnionToIntersection<InferSliceTarget<Slices[number]>>;
 
+const combinedSlices = new WeakMap<AnySlice, readonly AnySlice[]>();
+
 /**
  * Combines multiple slices into a single slice.
  *
@@ -33,7 +35,7 @@ export function combine<const Slices extends readonly AnySlice[]>(
     warnDuplicates('derived', derivedDefinitions);
   }
 
-  return {
+  const combined: Slice<Target, SourceState, UnionSliceDerivedState<Slices>> = {
     state: (ctx: StateContext<Target>) => {
       const states = slices.map((slice) => slice.state(ctx));
 
@@ -59,6 +61,26 @@ export function combine<const Slices extends readonly AnySlice[]>(
       }
     },
   };
+
+  combinedSlices.set(combined, slices);
+
+  return combined;
+}
+
+/**
+ * Collects a slice together with every slice nested inside it through `combine()`.
+ *
+ * Stores tag their snapshots with this set so selectors can check membership by slice identity instead of guessing from
+ * state keys.
+ */
+export function collectSlices(slice: AnySlice, into = new Set<AnySlice>()): ReadonlySet<AnySlice> {
+  into.add(slice);
+
+  for (const child of combinedSlices.get(slice) ?? []) {
+    collectSlices(child, into);
+  }
+
+  return into;
 }
 
 function warnDuplicates(namespace: string, objects: readonly object[]): void {

--- a/packages/store/src/core/index.ts
+++ b/packages/store/src/core/index.ts
@@ -6,5 +6,6 @@ export { createSelector } from './selector';
 export type { Comparator, Selector } from './shallow-equal';
 export { shallowEqual } from './shallow-equal';
 export * from './slice';
-export * from './state';
+export { createState, flush, isState } from './state';
+export type { State, StateChange, SubscribeOptions, UnknownState, WritableState } from './state';
 export * from './store';

--- a/packages/store/src/core/selector.ts
+++ b/packages/store/src/core/selector.ts
@@ -4,6 +4,7 @@ import { AbortControllerRegistry } from './abort-controller-registry';
 import { throwNoTargetError } from './errors';
 import type { Selector } from './shallow-equal';
 import type { AnySlice, InferSliceState, StateContext } from './slice';
+import { getSnapshotSlices } from './state';
 
 const stateContext: StateContext<unknown> = {
   target: throwNoTargetError,
@@ -16,6 +17,10 @@ const stateContext: StateContext<unknown> = {
  * Create a type-safe selector for a slice's state.
  *
  * The selector returns the slice's state, or `undefined` if the slice is not configured in the store.
+ *
+ * Store snapshots record which slice objects built them, so the selector matches by identity: the slice passed to
+ * `createStore` (directly or through `combine`) must be the same object passed here. Plain objects and copied snapshots
+ * carry no such record and fall back to checking for the slice's first state key.
  *
  * @example
  *   ```ts
@@ -31,12 +36,23 @@ export function createSelector<S extends AnySlice>(slice: S): Selector<object, I
   const keys = [...Object.keys(initialState as object), ...Object.keys(slice.derived ?? {})];
 
   const firstKey = keys[0];
-  if (!firstKey) return Object.assign(() => undefined, { displayName: slice.name });
+  const hasShape = (state: object) => firstKey !== undefined && firstKey in state;
+
+  let warnedIdentity = false;
 
   return Object.assign(
     (state: object) => {
-      // WARN: Could be the source of a bug if two slices have overlapping state keys
-      if (!(firstKey in state)) return undefined;
+      const slices = getSnapshotSlices(state);
+      const configured = slices ? slices.has(slice) : hasShape(state);
+
+      if (__DEV__ && slices && !configured && !warnedIdentity && hasShape(state)) {
+        warnedIdentity = true;
+        console.warn(
+          `[vjs-store] createSelector(): store state has the keys of slice "${slice.name ?? 'anonymous'}" but the store was not built from that slice object. Selectors match slices by identity; pass the same slice to createStore() and createSelector().`
+        );
+      }
+
+      if (!configured) return undefined;
 
       return pick(state as Record<string, unknown>, keys) as InferSliceState<S>;
     },

--- a/packages/store/src/core/state.ts
+++ b/packages/store/src/core/state.ts
@@ -1,6 +1,8 @@
 import { noop } from '@videojs/utils/function';
 import { shallowEqual } from '@videojs/utils/object';
 
+import type { AnySlice } from './slice';
+
 export type StateChange = () => void;
 
 export type UnknownState = Record<string, unknown>;
@@ -40,13 +42,18 @@ export function flush(): void {
 
 const hasOwnProp = Object.prototype.hasOwnProperty;
 
+// Snapshots are frozen copies, so membership lives beside them instead of on them.
+const snapshotSlices = new WeakMap<object, ReadonlySet<AnySlice>>();
+
 class StateContainer<T> implements WritableState<T> {
   #current: T;
+  #slices: ReadonlySet<AnySlice> | undefined;
   #listeners = new Set<StateChange>();
   #pending = false;
 
-  constructor(initial: T) {
-    this.#current = Object.freeze({ ...initial });
+  constructor(initial: T, slices?: ReadonlySet<AnySlice>) {
+    this.#slices = slices;
+    this.#current = this.#publish({ ...initial });
   }
 
   get current(): Readonly<T> {
@@ -70,7 +77,7 @@ class StateContainer<T> implements WritableState<T> {
     }
 
     if (changed) {
-      this.#current = Object.freeze(next);
+      this.#current = this.#publish(next);
       this.#markPending();
     }
   }
@@ -80,7 +87,7 @@ class StateContainer<T> implements WritableState<T> {
     // resolved title stays the same. Preserve the public snapshot in that case.
     if (shallowEqual(this.#current, next)) return;
 
-    this.#current = Object.freeze({ ...next });
+    this.#current = this.#publish({ ...next });
     this.#markPending();
   }
 
@@ -117,10 +124,28 @@ class StateContainer<T> implements WritableState<T> {
     pendingContainers.add(this);
     scheduleFlush();
   }
+
+  #publish(next: T): T {
+    const snapshot = Object.freeze(next);
+
+    if (this.#slices) snapshotSlices.set(snapshot as object, this.#slices);
+
+    return snapshot;
+  }
 }
 
-export function createState<T>(initial: T): WritableState<T> {
-  return new StateContainer(initial);
+/**
+ * @param initial - Initial state; the container publishes frozen copies.
+ * @param slices - Slices the state was built from. Every snapshot the container publishes is tagged with them so
+ *   `createSelector` can check membership by identity. Copies of a snapshot carry no tag.
+ */
+export function createState<T>(initial: T, slices?: ReadonlySet<AnySlice>): WritableState<T> {
+  return new StateContainer(initial, slices);
+}
+
+/** Returns the slices a store-owned snapshot was built from, or `undefined` for any other object. */
+export function getSnapshotSlices(snapshot: object): ReadonlySet<AnySlice> | undefined {
+  return snapshotSlices.get(snapshot);
 }
 
 export function isState(value: unknown): value is State<object> {

--- a/packages/store/src/core/store.ts
+++ b/packages/store/src/core/store.ts
@@ -1,6 +1,7 @@
 import { isNull, isObject } from '@videojs/utils/predicate';
 
 import { AbortControllerRegistry } from './abort-controller-registry';
+import { collectSlices } from './combine';
 import type { StoreCallbacks } from './config';
 import { throwDestroyedError, throwNoTargetError } from './errors';
 import type {
@@ -71,7 +72,7 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
     sourceState = initialSourceState;
     const initialDerivedState = derive(sourceState);
 
-    state = createState(publish(sourceState, initialDerivedState));
+    state = createState(publish(sourceState, initialDerivedState), collectSlices(slice));
 
     const store = {
       [STORE_SYMBOL]: true,

--- a/packages/store/src/core/tests/combine.test.ts
+++ b/packages/store/src/core/tests/combine.test.ts
@@ -1,6 +1,6 @@
 import { assertType, describe, expect, it, vi } from 'vite-plus/test';
 
-import { combine } from '../combine';
+import { collectSlices, combine } from '../combine';
 import { defineSlice, type InferSliceTarget } from '../slice';
 import { createStore } from '../store';
 
@@ -118,5 +118,23 @@ describe('combine', () => {
     expect(store.label).toBe('second');
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate derived key "label"'));
     warn.mockRestore();
+  });
+});
+
+describe('collectSlices', () => {
+  it('returns a leaf slice by itself', () => {
+    const a = slice({ state: () => ({ count: 0 }) });
+
+    expect([...collectSlices(a)]).toEqual([a]);
+  });
+
+  it('includes every slice nested through combine', () => {
+    const a = slice({ state: () => ({ count: 0 }) });
+    const b = slice({ state: () => ({ label: '' }) });
+    const c = slice({ state: () => ({ flag: false }) });
+    const inner = combine(a, b);
+    const outer = combine(inner, c);
+
+    expect(collectSlices(outer)).toEqual(new Set([outer, inner, a, b, c]));
   });
 });

--- a/packages/store/src/core/tests/selector.test.ts
+++ b/packages/store/src/core/tests/selector.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
+import { combine } from '../combine';
 import { createSelector } from '../selector';
 import { defineSlice } from '../slice';
+import { createStore } from '../store';
 
 const NativeAbortController = globalThis.AbortController;
 
@@ -46,6 +48,108 @@ describe('createSelector', () => {
       muted: true,
       setVolume: state.setVolume,
     });
+  });
+
+  it('selects a slice configured directly in a store', () => {
+    const selectVolume = createSelector(volumeSlice);
+    const store = createStore<MockMedia>()(volumeSlice);
+
+    expect(selectVolume(store.state)).toEqual({
+      volume: 1,
+      muted: false,
+      setVolume: store.setVolume,
+    });
+  });
+
+  it('selects from replacement snapshots', () => {
+    const countSlice = defineSlice<MockMedia>()({
+      state: ({ set }) => ({
+        count: 0,
+        setCount: (count: number) => set({ count }),
+      }),
+    });
+    const selectCount = createSelector(countSlice);
+    const store = createStore<MockMedia>()(countSlice);
+
+    store.setCount(1);
+
+    expect(selectCount(store.state)).toEqual({ count: 1, setCount: store.setCount });
+    expect(Object.getOwnPropertySymbols(store.state)).toEqual([]);
+  });
+
+  it('returns undefined when store keys overlap an unconfigured slice', () => {
+    const sameShapeSlice = defineSlice<MockMedia>()({
+      name: 'same-shape',
+      state: () => ({
+        volume: 0.25,
+        muted: true,
+        setVolume: (value: number) => value,
+      }),
+    });
+    const store = createStore<MockMedia>()(sameShapeSlice);
+
+    expect(createSelector(volumeSlice)(store.state)).toBeUndefined();
+    expect(createSelector(sameShapeSlice)(store.state)).toEqual({
+      volume: 0.25,
+      muted: true,
+      setVolume: store.setVolume,
+    });
+  });
+
+  it('warns once when store keys match a slice the store was not built from', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const lookalike = defineSlice<MockMedia>()({
+      state: () => ({ volume: 1, muted: false, setVolume: (value: number) => value }),
+    });
+    const store = createStore<MockMedia>()(lookalike);
+    const selectVolume = createSelector(volumeSlice);
+
+    selectVolume(store.state);
+    selectVolume(store.state);
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]![0]).toContain('slice "volume"');
+    warn.mockRestore();
+  });
+
+  it('falls back to key detection for a copied store snapshot', () => {
+    const selectVolume = createSelector(volumeSlice);
+    const store = createStore<MockMedia>()(volumeSlice);
+
+    expect(selectVolume({ ...store.state })).toEqual({
+      volume: 1,
+      muted: false,
+      setVolume: store.setVolume,
+    });
+  });
+
+  it('selects leaf and combined slices from a combined store', () => {
+    const combinedSlice = combine(volumeSlice, playbackSlice);
+    const store = createStore<MockMedia>()(combinedSlice);
+
+    expect(createSelector(volumeSlice)(store.state)).toEqual({
+      volume: 1,
+      muted: false,
+      setVolume: store.setVolume,
+    });
+    expect(createSelector(playbackSlice)(store.state)).toEqual({ paused: true, ended: false });
+    expect(createSelector(combinedSlice)(store.state)).toEqual({
+      volume: 1,
+      muted: false,
+      setVolume: store.setVolume,
+      paused: true,
+      ended: false,
+    });
+  });
+
+  it('selects leaf slices through nested combinations', () => {
+    const presentationSlice = defineSlice<MockMedia>()({ state: () => ({ fullscreen: false }) });
+    const mediaSlice = combine(volumeSlice, playbackSlice);
+    const store = createStore<MockMedia>()(combine(mediaSlice, presentationSlice));
+
+    expect(createSelector(volumeSlice)(store.state)).toBeDefined();
+    expect(createSelector(mediaSlice)(store.state)).toBeDefined();
+    expect(createSelector(presentationSlice)(store.state)).toEqual({ fullscreen: false });
   });
 
   it('returns undefined when slice is not configured', () => {
@@ -112,14 +216,16 @@ describe('createSelector', () => {
     expect(selector.displayName).toBeUndefined();
   });
 
-  it('returns undefined for empty-state slice', () => {
+  it('selects an empty slice only from a store built with it', () => {
     const emptySlice = defineSlice<MockMedia>()({
       name: 'empty',
       state: () => ({}),
     });
     const selector = createSelector(emptySlice);
+    const store = createStore<MockMedia>()(combine(emptySlice, playbackSlice));
 
     expect(selector({})).toBeUndefined();
+    expect(selector(store.state)).toEqual({});
     expect(selector.displayName).toBe('empty');
   });
 

--- a/packages/store/src/core/tests/state.test.ts
+++ b/packages/store/src/core/tests/state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vite-plus/test';
 
-import { createState, flush, isState } from '../state';
+import type { AnySlice } from '../slice';
+import { createState, flush, getSnapshotSlices, isState } from '../state';
 
 describe('createState', () => {
   interface TestState {
@@ -144,5 +145,38 @@ describe('createState', () => {
       expect(isState(42)).toBe(false);
       expect(isState('string')).toBe(false);
     });
+  });
+});
+
+describe('getSnapshotSlices', () => {
+  const slice: AnySlice = { state: () => ({ volume: 1 }) };
+  const slices = new Set([slice]);
+
+  it('returns undefined for untagged containers and plain objects', () => {
+    const state = createState({ volume: 1 });
+
+    expect(getSnapshotSlices(state.current)).toBeUndefined();
+    expect(getSnapshotSlices({ volume: 1 })).toBeUndefined();
+  });
+
+  it('tags the initial snapshot and every snapshot after patch or replace', () => {
+    const state = createState({ volume: 1 }, slices);
+    const initial = state.current;
+
+    state.patch({ volume: 0.5 });
+    const patched = state.current;
+
+    state.replace({ volume: 0.25 });
+    const replaced = state.current;
+
+    expect(getSnapshotSlices(initial)).toBe(slices);
+    expect(getSnapshotSlices(patched)).toBe(slices);
+    expect(getSnapshotSlices(replaced)).toBe(slices);
+  });
+
+  it('does not tag copies of a snapshot', () => {
+    const state = createState({ volume: 1 }, slices);
+
+    expect(getSnapshotSlices({ ...state.current })).toBeUndefined();
   });
 });

--- a/site/src/content/docs/reference/create-selector.mdx
+++ b/site/src/content/docs/reference/create-selector.mdx
@@ -17,6 +17,8 @@ import { createSelector } from "@videojs/store";
 
 `createSelector` creates a type-safe selector function for a given slice. The returned selector extracts that slice's state from the full store state, or returns `undefined` if the slice is not configured.
 
+Store state remembers which slice objects built it, so a selector matches by identity: pass the same slice object to `createStore` (directly or through `combine`) and to `createSelector`. Two slices with the same keys are not interchangeable. Plain objects and copied snapshots carry no slice record and fall back to checking for the slice's first state key.
+
 The built-in selectors (<DocsLink slug="reference/feature-playback">`selectPlayback`</DocsLink>, <DocsLink slug="reference/feature-buffer">`selectBuffer`</DocsLink>, etc.) are all created with `createSelector`. Use it to create selectors for custom slices.
 
 ```ts title="my-custom-selector.ts"


### PR DESCRIPTION
Refs #2362
Alternative to #2309

## Summary

Feature selectors inferred slice availability from the first state key, so an unconfigured slice appeared present whenever another slice shared that key. Store snapshots now remember which slice objects built them and selectors match by identity. This is a smaller take on #2309: no symbol identities, no separate module, and the plain-object fallback is unchanged so core and React fixtures are untouched.

## Changes

- `combine` records its children and exposes a `collectSlices` walk, so nested combinations preserve leaf membership
- The state container tags every snapshot it publishes with the store's slice set, in one place, so replacements are covered without follow-up registration calls
- Selectors check identity on store snapshots and keep the existing first-key fallback for plain objects and copied snapshots
- In dev, a selector warns once when store state has a slice's keys but the store was built from a different slice object, which is the new silent failure mode
- HTML component tests build stores from the real features through a shared helper instead of lookalike slices
- Public state and slice shapes are unchanged; the snapshot lookup stays internal

<details>
<summary>Implementation details</summary>

Slice objects themselves are the identity. Membership is a `ReadonlySet<AnySlice>` held in `WeakMap`s keyed by combined slice and by frozen snapshot, so nothing is added to public objects and copies naturally lose provenance. An empty slice now selects as `{}` from a store built with it instead of always returning `undefined`.

</details>

## Testing

- `pnpm -F @videojs/store test`
- `pnpm -F @videojs/core test`, `pnpm -F @videojs/react test` (no fixture changes needed)
- `pnpm -F @videojs/html test`
- `pnpm typecheck`, `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core store selector semantics for tagged snapshots (behavior fix for overlapping keys); runtime impact is limited because plain-object fallback is unchanged, but any code relying on key-only matching against real store state could now see `undefined`.
> 
> **Overview**
> Fixes **false positives** where `createSelector` treated a slice as present whenever another slice shared the same first state key.
> 
> **`@videojs/store`:** Published store snapshots are tagged (via internal `WeakMap`s) with the slice objects from `createStore` / nested `combine`. Selectors prefer **slice identity** on those snapshots; plain objects and spread copies still use the old first-key heuristic. `combine` gains `collectSlices` for nested membership. In dev, a one-time warning fires when keys look right but the slice object does not match.
> 
> **`@videojs/html`:** Component tests stop using hand-rolled `createStore` mocks and build stores from real feature slices through **`createTestPlayerStore`**, with `setState` for fixtures—so selectors align with production.
> 
> Docs for `createSelector` describe the identity contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85b9c4be208f2b961e0af3656c0d19026fddf7ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->