### PR TITLE
fix(core): retarget thumbnail listeners when elements change

### DIFF
--- a/packages/core/src/dom/ui/tests/thumbnail.test.ts
+++ b/packages/core/src/dom/ui/tests/thumbnail.test.ts
@@ -347,6 +347,64 @@ describe('createThumbnail', () => {
       handle.destroy();
     });
 
+    it('retargets img listeners and resize observation when the elements change', () => {
+      let img = document.createElement('img');
+      let container = createMockContainer();
+      const firstImg = img;
+      const onStateChange = vi.fn();
+      const handle = createThumbnail(
+        createOptions({ getContainer: () => container, getImg: () => img, onStateChange })
+      );
+
+      Object.defineProperty(firstImg, 'complete', { value: false, configurable: true });
+      handle.updateSrc('sprite.jpg');
+      handle.connect();
+
+      expect(ResizeObserverStub.instances).toHaveLength(1);
+      expect(ResizeObserverStub.instances[0]!.observe).toHaveBeenCalledWith(container);
+
+      img = document.createElement('img');
+      container = createMockContainer();
+      Object.defineProperty(img, 'complete', { value: false, configurable: true });
+      handle.connect();
+
+      expect(ResizeObserverStub.instances[0]!.disconnect).toHaveBeenCalledOnce();
+      expect(ResizeObserverStub.instances).toHaveLength(2);
+      expect(ResizeObserverStub.instances[1]!.observe).toHaveBeenCalledWith(container);
+
+      firstImg.dispatchEvent(new Event('error'));
+
+      expect(onStateChange).not.toHaveBeenCalled();
+      expect(handle.error).toBe(false);
+
+      img.dispatchEvent(new Event('error'));
+
+      expect(onStateChange).toHaveBeenCalledOnce();
+      expect(handle.error).toBe(true);
+
+      handle.destroy();
+    });
+
+    it('does not notify again when connect finds an already-settled img unchanged', () => {
+      const img = createMockImg();
+      const container = createMockContainer();
+      const onStateChange = vi.fn();
+      const handle = createThumbnail(
+        createOptions({ getContainer: () => container, getImg: () => img, onStateChange })
+      );
+
+      handle.updateSrc('sprite.jpg');
+      handle.connect();
+
+      expect(onStateChange).toHaveBeenCalledOnce();
+
+      handle.connect();
+
+      expect(onStateChange).toHaveBeenCalledOnce();
+
+      handle.destroy();
+    });
+
     it('detects already-loaded img on connect', () => {
       const img = createMockImg();
 

--- a/packages/core/src/dom/ui/thumbnail.ts
+++ b/packages/core/src/dom/ui/thumbnail.ts
@@ -23,15 +23,15 @@ export interface ThumbnailApi {
 export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
   const { getContainer, getImg, onStateChange } = options;
   const core = new ThumbnailCore();
-  const abort = new AbortController();
-  const signal = abort.signal;
 
   let loading = false;
   let error = false;
   let naturalWidth = 0;
   let naturalHeight = 0;
   let lastSrc = '';
-  let imgBound = false;
+  let boundImg: HTMLImageElement | null = null;
+  let stopListeningImg: (() => void) | null = null;
+  let observedContainer: HTMLElement | null = null;
   let stopObservingResize: (() => void) | null = null;
 
   // Sprite sheets that have already failed, so re-entering one does not restart the loading state.
@@ -40,11 +40,9 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
   // --- img event listeners ---
 
   function onImgLoad() {
-    const img = getImg();
-
-    if (img) {
-      naturalWidth = img.naturalWidth;
-      naturalHeight = img.naturalHeight;
+    if (boundImg) {
+      naturalWidth = boundImg.naturalWidth;
+      naturalHeight = boundImg.naturalHeight;
     }
 
     // A sheet that succeeds on a later attempt stops counting as failed.
@@ -66,30 +64,42 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
     onStateChange();
   }
 
-  function bindImg(img: HTMLImageElement): void {
-    listen(img, 'load', onImgLoad, { signal });
-    listen(img, 'error', onImgError, { signal });
+  // --- Element bindings ---
+  //
+  // Render overrides and remounts can hand back a different img or container for the same source, so every binding
+  // pass retargets the listeners and resize observation to whichever elements are in the DOM now.
+
+  function bindImg(img: HTMLImageElement | null): void {
+    if (img === boundImg) return;
+
+    stopListeningImg?.();
+    stopListeningImg = null;
+    boundImg = img;
+
+    if (!img) return;
+
+    const stopLoad = listen(img, 'load', onImgLoad);
+    const stopError = listen(img, 'error', onImgError);
+
+    stopListeningImg = () => {
+      stopLoad();
+      stopError();
+    };
   }
 
-  // --- Lazy binding ---
+  function observeContainer(container: HTMLElement | null): void {
+    if (container === observedContainer) return;
+
+    stopObservingResize?.();
+    stopObservingResize = null;
+    observedContainer = container;
+
+    if (container) stopObservingResize = observeResize(container, onStateChange);
+  }
 
   function ensureBindings(): void {
-    if (!imgBound) {
-      const img = getImg();
-
-      if (img) {
-        bindImg(img);
-        imgBound = true;
-      }
-    }
-
-    if (!stopObservingResize) {
-      const container = getContainer();
-
-      if (container) {
-        stopObservingResize = observeResize(container, onStateChange);
-      }
-    }
+    bindImg(getImg());
+    observeContainer(getContainer());
   }
 
   // --- src tracking ---
@@ -123,28 +133,37 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
   function connect(): void {
     ensureBindings();
 
-    // Handle the case where the img already loaded or errored before listeners
-    // were bound (e.g., cached image in React where mount happens before useEffect).
-    const img = getImg();
+    // Settle an image that loaded or failed before its listeners were bound (e.g. a cached image in React, where the
+    // element mounts before the effect runs). Notify only when something changed so callers can connect on every commit.
+    const img = boundImg;
+    if (!img?.complete || !lastSrc) return;
 
-    if (img?.complete && lastSrc) {
-      if (img.naturalWidth > 0) {
-        naturalWidth = img.naturalWidth;
-        naturalHeight = img.naturalHeight;
-        loading = false;
-        error = false;
-      } else {
-        markFailed();
-      }
+    const wasLoading = loading;
+    const wasError = error;
+    const previousWidth = naturalWidth;
+    const previousHeight = naturalHeight;
 
-      onStateChange();
+    if (img.naturalWidth > 0) {
+      naturalWidth = img.naturalWidth;
+      naturalHeight = img.naturalHeight;
+      loading = false;
+      error = false;
+    } else {
+      markFailed();
     }
+
+    const changed =
+      loading !== wasLoading ||
+      error !== wasError ||
+      naturalWidth !== previousWidth ||
+      naturalHeight !== previousHeight;
+
+    if (changed) onStateChange();
   }
 
   function destroy(): void {
-    abort.abort();
-    stopObservingResize?.();
-    stopObservingResize = null;
+    bindImg(null);
+    observeContainer(null);
   }
 
   return {

--- a/packages/react/src/ui/thumbnail/tests/thumbnail.test.tsx
+++ b/packages/react/src/ui/thumbnail/tests/thumbnail.test.tsx
@@ -1,11 +1,97 @@
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import type { CreateThumbnailOptions, ThumbnailApi } from '@videojs/core/dom';
 import type { MediaTextTrackState } from '@videojs/media';
-import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { Component, type ErrorInfo, type ReactNode, StrictMode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vite-plus/test';
 
 import { createPlayerWrapper } from '../../../testing/mocks';
+import type { HTMLProps } from '../../../utils/types';
 import { Thumbnail, type ThumbnailProps } from '../thumbnail';
 
-afterEach(cleanup);
+interface ThumbnailRecord {
+  handle: ThumbnailApi;
+  updateSrc: Mock<ThumbnailApi['updateSrc']>;
+  onStateChange: Mock<() => void>;
+}
+
+const thumbnailMocks = vi.hoisted(() => ({ records: [] as ThumbnailRecord[] }));
+
+vi.mock('@videojs/core/dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@videojs/core/dom')>();
+
+  return {
+    ...actual,
+    createThumbnail(options: CreateThumbnailOptions) {
+      const onStateChange = vi.fn(options.onStateChange);
+      const handle = actual.createThumbnail({ ...options, onStateChange });
+      const updateSrc = vi.fn(handle.updateSrc);
+
+      handle.updateSrc = updateSrc;
+      thumbnailMocks.records.push({ handle, updateSrc, onStateChange });
+
+      return handle;
+    },
+  };
+});
+
+class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = [];
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+/** Swallows a descendant's render error so a test can assert what the abandoned render did not commit. */
+class Boundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  override state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  override componentDidCatch(_error: Error, _info: ErrorInfo) {}
+
+  override render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
+function Thrower({ abandon }: { abandon: boolean }): ReactNode {
+  if (abandon) throw new Error('abandon render');
+
+  return null;
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+});
+
+afterEach(() => {
+  cleanup();
+  thumbnailMocks.records.length = 0;
+  ResizeObserverStub.instances.length = 0;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function createThumbnailWrapper() {
+  return createPlayerWrapper({
+    chaptersCues: [],
+    thumbnailCues: [],
+    thumbnailTrackSrc: null,
+    thumbnailTrackCrossOrigin: null,
+    textTrackList: [],
+    subtitlesShowing: false,
+    toggleSubtitles: vi.fn(),
+    selectSubtitlesTrack: vi.fn(),
+  }).Wrapper;
+}
 
 /**
  * Render a thumbnail inside a player reporting the given media CORS mode and return the `crossorigin` attribute its
@@ -32,6 +118,165 @@ function renderCrossOrigin(
 }
 
 describe('Thumbnail', () => {
+  it('publishes the source to the handle only from committed renders', () => {
+    const Wrapper = createThumbnailWrapper();
+    const first = [{ url: 'first.jpg', startTime: 0 }];
+    const second = [{ url: 'second.jpg', startTime: 0 }];
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <Wrapper>
+        <Boundary>
+          <Thumbnail thumbnails={first} />
+          <Thrower abandon={false} />
+        </Boundary>
+      </Wrapper>
+    );
+    const record = thumbnailMocks.records.at(-1)!;
+
+    expect(record.updateSrc).toHaveBeenCalledWith('first.jpg');
+
+    rerender(
+      <Wrapper>
+        <Boundary>
+          <Thumbnail thumbnails={second} />
+          <Thrower abandon />
+        </Boundary>
+      </Wrapper>
+    );
+
+    expect(record.updateSrc).not.toHaveBeenCalledWith('second.jpg');
+  });
+
+  it('projects the loading state during server rendering without touching the handle', () => {
+    const Wrapper = createThumbnailWrapper();
+    const html = renderToString(
+      <Wrapper>
+        <Thumbnail thumbnails={[{ url: 'server.jpg', startTime: 0 }]} />
+      </Wrapper>
+    );
+    const record = thumbnailMocks.records.at(-1)!;
+
+    expect(html).toContain('data-loading=""');
+    expect(record.updateSrc).not.toHaveBeenCalled();
+  });
+
+  it('binds only the committed handle under StrictMode replay', () => {
+    const Wrapper = createThumbnailWrapper();
+
+    render(
+      <StrictMode>
+        <Wrapper>
+          <Thumbnail thumbnails={[{ url: 'strict.jpg', startTime: 0 }]} />
+        </Wrapper>
+      </StrictMode>
+    );
+
+    const bound = thumbnailMocks.records.filter(({ updateSrc }) => updateSrc.mock.calls.length > 0);
+
+    expect(bound).toHaveLength(1);
+    expect(bound[0]!.updateSrc).toHaveBeenCalledWith('strict.jpg');
+  });
+
+  it('settles an already-cached image during the layout commit', () => {
+    vi.spyOn(HTMLImageElement.prototype, 'complete', 'get').mockReturnValue(true);
+    vi.spyOn(HTMLImageElement.prototype, 'naturalWidth', 'get').mockReturnValue(640);
+    vi.spyOn(HTMLImageElement.prototype, 'naturalHeight', 'get').mockReturnValue(360);
+    const Wrapper = createThumbnailWrapper();
+
+    const { getByTestId } = render(
+      <Wrapper>
+        <Thumbnail data-testid="thumbnail" thumbnails={[{ url: 'cached.jpg', startTime: 0 }]} />
+      </Wrapper>
+    );
+
+    expect(getByTestId('thumbnail').hasAttribute('data-loading')).toBe(false);
+    expect(getByTestId('thumbnail').hasAttribute('data-error')).toBe(false);
+  });
+
+  it('shows the error state before paint when returning to a sheet that already failed', () => {
+    vi.spyOn(HTMLImageElement.prototype, 'complete', 'get').mockReturnValue(true);
+    vi.spyOn(HTMLImageElement.prototype, 'naturalWidth', 'get').mockReturnValue(0);
+    const Wrapper = createThumbnailWrapper();
+    const failing = [{ url: 'failing.jpg', startTime: 0 }];
+    const other = [{ url: 'other.jpg', startTime: 0 }];
+
+    const { getByTestId, rerender } = render(
+      <Wrapper>
+        <Thumbnail data-testid="thumbnail" thumbnails={failing} />
+      </Wrapper>
+    );
+
+    expect(getByTestId('thumbnail').hasAttribute('data-error')).toBe(true);
+
+    rerender(
+      <Wrapper>
+        <Thumbnail data-testid="thumbnail" thumbnails={other} />
+      </Wrapper>
+    );
+    rerender(
+      <Wrapper>
+        <Thumbnail data-testid="thumbnail" thumbnails={failing} />
+      </Wrapper>
+    );
+
+    expect(getByTestId('thumbnail').hasAttribute('data-error')).toBe(true);
+    expect(getByTestId('thumbnail').hasAttribute('data-loading')).toBe(false);
+  });
+
+  it('retargets image listeners and resize observation when a render override replaces the elements', () => {
+    vi.spyOn(HTMLImageElement.prototype, 'complete', 'get').mockReturnValue(false);
+    const Wrapper = createThumbnailWrapper();
+    const thumbnails = [{ url: 'same.jpg', startTime: 0 }];
+    const override = (version: string) =>
+      function renderThumbnail(props: HTMLProps) {
+        return (
+          <section {...props} key={version} data-testid={`container-${version}`}>
+            {props.children}
+          </section>
+        );
+      };
+    const { getByTestId, rerender } = render(
+      <Wrapper>
+        <Thumbnail render={override('first')} thumbnails={thumbnails} />
+      </Wrapper>
+    );
+    const firstContainer = getByTestId('container-first');
+    const firstImg = firstContainer.querySelector('img')!;
+    const firstObserver = ResizeObserverStub.instances.at(-1)!;
+
+    rerender(
+      <Wrapper>
+        <Thumbnail render={override('second')} thumbnails={thumbnails} />
+      </Wrapper>
+    );
+
+    const secondContainer = getByTestId('container-second');
+    const secondImg = secondContainer.querySelector('img')!;
+    const secondObserver = ResizeObserverStub.instances.at(-1)!;
+    const record = thumbnailMocks.records.at(-1)!;
+
+    expect(secondContainer).not.toBe(firstContainer);
+    expect(secondImg).not.toBe(firstImg);
+    expect(firstObserver.disconnect).toHaveBeenCalledOnce();
+    expect(secondObserver).not.toBe(firstObserver);
+    expect(secondObserver.observe).toHaveBeenCalledWith(secondContainer);
+
+    fireEvent.error(firstImg);
+
+    expect(secondContainer.hasAttribute('data-error')).toBe(false);
+
+    fireEvent.error(secondImg);
+
+    expect(secondContainer.hasAttribute('data-error')).toBe(true);
+
+    record.onStateChange.mockClear();
+    // SAFETY: The stub is what `new ResizeObserver()` returns here, and the callback ignores this argument.
+    secondObserver.callback([], secondObserver as unknown as ResizeObserver);
+
+    expect(record.onStateChange).toHaveBeenCalledOnce();
+  });
+
   describe('crossOrigin', () => {
     it('inherits the media element CORS mode when unset', () => {
       expect(renderCrossOrigin('anonymous')).toBe('anonymous');

--- a/packages/react/src/ui/thumbnail/thumbnail.tsx
+++ b/packages/react/src/ui/thumbnail/thumbnail.tsx
@@ -9,12 +9,16 @@ import { createThumbnail, selectTextTrack } from '@videojs/core/dom';
 import type { MediaTextTrackState } from '@videojs/media';
 import { isNull, isUndefined } from '@videojs/utils/predicate';
 import type { CSSProperties } from 'react';
-import { forwardRef, useMemo, useRef, useState } from 'react';
+import { forwardRef, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { useOptionalPlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { useDestroy } from '../../utils/use-destroy';
+import { useForceRender } from '../../utils/use-force-render';
 import { renderElement } from '../../utils/use-render';
+
+// `ThumbnailCore` holds no state, so one shared instance projects every render.
+const thumbnailCore = new ThumbnailCore();
 
 export interface ThumbnailProps extends UIComponentProps<'div', ThumbnailCore.State>, ThumbnailCore.Props {
   /** Pre-parsed thumbnail images — bypasses the automatic `<track>` detection. */
@@ -56,25 +60,22 @@ export const Thumbnail = forwardRef<HTMLDivElement, ThumbnailProps>(function Thu
     ...elementProps
   } = componentProps;
 
-  const [core] = useState(() => new ThumbnailCore());
-
   const divRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
-
+  const committedSrcRef = useRef('');
   const textTrack = useOptionalPlayer(selectTextTrack);
 
-  // Force re-render when the handle's state changes (img load/error, resize).
-  const [, setRenderToken] = useState(0);
-
+  // Re-render when the handle's state changes (img load/error, resize).
+  const forceRender = useForceRender();
   const [handle] = useState(() =>
     createThumbnail({
       getContainer: () => divRef.current,
       getImg: () => imgRef.current,
-      onStateChange: () => setRenderToken((n) => n + 1),
+      onStateChange: forceRender,
     })
   );
 
-  useDestroy(handle, () => handle.connect());
+  useDestroy(handle);
 
   // Resolve thumbnails: external prop takes priority over auto <track> path.
   const thumbnails = useMemo(() => {
@@ -85,14 +86,29 @@ export const Thumbnail = forwardRef<HTMLDivElement, ThumbnailProps>(function Thu
       : [];
   }, [externalThumbnails, textTrack]);
 
-  const thumbnail = useMemo(() => core.findActiveThumbnail(thumbnails, time), [core, thumbnails, time]);
+  const thumbnail = useMemo(() => thumbnailCore.findActiveThumbnail(thumbnails, time), [thumbnails, time]);
 
   const resolvedCrossOrigin = resolveCrossOrigin(crossOrigin, externalThumbnails, textTrack?.thumbnailTrackCrossOrigin);
+  const src = thumbnail?.url;
 
-  // Track src changes via the handle.
-  handle.updateSrc(thumbnail?.url);
+  // Project the requested source during render and publish it to the retained handle only once this render commits,
+  // so an abandoned render never restarts loading or rebinds listeners for a source that was never shown.
+  const srcPending = (src ?? '') !== committedSrcRef.current;
+  const projected = srcPending
+    ? { loading: Boolean(src), error: false }
+    : { loading: handle.loading, error: handle.error };
 
-  const state = core.getState(handle.loading, handle.error, thumbnail);
+  useLayoutEffect(() => {
+    handle.updateSrc(src);
+    committedSrcRef.current = src ?? '';
+    handle.connect();
+
+    // The handle can settle differently from the projection (e.g. a sheet already known to fail), so correct the
+    // committed tree before paint.
+    if (handle.loading !== projected.loading || handle.error !== projected.error) forceRender();
+  });
+
+  const state = thumbnailCore.getState(projected.loading, projected.error, thumbnail);
 
   // Compute styles declaratively from resize result.
   let containerStyle: CSSProperties = { overflow: 'hidden' };
@@ -100,7 +116,7 @@ export const Thumbnail = forwardRef<HTMLDivElement, ThumbnailProps>(function Thu
 
   if (thumbnail && handle.naturalWidth && handle.naturalHeight) {
     const constraints = handle.readConstraints();
-    const result = core.resize(thumbnail, handle.naturalWidth, handle.naturalHeight, constraints);
+    const result = thumbnailCore.resize(thumbnail, handle.naturalWidth, handle.naturalHeight, constraints);
 
     if (result) {
       containerStyle = {
@@ -126,7 +142,7 @@ export const Thumbnail = forwardRef<HTMLDivElement, ThumbnailProps>(function Thu
       stateAttrMap: ThumbnailDataAttrs,
       ref: [forwardedRef, divRef],
       props: [
-        core.getAttrs(state),
+        thumbnailCore.getAttrs(state),
         { style: containerStyle },
         elementProps,
         {
@@ -136,7 +152,7 @@ export const Thumbnail = forwardRef<HTMLDivElement, ThumbnailProps>(function Thu
               alt=""
               aria-hidden="true"
               decoding="async"
-              src={thumbnail?.url}
+              src={src}
               crossOrigin={resolvedCrossOrigin}
               loading={loading}
               style={imgStyle}


### PR DESCRIPTION
Refs #1679

Independent of the #2325 stack; based on `main`.

## Summary

`createThumbnail` bound its `load`/`error` listeners to the first `<img>` it saw and observed the first container, then never looked again. When a React `render` override (or any remount) replaces those nodes for the same source, the retained handle kept listening to detached elements, so load/error and resize updates stopped arriving. On the React side, `Thumbnail` also wrote the requested source into the retained handle during render, so an abandoned render could restart loading or rebind listeners for a source that was never shown.

## Changes

- `packages/core/src/dom/ui/thumbnail.ts`: retarget the img listeners and resize observation whenever `getImg()`/`getContainer()` return different elements; `destroy()` releases both. `connect()` now notifies only when settling an already-complete image actually changes state, so callers can connect on every commit. The failed-sheet memory from #2517 (`failedSrcs`/`markFailed`) is preserved unchanged.
- `packages/react/src/ui/thumbnail/thumbnail.tsx`: publish `updateSrc` and `connect` from a layout effect on every commit instead of during render and mount only; project the pending source's loading state during render and correct it before paint if the committed handle settles differently (for example a sheet already known to fail); share one stateless `ThumbnailCore` instance and use `useForceRender`.
- Tests: listener/observer retargeting and idempotent `connect()` in `packages/core/src/dom/ui/tests/thumbnail.test.ts`; committed-only source publication, SSR projection, StrictMode replay, cached-image settling, failed-sheet re-entry, and render-override retargeting in `packages/react/src/ui/thumbnail/tests/thumbnail.test.tsx`.

The HTML `<media-thumbnail>` element only calls `updateSrc` with a stable img and container, so its behaviour is unchanged.

## Testing

- `pnpm -F @videojs/core test`: 102 files, 1,493 tests passed (`src/dom/ui`: 16 files, 365 tests)
- `pnpm -F @videojs/react test`: 65 files, 544 tests passed
- `pnpm -F @videojs/html test src/ui/thumbnail`: 6 tests passed against the rebuilt core
- `pnpm build --filter=@videojs/core`, `pnpm build --filter=@videojs/react`
- `pnpm typecheck`
- `pnpm lint:fix:file` on touched files and `git diff --check`
