### PR TITLE
test(html): support slider keyboard release

### DIFF
--- a/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
+++ b/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
@@ -47,7 +47,7 @@ function createSliderContext(state: Partial<SliderState> = {}, pointerValue = 0)
     stateAttrMap: SliderDataAttrs,
     pointerValue,
     thumbAttrs: {},
-    thumbProps: { onKeyDownCapture: () => {}, onFocus: () => {}, onBlur: () => {} },
+    thumbProps: { onKeyDownCapture: () => {}, onKeyUpCapture: () => {}, onFocus: () => {}, onBlur: () => {} },
   };
 }
 


### PR DESCRIPTION
Refs #2553

## Summary

Stacked on #2607. Update the HTML time-slider test adapter for the shared slider keyboard lifecycle.

## Changes

- Provide the keyup capture handler expected by the shared slider API
- Keep HTML runtime behavior in the shared core layer instead of duplicating framework-specific logic

## Testing

- `pnpm -F @videojs/html test src/ui/time-slider/tests/time-slider-element.test.ts`
- `pnpm build:packages`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:workspace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock update with no runtime or security impact.
> 
> **Overview**
> Updates the HTML **time-slider** test helper so mocked `thumbProps` match the shared slider thumb keyboard lifecycle.
> 
> `createSliderContext` now includes a no-op **`onKeyUpCapture`** alongside the existing keydown/focus/blur stubs, so tests stay aligned when the core slider API handles key release (refs #2553, stacked on #2607). **No production HTML runtime changes** in this diff—only the test adapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 648e554973c3fa86b5ab0aae6b146ab0fbe4973d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->