### PR TITLE
fix(react): project slider state per render

### DIFF
--- a/packages/react/src/ui/hooks/use-slider.ts
+++ b/packages/react/src/ui/hooks/use-slider.ts
@@ -13,9 +13,8 @@ import { applyStyles } from '@videojs/utils/dom';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { useOptionalPlayer } from '../../player/context';
+import { useCommittedRef } from '../../utils/use-committed-ref';
 import { useDestroy } from '../../utils/use-destroy';
-import { useForceRender } from '../../utils/use-force-render';
-import { useLatestRef } from '../../utils/use-latest-ref';
 
 export interface UseSliderOptions<State extends SliderState = SliderState> extends Pick<
   SliderOptions,
@@ -59,7 +58,8 @@ export interface UseSliderReturnValue<State extends SliderState = SliderState> {
 export function useSlider<State extends SliderState = SliderState>(
   options: UseSliderOptions<State>
 ): UseSliderReturnValue<State> {
-  const optionsRef = useLatestRef(options);
+  // The retained slider reads options through this ref, so only committed renders reach its callbacks.
+  const optionsRef = useCommittedRef(options);
 
   const controls = useOptionalPlayer(selectControls);
   const requestControlsLock = controls?.requestControlsLock;
@@ -74,7 +74,6 @@ export function useSlider<State extends SliderState = SliderState>(
 
   const rootElementRef = useRef<HTMLElement | null>(null);
   const thumbElementRef = useRef<HTMLElement | null>(null);
-  const forceRender = useForceRender();
 
   // Lazy-init the slider handle. Stable across re-renders.
   const [slider] = useState<SliderApi>(() => {
@@ -87,7 +86,10 @@ export function useSlider<State extends SliderState = SliderState>(
       getStepPercent: () => optionsRef.current.getStepPercent(),
       getLargeStepPercent: () => optionsRef.current.getLargeStepPercent(),
       changeThrottle: optionsRef.current.changeThrottle,
-      adjustPercent: optionsRef.current.adjustPercent,
+      adjustPercent: optionsRef.current.adjustPercent
+        ? (rawPercent, thumbSize, trackSize) =>
+            optionsRef.current.adjustPercent?.(rawPercent, thumbSize, trackSize) ?? rawPercent
+        : undefined,
       onValueChange: (percent) => optionsRef.current.onValueChange?.(percent),
       onValueCommit: (percent) => optionsRef.current.onValueCommit?.(percent),
       onPressStart: () => {
@@ -119,14 +121,6 @@ export function useSlider<State extends SliderState = SliderState>(
   // Compute derived state from input + caller-provided projection.
   const state = options.computeState(input);
 
-  // Force a synchronous re-render after mount so edge thumb alignment
-  // can read DOM measurements from the now-populated element refs.
-  useLayoutEffect(() => {
-    if (state.thumbAlignment === 'edge' && rootElementRef.current && thumbElementRef.current) {
-      forceRender();
-    }
-  }, [state.thumbAlignment]);
-
   // Adjust CSS var percents for edge thumb alignment using live DOM measurements.
   const cssVars = options.getCSSVars(slider.adjustForAlignment(state));
 
@@ -141,10 +135,14 @@ export function useSlider<State extends SliderState = SliderState>(
     [slider]
   );
 
+  useLayoutEffect(() => slider.input.subscribe(syncStyles), [slider, syncStyles]);
+
+  // Edge alignment needs DOM measurements that only exist after commit, and the render above adjusted percents
+  // through the previously committed options. Re-apply the committed CSS vars on mount and whenever alignment
+  // changes so the DOM never keeps a stale adjustment.
   useLayoutEffect(() => {
     syncStyles();
-    return slider.input.subscribe(syncStyles);
-  }, [slider, syncStyles]);
+  }, [syncStyles, state.thumbAlignment]);
 
   // Ref callbacks for root and thumb elements.
   const rootRef = useCallback(

--- a/packages/react/src/ui/slider/slider-root.tsx
+++ b/packages/react/src/ui/slider/slider-root.tsx
@@ -2,7 +2,7 @@ import { SliderCore, SliderDataAttrs } from '@videojs/core';
 import { getSliderCSSVars } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';
 import type { ForwardedRef } from 'react';
-import { forwardRef, useState } from 'react';
+import { forwardRef } from 'react';
 
 import { useTranslator } from '../../i18n/context';
 import type { UIComponentProps } from '../../utils/types';
@@ -41,10 +41,9 @@ export const SliderRoot = forwardRef(function SliderRoot(
     ...elementProps
   } = componentProps;
 
-  const [core] = useState(() => new SliderCore());
+  // Project this render's props. The core is render-local, so the retained slider only ever sees the committed one.
+  const core = new SliderCore({ label, min, max, step, largeStep, orientation, disabled, thumbAlignment });
   const translator = useTranslator();
-
-  core.setProps({ label, min, max, step, largeStep, orientation, disabled, thumbAlignment });
 
   const {
     state,

--- a/packages/react/src/ui/slider/tests/slider.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider.test.tsx
@@ -1,8 +1,8 @@
 import { cleanup, fireEvent, render } from '@testing-library/react';
-import { createRef } from 'react';
+import { createRef, StrictMode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
-import { createPlayerWrapper } from '../../../testing/mocks';
+import { createPlayerWrapper, MockErrorBoundary } from '../../../testing/mocks';
 import { SliderBuffer } from '../slider-buffer';
 import { SliderFill } from '../slider-fill';
 import { SliderRoot } from '../slider-root';
@@ -10,40 +10,50 @@ import { SliderThumb } from '../slider-thumb';
 import { SliderTrack } from '../slider-track';
 import { SliderValue } from '../slider-value';
 
-const { mockSliderApi, sliderOptionsRef } = vi.hoisted(() => {
-  const sliderOptionsRef: {
-    current:
-      | {
-          onPressStart?: () => void;
-          onPressEnd?: () => void;
-          onDragStart?: () => void;
-          onDragEnd?: () => void;
-        }
-      | undefined;
-  } = { current: undefined };
+const { mockSliderApi, sliderOptionsRef, sliderInputRef } = vi.hoisted(() => {
+  interface MockSliderOptions {
+    getElement?: () => HTMLElement;
+    getThumbElement?: () => HTMLElement | null;
+    isDisabled?: () => boolean;
+    getPercent?: () => number;
+    adjustPercent?: (raw: number, thumb: number, track: number) => number;
+    onValueChange?: (percent: number) => void;
+    onValueCommit?: (percent: number) => void;
+    onPressStart?: () => void;
+    onPressEnd?: () => void;
+    onDragStart?: () => void;
+    onDragEnd?: () => void;
+  }
+
+  interface MockSliderInput {
+    pointerPercent: number;
+    dragPercent: number;
+    dragging: boolean;
+    pointing: boolean;
+    focused: boolean;
+  }
+
+  const sliderOptionsRef: { current: MockSliderOptions | undefined } = { current: undefined };
+  const sliderInputRef: { current: MockSliderInput | undefined } = { current: undefined };
 
   return {
     sliderOptionsRef,
-    mockSliderApi: (options?: {
-      getElement?: () => HTMLElement;
-      getThumbElement?: () => HTMLElement | null;
-      adjustPercent?: (raw: number, thumb: number, track: number) => number;
-      onPressStart?: () => void;
-      onPressEnd?: () => void;
-      onDragStart?: () => void;
-      onDragEnd?: () => void;
-    }) => {
+    sliderInputRef,
+    mockSliderApi: (options?: MockSliderOptions) => {
+      const input: MockSliderInput = {
+        pointerPercent: 0,
+        dragPercent: 0,
+        dragging: false,
+        pointing: false,
+        focused: false,
+      };
+
       sliderOptionsRef.current = options;
+      sliderInputRef.current = input;
 
       return {
         input: {
-          current: {
-            pointerPercent: 0,
-            dragPercent: 0,
-            dragging: false,
-            pointing: false,
-            focused: false,
-          },
+          current: input,
           subscribe: vi.fn(() => vi.fn()),
         },
         rootProps: {
@@ -94,7 +104,14 @@ vi.mock('@videojs/store/react', () => ({
   ),
 }));
 
-afterEach(cleanup);
+function Throw(): null {
+  throw new Error('abandon render');
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe('SliderRoot', () => {
   it('renders a div element', () => {
@@ -153,6 +170,119 @@ describe('SliderRoot', () => {
 
     sliderOptionsRef.current?.onPressEnd?.();
     expect(releaseControlsLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps holding the controls lock across re-renders during a press', () => {
+    const releaseControlsLock = vi.fn();
+    const requestControlsLock = vi.fn(() => releaseControlsLock);
+    const { Wrapper } = createPlayerWrapper({
+      userActive: true,
+      controlsVisible: true,
+      requestControlsLock,
+      toggleControls: vi.fn(),
+    });
+
+    const { rerender } = render(<SliderRoot value={10} />, { wrapper: Wrapper });
+
+    sliderOptionsRef.current?.onPressStart?.();
+    rerender(<SliderRoot value={20} />);
+
+    expect(requestControlsLock).toHaveBeenCalledTimes(1);
+    expect(releaseControlsLock).not.toHaveBeenCalled();
+
+    sliderOptionsRef.current?.onPressEnd?.();
+    expect(releaseControlsLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps value callbacks and thumb ARIA through the latest committed props while dragging', () => {
+    const onValueChange = vi.fn();
+    const onValueCommit = vi.fn();
+    const { container, rerender } = render(
+      <SliderRoot value={50} max={100} onValueChange={onValueChange} onValueCommit={onValueCommit}>
+        <SliderThumb data-testid="thumb" />
+      </SliderRoot>
+    );
+
+    Object.assign(sliderInputRef.current!, { dragging: true, pointerPercent: 75, dragPercent: 75 });
+    rerender(
+      <SliderRoot value={150} max={200} onValueChange={onValueChange} onValueCommit={onValueCommit}>
+        <SliderThumb data-testid="thumb" />
+      </SliderRoot>
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    const thumb = container.querySelector('[data-testid="thumb"]');
+
+    expect(root.hasAttribute('data-dragging')).toBe(true);
+    expect(thumb?.getAttribute('aria-valuenow')).toBe('150');
+    expect(thumb?.getAttribute('aria-valuemax')).toBe('200');
+
+    sliderOptionsRef.current?.onValueChange?.(75);
+    sliderOptionsRef.current?.onValueCommit?.(75);
+
+    expect(onValueChange).toHaveBeenCalledExactlyOnceWith(150);
+    expect(onValueCommit).toHaveBeenCalledExactlyOnceWith(150);
+  });
+
+  it('keeps the committed projection when a re-render is abandoned', () => {
+    const committed = vi.fn();
+    const abandoned = vi.fn();
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rerender } = render(
+      <MockErrorBoundary>
+        <SliderRoot value={50} max={100} onValueChange={committed} />
+      </MockErrorBoundary>
+    );
+
+    rerender(
+      <MockErrorBoundary>
+        <SliderRoot value={50} max={200} disabled onValueChange={abandoned} />
+        <Throw />
+      </MockErrorBoundary>
+    );
+
+    // The retained slider outlives the abandoned render and must still project the committed props.
+    expect(sliderOptionsRef.current?.getPercent?.()).toBe(50);
+    expect(sliderOptionsRef.current?.isDisabled?.()).toBe(false);
+
+    sliderOptionsRef.current?.onValueChange?.(50);
+
+    expect(committed).toHaveBeenCalledExactlyOnceWith(50);
+    expect(abandoned).not.toHaveBeenCalled();
+  });
+
+  it('projects the latest committed props under StrictMode', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { container, rerender } = render(
+      <StrictMode>
+        <SliderRoot value={50} max={100} onValueChange={first}>
+          <SliderThumb data-testid="thumb" />
+        </SliderRoot>
+      </StrictMode>
+    );
+
+    rerender(
+      <StrictMode>
+        <SliderRoot value={50} max={200} onValueChange={second}>
+          <SliderThumb data-testid="thumb" />
+        </SliderRoot>
+      </StrictMode>
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    const thumb = container.querySelector('[data-testid="thumb"]');
+
+    expect(thumb?.getAttribute('aria-valuemax')).toBe('200');
+    expect(root.style.getPropertyValue('--media-slider-fill')).toBe('25.000%');
+    expect(sliderOptionsRef.current?.getPercent?.()).toBe(25);
+
+    sliderOptionsRef.current?.onValueChange?.(50);
+
+    expect(second).toHaveBeenCalledExactlyOnceWith(100);
+    expect(first).not.toHaveBeenCalled();
   });
 });
 
@@ -357,6 +487,28 @@ describe('thumbAlignment', () => {
     );
 
     // thumbHalf = (20/200 * 100) / 2 = 5%.  Adjusted 0% → 5%.
+    expect(root.style.getPropertyValue('--media-slider-fill')).toBe('5.000%');
+  });
+
+  it('applies edge alignment in the same commit that switches alignment on', () => {
+    const { container, rerender } = render(
+      <SliderRoot value={0}>
+        <SliderThumb />
+      </SliderRoot>
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    const thumb = root.querySelector('[role="slider"]') as HTMLElement;
+
+    Object.defineProperty(root, 'offsetWidth', { value: 200, configurable: true });
+    Object.defineProperty(thumb, 'offsetWidth', { value: 20, configurable: true });
+
+    rerender(
+      <SliderRoot value={0} thumbAlignment="edge">
+        <SliderThumb />
+      </SliderRoot>
+    );
+
     expect(root.style.getPropertyValue('--media-slider-fill')).toBe('5.000%');
   });
 

--- a/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
+++ b/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
@@ -5,7 +5,7 @@ import { createRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { I18nProvider } from '../../../i18n';
-import { createPlayerWrapper } from '../../../testing/mocks';
+import { createPlayerWrapper, MockErrorBoundary } from '../../../testing/mocks';
 import { SliderBuffer } from '../../slider/slider-buffer';
 import { SliderFill } from '../../slider/slider-fill';
 import { SliderThumb } from '../../slider/slider-thumb';
@@ -26,7 +26,15 @@ const {
   mockTextTrackState,
   capturedSliderOptions,
 } = vi.hoisted(() => {
-  const capturedSliderOptions: { current: { onDragStart?: () => void; onDragEnd?: () => void } } = {
+  const capturedSliderOptions: {
+    current: {
+      isDisabled?: () => boolean;
+      getPercent?: () => number;
+      onValueCommit?: (percent: number) => void;
+      onDragStart?: () => void;
+      onDragEnd?: () => void;
+    };
+  } = {
     current: {},
   };
   const mockSliderInput = {
@@ -121,8 +129,13 @@ vi.mock('@videojs/store/react', () => ({
   }),
 }));
 
+function Throw(): null {
+  throw new Error('abandon render');
+}
+
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   Object.assign(mockSliderInput, {
     pointerPercent: 0,
     dragPercent: 0,
@@ -451,6 +464,68 @@ describe('TimeSlider compound', () => {
     expect(thumb?.getAttribute('aria-valuetext')).toBe(
       `${formatTimeAsPhrase(30, { locale: 'fr' })} sur ${formatTimeAsPhrase(120, { locale: 'fr' })}`
     );
+  });
+
+  it('announces the pointer position on the thumb while dragging', () => {
+    mockSliderInput.dragging = true;
+    mockSliderInput.pointerPercent = 75;
+    mockSliderInput.dragPercent = 75;
+
+    const { Wrapper } = createPlayerWrapper();
+    const { container } = render(
+      <Wrapper>
+        <TimeSliderRoot>
+          <SliderThumb data-testid="thumb" />
+        </TimeSliderRoot>
+      </Wrapper>
+    );
+
+    const thumb = container.querySelector('[data-testid="thumb"]');
+
+    expect(thumb?.getAttribute('aria-valuenow')).toBe('90');
+    expect(thumb?.getAttribute('aria-valuetext')).toContain(formatTimeAsPhrase(90));
+    expect(container.querySelector('[data-orientation]')?.hasAttribute('data-dragging')).toBe(true);
+  });
+
+  it('seeks through the committed media when a value commits', () => {
+    mockTimeState.seek.mockClear();
+
+    const { Wrapper } = createPlayerWrapper();
+
+    render(
+      <Wrapper>
+        <TimeSliderRoot />
+      </Wrapper>
+    );
+
+    capturedSliderOptions.current.onValueCommit?.(50);
+
+    expect(mockTimeState.seek).toHaveBeenCalledExactlyOnceWith(60);
+  });
+
+  it('keeps the committed projection when a re-render is abandoned', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { Wrapper } = createPlayerWrapper();
+    const { rerender } = render(
+      <Wrapper>
+        <MockErrorBoundary>
+          <TimeSliderRoot />
+        </MockErrorBoundary>
+      </Wrapper>
+    );
+
+    rerender(
+      <Wrapper>
+        <MockErrorBoundary>
+          <TimeSliderRoot disabled />
+          <Throw />
+        </MockErrorBoundary>
+      </Wrapper>
+    );
+
+    expect(capturedSliderOptions.current.isDisabled?.()).toBe(false);
+    expect(capturedSliderOptions.current.getPercent?.()).toBe(25);
   });
 
   it('SliderValue displays formatted time', () => {

--- a/packages/react/src/ui/time-slider/time-slider-root.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-root.tsx
@@ -2,12 +2,12 @@ import { TimeSliderCore, TimeSliderDataAttrs } from '@videojs/core';
 import { getTimeSliderCSSVars, selectBuffer, selectPlayback, selectTime } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';
 import { formatTime } from '@videojs/utils/time';
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useEffect, useLayoutEffect, useState } from 'react';
 
 import { useLocale, useTranslator } from '../../i18n/context';
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
-import { useLatestRef } from '../../utils/use-latest-ref';
+import { useCommittedRef } from '../../utils/use-committed-ref';
 import { renderElement } from '../../utils/use-render';
 import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
 import { useSlider } from '../hooks/use-slider';
@@ -46,9 +46,9 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
     const translator = useTranslator();
     const locale = useLocale();
 
-    const [core] = useState(() => new TimeSliderCore());
-
-    core.setProps({
+    // Project this render's props and media. The core is render-local, so the retained slider only ever sees the
+    // committed one.
+    const core = new TimeSliderCore({
       label,
       step,
       largeStep,
@@ -58,17 +58,25 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
       pauseOnDrag,
       changeThrottle,
     });
+
     core.setFormatLocale(locale);
 
-    // Keep a ref to the latest media state for callbacks that fire outside the render cycle.
-    const mediaRef = useLatestRef(time && buffer ? { ...time, ...buffer } : null);
-    const playbackRef = useLatestRef(playback);
+    const media = time && buffer ? { ...time, ...buffer } : null;
+    const playbackRef = useCommittedRef(playback);
+
+    // Whether a drag paused playback must outlive renders, so it lives on a retained core whose only input,
+    // `pauseOnDrag`, is committed from a layout effect instead of being written during render.
+    const [dragCore] = useState(() => new TimeSliderCore());
+
+    useLayoutEffect(() => {
+      dragCore.setProps({ pauseOnDrag });
+    }, [dragCore, pauseOnDrag]);
 
     // Resume playback if the slider unmounts mid-drag — createSlider's destroy()
     // does not fire onDragEnd, so without this the player would stay paused.
     useEffect(() => {
-      return () => core.endDrag(playbackRef.current);
-    }, [core]);
+      return () => dragCore.endDrag(playbackRef.current);
+    }, [dragCore, playbackRef]);
 
     const duration = time?.duration ?? 0;
 
@@ -77,7 +85,7 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
         computeState: (input) => {
           core.setInput(input);
 
-          if (!time || !buffer) {
+          if (!media) {
             core.setMedia({
               currentTime: 0,
               duration: 0,
@@ -87,7 +95,7 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
               seekable: [],
             });
           } else {
-            core.setMedia({ ...time, ...buffer });
+            core.setMedia(media);
           }
 
           return core.getState();
@@ -102,16 +110,14 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
           core.adjustPercentForAlignment(rawPercent, thumbSize, trackSize),
         getCSSVars: getTimeSliderCSSVars,
         onValueCommit: (percent) => {
-          const media = mediaRef.current;
-
           if (media) media.seek(core.rawValueFromPercent(percent));
         },
         onDragStart: () => {
-          core.startDrag(playbackRef.current);
+          dragCore.startDrag(playbackRef.current);
           onDragStart?.();
         },
         onDragEnd: () => {
-          core.endDrag(playbackRef.current);
+          dragCore.endDrag(playbackRef.current);
           onDragEnd?.();
         },
       });

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -1,8 +1,8 @@
 import { cleanup, render } from '@testing-library/react';
-import { createRef } from 'react';
+import { createRef, StrictMode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
-import { createPlayerWrapper } from '../../../testing/mocks';
+import { createPlayerWrapper, MockErrorBoundary } from '../../../testing/mocks';
 import { SliderFill } from '../../slider/slider-fill';
 import { SliderThumb } from '../../slider/slider-thumb';
 import { SliderTrack } from '../../slider/slider-track';
@@ -11,7 +11,7 @@ import { VolumeSliderRoot } from '../volume-slider-root';
 
 // --- Hoisted mock data (available inside vi.mock factories) ---
 
-const { mockSliderApi, mockVolumeState, mutableVolume } = vi.hoisted(() => {
+const { mockSliderApi, mockVolumeState, mutableVolume, capturedSliderOptions } = vi.hoisted(() => {
   const volumeState = {
     volume: 0.8,
     muted: false,
@@ -20,31 +20,44 @@ const { mockSliderApi, mockVolumeState, mutableVolume } = vi.hoisted(() => {
     toggleMuted: vi.fn(),
   };
 
+  interface MockSliderOptions {
+    isDisabled?: () => boolean;
+    getPercent?: () => number;
+    getStepPercent?: () => number;
+  }
+
+  const capturedSliderOptions: { current: MockSliderOptions } = { current: {} };
+
   return {
-    mockSliderApi: () => ({
-      input: {
-        current: {
-          pointerPercent: 0,
-          dragPercent: 0,
-          dragging: false,
-          pointing: false,
-          focused: false,
+    capturedSliderOptions,
+    mockSliderApi: (options: MockSliderOptions) => {
+      capturedSliderOptions.current = options;
+
+      return {
+        input: {
+          current: {
+            pointerPercent: 0,
+            dragPercent: 0,
+            dragging: false,
+            pointing: false,
+            focused: false,
+          },
+          subscribe: vi.fn(() => vi.fn()),
         },
-        subscribe: vi.fn(() => vi.fn()),
-      },
-      rootProps: {
-        onPointerDown: vi.fn(),
-        onPointerMove: vi.fn(),
-        onPointerLeave: vi.fn(),
-      },
-      thumbProps: {
-        onKeyDownCapture: vi.fn(),
-        onFocus: vi.fn(),
-        onBlur: vi.fn(),
-      },
-      adjustForAlignment: <S,>(state: S): S => state,
-      destroy: vi.fn(),
-    }),
+        rootProps: {
+          onPointerDown: vi.fn(),
+          onPointerMove: vi.fn(),
+          onPointerLeave: vi.fn(),
+        },
+        thumbProps: {
+          onKeyDownCapture: vi.fn(),
+          onFocus: vi.fn(),
+          onBlur: vi.fn(),
+        },
+        adjustForAlignment: <S,>(state: S): S => state,
+        destroy: vi.fn(),
+      };
+    },
     mockVolumeState: volumeState,
     // Mutable holder so tests can swap between null and available volume.
     mutableVolume: {
@@ -85,8 +98,13 @@ vi.mock('@videojs/store/react', () => ({
   }),
 }));
 
+function Throw(): null {
+  throw new Error('abandon render');
+}
+
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   mutableVolume.current = mockVolumeState;
   mockVolumeState.setVolume.mockClear();
   mockVolumeState.toggleMuted.mockClear();
@@ -170,6 +188,54 @@ describe('VolumeSliderRoot', () => {
 
     expect(el?.style.getPropertyValue('--media-slider-fill')).toBeTruthy();
     expect(el?.style.getPropertyValue('--media-slider-pointer')).toBeTruthy();
+  });
+});
+
+describe('VolumeSliderRoot projection', () => {
+  it('projects the latest committed props into the retained slider', () => {
+    const { Wrapper } = createPlayerWrapper();
+    const { rerender } = render(
+      <Wrapper>
+        <VolumeSliderRoot step={5} />
+      </Wrapper>
+    );
+
+    expect(capturedSliderOptions.current.getStepPercent?.()).toBe(5);
+
+    rerender(
+      <Wrapper>
+        <VolumeSliderRoot step={10} disabled />
+      </Wrapper>
+    );
+
+    expect(capturedSliderOptions.current.getStepPercent?.()).toBe(10);
+    expect(capturedSliderOptions.current.isDisabled?.()).toBe(true);
+    expect(capturedSliderOptions.current.getPercent?.()).toBe(80);
+  });
+
+  it('keeps the committed projection when a re-render is abandoned', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { Wrapper } = createPlayerWrapper();
+    const { rerender } = render(
+      <Wrapper>
+        <MockErrorBoundary>
+          <VolumeSliderRoot step={5} />
+        </MockErrorBoundary>
+      </Wrapper>
+    );
+
+    rerender(
+      <Wrapper>
+        <MockErrorBoundary>
+          <VolumeSliderRoot step={10} disabled />
+          <Throw />
+        </MockErrorBoundary>
+      </Wrapper>
+    );
+
+    expect(capturedSliderOptions.current.getStepPercent?.()).toBe(5);
+    expect(capturedSliderOptions.current.isDisabled?.()).toBe(false);
   });
 });
 
@@ -287,6 +353,33 @@ describe('VolumeSliderRoot wheel handling', () => {
 
     el.dispatchEvent(new WheelEvent('wheel', { deltaY: -120, bubbles: true }));
     expect(mockVolumeState.setVolume).toHaveBeenCalled();
+  });
+
+  it('honors disabled prop changes under StrictMode', () => {
+    const { Wrapper } = createPlayerWrapper();
+    const { container, rerender } = render(
+      <StrictMode>
+        <Wrapper>
+          <VolumeSliderRoot disabled />
+        </Wrapper>
+      </StrictMode>
+    );
+
+    const el = container.querySelector('[data-orientation]') as HTMLElement;
+
+    el.dispatchEvent(new WheelEvent('wheel', { deltaY: -120, bubbles: true }));
+    expect(mockVolumeState.setVolume).not.toHaveBeenCalled();
+
+    rerender(
+      <StrictMode>
+        <Wrapper>
+          <VolumeSliderRoot disabled={false} />
+        </Wrapper>
+      </StrictMode>
+    );
+
+    el.dispatchEvent(new WheelEvent('wheel', { deltaY: -120, bubbles: true }));
+    expect(mockVolumeState.setVolume).toHaveBeenCalledOnce();
   });
 
   it('attaches wheel handling when volume appears after initial null', () => {

--- a/packages/react/src/ui/volume-slider/volume-slider-root.tsx
+++ b/packages/react/src/ui/volume-slider/volume-slider-root.tsx
@@ -7,7 +7,7 @@ import { forwardRef, useCallback, useRef, useState } from 'react';
 import { useLocale, useTranslator } from '../../i18n/context';
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
-import { useLatestRef } from '../../utils/use-latest-ref';
+import { useCommittedRef } from '../../utils/use-committed-ref';
 import { renderElement } from '../../utils/use-render';
 import { useLogMissingFeature } from '../hooks/use-log-missing-feature';
 import { useSlider } from '../hooks/use-slider';
@@ -52,14 +52,15 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
     const isUnavailable = volume?.volumeAvailability !== 'available';
     const isDisabled = Boolean(disabled) || isUnavailable;
 
-    const [core] = useState(() => new VolumeSliderCore());
+    // Project this render's props. The core is render-local, so retained handlers only ever see the committed one.
+    const core = new VolumeSliderCore({ label, orientation, step, largeStep, wheelStep, disabled, thumbAlignment });
 
-    core.setProps({ label, orientation, step, largeStep, wheelStep, disabled, thumbAlignment });
     core.setFormatLocale(locale);
 
-    // Keep refs to the latest dynamic values for stable closures.
-    const volumeRef = useLatestRef(volume);
-    const disabledRef = useLatestRef(isDisabled);
+    // The retained wheel handler reads these refs, so only committed renders reach it.
+    const coreRef = useCommittedRef(core);
+    const volumeRef = useCommittedRef(volume);
+    const disabledRef = useCommittedRef(isDisabled);
 
     const getPercent = () => (volumeRef.current?.volume ?? 0) * 100;
     const getStepPercent = () => core.getStepPercent();
@@ -90,7 +91,7 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
       createWheelStep({
         isDisabled: () => disabledRef.current,
         getPercent: () => (volumeRef.current?.volume ?? 0) * 100,
-        getStepPercent: () => core.getWheelStepPercent(),
+        getStepPercent: () => coreRef.current.getWheelStepPercent(),
         onValueChange: (percent) => volumeRef.current?.setVolume(percent / 100),
       })
     );


### PR DESCRIPTION
Refs #1679

Depends on #2594.

## Summary

#2589 left `SliderCore`, `TimeSliderCore` and `VolumeSliderCore` retained because `useSlider`'s callbacks mutate them and `TimeSliderCore` carries drag intent. This finishes that conversion without touching the public `useSlider`, `Slider.Root` callback, or `computeState` contracts: the render-derived projection (props, media, locale, ARIA, value mapping, CSS vars) is now a render-local core built per render, while the interaction machinery stays retained and reads only committed values.

## Changes

- `Slider.Root`, `TimeSlider.Root`, `VolumeSlider.Root`: build the core per render (`new *Core(props)`) instead of `useState(() => new *Core())` plus `setProps`/`setFormatLocale` in render. `computeState` still calls `setInput`/`setMedia` on that core, but the core now belongs to the render that created it, so no other render can observe the mutation. The `syncStyles` subscription re-projects through the committed render's `computeState` for CSS var updates that bypass React, exactly as before.
- `useSlider`: `optionsRef` is a `useCommittedRef`, so the retained `createSlider` binder only ever reaches committed callbacks and cores; `adjustPercent` is read through the ref at call time instead of being captured from the first render (the captured version would have pinned the first render's core). The mount-time `useForceRender` layout effect is gone: edge alignment is applied by `syncStyles()` from a layout effect on mount and whenever `thumbAlignment` changes, which also covers a render that adjusted percents through the previously committed options.
- `TimeSlider.Root`: the render-local core projects props and media; a separate retained `dragCore` owns the pause-on-drag intent, with `pauseOnDrag` committed from a layout effect and `startDrag`/`endDrag` (including the unmount resume) driven from committed refs. `mediaRef` is replaced by the committed options closure.
- `VolumeSlider.Root`: the retained `createWheelStep` handler reads the committed core, volume and disabled state through `useCommittedRef` (previously `getStepPercent` captured the first render's core).
- Geometry math stays in core: React still calls `core.adjustPercentForAlignment` and `slider.adjustForAlignment`.

## What remains retained and why

- `createSlider` (`SliderApi`): pointer capture, drag threshold, throttling, keyboard stepping and the `input` state store are interaction state that must outlive renders; its callbacks read committed options through `useCommittedRef`.
- `dragCore` (`TimeSliderCore`) in `TimeSlider.Root`: only holds whether a drag paused playback so `endDrag` can resume it (also on unmount). Its single input, `pauseOnDrag`, is committed in a layout effect rather than written during render.
- `createWheelStep` in `VolumeSlider.Root`: a listener attached through a callback ref; reads committed refs only.
- The press-based controls lock from #2505 (`onPressStart`/`onPressEnd` in `useSlider`) is unchanged.
- Thumb ARIA during drag is unchanged: the root still reads `slider.input.current` on each render, so `aria-valuenow`/`aria-valuetext` follow the pointer whenever the root re-renders during a drag (covered by a new test). Splitting motion from semantic state (#2327) remains out of scope.

## Notes

- Pre-existing bug found while testing, not fixed here: `VolumeSliderCore.getWheelStepPercent()` returns `NaN` because `SliderCore.setProps` uses `defaults(props, SliderCore.defaultProps)`, which drops `wheelStep`. Both the React and HTML volume sliders call `setVolume(NaN)` on wheel. Worth a separate core fix with a core test.

## Testing

- `slider.test.tsx`: an abandoned re-render inside `MockErrorBoundary` does not change what the retained slider projects (`getPercent`, `isDisabled`) or which `onValueChange` it calls; StrictMode replay projects the latest committed props into ARIA, CSS vars and callbacks; dragging updates `data-dragging` and thumb ARIA and value callbacks map through the latest committed range; the controls lock is held across re-renders during a press; switching `thumbAlignment` to `edge` applies adjusted CSS vars in the same commit.
- `time-slider.test.tsx`: thumb announces the pointer position while dragging; `onValueCommit` seeks through the committed media; abandoned re-render keeps the committed projection; existing `pauseOnDrag` tests cover `dragCore`, including unmount resume.
- `volume-slider.test.tsx`: committed step/disabled projection, abandoned re-render, and wheel disabled handling under StrictMode.
- The three abandoned-render tests were verified to fail against the previous retained-core sources.
- `pnpm -F @videojs/react test`: 76 files, 596 tests passed
- `pnpm build --filter=@videojs/react`
- `pnpm typecheck`
- `pnpm lint:fix:file` on touched files and `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
