### PR TITLE
fix(media): make Mux declarations consumable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Check public declarations (media)
+        run: pnpm exec vp run @videojs/media#check:public-types
+
       - name: Check public declarations (html)
         run: pnpm exec vp run @videojs/html#check:public-types
 

--- a/packages/html/tests/public-types/index.ts
+++ b/packages/html/tests/public-types/index.ts
@@ -16,8 +16,11 @@ import {
   UIElement,
   videoFeatures,
 } from '@videojs/html';
+import { MuxDataElement } from '@videojs/html/extensions/mux-data';
 import { createI18n, type Locale } from '@videojs/html/i18n';
 import '@videojs/html/media/hls-video';
+import '@videojs/html/media/mux-audio';
+import '@videojs/html/media/mux-video';
 import '@videojs/html/ui/play-button';
 import '@videojs/html/ui/slider-thumbnail';
 import '@videojs/html/ui/thumbnail';
@@ -60,6 +63,13 @@ const skin: VideoSkinElement = document.createElement('video-skin');
 const player: VideoPlayerElement = document.createElement('video-player');
 const hls: HTMLElementTagNameMap['hls-video'] = document.createElement('hls-video');
 
+// The Mux entries resolve without `mux-embed`'s own types, which that package does not publish.
+const muxVideo: HTMLElementTagNameMap['mux-video'] = document.createElement('mux-video');
+const muxAudio: HTMLElementTagNameMap['mux-audio'] = document.createElement('mux-audio');
+const muxData = new MuxDataElement();
+
+muxData.metadata = { video_title: 'Title', view_session_id: 'session' };
+
 // Define modules must register tag names for both the base and the derived thumbnail element.
 const thumbnail: ThumbnailElement = document.createElement('media-thumbnail');
 const sliderThumbnail: SliderThumbnailElement = document.createElement('media-slider-thumbnail');
@@ -82,6 +92,9 @@ void [
   skin,
   player,
   hls,
+  muxVideo,
+  muxAudio,
+  muxData,
   thumbnail,
   sliderThumbnail,
   playButton,

--- a/packages/media/src/dom/mux/index.ts
+++ b/packages/media/src/dom/mux/index.ts
@@ -1,7 +1,14 @@
 export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from '../../core/drm';
 export { KeySystems } from '../../core/drm';
 export * from './media';
-export { MuxData, type MuxDataProps, muxDataDefaultProps } from './mux-data';
+export {
+  MuxData,
+  type MuxDataMetadata,
+  type MuxDataMonitorOptions,
+  type MuxDataProps,
+  type MuxDataSdk,
+  muxDataDefaultProps,
+} from './mux-data';
 // The engine-neutral source layer, re-exported so this stays the one import for
 // the hls.js-backed Media. Its own entry point, `@videojs/media/dom/mux/source`,
 // is what a Media on another engine imports — reaching it through here would

--- a/packages/media/src/dom/mux/mux-data-engine.ts
+++ b/packages/media/src/dom/mux/mux-data-engine.ts
@@ -1,13 +1,20 @@
 import { hasMethods, isFunction, isObject, isString } from '@videojs/utils/predicate';
 
-import type { MuxDataOptions } from './types';
+/**
+ * A playback engine the way `mux-embed` types one: an object whose shape it reads at runtime. `mux-embed` publishes no
+ * `types`, so the shape is stated here rather than taken from it.
+ */
+export type MuxDataEngineHandle = Record<PropertyKey, unknown>;
 
 /** The `mux-embed` monitor options that hook a playback engine's own telemetry. */
-export type MuxDataEngineOptions = Partial<Pick<MuxDataOptions, 'Hls' | 'hlsjs' | 'dashjs'>>;
-
-type MuxDataHlsJsEngine = NonNullable<MuxDataOptions['hlsjs']>;
-type MuxDataHlsJsClass = NonNullable<MuxDataOptions['Hls']>;
-type MuxDataDashJsEngine = NonNullable<MuxDataOptions['dashjs']>;
+export interface MuxDataEngineOptions {
+  /** The hls.js instance being monitored. */
+  hlsjs?: MuxDataEngineHandle;
+  /** Hls.js's class, which `mux-embed` reads event names and error details from. */
+  Hls?: MuxDataEngineHandle;
+  /** The dash.js player being monitored. */
+  dashjs?: MuxDataEngineHandle;
+}
 
 const warnedEngines = new WeakSet<object>();
 
@@ -54,12 +61,12 @@ export function toMuxDataEngineOptions(engine: unknown): MuxDataEngineOptions {
 // through `on` / `off`; the rendition APIs are what tell the two engines apart.
 
 /** Hls.js: its monitor reads renditions from `levels`. */
-function isHlsJsEngine(engine: unknown): engine is MuxDataHlsJsEngine {
+function isHlsJsEngine(engine: unknown): engine is MuxDataEngineHandle {
   return hasMethods(engine, ['on', 'off']) && Array.isArray((engine as { levels?: unknown }).levels);
 }
 
 /** Dash.js: its monitor reads renditions through the track and rendition-list getters. */
-function isDashJsEngine(engine: unknown): engine is MuxDataDashJsEngine {
+function isDashJsEngine(engine: unknown): engine is MuxDataEngineHandle {
   if (!hasMethods(engine, ['on', 'off', 'getCurrentTrackFor'])) return false;
 
   // dash.js v5 replaced `getBitrateInfoListFor` with `getRepresentationsByType`.
@@ -68,11 +75,11 @@ function isDashJsEngine(engine: unknown): engine is MuxDataDashJsEngine {
 }
 
 /** Hls.js's own class, the only place its event names and error details are published. */
-function toHlsJsClass(engine: object): MuxDataHlsJsClass | undefined {
+function toHlsJsClass(engine: object): MuxDataEngineHandle | undefined {
   const engineClass: unknown = engine.constructor;
   if (!isFunction(engineClass)) return undefined;
 
-  const statics = engineClass as unknown as MuxDataHlsJsClass;
+  const statics = engineClass as unknown as MuxDataEngineHandle;
 
   return isObject(statics.Events) && isObject(statics.ErrorDetails) && isString(statics.version) ? statics : undefined;
 }

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -1,10 +1,57 @@
+// `mux-embed` publishes no `types`, so its declarations are pulled in by path for this implementation alone. Nothing
+// exported from here names them: the public types below spell out the shapes Mux Data relies on, and the declaration
+// emit drops the directive, so consumers typecheck against this module without `mux-embed`'s types in reach.
+/// <reference path="../../../node_modules/mux-embed/dist/types/mux-embed.d.ts" />
 import Mux from 'mux-embed';
 
 import { getPlayerVersion } from './env';
 import { type MuxDataEngineOptions, toMuxDataEngineOptions } from './mux-data-engine';
-import type { MuxDataOptions, MuxDataSdk } from './types';
+
+/**
+ * Metadata reported with a Mux Data view, keyed the way the beacons spell it.
+ *
+ * The keys named here are the ones Mux Data reads or fills in itself; any other key the Mux Data SDK documents is
+ * accepted alongside them.
+ *
+ * @see https://docs.mux.com/guides/data/make-your-data-actionable-with-metadata
+ */
+export interface MuxDataMetadata {
+  /** Mux Data environment key. Filled in from {@link MuxDataProps.envKey}. */
+  env_key?: string;
+  /** Identifies the video within the environment. Derived from the source when omitted; see {@link toVideoId}. */
+  video_id?: string;
+  /** Groups the views of one player into a session. Generated once per {@link MuxData} when omitted. */
+  view_session_id?: string;
+  player_software_name?: string;
+  player_software?: string;
+  player_software_version?: string;
+  player_init_time?: number;
+  [key: string]: string | number | boolean | undefined;
+}
+
+/** The `mux-embed` monitor options Mux Data passes: element-level settings, engine hooks, and the view's metadata. */
+export interface MuxDataMonitorOptions extends MuxDataEngineOptions {
+  debug?: boolean;
+  beaconCollectionDomain?: string;
+  disableCookies?: boolean;
+  data?: MuxDataMetadata;
+}
+
+/**
+ * What Mux Data needs from the SDK it monitors with: the surface of `mux-embed` this integration calls. The bundled SDK
+ * is the default; a page that loads its own passes that instead.
+ */
+export interface MuxDataSdk {
+  /** Start monitoring a media element, installing the SDK's monitor handle on it. */
+  monitor(target: HTMLMediaElement, options?: MuxDataMonitorOptions): void;
+  utils: {
+    generateUUID(): string;
+    now(): number;
+  };
+}
 
 export interface MuxDataProps {
+  /** The Mux Data SDK to monitor with. `undefined` turns monitoring off. */
   MuxDataSdk: MuxDataSdk | undefined;
   beaconCollectionDomain: string | undefined;
   debug: boolean;
@@ -13,7 +60,7 @@ export interface MuxDataProps {
   playerSoftwareName: string | undefined;
   playerSoftwareVersion: string | undefined;
   playerInitTime: number | undefined;
-  metadata: MuxDataOptions['data'] | undefined;
+  metadata: MuxDataMetadata | undefined;
 }
 
 export const muxDataDefaultProps: MuxDataProps = {
@@ -54,7 +101,7 @@ export class MuxData implements MuxDataProps {
   #beaconCollectionDomain: string | undefined = muxDataDefaultProps.beaconCollectionDomain;
   #debug = muxDataDefaultProps.debug;
   #disableCookies = muxDataDefaultProps.disableCookies;
-  #metadata: MuxDataOptions['data'] | undefined = muxDataDefaultProps.metadata;
+  #metadata: MuxDataMetadata | undefined = muxDataDefaultProps.metadata;
   #envKey: string | undefined = muxDataDefaultProps.envKey;
   #playerSoftwareName: string | undefined = muxDataDefaultProps.playerSoftwareName;
   #playerSoftwareVersion: string | undefined = muxDataDefaultProps.playerSoftwareVersion;
@@ -342,7 +389,7 @@ export class MuxData implements MuxDataProps {
     const view_session_id = metadata.view_session_id ?? (this.#viewSessionId ??= this.MuxDataSdk?.utils.generateUUID());
     const video_id = toVideoId({ metadata, src: media.src });
 
-    const derived: NonNullable<MuxDataOptions['data']> = {};
+    const derived: MuxDataMetadata = {};
 
     if (view_session_id) derived.view_session_id = view_session_id;
 

--- a/packages/media/src/dom/mux/tests/mux-data.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { MuxData } from '..';
-import type { MuxDataSdk } from '../types';
+import type { MuxDataSdk } from '../mux-data';
 
 function createSdk() {
   const emit = vi.fn();

--- a/packages/media/src/dom/mux/types.ts
+++ b/packages/media/src/dom/mux/types.ts
@@ -1,2 +1,0 @@
-/// <reference path="../../../node_modules/mux-embed/dist/types/mux-embed.d.ts" preserve="true" />
-export type { Mux as MuxDataSdk, Options as MuxDataOptions } from 'mux-embed';

--- a/packages/media/tests/public-types/index.ts
+++ b/packages/media/tests/public-types/index.ts
@@ -1,0 +1,88 @@
+/**
+ * Strict consumer of the emitted `@videojs/media` declarations.
+ *
+ * Resolves the package through its own `exports` map, so every import below lands on `dist/dev/**.d.ts` rather than
+ * source. `skipLibCheck: false` makes the compiler check those declaration files themselves, which is what a strict
+ * downstream project sees and what the source typecheck cannot observe. `@videojs/html` and `@videojs/react` build on
+ * these declarations, so a leak here reaches every player.
+ *
+ * `dom/vimeo` and `dom/wistia` stay out: their declarations reach into `@vimeo/player` and `@wistia/wistia-player`,
+ * whose published types import modules they do not ship (`timing-object`, `@wistia/type-guards`), which a strict
+ * consumer sees as errors of its own.
+ */
+import { type MediaStreamType, MediaStreamTypes } from '@videojs/media';
+import { KeySystems } from '@videojs/media/dom';
+import { HTMLAudioElementHost } from '@videojs/media/dom/audio-host';
+import { CloudflareMedia } from '@videojs/media/dom/cloudflare';
+import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
+import { DashMedia } from '@videojs/media/dom/dash';
+import { GoogleCast } from '@videojs/media/dom/google-cast';
+import { HlsJsMedia } from '@videojs/media/dom/hls-js';
+import { HTMLMediaElementHost } from '@videojs/media/dom/media-host';
+import { MediaPlayedRangesMixin } from '@videojs/media/dom/media-played-ranges';
+import {
+  MuxData,
+  type MuxDataMetadata,
+  type MuxDataProps,
+  type MuxDataSdk,
+  MuxMedia,
+  type MuxSource,
+} from '@videojs/media/dom/mux';
+import { createMuxVideoURL, parseMuxVideoURL } from '@videojs/media/dom/mux/source';
+import { NativeHlsMedia } from '@videojs/media/dom/native-hls';
+import { ShakaMedia } from '@videojs/media/dom/shaka';
+import { SpotifyMedia } from '@videojs/media/dom/spotify';
+import { TikTokMedia } from '@videojs/media/dom/tiktok';
+import { TwitchMedia } from '@videojs/media/dom/twitch';
+import { HTMLVideoElementHost } from '@videojs/media/dom/video-host';
+import { YouTubeMedia } from '@videojs/media/dom/youtube';
+import { MediaTracksMixin } from '@videojs/media/media-tracks';
+
+type Extends<A, B extends A> = B;
+
+// Mux Data's SDK contract is implementable without `mux-embed`, which publishes no types of its own.
+const sdk: MuxDataSdk = {
+  monitor(target, options) {
+    void [target.currentSrc, options?.data?.video_id, options?.hlsjs];
+  },
+  utils: { generateUUID: () => 'uuid', now: () => Date.now() },
+};
+const metadata: MuxDataMetadata = { video_id: 'abc123', video_title: 'Title', player_init_time: 0 };
+const muxData = new MuxData({ MuxDataSdk: sdk, metadata, playerSoftwareName: 'mux-video' });
+
+// The Mux source layer round-trips between structured sources and stream URLs.
+const muxSource: MuxSource = { playbackId: 'abc123' };
+const muxURL: string | undefined =
+  createMuxVideoURL(muxSource) ?? parseMuxVideoURL('https://stream.mux.com/abc123.m3u8')?.playbackId;
+
+// Relationships the declarations must preserve; a broken constraint is a compile error.
+export type PublicTypeAssertions = [
+  Extends<MuxDataProps['metadata'], MuxDataMetadata | undefined>,
+  Extends<MediaStreamType, typeof MediaStreamTypes.LIVE>,
+];
+
+const streamType: MediaStreamType = MediaStreamTypes.LIVE;
+
+void [
+  KeySystems,
+  HTMLAudioElementHost,
+  CloudflareMedia,
+  CustomMediaElement,
+  DashMedia,
+  GoogleCast,
+  HlsJsMedia,
+  HTMLMediaElementHost,
+  MediaPlayedRangesMixin,
+  MuxMedia,
+  muxData,
+  muxURL,
+  NativeHlsMedia,
+  ShakaMedia,
+  SpotifyMedia,
+  TikTokMedia,
+  TwitchMedia,
+  HTMLVideoElementHost,
+  YouTubeMedia,
+  MediaTracksMixin,
+  streamType,
+];

--- a/packages/media/tests/public-types/tsconfig.json
+++ b/packages/media/tests/public-types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "incremental": false,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": false,
+    "strict": true,
+    "target": "ES2022",
+    "types": [],
+    "verbatimModuleSyntax": true
+  },
+  "include": ["index.ts"]
+}

--- a/packages/media/vite.config.ts
+++ b/packages/media/vite.config.ts
@@ -54,6 +54,13 @@ export default defineConfig({
         input: cachedTaskInputs,
         output: ['dist/**'],
       },
+      'check:public-types': {
+        // Compiles a strict consumer (`skipLibCheck: false`) against the emitted declarations through the package
+        // `exports` map. The source typecheck cannot see what the dts pipeline emits, so this is the only place a
+        // consumer-facing declaration error surfaces before publish.
+        command: 'tsgo --project tests/public-types/tsconfig.json',
+        dependsOn: ['build'],
+      },
       'test:ci': packageTestTask(),
     },
   },

--- a/packages/react/tests/public-types/index.tsx
+++ b/packages/react/tests/public-types/index.tsx
@@ -4,9 +4,6 @@
  * Resolves the package through its own `exports` map, so every import below lands on `dist/dev/**.d.ts` rather than
  * source. `skipLibCheck: false` makes the compiler check those declaration files themselves, which is what a strict
  * downstream project sees and what the source typecheck cannot observe.
- *
- * The Mux entries (`media/mux-*`, `extensions/mux-data`) stay out until `@videojs/media/dom/mux` stops leaking
- * `mux-embed` types, which that package does not publish through `types`.
  */
 import type { PlayerStore, UIComponentProps, VideoPlayerStore } from '@videojs/react';
 import {
@@ -30,6 +27,7 @@ import {
 import { AudioPlayer, AudioSkin, usePlayer as useAudioPlayer } from '@videojs/react/audio';
 import { BackgroundVideoPlayer, usePlayer as useBackgroundPlayer } from '@videojs/react/background';
 import { GoogleCast } from '@videojs/react/extensions/google-cast';
+import { MuxData, type MuxDataProps } from '@videojs/react/extensions/mux-data';
 import { createI18n, I18nProvider, type Locale, useTranslator } from '@videojs/react/i18n';
 import '@videojs/react/i18n/locales/en/register';
 import { type IconProps, PlayIcon } from '@videojs/react/icons';
@@ -37,6 +35,10 @@ import { PlayIcon as MinimalPlayIcon } from '@videojs/react/icons/minimal';
 import { LiveAudioPlayer, usePlayer as useLiveAudioPlayer } from '@videojs/react/live-audio';
 import { LiveVideoPlayer, LiveVideoSkin, usePlayer as useLiveVideoPlayer } from '@videojs/react/live-video';
 import { HlsVideo } from '@videojs/react/media/hls-video';
+import { MuxAudio } from '@videojs/react/media/mux-audio/hls-js';
+import { MuxAudio as SpfMuxAudio } from '@videojs/react/media/mux-audio/spf';
+import { MuxVideo } from '@videojs/react/media/mux-video/hls-js';
+import { MuxVideo as SpfMuxVideo } from '@videojs/react/media/mux-video/spf';
 import {
   MinimalVideoSkin,
   usePlayer as useVideoPlayer,
@@ -105,6 +107,21 @@ function Preset(): ReactNode {
   );
 }
 
+// The Mux entries resolve without `mux-embed`'s own types, which that package does not publish.
+function MuxPreset(): ReactNode {
+  const metadata: MuxDataProps['metadata'] = { video_title: 'Title', view_session_id: 'session' };
+
+  return (
+    <VideoPlayer>
+      <MuxVideo source={{ playbackId: 'abc123' }} />
+      <MuxAudio src="https://stream.mux.com/abc123.m3u8" />
+      <SpfMuxVideo source={{ playbackId: 'abc123' }} />
+      <SpfMuxAudio src="https://stream.mux.com/abc123.m3u8" />
+      <MuxData playerSoftwareName="mux-video" metadata={metadata} MuxDataSdk={undefined} />
+    </VideoPlayer>
+  );
+}
+
 // Every preset hook must resolve its store through the public feature types, not a synthesized barrel namespace.
 function PresetHooks(): ReactNode {
   const liveEdgeStart: number = useLiveVideoPlayer((state) => state.liveEdgeStart);
@@ -160,4 +177,4 @@ export type PublicTypeAssertions = [
 const locale: Locale = 'en';
 const i18n = createI18n();
 
-void [BoundConsumer, GenericConsumer, Preset, PresetHooks, Composed, merged, locale, i18n];
+void [BoundConsumer, GenericConsumer, Preset, MuxPreset, PresetHooks, Composed, merged, locale, i18n];


### PR DESCRIPTION
Refs #2369
Depends on #2593

## Summary

Adding the Mux entries to the `@videojs/html` and `@videojs/react` public-types fixtures (`media/mux-video`, `media/mux-audio`, `extensions/mux-data`, and the react `hls-js`/`spf` flavors) fails a strict consumer (`skipLibCheck: false`) with errors that all come from `@videojs/media`:

- `packages/media/dist/dev/dom/mux/types.d.ts(1,22): error TS6053: File '../../../../../Users/<build-machine>/packages/media/node_modules/mux-embed/dist/types/mux-embed.d.ts' not found.`
- `packages/media/dist/dev/dom/mux/types.d.ts(2,62): error TS7016: Could not find a declaration file for module 'mux-embed'.`
- `packages/media/dist/dev/dom/mux/mux-data.d.ts(56,26)` and `(57,30): error TS7016: Could not find a declaration file for module 'mux-embed'.` (`get/set metadata(): import("mux-embed").Metadata`)

How the types leaked: `mux-embed` publishes no `types`; its declarations live at `dist/types/mux-embed.d.ts` as an ambient `declare module 'mux-embed'`. `src/dom/mux/types.ts` pulled that file in with `/// <reference path="../../../node_modules/..." preserve="true" />` and re-exported `Mux`/`Options` from it. `preserve="true"` kept the directive in the emitted declarations, where the path is rewritten relative to the output (hence the absolute build-machine path), and `MuxDataProps.metadata: MuxDataOptions['data']` resolved through the ambient module so the emitter printed `import("mux-embed").Metadata`. Consumers never have that ambient module in their program, so every Mux entry downstream failed to typecheck.

## Changes

- `packages/media/src/dom/mux/mux-data.ts`: define the public shapes Mux Data relies on locally — `MuxDataMetadata` (the keys Mux Data reads or derives, plus an index signature for every other documented key), `MuxDataMonitorOptions`, and `MuxDataSdk` (the `monitor()`/`utils` surface this integration calls). `MuxDataProps` uses them. The `mux-embed` reference directive stays for the implementation only, without `preserve`, so declaration emit drops it and nothing exported names `mux-embed`. The real SDK is still checked against `MuxDataSdk` at `muxDataDefaultProps.MuxDataSdk = Mux`, and the real `Metadata`/`HlsOptions` at the `target.mux.*` call sites.
- `packages/media/src/dom/mux/mux-data-engine.ts`: `MuxDataEngineOptions` becomes a local interface over `MuxDataEngineHandle` (`Record<PropertyKey, unknown>`, matching `mux-embed`'s own `GenericObject`).
- `packages/media/src/dom/mux/index.ts`: export `MuxDataMetadata`, `MuxDataMonitorOptions`, `MuxDataSdk` so consumers can name what `MuxDataProps` refers to. `types.ts` is removed.
- `packages/media/tests/public-types/{index.ts,tsconfig.json}` + `check:public-types` task in `packages/media/vite.config.ts` + CI step: strict consumer of the root entry, `/dom`, `/media-tracks`, and every `dom/*` subpath. `dom/vimeo` and `dom/wistia` are left out with a note (see below).
- `packages/html/tests/public-types/index.ts`, `packages/react/tests/public-types/index.tsx`: add the Mux entries, including a `metadata` assignment and a `MuxDataSdk={undefined}` opt-out.

Option (a) from the issue was chosen over shipping an ambient `declare module 'mux-embed'` because an ambient module in our published declarations would collide with any consumer's own `declare module 'mux-embed'` shim, would need the dts pipeline to copy a vendored 1000-line file, and would force `mux-embed`'s global `HTMLMediaElement` augmentation on every consumer.

## Known leaks outside this PR

The new media fixture surfaced two pre-existing third-party declaration problems that are unrelated to Mux and are excluded here rather than papered over: `@vimeo/player`'s types import `timing-object` and `../src/lib/timing-src-connector` (TS2307/TS7016), and `@wistia/wistia-player`'s types import `@wistia/type-guards` (TS2307). A strict consumer of `@videojs/media/dom/vimeo`, `@videojs/media/dom/wistia`, or the html/react `vimeo-video`/`wistia-video` entries hits these today. Worth a follow-up issue.

## Testing

- `pnpm exec vp run @videojs/media#build` — no `mux-embed` import or `/// <reference` remains in `packages/media/dist/dev/**/*.d.ts` (only in comments).
- `pnpm exec tsgo --project packages/media/tsconfig.dts.json --noEmit` — clean.
- `pnpm exec vp run @videojs/media#check:public-types`, `@videojs/html#check:public-types`, `@videojs/react#check:public-types` — all pass (html/react fail on the base branch once the Mux entries are added).
- `pnpm -F @videojs/media test` — 48 files, 1141 tests pass.
- `pnpm typecheck`, `pnpm check:workspace`, `pnpm lint:fix:file` on touched files, `git diff --check` — clean. Lint reports advisory `anti-slop` warnings only (including one on `Record<PropertyKey, unknown>`), matching the pre-existing warnings in these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
