### PR TITLE
fix(core): resolve slider defaults from the subclass

### DIFF
--- a/packages/core/src/core/ui/slider/core.ts
+++ b/packages/core/src/core/ui/slider/core.ts
@@ -91,8 +91,13 @@ export class SliderCore {
     focused: false,
   };
 
-  #props = { ...SliderCore.defaultProps };
+  #props = { ...this.#defaultProps };
   #input: SliderInput = { ...SliderCore.defaultInput };
+
+  /** Subclasses extend `defaultProps`; resolving through the instantiated class keeps their extra keys in `#props`. */
+  get #defaultProps(): NonNullableObject<SliderProps> {
+    return (this.constructor as typeof SliderCore).defaultProps;
+  }
 
   get props(): Readonly<NonNullableObject<SliderProps>> {
     return this.#props;
@@ -107,7 +112,7 @@ export class SliderCore {
   }
 
   setProps(props: SliderProps): void {
-    this.#props = defaults(props, SliderCore.defaultProps);
+    this.#props = defaults(props, this.#defaultProps);
   }
 
   setInput(input: SliderInput): void {

--- a/packages/core/src/core/ui/volume-slider/core.ts
+++ b/packages/core/src/core/ui/volume-slider/core.ts
@@ -1,5 +1,4 @@
 import type { MediaFeatureAvailability, MediaVolumeState } from '@videojs/media';
-import { defaults } from '@videojs/utils/object';
 import { formatPercent } from '@videojs/utils/percent';
 import type { NonNullableObject } from '@videojs/utils/types';
 
@@ -43,7 +42,7 @@ export class VolumeSliderCore extends SliderCore {
   }
 
   override setProps(props: VolumeSliderProps): void {
-    super.setProps(defaults(props, VolumeSliderCore.defaultProps));
+    super.setProps(props);
   }
 
   setMedia(media: MediaVolumeState): void {

--- a/packages/core/src/core/ui/volume-slider/tests/core.test.ts
+++ b/packages/core/src/core/ui/volume-slider/tests/core.test.ts
@@ -211,6 +211,29 @@ describe('VolumeSliderCore', () => {
     });
   });
 
+  describe('getWheelStepPercent', () => {
+    it('uses the default wheel step', () => {
+      const core = new VolumeSliderCore({ min: 0, max: 100 });
+
+      expect(core.props).toMatchObject({ wheelStep: 5 });
+      expect(core.getWheelStepPercent()).toBe(5);
+    });
+
+    it('uses an explicit wheel step', () => {
+      const core = new VolumeSliderCore({ min: 0, max: 100, wheelStep: 10 });
+
+      expect(core.props).toMatchObject({ wheelStep: 10 });
+      expect(core.getWheelStepPercent()).toBe(10);
+    });
+
+    it('keeps subclass defaults when constructed without props', () => {
+      const core = new VolumeSliderCore();
+
+      expect(core.props).toMatchObject({ step: 5, wheelStep: 5 });
+      expect(core.getWheelStepPercent()).toBe(5);
+    });
+  });
+
   describe('setProps', () => {
     it('updates label', () => {
       const core = new VolumeSliderCore();

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -289,6 +289,21 @@ describe('VolumeSliderRoot wheel handling', () => {
     expect(mockVolumeState.setVolume).toHaveBeenCalled();
   });
 
+  it('steps volume by the default wheel step', () => {
+    const { Wrapper } = createPlayerWrapper();
+    const { container } = render(
+      <Wrapper>
+        <VolumeSliderRoot />
+      </Wrapper>
+    );
+
+    const el = container.querySelector('[data-orientation]') as HTMLElement;
+
+    // Volume starts at 0.8 and the default wheel step is 5%, so scrolling up lands on 0.85 rather than NaN.
+    el.dispatchEvent(new WheelEvent('wheel', { deltaY: -120, bubbles: true }));
+    expect(mockVolumeState.setVolume).toHaveBeenLastCalledWith(expect.closeTo(0.85, 10));
+  });
+
   it('attaches wheel handling when volume appears after initial null', () => {
     // Start with no volume — component returns null.
     mutableVolume.current = null;


### PR DESCRIPTION
## Summary

Scrolling the mouse wheel over the volume slider called `setVolume(NaN)` in both the HTML and React players.

`SliderCore.setProps` resolved defaults against the static base-class `SliderCore.defaultProps`, and `defaults()` (`@videojs/utils/object`) only copies keys owned by its defaults argument. `VolumeSliderCore` declares `static override defaultProps` with an extra `wheelStep`, and its own `setProps` override did pre-fill it, but handing the result to `super.setProps` re-ran `defaults()` against the base defaults and stripped `wheelStep` from `#props`. `getWheelStepPercent()` then computed `undefined / range * 100 = NaN`, which `createWheelStep` fed straight into `setVolume`.

The same static lookup in the `#props` field initializer also meant a no-arg `new VolumeSliderCore()` kept the base `step: 1` instead of the volume default `5`.

`TimeSliderCore` is not affected: it shadows `#props` with its own copy and reads `pauseOnDrag` / `changeThrottle` from there.

Surfaced while writing the tests for #2595.

## Changes

- `packages/core/src/core/ui/slider/core.ts`: resolve `defaultProps` through the instantiated class (`this.constructor`) via a private `#defaultProps` getter, used by both the `#props` initializer and `setProps`. No public API shape changes; the `props` getter type is unchanged.
- `packages/core/src/core/ui/volume-slider/core.ts`: drop the now-redundant re-defaulting in `setProps`; the override remains only to widen the accepted props type.
- `packages/core/src/core/ui/volume-slider/tests/core.test.ts`: add `getWheelStepPercent` tests for the default step, an explicit `wheelStep`, and no-arg construction. All three fail on `main`.
- `packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx`: the existing wheel tests only asserted `setVolume` was called; add one that asserts the value (`0.8` volume + default 5% step = `0.85`). Verified it fails with `Received: NaN` against the pre-fix core.

## Testing

- `pnpm -F @videojs/core test src/core/ui`: 45 files, 585 tests passed
- `pnpm exec vp run @videojs/core#build`
- `pnpm -F @videojs/html test src/ui/volume-slider`: 9 passed
- `pnpm -F @videojs/react test src/ui/volume-slider`: 13 passed
- `pnpm lint:fix:file` on touched files: 0 errors
- `pnpm typecheck`: clean
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
