### PR TITLE
fix(react): preserve slider keyboard state

### DIFF
--- a/packages/react/src/ui/hooks/use-slider.ts
+++ b/packages/react/src/ui/hooks/use-slider.ts
@@ -134,6 +134,11 @@ export function useSlider<State extends SliderState = SliderState>(
     (element = rootElementRef.current) => {
       if (!element) return;
 
+      const { dragging, pointing } = slider.input.current;
+      // Keyboard values come from the controlled state. Applying them here would
+      // briefly write the previous value before the caller handles the key.
+      if (!dragging && !pointing) return;
+
       const next = optionsRef.current.computeState(slider.input.current);
 
       applyStyles(element, optionsRef.current.getCSSVars(slider.adjustForAlignment(next)));

--- a/packages/react/src/ui/slider/tests/slider-preview.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider-preview.test.tsx
@@ -33,6 +33,7 @@ const { mockSliderApi } = vi.hoisted(() => ({
     },
     thumbProps: {
       onKeyDownCapture: vi.fn(),
+      onKeyUpCapture: vi.fn(),
       onFocus: vi.fn(),
       onBlur: vi.fn(),
     },

--- a/packages/react/src/ui/slider/tests/slider-thumbnail.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider-thumbnail.test.tsx
@@ -24,6 +24,7 @@ const { mockSliderApi, mockThumbnailApi } = vi.hoisted(() => ({
     },
     thumbProps: {
       onKeyDownCapture: vi.fn(),
+      onKeyUpCapture: vi.fn(),
       onFocus: vi.fn(),
       onBlur: vi.fn(),
     },

--- a/packages/react/src/ui/slider/tests/slider.test.tsx
+++ b/packages/react/src/ui/slider/tests/slider.test.tsx
@@ -53,6 +53,7 @@ const { mockSliderApi, sliderOptionsRef } = vi.hoisted(() => {
         },
         thumbProps: {
           onKeyDownCapture: (event: { preventDefault(): void }) => event.preventDefault(),
+          onKeyUpCapture: vi.fn(),
           onFocus: vi.fn(),
           onBlur: vi.fn(),
         },

--- a/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
+++ b/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
@@ -52,6 +52,7 @@ const {
         },
         thumbProps: {
           onKeyDownCapture: vi.fn(),
+          onKeyUpCapture: vi.fn(),
           onFocus: vi.fn(),
           onBlur: vi.fn(),
         },

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -39,6 +39,7 @@ const { mockSliderApi, mockVolumeState, mutableVolume } = vi.hoisted(() => {
       },
       thumbProps: {
         onKeyDownCapture: vi.fn(),
+        onKeyUpCapture: vi.fn(),
         onFocus: vi.fn(),
         onBlur: vi.fn(),
       },


### PR DESCRIPTION
Refs #2553

## Summary

Stacked on #2608. Keep React slider rendering from overwriting keyboard-driven values while controlled state catches up.

## Changes

- Restrict imperative CSS variable synchronization to active pointer interactions
- Preserve keyboard values until the controlled React state updates
- Update slider test adapters for the shared keyup lifecycle

## Testing

- `pnpm -F @videojs/react test src/ui/slider/tests/slider-preview.test.tsx src/ui/slider/tests/slider-thumbnail.test.tsx src/ui/slider/tests/slider.test.tsx src/ui/time-slider/tests/time-slider.test.tsx src/ui/volume-slider/tests/volume-slider.test.tsx`
- `pnpm build:packages`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:workspace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to when imperative slider styles sync; pointer/drag behavior unchanged, with test-only mock updates.
> 
> **Overview**
> Fixes a flash where keyboard nudges on React sliders briefly showed the **previous** value because imperative style sync ran on every slider input update.
> 
> **`useSlider`** now runs `syncStyles` (inline CSS custom properties from live input) only while **`dragging` or `pointing`** is true. Keyboard-driven updates rely on React’s controlled `cssVars` until state catches up, so arrow keys no longer get overwritten by stale percents before the key handler commits.
> 
> Slider-related test mocks add **`onKeyUpCapture`** on `thumbProps` to match the shared thumb keyboard lifecycle from the stacked work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2143e3c006e8110fd5d4e1c418b7e8022adad22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->