### PR TITLE
fix(react): make emitted declarations consumable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,11 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Check public declarations
+      - name: Check public declarations (html)
         run: pnpm exec vp run @videojs/html#check:public-types
+
+      - name: Check public declarations (react)
+        run: pnpm exec vp run @videojs/react#check:public-types
 
   test:
     needs: install

--- a/packages/react/src/presets/audio/index.ts
+++ b/packages/react/src/presets/audio/index.ts
@@ -2,7 +2,7 @@
 'use client';
 
 export { audioFeatures } from '@videojs/core/dom';
-export { Audio, type AudioProps } from '@/media/audio';
+export { Audio, type AudioProps } from '../../media/audio';
 export * from './minimal-skin';
 export * from './minimal-skin.tailwind';
 export { AudioPlayer, usePlayer } from './player';

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -22,8 +22,8 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { DEFAULT_SEEK_STEP } from '@/constants';
-import { useTranslator } from '@/i18n/context';
+import { DEFAULT_SEEK_STEP } from '../../constants';
+import { useTranslator } from '../../i18n/context';
 import {
   CheckIcon,
   PauseIcon,
@@ -34,26 +34,25 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons/minimal';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { Hotkey } from '@/ui/hotkey';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PlayButton } from '@/ui/play-button';
-import { usePlaybackRateOptions } from '@/ui/playback-rate';
-import { PlaybackRateButton } from '@/ui/playback-rate-button';
-import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '@/ui/playback-rate-radio-group';
-import { Popover } from '@/ui/popover';
-import { SeekButton } from '@/ui/seek-button';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { Time } from '@/ui/time';
-import { TimeSlider } from '@/ui/time-slider';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons/minimal';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { Hotkey } from '../../ui/hotkey';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PlayButton } from '../../ui/play-button';
+import { usePlaybackRateOptions } from '../../ui/playback-rate';
+import { PlaybackRateButton } from '../../ui/playback-rate-button';
+import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '../../ui/playback-rate-radio-group';
+import { Popover } from '../../ui/popover';
+import { SeekButton } from '../../ui/seek-button';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { Time } from '../../ui/time';
+import { TimeSlider } from '../../ui/time-slider';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { MinimalAudioSkinProps } from './minimal-skin';
 
 /* --------------------------------------- Components ---------------------------------------- */

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -4,8 +4,8 @@ import { playbackRateText } from '@videojs/core/i18n/text/menu';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { DEFAULT_SEEK_STEP } from '@/constants';
-import { useTranslator } from '@/i18n/context';
+import { DEFAULT_SEEK_STEP } from '../../constants';
+import { useTranslator } from '../../i18n/context';
 import {
   CheckIcon,
   PauseIcon,
@@ -16,26 +16,25 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons/minimal';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { Hotkey } from '@/ui/hotkey';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PlayButton } from '@/ui/play-button';
-import { usePlaybackRateOptions } from '@/ui/playback-rate';
-import { PlaybackRateButton } from '@/ui/playback-rate-button';
-import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '@/ui/playback-rate-radio-group';
-import { Popover } from '@/ui/popover';
-import { SeekButton } from '@/ui/seek-button';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { Time } from '@/ui/time';
-import { TimeSlider } from '@/ui/time-slider';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons/minimal';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { Hotkey } from '../../ui/hotkey';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PlayButton } from '../../ui/play-button';
+import { usePlaybackRateOptions } from '../../ui/playback-rate';
+import { PlaybackRateButton } from '../../ui/playback-rate-button';
+import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '../../ui/playback-rate-radio-group';
+import { Popover } from '../../ui/popover';
+import { SeekButton } from '../../ui/seek-button';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { Time } from '../../ui/time';
+import { TimeSlider } from '../../ui/time-slider';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { BaseSkinProps } from '../types';
 
 export type MinimalAudioSkinProps = BaseSkinProps;

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -22,8 +22,8 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { DEFAULT_SEEK_STEP } from '@/constants';
-import { useTranslator } from '@/i18n/context';
+import { DEFAULT_SEEK_STEP } from '../../constants';
+import { useTranslator } from '../../i18n/context';
 import {
   CheckIcon,
   PauseIcon,
@@ -34,26 +34,25 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { Hotkey } from '@/ui/hotkey';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PlayButton } from '@/ui/play-button';
-import { usePlaybackRateOptions } from '@/ui/playback-rate';
-import { PlaybackRateButton } from '@/ui/playback-rate-button';
-import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '@/ui/playback-rate-radio-group';
-import { Popover } from '@/ui/popover';
-import { SeekButton } from '@/ui/seek-button';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { Time } from '@/ui/time';
-import { TimeSlider } from '@/ui/time-slider';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { Hotkey } from '../../ui/hotkey';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PlayButton } from '../../ui/play-button';
+import { usePlaybackRateOptions } from '../../ui/playback-rate';
+import { PlaybackRateButton } from '../../ui/playback-rate-button';
+import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '../../ui/playback-rate-radio-group';
+import { Popover } from '../../ui/popover';
+import { SeekButton } from '../../ui/seek-button';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { Time } from '../../ui/time';
+import { TimeSlider } from '../../ui/time-slider';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { AudioSkinProps } from './skin';
 
 /* --------------------------------------- Components ---------------------------------------- */

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -4,8 +4,8 @@ import { playbackRateText } from '@videojs/core/i18n/text/menu';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { DEFAULT_SEEK_STEP } from '@/constants';
-import { useTranslator } from '@/i18n/context';
+import { DEFAULT_SEEK_STEP } from '../../constants';
+import { useTranslator } from '../../i18n/context';
 import {
   CheckIcon,
   PauseIcon,
@@ -16,26 +16,25 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { Hotkey } from '@/ui/hotkey';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PlayButton } from '@/ui/play-button';
-import { usePlaybackRateOptions } from '@/ui/playback-rate';
-import { PlaybackRateButton } from '@/ui/playback-rate-button';
-import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '@/ui/playback-rate-radio-group';
-import { Popover } from '@/ui/popover';
-import { SeekButton } from '@/ui/seek-button';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { Time } from '@/ui/time';
-import { TimeSlider } from '@/ui/time-slider';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { Hotkey } from '../../ui/hotkey';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PlayButton } from '../../ui/play-button';
+import { usePlaybackRateOptions } from '../../ui/playback-rate';
+import { PlaybackRateButton } from '../../ui/playback-rate-button';
+import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '../../ui/playback-rate-radio-group';
+import { Popover } from '../../ui/popover';
+import { SeekButton } from '../../ui/seek-button';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { Time } from '../../ui/time';
+import { TimeSlider } from '../../ui/time-slider';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { BaseSkinProps } from '../types';
 
 export type AudioSkinProps = BaseSkinProps;

--- a/packages/react/src/presets/background/index.ts
+++ b/packages/react/src/presets/background/index.ts
@@ -2,6 +2,6 @@
 'use client';
 
 export { backgroundFeatures } from '@videojs/core/dom';
-export { BackgroundVideo, type BackgroundVideoProps } from '@/media/background-video';
+export { BackgroundVideo, type BackgroundVideoProps } from '../../media/background-video';
 export { BackgroundVideoPlayer, usePlayer } from './player';
 export * from './skin';

--- a/packages/react/src/presets/live-audio/index.ts
+++ b/packages/react/src/presets/live-audio/index.ts
@@ -5,7 +5,7 @@
 'use client';
 
 export { liveAudioFeatures } from '@videojs/core/dom';
-export { Audio, type AudioProps } from '@/media/audio';
+export { Audio, type AudioProps } from '../../media/audio';
 export * from './minimal-skin';
 export * from './minimal-skin.tailwind';
 export { LiveAudioPlayer, usePlayer } from './player';

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -24,20 +24,19 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons/minimal';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { Hotkey } from '@/ui/hotkey';
-import { LiveButton } from '@/ui/live-button';
-import { MuteButton } from '@/ui/mute-button';
-import { PlayButton } from '@/ui/play-button';
-import { Popover } from '@/ui/popover';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons/minimal';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { Hotkey } from '../../ui/hotkey';
+import { LiveButton } from '../../ui/live-button';
+import { MuteButton } from '../../ui/mute-button';
+import { PlayButton } from '../../ui/play-button';
+import { Popover } from '../../ui/popover';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { MinimalLiveAudioSkinProps } from './minimal-skin';
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -11,20 +11,19 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons/minimal';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { Hotkey } from '@/ui/hotkey';
-import { LiveButton } from '@/ui/live-button';
-import { MuteButton } from '@/ui/mute-button';
-import { PlayButton } from '@/ui/play-button';
-import { Popover } from '@/ui/popover';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons/minimal';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { Hotkey } from '../../ui/hotkey';
+import { LiveButton } from '../../ui/live-button';
+import { MuteButton } from '../../ui/mute-button';
+import { PlayButton } from '../../ui/play-button';
+import { Popover } from '../../ui/popover';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { BaseSkinProps } from '../types';
 
 export type MinimalLiveAudioSkinProps = BaseSkinProps;

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -16,20 +16,27 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { PauseIcon, PlayIcon, RestartIcon, SpinnerIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { Hotkey } from '@/ui/hotkey';
-import { LiveButton } from '@/ui/live-button';
-import { MuteButton } from '@/ui/mute-button';
-import { PlayButton } from '@/ui/play-button';
-import { Popover } from '@/ui/popover';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+import {
+  PauseIcon,
+  PlayIcon,
+  RestartIcon,
+  SpinnerIcon,
+  VolumeHighIcon,
+  VolumeLowIcon,
+  VolumeOffIcon,
+} from '../../icons';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { Hotkey } from '../../ui/hotkey';
+import { LiveButton } from '../../ui/live-button';
+import { MuteButton } from '../../ui/mute-button';
+import { PlayButton } from '../../ui/play-button';
+import { Popover } from '../../ui/popover';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { LiveAudioSkinProps } from './skin';
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -3,20 +3,27 @@
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { PauseIcon, PlayIcon, RestartIcon, SpinnerIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { Hotkey } from '@/ui/hotkey';
-import { LiveButton } from '@/ui/live-button';
-import { MuteButton } from '@/ui/mute-button';
-import { PlayButton } from '@/ui/play-button';
-import { Popover } from '@/ui/popover';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+import {
+  PauseIcon,
+  PlayIcon,
+  RestartIcon,
+  SpinnerIcon,
+  VolumeHighIcon,
+  VolumeLowIcon,
+  VolumeOffIcon,
+} from '../../icons';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { Hotkey } from '../../ui/hotkey';
+import { LiveButton } from '../../ui/live-button';
+import { MuteButton } from '../../ui/mute-button';
+import { PlayButton } from '../../ui/play-button';
+import { Popover } from '../../ui/popover';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { BaseSkinProps } from '../types';
 
 export type LiveAudioSkinProps = BaseSkinProps;

--- a/packages/react/src/presets/live-video/index.ts
+++ b/packages/react/src/presets/live-video/index.ts
@@ -5,7 +5,7 @@
 'use client';
 
 export { liveVideoFeatures } from '@videojs/core/dom';
-export { Video, type VideoProps } from '@/media/video';
+export { Video, type VideoProps } from '../../media/video';
 export * from './minimal-skin';
 export * from './minimal-skin.tailwind';
 export { LiveVideoPlayer, usePlayer } from './player';

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -24,7 +24,7 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { useTranslator } from '@/i18n/context';
+import { useTranslator } from '../../i18n/context';
 import {
   AirPlayEnterIcon,
   AirPlayExitIcon,
@@ -44,32 +44,31 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons/minimal';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { AirPlayButton } from '@/ui/airplay-button';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { CaptionsButton } from '@/ui/captions-button';
-import { useCaptionsOptions } from '@/ui/captions-radio-group';
-import { CastButton } from '@/ui/cast-button';
-import { Controls } from '@/ui/controls';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { FullscreenButton } from '@/ui/fullscreen-button';
-import { Gesture } from '@/ui/gesture';
-import { Hotkey } from '@/ui/hotkey';
-import { LiveButton } from '@/ui/live-button';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PiPButton } from '@/ui/pip-button';
-import { PlayButton } from '@/ui/play-button';
-import { Popover } from '@/ui/popover';
-import { Poster } from '@/ui/poster';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { StatusIndicator } from '@/ui/status-indicator';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeIndicator } from '@/ui/volume-indicator';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons/minimal';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { AirPlayButton } from '../../ui/airplay-button';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { CaptionsButton } from '../../ui/captions-button';
+import { useCaptionsOptions } from '../../ui/captions-radio-group';
+import { CastButton } from '../../ui/cast-button';
+import { Controls } from '../../ui/controls';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { FullscreenButton } from '../../ui/fullscreen-button';
+import { Gesture } from '../../ui/gesture';
+import { Hotkey } from '../../ui/hotkey';
+import { LiveButton } from '../../ui/live-button';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PiPButton } from '../../ui/pip-button';
+import { PlayButton } from '../../ui/play-button';
+import { Popover } from '../../ui/popover';
+import { Poster } from '../../ui/poster';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { StatusIndicator } from '../../ui/status-indicator';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeIndicator } from '../../ui/volume-indicator';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { MinimalLiveVideoSkinProps } from './minimal-skin';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -4,7 +4,7 @@ import { captionsText } from '@videojs/core/i18n/text/menu';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { useTranslator } from '@/i18n/context';
+import { useTranslator } from '../../i18n/context';
 import {
   AirPlayEnterIcon,
   AirPlayExitIcon,
@@ -24,32 +24,31 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons/minimal';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { AirPlayButton } from '@/ui/airplay-button';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { CaptionsButton } from '@/ui/captions-button';
-import { useCaptionsOptions } from '@/ui/captions-radio-group';
-import { CastButton } from '@/ui/cast-button';
-import { Controls } from '@/ui/controls';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { FullscreenButton } from '@/ui/fullscreen-button';
-import { Gesture } from '@/ui/gesture';
-import { Hotkey } from '@/ui/hotkey';
-import { LiveButton } from '@/ui/live-button';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PiPButton } from '@/ui/pip-button';
-import { PlayButton } from '@/ui/play-button';
-import { Popover } from '@/ui/popover';
-import { Poster } from '@/ui/poster';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { StatusIndicator } from '@/ui/status-indicator';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeIndicator } from '@/ui/volume-indicator';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons/minimal';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { AirPlayButton } from '../../ui/airplay-button';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { CaptionsButton } from '../../ui/captions-button';
+import { useCaptionsOptions } from '../../ui/captions-radio-group';
+import { CastButton } from '../../ui/cast-button';
+import { Controls } from '../../ui/controls';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { FullscreenButton } from '../../ui/fullscreen-button';
+import { Gesture } from '../../ui/gesture';
+import { Hotkey } from '../../ui/hotkey';
+import { LiveButton } from '../../ui/live-button';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PiPButton } from '../../ui/pip-button';
+import { PlayButton } from '../../ui/play-button';
+import { Popover } from '../../ui/popover';
+import { Poster } from '../../ui/poster';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { StatusIndicator } from '../../ui/status-indicator';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeIndicator } from '../../ui/volume-indicator';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { BaseVideoSkinProps } from '../types';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -25,7 +25,7 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { useTranslator } from '@/i18n/context';
+import { useTranslator } from '../../i18n/context';
 import {
   AirPlayEnterIcon,
   AirPlayExitIcon,
@@ -45,32 +45,31 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { AirPlayButton } from '@/ui/airplay-button';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { CaptionsButton } from '@/ui/captions-button';
-import { useCaptionsOptions } from '@/ui/captions-radio-group';
-import { CastButton } from '@/ui/cast-button';
-import { Controls } from '@/ui/controls';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { FullscreenButton } from '@/ui/fullscreen-button';
-import { Gesture } from '@/ui/gesture';
-import { Hotkey } from '@/ui/hotkey';
-import { LiveButton } from '@/ui/live-button';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PiPButton } from '@/ui/pip-button';
-import { PlayButton } from '@/ui/play-button';
-import { Popover } from '@/ui/popover';
-import { Poster } from '@/ui/poster';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { StatusIndicator } from '@/ui/status-indicator';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeIndicator } from '@/ui/volume-indicator';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { AirPlayButton } from '../../ui/airplay-button';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { CaptionsButton } from '../../ui/captions-button';
+import { useCaptionsOptions } from '../../ui/captions-radio-group';
+import { CastButton } from '../../ui/cast-button';
+import { Controls } from '../../ui/controls';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { FullscreenButton } from '../../ui/fullscreen-button';
+import { Gesture } from '../../ui/gesture';
+import { Hotkey } from '../../ui/hotkey';
+import { LiveButton } from '../../ui/live-button';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PiPButton } from '../../ui/pip-button';
+import { PlayButton } from '../../ui/play-button';
+import { Popover } from '../../ui/popover';
+import { Poster } from '../../ui/poster';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { StatusIndicator } from '../../ui/status-indicator';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeIndicator } from '../../ui/volume-indicator';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { LiveVideoSkinProps } from './skin';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -4,7 +4,7 @@ import { captionsText } from '@videojs/core/i18n/text/menu';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { useTranslator } from '@/i18n/context';
+import { useTranslator } from '../../i18n/context';
 import {
   AirPlayEnterIcon,
   AirPlayExitIcon,
@@ -24,32 +24,31 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { AirPlayButton } from '@/ui/airplay-button';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { CaptionsButton } from '@/ui/captions-button';
-import { useCaptionsOptions } from '@/ui/captions-radio-group';
-import { CastButton } from '@/ui/cast-button';
-import { Controls } from '@/ui/controls';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { FullscreenButton } from '@/ui/fullscreen-button';
-import { Gesture } from '@/ui/gesture';
-import { Hotkey } from '@/ui/hotkey';
-import { LiveButton } from '@/ui/live-button';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PiPButton } from '@/ui/pip-button';
-import { PlayButton } from '@/ui/play-button';
-import { Popover } from '@/ui/popover';
-import { Poster } from '@/ui/poster';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { StatusIndicator } from '@/ui/status-indicator';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeIndicator } from '@/ui/volume-indicator';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { AirPlayButton } from '../../ui/airplay-button';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { CaptionsButton } from '../../ui/captions-button';
+import { useCaptionsOptions } from '../../ui/captions-radio-group';
+import { CastButton } from '../../ui/cast-button';
+import { Controls } from '../../ui/controls';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { FullscreenButton } from '../../ui/fullscreen-button';
+import { Gesture } from '../../ui/gesture';
+import { Hotkey } from '../../ui/hotkey';
+import { LiveButton } from '../../ui/live-button';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PiPButton } from '../../ui/pip-button';
+import { PlayButton } from '../../ui/play-button';
+import { Popover } from '../../ui/popover';
+import { Poster } from '../../ui/poster';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { StatusIndicator } from '../../ui/status-indicator';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeIndicator } from '../../ui/volume-indicator';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { BaseVideoSkinProps } from '../types';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;

--- a/packages/react/src/presets/types.ts
+++ b/packages/react/src/presets/types.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties, PropsWithChildren } from 'react';
 
-import type { Poster } from '@/ui/poster';
+import type { Poster } from '../ui/poster';
 
 /** Shared layout props for React skins, combined with any skin-specific props in `T`. */
 export type BaseSkinProps<T = unknown> = PropsWithChildren<

--- a/packages/react/src/presets/video/index.ts
+++ b/packages/react/src/presets/video/index.ts
@@ -2,7 +2,7 @@
 'use client';
 
 export { videoFeatures } from '@videojs/core/dom';
-export { Video, type VideoProps } from '@/media/video';
+export { Video, type VideoProps } from '../../media/video';
 export * from './minimal-skin';
 export * from './minimal-skin.tailwind';
 export { usePlayer, VideoPlayer } from './player';

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -35,7 +35,7 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { useTranslator } from '@/i18n/context';
+import { useTranslator } from '../../i18n/context';
 import {
   AirPlayEnterIcon,
   AirPlayExitIcon,
@@ -60,41 +60,40 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons/minimal';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { AirPlayButton } from '@/ui/airplay-button';
-import { useAudioTrackOptions } from '@/ui/audio-track';
-import { AudioTrackRadioGroup } from '@/ui/audio-track-radio-group';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { CaptionsButton } from '@/ui/captions-button';
-import { CaptionsRadioGroup, useCaptionsOptions } from '@/ui/captions-radio-group';
-import { CastButton } from '@/ui/cast-button';
-import { Controls } from '@/ui/controls';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { FullscreenButton } from '@/ui/fullscreen-button';
-import { Gesture } from '@/ui/gesture';
-import { Hotkey } from '@/ui/hotkey';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PiPButton } from '@/ui/pip-button';
-import { PlayButton } from '@/ui/play-button';
-import { usePlaybackRateOptions } from '@/ui/playback-rate';
-import { PlaybackRateRadioGroup } from '@/ui/playback-rate-radio-group';
-import { Popover } from '@/ui/popover';
-import { Poster } from '@/ui/poster';
-import { useQualityOptions } from '@/ui/quality';
-import { QualityRadioGroup } from '@/ui/quality-radio-group';
-import { SeekIndicator } from '@/ui/seek-indicator';
-import { Slider } from '@/ui/slider';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { StatusIndicator } from '@/ui/status-indicator';
-import { Time } from '@/ui/time';
-import { TimeSlider } from '@/ui/time-slider';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeIndicator } from '@/ui/volume-indicator';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons/minimal';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { AirPlayButton } from '../../ui/airplay-button';
+import { useAudioTrackOptions } from '../../ui/audio-track';
+import { AudioTrackRadioGroup } from '../../ui/audio-track-radio-group';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { CaptionsButton } from '../../ui/captions-button';
+import { CaptionsRadioGroup, useCaptionsOptions } from '../../ui/captions-radio-group';
+import { CastButton } from '../../ui/cast-button';
+import { Controls } from '../../ui/controls';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { FullscreenButton } from '../../ui/fullscreen-button';
+import { Gesture } from '../../ui/gesture';
+import { Hotkey } from '../../ui/hotkey';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PiPButton } from '../../ui/pip-button';
+import { PlayButton } from '../../ui/play-button';
+import { usePlaybackRateOptions } from '../../ui/playback-rate';
+import { PlaybackRateRadioGroup } from '../../ui/playback-rate-radio-group';
+import { Popover } from '../../ui/popover';
+import { Poster } from '../../ui/poster';
+import { useQualityOptions } from '../../ui/quality';
+import { QualityRadioGroup } from '../../ui/quality-radio-group';
+import { SeekIndicator } from '../../ui/seek-indicator';
+import { Slider } from '../../ui/slider';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { StatusIndicator } from '../../ui/status-indicator';
+import { Time } from '../../ui/time';
+import { TimeSlider } from '../../ui/time-slider';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeIndicator } from '../../ui/volume-indicator';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { MinimalVideoSkinProps } from './minimal-skin';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -11,7 +11,7 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { useTranslator } from '@/i18n/context';
+import { useTranslator } from '../../i18n/context';
 import {
   AirPlayEnterIcon,
   AirPlayExitIcon,
@@ -36,41 +36,40 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons/minimal';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { AirPlayButton } from '@/ui/airplay-button';
-import { useAudioTrackOptions } from '@/ui/audio-track';
-import { AudioTrackRadioGroup } from '@/ui/audio-track-radio-group';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { CaptionsButton } from '@/ui/captions-button';
-import { CaptionsRadioGroup, useCaptionsOptions } from '@/ui/captions-radio-group';
-import { CastButton } from '@/ui/cast-button';
-import { Controls } from '@/ui/controls';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { FullscreenButton } from '@/ui/fullscreen-button';
-import { Gesture } from '@/ui/gesture';
-import { Hotkey } from '@/ui/hotkey';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PiPButton } from '@/ui/pip-button';
-import { PlayButton } from '@/ui/play-button';
-import { usePlaybackRateOptions } from '@/ui/playback-rate';
-import { PlaybackRateRadioGroup } from '@/ui/playback-rate-radio-group';
-import { Popover } from '@/ui/popover';
-import { Poster } from '@/ui/poster';
-import { useQualityOptions } from '@/ui/quality';
-import { QualityRadioGroup } from '@/ui/quality-radio-group';
-import { SeekIndicator } from '@/ui/seek-indicator';
-import { Slider } from '@/ui/slider';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { StatusIndicator } from '@/ui/status-indicator';
-import { Time } from '@/ui/time';
-import { TimeSlider } from '@/ui/time-slider';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeIndicator } from '@/ui/volume-indicator';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons/minimal';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { AirPlayButton } from '../../ui/airplay-button';
+import { useAudioTrackOptions } from '../../ui/audio-track';
+import { AudioTrackRadioGroup } from '../../ui/audio-track-radio-group';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { CaptionsButton } from '../../ui/captions-button';
+import { CaptionsRadioGroup, useCaptionsOptions } from '../../ui/captions-radio-group';
+import { CastButton } from '../../ui/cast-button';
+import { Controls } from '../../ui/controls';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { FullscreenButton } from '../../ui/fullscreen-button';
+import { Gesture } from '../../ui/gesture';
+import { Hotkey } from '../../ui/hotkey';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PiPButton } from '../../ui/pip-button';
+import { PlayButton } from '../../ui/play-button';
+import { usePlaybackRateOptions } from '../../ui/playback-rate';
+import { PlaybackRateRadioGroup } from '../../ui/playback-rate-radio-group';
+import { Popover } from '../../ui/popover';
+import { Poster } from '../../ui/poster';
+import { useQualityOptions } from '../../ui/quality';
+import { QualityRadioGroup } from '../../ui/quality-radio-group';
+import { SeekIndicator } from '../../ui/seek-indicator';
+import { Slider } from '../../ui/slider';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { StatusIndicator } from '../../ui/status-indicator';
+import { Time } from '../../ui/time';
+import { TimeSlider } from '../../ui/time-slider';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeIndicator } from '../../ui/volume-indicator';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { BaseVideoSkinProps } from '../types';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -37,7 +37,7 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { useTranslator } from '@/i18n/context';
+import { useTranslator } from '../../i18n/context';
 import {
   AirPlayEnterIcon,
   AirPlayExitIcon,
@@ -62,41 +62,40 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { AirPlayButton } from '@/ui/airplay-button';
-import { useAudioTrackOptions } from '@/ui/audio-track';
-import { AudioTrackRadioGroup } from '@/ui/audio-track-radio-group';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { CaptionsButton } from '@/ui/captions-button';
-import { CaptionsRadioGroup, useCaptionsOptions } from '@/ui/captions-radio-group';
-import { CastButton } from '@/ui/cast-button';
-import { Controls } from '@/ui/controls';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { FullscreenButton } from '@/ui/fullscreen-button';
-import { Gesture } from '@/ui/gesture';
-import { Hotkey } from '@/ui/hotkey';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PiPButton } from '@/ui/pip-button';
-import { PlayButton } from '@/ui/play-button';
-import { usePlaybackRateOptions } from '@/ui/playback-rate';
-import { PlaybackRateRadioGroup } from '@/ui/playback-rate-radio-group';
-import { Popover } from '@/ui/popover';
-import { Poster } from '@/ui/poster';
-import { useQualityOptions } from '@/ui/quality';
-import { QualityRadioGroup } from '@/ui/quality-radio-group';
-import { SeekIndicator } from '@/ui/seek-indicator';
-import { Slider } from '@/ui/slider';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { StatusIndicator } from '@/ui/status-indicator';
-import { Time } from '@/ui/time';
-import { TimeSlider } from '@/ui/time-slider';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeIndicator } from '@/ui/volume-indicator';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { AirPlayButton } from '../../ui/airplay-button';
+import { useAudioTrackOptions } from '../../ui/audio-track';
+import { AudioTrackRadioGroup } from '../../ui/audio-track-radio-group';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { CaptionsButton } from '../../ui/captions-button';
+import { CaptionsRadioGroup, useCaptionsOptions } from '../../ui/captions-radio-group';
+import { CastButton } from '../../ui/cast-button';
+import { Controls } from '../../ui/controls';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { FullscreenButton } from '../../ui/fullscreen-button';
+import { Gesture } from '../../ui/gesture';
+import { Hotkey } from '../../ui/hotkey';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PiPButton } from '../../ui/pip-button';
+import { PlayButton } from '../../ui/play-button';
+import { usePlaybackRateOptions } from '../../ui/playback-rate';
+import { PlaybackRateRadioGroup } from '../../ui/playback-rate-radio-group';
+import { Popover } from '../../ui/popover';
+import { Poster } from '../../ui/poster';
+import { useQualityOptions } from '../../ui/quality';
+import { QualityRadioGroup } from '../../ui/quality-radio-group';
+import { SeekIndicator } from '../../ui/seek-indicator';
+import { Slider } from '../../ui/slider';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { StatusIndicator } from '../../ui/status-indicator';
+import { Time } from '../../ui/time';
+import { TimeSlider } from '../../ui/time-slider';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeIndicator } from '../../ui/volume-indicator';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { VideoSkinProps } from './skin';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -11,7 +11,7 @@ import {
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { useTranslator } from '@/i18n/context';
+import { useTranslator } from '../../i18n/context';
 import {
   AirPlayEnterIcon,
   AirPlayExitIcon,
@@ -36,41 +36,40 @@ import {
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
-} from '@/icons';
-import { Container } from '@/player/container';
-import { usePlayer } from '@/player/context';
-import { AirPlayButton } from '@/ui/airplay-button';
-import { useAudioTrackOptions } from '@/ui/audio-track';
-import { AudioTrackRadioGroup } from '@/ui/audio-track-radio-group';
-import { BufferingIndicator } from '@/ui/buffering-indicator';
-import { CaptionsButton } from '@/ui/captions-button';
-import { CaptionsRadioGroup, useCaptionsOptions } from '@/ui/captions-radio-group';
-import { CastButton } from '@/ui/cast-button';
-import { Controls } from '@/ui/controls';
-import { ErrorDialog } from '@/ui/error-dialog';
-import { FullscreenButton } from '@/ui/fullscreen-button';
-import { Gesture } from '@/ui/gesture';
-import { Hotkey } from '@/ui/hotkey';
-import { Menu } from '@/ui/menu';
-import { MuteButton } from '@/ui/mute-button';
-import { PiPButton } from '@/ui/pip-button';
-import { PlayButton } from '@/ui/play-button';
-import { usePlaybackRateOptions } from '@/ui/playback-rate';
-import { PlaybackRateRadioGroup } from '@/ui/playback-rate-radio-group';
-import { Popover } from '@/ui/popover';
-import { Poster } from '@/ui/poster';
-import { useQualityOptions } from '@/ui/quality';
-import { QualityRadioGroup } from '@/ui/quality-radio-group';
-import { SeekIndicator } from '@/ui/seek-indicator';
-import { Slider } from '@/ui/slider';
-import { StatusAnnouncer } from '@/ui/status-announcer';
-import { StatusIndicator } from '@/ui/status-indicator';
-import { Time } from '@/ui/time';
-import { TimeSlider } from '@/ui/time-slider';
-import { Tooltip } from '@/ui/tooltip';
-import { VolumeIndicator } from '@/ui/volume-indicator';
-import { VolumeSlider } from '@/ui/volume-slider';
-
+} from '../../icons';
+import { Container } from '../../player/container';
+import { usePlayer } from '../../player/context';
+import { AirPlayButton } from '../../ui/airplay-button';
+import { useAudioTrackOptions } from '../../ui/audio-track';
+import { AudioTrackRadioGroup } from '../../ui/audio-track-radio-group';
+import { BufferingIndicator } from '../../ui/buffering-indicator';
+import { CaptionsButton } from '../../ui/captions-button';
+import { CaptionsRadioGroup, useCaptionsOptions } from '../../ui/captions-radio-group';
+import { CastButton } from '../../ui/cast-button';
+import { Controls } from '../../ui/controls';
+import { ErrorDialog } from '../../ui/error-dialog';
+import { FullscreenButton } from '../../ui/fullscreen-button';
+import { Gesture } from '../../ui/gesture';
+import { Hotkey } from '../../ui/hotkey';
+import { Menu } from '../../ui/menu';
+import { MuteButton } from '../../ui/mute-button';
+import { PiPButton } from '../../ui/pip-button';
+import { PlayButton } from '../../ui/play-button';
+import { usePlaybackRateOptions } from '../../ui/playback-rate';
+import { PlaybackRateRadioGroup } from '../../ui/playback-rate-radio-group';
+import { Popover } from '../../ui/popover';
+import { Poster } from '../../ui/poster';
+import { useQualityOptions } from '../../ui/quality';
+import { QualityRadioGroup } from '../../ui/quality-radio-group';
+import { SeekIndicator } from '../../ui/seek-indicator';
+import { Slider } from '../../ui/slider';
+import { StatusAnnouncer } from '../../ui/status-announcer';
+import { StatusIndicator } from '../../ui/status-indicator';
+import { Time } from '../../ui/time';
+import { TimeSlider } from '../../ui/time-slider';
+import { Tooltip } from '../../ui/tooltip';
+import { VolumeIndicator } from '../../ui/volume-indicator';
+import { VolumeSlider } from '../../ui/volume-slider';
 import type { BaseVideoSkinProps } from '../types';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;

--- a/packages/react/src/ui/create-context-part.tsx
+++ b/packages/react/src/ui/create-context-part.tsx
@@ -2,8 +2,7 @@ import type { StateAttrMap } from '@videojs/core';
 import type { ForwardRefExoticComponent } from 'react';
 import { forwardRef } from 'react';
 
-import type { UIComponentProps } from '@/utils/types';
-
+import type { UIComponentProps } from '../utils/types';
 import type { renderElement as renderElementFn } from '../utils/use-render';
 import { renderElement } from '../utils/use-render';
 

--- a/packages/react/tests/public-types/index.tsx
+++ b/packages/react/tests/public-types/index.tsx
@@ -1,0 +1,163 @@
+/**
+ * Strict consumer of the emitted `@videojs/react` declarations.
+ *
+ * Resolves the package through its own `exports` map, so every import below lands on `dist/dev/**.d.ts` rather than
+ * source. `skipLibCheck: false` makes the compiler check those declaration files themselves, which is what a strict
+ * downstream project sees and what the source typecheck cannot observe.
+ *
+ * The Mux entries (`media/mux-*`, `extensions/mux-data`) stay out until `@videojs/media/dom/mux` stops leaking
+ * `mux-embed` types, which that package does not publish through `types`.
+ */
+import type { PlayerStore, UIComponentProps, VideoPlayerStore } from '@videojs/react';
+import {
+  Container,
+  createPlayer,
+  Menu,
+  mergeProps,
+  PlayButton,
+  type PlayButtonProps,
+  Poster,
+  selectPlayback,
+  Slider,
+  StatusAnnouncer,
+  Time,
+  TimeSlider,
+  Tooltip,
+  usePlayer,
+  useStore,
+  videoFeatures,
+} from '@videojs/react';
+import { AudioPlayer, AudioSkin, usePlayer as useAudioPlayer } from '@videojs/react/audio';
+import { BackgroundVideoPlayer, usePlayer as useBackgroundPlayer } from '@videojs/react/background';
+import { GoogleCast } from '@videojs/react/extensions/google-cast';
+import { createI18n, I18nProvider, type Locale, useTranslator } from '@videojs/react/i18n';
+import '@videojs/react/i18n/locales/en/register';
+import { type IconProps, PlayIcon } from '@videojs/react/icons';
+import { PlayIcon as MinimalPlayIcon } from '@videojs/react/icons/minimal';
+import { LiveAudioPlayer, usePlayer as useLiveAudioPlayer } from '@videojs/react/live-audio';
+import { LiveVideoPlayer, LiveVideoSkin, usePlayer as useLiveVideoPlayer } from '@videojs/react/live-video';
+import { HlsVideo } from '@videojs/react/media/hls-video';
+import {
+  MinimalVideoSkin,
+  usePlayer as useVideoPlayer,
+  Video,
+  VideoPlayer,
+  VideoSkin,
+  type VideoSkinProps,
+} from '@videojs/react/video';
+import type { ComponentProps, ReactNode } from 'react';
+
+type Extends<A, B extends A> = B;
+
+// createPlayer returns the provider plus hooks typed by the selected features.
+const { Player, usePlayer: useBoundPlayer, useMedia } = createPlayer({ features: videoFeatures });
+
+function BoundConsumer(): ReactNode {
+  const store: VideoPlayerStore = useBoundPlayer();
+  const paused: boolean = useBoundPlayer((state) => state.paused);
+  const media = useMedia();
+
+  return <span data-paused={paused} data-media={media !== null} data-store={store.destroyed} />;
+}
+
+// Root hooks stay generic; selectors and store bindings resolve through the barrel.
+function GenericConsumer(): ReactNode {
+  const store = usePlayer();
+  const paused = usePlayer((state) => selectPlayback(state)?.paused ?? true);
+  const playback = useStore(store, selectPlayback);
+  const translate = useTranslator();
+
+  return <span data-paused={paused} data-from-store={playback?.paused} title={translate('Play')} />;
+}
+
+// Component props types are usable both as annotations and through the namespace shorthand.
+const playButtonProps: PlayButtonProps = {
+  className: (state) => (state.paused ? 'paused' : 'playing'),
+  render: (props, state) => <button {...props} data-paused={state.paused} />,
+};
+const posterProps: Poster.Props = { render: (props) => <img {...props} alt="" /> };
+const iconProps: IconProps = { width: 24 };
+const merged: ComponentProps<'button'> = mergeProps({ className: 'a' }, { className: 'b' });
+
+function Preset(): ReactNode {
+  const skinProps: VideoSkinProps = { renderPoster: posterProps.render };
+
+  return (
+    <I18nProvider>
+      <VideoPlayer title="Title">
+        <VideoSkin {...skinProps}>
+          <Video src="video.mp4" />
+          <GoogleCast />
+        </VideoSkin>
+        <MinimalVideoSkin>
+          <HlsVideo src="stream.m3u8" />
+        </MinimalVideoSkin>
+      </VideoPlayer>
+      <AudioPlayer>
+        <AudioSkin />
+      </AudioPlayer>
+      <LiveVideoPlayer>
+        <LiveVideoSkin />
+      </LiveVideoPlayer>
+      <LiveAudioPlayer>{null}</LiveAudioPlayer>
+      <BackgroundVideoPlayer>{null}</BackgroundVideoPlayer>
+    </I18nProvider>
+  );
+}
+
+// Every preset hook must resolve its store through the public feature types, not a synthesized barrel namespace.
+function PresetHooks(): ReactNode {
+  const liveEdgeStart: number = useLiveVideoPlayer((state) => state.liveEdgeStart);
+  const liveAudioEdgeStart: number = useLiveAudioPlayer((state) => state.liveEdgeStart);
+  // The background preset selects no features yet, so its store carries no feature state.
+  const background: PlayerStore<[]> = useBackgroundPlayer();
+
+  return <span data-live={liveEdgeStart} data-live-audio={liveAudioEdgeStart} data-background={background.destroyed} />;
+}
+
+function Composed(): ReactNode {
+  return (
+    <Player>
+      <Container>
+        <PlayButton {...playButtonProps}>
+          <PlayIcon {...iconProps} />
+          <MinimalPlayIcon />
+        </PlayButton>
+        <Tooltip.Root>
+          <Tooltip.Trigger />
+          <Tooltip.Popup>
+            <Tooltip.Label>Play</Tooltip.Label>
+          </Tooltip.Popup>
+        </Tooltip.Root>
+        <TimeSlider.Root>
+          <TimeSlider.Track>
+            <TimeSlider.Fill />
+          </TimeSlider.Track>
+        </TimeSlider.Root>
+        <Slider.Root>
+          <Slider.Thumb />
+        </Slider.Root>
+        <Time.Group>
+          <Time.Value type="current" />
+        </Time.Group>
+        <Menu.Root>
+          <Menu.Trigger />
+        </Menu.Root>
+        <StatusAnnouncer closeDelay={500} />
+      </Container>
+    </Player>
+  );
+}
+
+// Relationships the declarations must preserve; a broken constraint is a compile error.
+export type PublicTypeAssertions = [
+  Extends<PlayerStore, VideoPlayerStore>,
+  Extends<UIComponentProps<'button', PlayButton.State>, PlayButtonProps>,
+  Extends<ReturnType<typeof useVideoPlayer>, ReturnType<typeof useBoundPlayer>>,
+  Extends<ReturnType<typeof useAudioPlayer>, PlayerStore>,
+];
+
+const locale: Locale = 'en';
+const i18n = createI18n();
+
+void [BoundConsumer, GenericConsumer, Preset, PresetHooks, Composed, merged, locale, i18n];

--- a/packages/react/tests/public-types/tsconfig.json
+++ b/packages/react/tests/public-types/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "incremental": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": false,
+    "strict": true,
+    "target": "ES2022",
+    "types": [],
+    "verbatimModuleSyntax": true
+  },
+  "include": ["index.tsx"]
+}

--- a/packages/react/tsconfig.dts.json
+++ b/packages/react/tsconfig.dts.json
@@ -5,10 +5,7 @@
     "incremental": false,
     "jsx": "react-jsx",
     "jsxImportSource": "react",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "lib": ["ES2020", "DOM", "DOM.Iterable"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -4,9 +4,6 @@
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "declarationDir": "types"
   },
   "include": ["src"],

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -10,8 +10,6 @@ import { cachedTaskInputs, packageTestTask, workspaceTaskDependencies } from '..
 import { LOCALES, localeAliases } from '../core/src/core/i18n/locales.ts';
 
 const skinsDir = resolve(dirname(fileURLToPath(import.meta.url)), '../skins/src');
-const srcDir = new URL('./src', import.meta.url).pathname;
-const srcAlias = { '@': srcDir };
 const localeTags = [...LOCALES, ...localeAliases(LOCALES)];
 
 const i18nLocaleEntries = Object.fromEntries([
@@ -32,7 +30,6 @@ const createPackConfig = (mode: PackageBuildMode): PackUserConfig => ({
   deps: {
     alwaysBundle: [/^@videojs\/skins/],
   },
-  alias: srcAlias,
   plugins: [copyCssPlugin({ skinsDir, outDir: `dist/${mode}`, rebuild: false })],
 });
 
@@ -45,6 +42,13 @@ export default defineConfig({
         input: cachedTaskInputs,
         output: ['dist/**'],
       },
+      'check:public-types': {
+        // Compiles a strict consumer (`skipLibCheck: false`) against the emitted declarations through the package
+        // `exports` map. The source typecheck cannot see what the dts pipeline emits, so this is the only place a
+        // consumer-facing declaration error surfaces before publish.
+        command: 'tsgo --project tests/public-types/tsconfig.json',
+        dependsOn: ['build'],
+      },
       'test:ci': packageTestTask(),
     },
   },
@@ -52,7 +56,6 @@ export default defineConfig({
     __DEV__: 'true',
   },
   resolve: {
-    alias: srcAlias,
     // These tests run in a simulated browser, but Vitest transforms through the SSR pipeline, where `browser`
     // is not a resolve condition. Without it a dependency that answers `browser` separately — `@videojs/media`
     // does, for the medias whose engine has a server build — hands its server stand-in to a jsdom suite.


### PR DESCRIPTION
Refs #2369
Depends on #2248

## Summary

Applies the #2248 declaration fix to `@videojs/react`. The package had the same `@/*` `paths` alias as `@videojs/html`, and the same emitter behaviour: tsgo resolved the preset player store types through `@/index`, the dts plugin synthesized an `index_d_exports` namespace for that barrel, and because that namespace drops `export *` re-exports every preset `usePlayer` hook failed to type-check in a strict consumer. This PR removes the alias, adds a strict consumer fixture that compiles against the emitted `dist/dev` declarations through the package `exports` map, and wires it into CI beside the html check.

## Changes

What the fixture found against the unmodified build (`tsgo --project packages/react/tests/public-types/tsconfig.json`):

```
packages/react/dist/dev/presets/audio/player.d.ts(10,42): error TS2694: Namespace 'index_d_exports' has no exported member 'AudioPlayerStore'.
packages/react/dist/dev/presets/video/player.d.ts(10,42): error TS2694: Namespace 'index_d_exports' has no exported member 'VideoPlayerStore'.
```

All five preset `player.d.ts` files carried the same shape (`index_d_exports.VideoPlayerStore`, `index_d_exports.AudioPlayerStore`, `index_d_exports.PlayerStore<index_d_exports.LiveVideoFeatures>`, `index_d_exports.PlayerStore<index_d_exports.LiveAudioFeatures>`, `index_d_exports.PlayerStore<[]>`); the fixture initially only imported two of them, so it now exercises every preset hook. No leaked third-party specifiers and no dropped `@ts-expect-error` suppressions were found in the react declarations; the only non-workspace specifier in `dist/dev/**/*.d.ts` is `react`.

- `packages/react/src/**`: rewrite all 387 `@/` imports (23 files, all under `src/presets/` plus `src/ui/create-context-part.tsx`) to relative paths.
- `packages/react/tsconfig.json`, `packages/react/tsconfig.dts.json`: drop the `@/*` `paths` alias.
- `packages/react/vite.config.ts`: drop the now-unused `srcAlias` from the pack config and the vitest `resolve.alias`; add the `check:public-types` task (`dependsOn: ['build']`) mirroring html.
- `packages/react/tests/public-types/{index.tsx,tsconfig.json}`: strict consumer (`strict`, `skipLibCheck: false`, `moduleResolution: bundler`, `jsx: react-jsx`, `types: []`) importing the root entry plus `audio`, `background`, `extensions/google-cast`, `i18n`, `i18n/locales/en/register`, `icons`, `icons/minimal`, `live-audio`, `live-video`, `media/hls-video`, and `video`. It exercises `createPlayer` and every preset `usePlayer` with selectors, `usePlayer`/`useStore` with `selectPlayback`, component props (`PlayButtonProps`, `Poster.Props`, `VideoSkinProps`), compound parts (`Tooltip`, `TimeSlider`, `Slider`, `Time`, `Menu`), and a few `Extends` assertions.
- `.github/workflows/ci.yml`: add `pnpm exec vp run @videojs/react#check:public-types` next to the html step (the html step is renamed to `Check public declarations (html)` so the two are distinguishable).

After the alias removal the emitted preset declarations reference `import("@videojs/core/dom").VideoPlayerStore` and friends directly, and the fixture passes with no explicit type re-exports added.

### Out of scope, surfaced by the fixture

`@videojs/media/dom/mux` leaks `mux-embed` types into its emitted declarations. `packages/media/dist/dev/dom/mux/types.d.ts` carries a `/// <reference path="../../../../../Users/.../packages/media/node_modules/mux-embed/dist/types/mux-embed.d.ts" />` (an absolute build-machine path mangled into a relative one) and `mux-data.d.ts` uses `import("mux-embed").Metadata`, but `mux-embed` publishes no `types` entry, so a strict consumer gets TS6053 and TS7016 through any `@videojs/react/media/mux-*` or `@videojs/react/extensions/mux-data` import (the html equivalents have the same exposure; the html fixture just does not import them). That is a `@videojs/media` fix, so the react fixture leaves the Mux entries out with a note and this PR does not touch `packages/media`.

## Testing

- `pnpm exec tsgo --project packages/react/tests/public-types/tsconfig.json` against the unmodified build: 2 errors (above).
- `pnpm exec vp run @videojs/react#build`: pass; `grep -rn 'index_d_exports\.' packages/react/dist/dev` now returns nothing.
- `pnpm exec vp run @videojs/react#check:public-types`: pass; second run is a 14/14 cache hit and replays.
- `pnpm -F @videojs/react test`: 65 files, 538 tests passed.
- `pnpm lint:fix:file` on every touched file: 0 errors (4 pre-existing `require-safety-comment-for-type-assertion` warnings in `create-context-part.tsx`, untouched).
- `pnpm typecheck` after deleting `packages/*/tsconfig*.tsbuildinfo` and `packages/*/types`: pass.
- `pnpm check:workspace`: 10 passed.
- `git diff --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
