### PR TITLE
feat(packages): add text track primitives

### DIFF
--- a/packages/media/src/core/types.ts
+++ b/packages/media/src/core/types.ts
@@ -242,7 +242,9 @@ export interface TextTrackLike {
   readonly src?: string;
   mode: 'showing' | 'disabled' | 'hidden';
   readonly cues: TextCueListLike | null;
+  readonly activeCues?: TextCueListLike | null;
   addCue?(cue: TextCueLike): void;
+  removeCue?(cue: TextCueLike): void;
 }
 
 export interface TextTrackListEvents {
@@ -261,6 +263,7 @@ export interface TextTrackListLike extends EventTargetLike<TextTrackListEvents> 
 export interface MediaTextTrackCapability {
   readonly textTracks: TextTrackListLike;
   addTextTrack(kind: TextTrackKind, label?: string, language?: string): TextTrackLike;
+  removeTextTrack?(track: TextTrackLike): void;
 }
 
 // ----------------------------------------

--- a/packages/media/src/dom/index.ts
+++ b/packages/media/src/dom/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './text-track';

--- a/packages/media/src/dom/media-host/media-host.ts
+++ b/packages/media/src/dom/media-host/media-host.ts
@@ -1,4 +1,4 @@
-import type { EventListenerFor, EventType, QueriedElement } from '@videojs/utils/dom';
+import { findTrackElement, type EventListenerFor, type EventType, type QueriedElement } from '@videojs/utils/dom';
 
 import { EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
 import {
@@ -10,6 +10,7 @@ import {
   type TextTrackKind,
   type TextTrackLike,
 } from '../../core/types';
+import { createTextTrackElement } from '../text-track';
 import { getMediaComponents, getMediaOwner, getMediaProp, setMediaProp } from '../utils';
 
 export { addMediaComponent, getMediaComponents, getMediaOwner, getMediaProp, setMediaProp } from '../utils';
@@ -308,7 +309,36 @@ export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events ext
   addTextTrack(kind: TextTrackKind, label?: string, language?: string) {
     const owner = getMediaOwner(this, 'addTextTrack');
 
+    if (owner instanceof HTMLMediaElement) {
+      const element = createTextTrackElement(owner, kind, label, language);
+      const track = element.track;
+
+      if (!track) {
+        element.remove();
+
+        // SAFETY: the native fallback implements the host's TextTrackLike contract when available.
+        return owner.addTextTrack?.(kind, label, language) as TextTrackLike;
+      }
+
+      track.mode = 'hidden';
+
+      // SAFETY: native TextTrack satisfies the framework-neutral TextTrackLike contract.
+      return track as TextTrackLike;
+    }
+
+    // SAFETY: a media component's addTextTrack override implements the host's TextTrackLike contract.
     return owner?.addTextTrack?.(kind, label, language) as TextTrackLike;
+  }
+
+  removeTextTrack(track: TextTrackLike) {
+    const owner = getMediaOwner(this, 'removeTextTrack');
+
+    if (owner?.removeTextTrack) {
+      owner.removeTextTrack(track);
+      return;
+    }
+
+    if (this.target) findTrackElement(this.target, track)?.remove();
   }
 
   get remote() {

--- a/packages/media/src/dom/tests/media-host.test.ts
+++ b/packages/media/src/dom/tests/media-host.test.ts
@@ -47,6 +47,54 @@ class CastLikeOverride implements MediaComponent {
 }
 
 describe('HTMLMediaElementHost', () => {
+  describe('text tracks', () => {
+    it('creates removable track elements on native media targets', () => {
+      const descriptor = Object.getOwnPropertyDescriptor(HTMLTrackElement.prototype, 'track');
+      const tracks = new WeakMap<HTMLTrackElement, TextTrack>();
+
+      Object.defineProperty(HTMLTrackElement.prototype, 'track', {
+        configurable: true,
+        get() {
+          let track = tracks.get(this);
+
+          if (!track) {
+            // SAFETY: this native-shaped test double covers the properties used by HTMLMediaElementHost.
+            track = {
+              kind: this.kind,
+              label: this.label,
+              language: this.srclang,
+              mode: 'disabled',
+            } as TextTrack;
+            tracks.set(this, track);
+          }
+
+          return track;
+        },
+      });
+
+      const host = new HTMLAudioElementHost();
+      const audio = document.createElement('audio');
+
+      try {
+        host.attach(audio);
+
+        const track = host.addTextTrack('metadata', 'Ads', 'en');
+        const element = audio.querySelector('track');
+
+        expect(element).toMatchObject({ kind: 'metadata', label: 'Ads', srclang: 'en' });
+        expect(element?.track).toBe(track);
+        expect(track.mode).toBe('hidden');
+
+        host.removeTextTrack(track);
+
+        expect(audio.querySelector('track')).toBeNull();
+      } finally {
+        if (descriptor) Object.defineProperty(HTMLTrackElement.prototype, 'track', descriptor);
+        else Reflect.deleteProperty(HTMLTrackElement.prototype, 'track');
+      }
+    });
+  });
+
   describe('component overrides', () => {
     it('returns the override value when a component exposes the property', () => {
       const host = new HTMLAudioElementHost();

--- a/packages/media/src/dom/tests/text-track.test.ts
+++ b/packages/media/src/dom/tests/text-track.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import type { Media, TextCueLike, TextTrackLike, TextTrackListLike } from '../../core/types';
+import {
+  addTextTrackCue,
+  createTextTrack,
+  getActiveTextTrack,
+  getTextTrackCues,
+  removeTextTrackCue,
+  watchActiveTextTrack,
+  watchTextTrackCues,
+} from '../text-track';
+
+class FakeTextTrack extends EventTarget implements TextTrackLike {
+  readonly id = '';
+  readonly language = '';
+  readonly cues: TextCueLike[] = [];
+  readonly activeCues: TextCueLike[] = [];
+
+  mode: TextTrackLike['mode'] = 'disabled';
+
+  constructor(
+    readonly kind: string,
+    readonly label = ''
+  ) {
+    super();
+  }
+
+  addCue(cue: TextCueLike): void {
+    this.cues.push(cue);
+  }
+
+  removeCue(cue: TextCueLike): void {
+    const index = this.cues.indexOf(cue);
+
+    if (index >= 0) this.cues.splice(index, 1);
+  }
+}
+
+class FakeTextTrackList extends EventTarget implements TextTrackListLike {
+  readonly [index: number]: TextTrackLike;
+  readonly #tracks: TextTrackLike[] = [];
+
+  get length(): number {
+    return this.#tracks.length;
+  }
+
+  add(track: TextTrackLike): void {
+    this.#tracks.push(track);
+    this.#syncIndexes();
+    this.dispatchEvent(new Event('addtrack'));
+  }
+
+  remove(track: TextTrackLike): void {
+    const index = this.#tracks.indexOf(track);
+    if (index < 0) return;
+
+    this.#tracks.splice(index, 1);
+    this.#syncIndexes();
+    this.dispatchEvent(new Event('removetrack'));
+  }
+
+  [Symbol.iterator](): Iterator<TextTrackLike> {
+    return this.#tracks[Symbol.iterator]();
+  }
+
+  #syncIndexes(): void {
+    for (const key of Object.keys(this)) {
+      if (/^\d+$/.test(key)) Reflect.deleteProperty(this, key);
+    }
+
+    for (const [index, track] of this.#tracks.entries()) {
+      Object.defineProperty(this, index, { configurable: true, value: track });
+    }
+  }
+}
+
+class FakeMedia extends EventTarget implements Media {
+  readonly textTracks = new FakeTextTrackList();
+
+  addTextTrack(kind: TextTrackLike['kind'], label?: string): FakeTextTrack {
+    const track = new FakeTextTrack(kind, label);
+
+    this.textTracks.add(track);
+
+    return track;
+  }
+
+  removeTextTrack(track: TextTrackLike): void {
+    this.textTracks.remove(track);
+  }
+
+  play(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe('createTextTrack', () => {
+  const trackDescriptor = Object.getOwnPropertyDescriptor(HTMLTrackElement.prototype, 'track');
+  const readyStateDescriptor = Object.getOwnPropertyDescriptor(HTMLTrackElement.prototype, 'readyState');
+  const readyStates = new WeakMap<HTMLTrackElement, number>();
+  const tracks = new WeakMap<HTMLTrackElement, FakeTextTrack>();
+
+  function mockTrackElements() {
+    Object.defineProperty(HTMLTrackElement.prototype, 'track', {
+      configurable: true,
+      get() {
+        let track = tracks.get(this);
+
+        if (!track) {
+          track = new FakeTextTrack(this.kind, this.label);
+          tracks.set(this, track);
+        }
+
+        return track;
+      },
+    });
+    Object.defineProperty(HTMLTrackElement.prototype, 'readyState', {
+      configurable: true,
+      get() {
+        return readyStates.get(this) ?? 0;
+      },
+    });
+  }
+
+  function settle(element: HTMLTrackElement, type: 'load' | 'error') {
+    readyStates.set(element, type === 'load' ? 2 : 3);
+    element.dispatchEvent(new Event(type));
+  }
+
+  afterEach(() => {
+    for (const [name, descriptor] of [
+      ['track', trackDescriptor],
+      ['readyState', readyStateDescriptor],
+    ] as const) {
+      if (descriptor) Object.defineProperty(HTMLTrackElement.prototype, name, descriptor);
+      else Reflect.deleteProperty(HTMLTrackElement.prototype, name);
+    }
+  });
+
+  it('creates a hidden track and removes it when destroyed', () => {
+    const media = new FakeMedia();
+    const handle = createTextTrack(media, { kind: 'metadata', label: 'Ads' });
+
+    expect(handle?.track).toMatchObject({ kind: 'metadata', label: 'Ads', mode: 'hidden' });
+    expect(media.textTracks.length).toBe(1);
+
+    handle?.destroy();
+    handle?.destroy();
+
+    expect(handle?.track.mode).toBe('disabled');
+    expect(media.textTracks.length).toBe(0);
+  });
+
+  it('notifies cue observers when cues are written through the handle', () => {
+    const media = new FakeMedia();
+    const handle = createTextTrack(media, { kind: 'metadata' })!;
+    const cue = { startTime: 0, endTime: 1 };
+    const onChange = vi.fn();
+
+    watchTextTrackCues(media, handle.track, false, onChange);
+    handle.addCue(cue);
+
+    expect(onChange).toHaveBeenLastCalledWith([cue]);
+
+    handle.removeCue(cue);
+
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('queues cue writes until the backing element has loaded', () => {
+    mockTrackElements();
+
+    const video = document.createElement('video');
+    const handle = createTextTrack(video, { kind: 'metadata', label: 'Ads' })!;
+    const element = video.querySelector('track')!;
+    const kept = { startTime: 0, endTime: 1 };
+    const dropped = { startTime: 1, endTime: 2 };
+    const onChange = vi.fn();
+
+    watchTextTrackCues(video, handle.track, false, onChange);
+
+    expect(handle.track.mode).toBe('hidden');
+    expect(element).toMatchObject({ kind: 'metadata', label: 'Ads' });
+
+    handle.addCue(kept);
+    handle.addCue(dropped);
+    handle.removeCue(dropped);
+
+    expect(handle.track.cues).toEqual([]);
+
+    settle(element, 'error');
+
+    expect(handle.track.cues).toEqual([kept]);
+    expect(onChange).toHaveBeenLastCalledWith([kept]);
+
+    handle.destroy();
+
+    expect(video.querySelector('track')).toBeNull();
+    expect(handle.track.mode).toBe('disabled');
+  });
+
+  it('applies a requested disabled mode after the element load settles', () => {
+    mockTrackElements();
+
+    const video = document.createElement('video');
+    const handle = createTextTrack(video, { kind: 'chapters', mode: 'disabled' })!;
+    const element = video.querySelector('track')!;
+
+    expect(handle.track.mode).toBe('hidden');
+
+    settle(element, 'load');
+
+    expect(handle.track.mode).toBe('disabled');
+  });
+
+  it('writes cues immediately when no backing element exists', () => {
+    const media = new FakeMedia();
+    const handle = createTextTrack(media, { kind: 'metadata', mode: 'showing' })!;
+    const cue = { startTime: 0, endTime: 1 };
+
+    handle.addCue(cue);
+
+    expect(handle.track.mode).toBe('showing');
+    expect(handle.track.cues).toEqual([cue]);
+  });
+});
+
+describe('addTextTrackCue', () => {
+  it('adds the cue and notifies observers of the same track only', () => {
+    const track = new FakeTextTrack('metadata');
+    const other = new FakeTextTrack('metadata');
+    const cue = { startTime: 0, endTime: 1 };
+    const onChange = vi.fn();
+    const onOtherChange = vi.fn();
+
+    const stop = watchTextTrackCues(null, track, false, onChange);
+
+    watchTextTrackCues(null, other, false, onOtherChange);
+    addTextTrackCue(track, cue);
+
+    expect(track.cues).toEqual([cue]);
+    expect(onChange).toHaveBeenLastCalledWith([cue]);
+    expect(onOtherChange).toHaveBeenCalledTimes(1);
+
+    stop();
+    removeTextTrackCue(track, cue);
+
+    expect(track.cues).toEqual([]);
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getActiveTextTrack', () => {
+  it('prefers showing tracks, falls back to hidden tracks, and ignores disabled tracks', () => {
+    const media = new FakeMedia();
+    const captions = media.addTextTrack('captions');
+    const chapters = media.addTextTrack('chapters');
+    const showingChapters = media.addTextTrack('chapters');
+
+    captions.mode = 'disabled';
+    chapters.mode = 'hidden';
+    showingChapters.mode = 'showing';
+
+    expect(getActiveTextTrack(media, ['captions', 'chapters'])).toBe(showingChapters);
+
+    showingChapters.mode = 'disabled';
+
+    expect(getActiveTextTrack(media, ['captions', 'chapters'])).toBe(chapters);
+  });
+});
+
+describe('watchActiveTextTrack', () => {
+  it('notifies when the active track changes and stops after cleanup', () => {
+    const media = new FakeMedia();
+    const captions = media.addTextTrack('captions');
+    const onChange = vi.fn();
+    const stop = watchActiveTextTrack(media, 'captions', onChange);
+
+    expect(onChange).toHaveBeenLastCalledWith(null);
+
+    captions.mode = 'showing';
+    media.textTracks.dispatchEvent(new Event('change'));
+
+    expect(onChange).toHaveBeenLastCalledWith(captions);
+
+    stop();
+    captions.mode = 'disabled';
+    media.textTracks.dispatchEvent(new Event('change'));
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getTextTrackCues', () => {
+  it('returns snapshots of all and active cues', () => {
+    const track = new FakeTextTrack('metadata');
+    const first = { startTime: 0, endTime: 1 };
+    const second = { startTime: 1, endTime: 2 };
+
+    track.cues.push(first, second);
+    track.activeCues.push(second);
+
+    expect(getTextTrackCues(track)).toEqual([first, second]);
+    expect(getTextTrackCues(track, true)).toEqual([second]);
+  });
+});
+
+describe('watchTextTrackCues', () => {
+  it('notifies with fresh cue snapshots on cue changes', () => {
+    const media = new FakeMedia();
+    const track = new FakeTextTrack('metadata');
+    const cue = { startTime: 0, endTime: 1 };
+    const onChange = vi.fn();
+
+    const stop = watchTextTrackCues(media, track, false, onChange);
+
+    expect(onChange).toHaveBeenLastCalledWith([]);
+
+    track.cues.push(cue);
+    track.dispatchEvent(new Event('cuechange'));
+
+    expect(onChange).toHaveBeenLastCalledWith([cue]);
+
+    stop();
+    track.cues.length = 0;
+    track.dispatchEvent(new Event('cuechange'));
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/media/src/dom/text-track.ts
+++ b/packages/media/src/dom/text-track.ts
@@ -1,0 +1,295 @@
+import { findTrackElement, listen } from '@videojs/utils/dom';
+import { noop } from '@videojs/utils/function';
+
+import type { Media, MediaTextTrackCapability, TextCueLike, TextTrackKind, TextTrackLike } from '../core/types';
+
+export type TextTrackKindFilter = TextTrackKind | readonly TextTrackKind[];
+
+export interface CreateTextTrackOptions {
+  /** The kind of timed text represented by the track. */
+  kind: TextTrackKind;
+  /** Human-readable track label. */
+  label?: string | undefined;
+  /** BCP 47 language tag. */
+  language?: string | undefined;
+  /** Initial track mode. Defaults to `hidden`, matching `HTMLMediaElement.addTextTrack()`. */
+  mode?: TextTrackLike['mode'] | undefined;
+}
+
+export interface TextTrackHandle {
+  readonly track: TextTrackLike;
+  /** Add a cue and notify cue observers. Waits for the backing `<track>` to finish loading when there is one. */
+  addCue(cue: TextCueLike): void;
+  /** Remove a cue and notify cue observers. Drops the cue if it is still waiting to be added. */
+  removeCue(cue: TextCueLike): void;
+  /** Disable the track and remove it from the media. Safe to call more than once. */
+  destroy(): void;
+}
+
+const cueListeners = new WeakMap<TextTrackLike, Set<() => void>>();
+
+/**
+ * Create a removable native text track on a media element.
+ *
+ * Element-backed tracks start loading as soon as they leave `disabled` mode, and browsers discard every cue added
+ * before that load settles. The returned handle queues `addCue()` and `removeCue()` until the backing `<track>` reports
+ * `load` or `error`, so callers can write cues immediately.
+ *
+ * @param media - Media element that will own the track.
+ * @param options - Track metadata and initial mode.
+ */
+export function createTextTrack(
+  media: MediaTextTrackCapability,
+  options: CreateTextTrackOptions
+): TextTrackHandle | null {
+  const element = isNativeMediaElement(media)
+    ? createTextTrackElement(media, options.kind, options.label, options.language)
+    : null;
+  const track = element ? element.track : media.addTextTrack(options.kind, options.label, options.language);
+
+  if (!track) {
+    element?.remove();
+    return null;
+  }
+
+  // Wrapped media create the backing element for us; find it so cue writes wait for its load as well.
+  const backing = element ?? (media instanceof EventTarget ? findTrackElement(media, track) : null);
+  const mode = options.mode ?? 'hidden';
+  const writer = createDeferredCueWriter(track, backing);
+
+  // Leaving `disabled` starts the element load. Apply a requested `disabled` mode once that load has settled so the
+  // track does not stay unloaded and wipe cues on a later mode change.
+  track.mode = 'hidden';
+
+  if (mode !== 'disabled') track.mode = mode;
+  else writer.whenSettled(() => (track.mode = 'disabled'));
+
+  let destroyed = false;
+
+  return {
+    track,
+    addCue: writer.addCue,
+    removeCue: writer.removeCue,
+    destroy() {
+      if (destroyed) return;
+
+      destroyed = true;
+      writer.dispose();
+      track.mode = 'disabled';
+
+      if (element) element.remove();
+      else media.removeTextTrack?.(track);
+    },
+  };
+}
+
+interface DeferredCueWriter {
+  addCue(cue: TextCueLike): void;
+  removeCue(cue: TextCueLike): void;
+  whenSettled(callback: () => void): void;
+  dispose(): void;
+}
+
+const TRACK_READY_STATE_LOADED = 2;
+
+function createDeferredCueWriter(track: TextTrackLike, element: HTMLTrackElement | null): DeferredCueWriter {
+  const pending: TextCueLike[] = [];
+  const callbacks: (() => void)[] = [];
+  let settled = !element || element.readyState >= TRACK_READY_STATE_LOADED;
+  let stop = noop;
+
+  const settle = () => {
+    stop();
+    stop = noop;
+    settled = true;
+
+    for (const cue of pending.splice(0)) addTextTrackCue(track, cue);
+
+    for (const callback of callbacks.splice(0)) callback();
+  };
+
+  if (!settled && element) {
+    const stopLoad = listen(element, 'load', settle);
+    const stopError = listen(element, 'error', settle);
+
+    stop = () => {
+      stopLoad();
+      stopError();
+    };
+  }
+
+  return {
+    addCue(cue) {
+      if (settled) addTextTrackCue(track, cue);
+      else pending.push(cue);
+    },
+    removeCue(cue) {
+      const index = pending.indexOf(cue);
+
+      if (index >= 0) pending.splice(index, 1);
+      else removeTextTrackCue(track, cue);
+    },
+    whenSettled(callback) {
+      if (settled) callback();
+      else callbacks.push(callback);
+    },
+    dispose() {
+      stop();
+      stop = noop;
+      pending.length = 0;
+      callbacks.length = 0;
+    },
+  };
+}
+
+/** Create the `<track>` backing a programmatically managed native text track. */
+export function createTextTrackElement(
+  media: HTMLMediaElement,
+  kind: TextTrackKind,
+  label?: string,
+  language?: string
+): HTMLTrackElement {
+  const element = media.ownerDocument.createElement('track');
+
+  element.kind = kind;
+  element.label = label ?? '';
+  element.srclang = language ?? '';
+  media.append(element);
+
+  return element;
+}
+
+/**
+ * Add a cue to a text track and notify `watchTextTrackCues` observers.
+ *
+ * Native `TextTrack.addCue()` fires no event, so observers only learn about programmatic cue changes made through this
+ * helper or a `TextTrackHandle`.
+ */
+export function addTextTrackCue(track: TextTrackLike, cue: TextCueLike): void {
+  track.addCue?.(cue);
+  notifyCueListeners(track);
+}
+
+/** Remove a cue from a text track and notify `watchTextTrackCues` observers. */
+export function removeTextTrackCue(track: TextTrackLike, cue: TextCueLike): void {
+  track.removeCue?.(cue);
+  notifyCueListeners(track);
+}
+
+/** Return the first enabled text track matching the requested kind. */
+export function getActiveTextTrack(media: MediaTextTrackCapability, kind: TextTrackKindFilter): TextTrackLike | null {
+  const kinds = Array.isArray(kind) ? kind : [kind];
+  const matches = Array.from(media.textTracks).filter((track) => kinds.some((kind) => kind === track.kind));
+
+  return matches.find((track) => track.mode === 'showing') ?? matches.find((track) => track.mode === 'hidden') ?? null;
+}
+
+/**
+ * Observe the enabled text track matching the requested kind.
+ *
+ * Native `hidden` tracks are active: their cues load and update without being rendered. This is the normal mode for
+ * chapters and metadata tracks.
+ */
+export function watchActiveTextTrack(
+  media: MediaTextTrackCapability,
+  kind: TextTrackKindFilter,
+  onChange: (track: TextTrackLike | null) => void
+): () => void {
+  let current: TextTrackLike | null | undefined;
+
+  const sync = () => {
+    const next = getActiveTextTrack(media, kind);
+    if (next === current) return;
+
+    current = next;
+    onChange(next);
+  };
+
+  sync();
+  media.textTracks.addEventListener('addtrack', sync);
+  media.textTracks.addEventListener('removetrack', sync);
+  media.textTracks.addEventListener('change', sync);
+
+  return () => {
+    media.textTracks.removeEventListener('addtrack', sync);
+    media.textTracks.removeEventListener('removetrack', sync);
+    media.textTracks.removeEventListener('change', sync);
+  };
+}
+
+/** Read either all cues or the currently active cues from a text track. */
+export function getTextTrackCues(track: TextTrackLike | null, active = false): TextCueLike[] {
+  const cues = active ? track?.activeCues : track?.cues;
+
+  return cues ? Array.from(cues) : [];
+}
+
+/**
+ * Observe cue snapshots for a text track.
+ *
+ * Snapshots refresh on native `cuechange`, when the backing `<track>` loads, when the media starts loading a new
+ * source, and after cues are added or removed through `addTextTrackCue()`, `removeTextTrackCue()`, or a
+ * `TextTrackHandle`.
+ *
+ * @param media - Media element that owns the track, used to observe source and `<track>` load events.
+ * @param track - Text track to observe.
+ * @param active - Whether to observe active cues instead of the complete cue list.
+ * @param onChange - Receives a fresh cue array whenever the observable state changes.
+ */
+export function watchTextTrackCues(
+  media: Media | null,
+  track: TextTrackLike,
+  active: boolean,
+  onChange: (cues: TextCueLike[]) => void
+): () => void {
+  const cleanups: (() => void)[] = [];
+  const sync = () => onChange(getTextTrackCues(track, active));
+
+  cleanups.push(listenCueChanges(track, sync));
+
+  if (track instanceof EventTarget) cleanups.push(listen(track, 'cuechange', sync));
+
+  if (media instanceof EventTarget) {
+    const trackElement = findTrackElement(media, track);
+
+    if (trackElement) cleanups.push(listen(trackElement, 'load', sync));
+
+    cleanups.push(listen(media, 'loadstart', sync));
+  }
+
+  sync();
+
+  return () => {
+    for (const cleanup of cleanups) cleanup();
+  };
+}
+
+function listenCueChanges(track: TextTrackLike, listener: () => void): () => void {
+  let listeners = cueListeners.get(track);
+
+  if (!listeners) {
+    listeners = new Set();
+    cueListeners.set(track, listeners);
+  }
+
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+
+    if (listeners.size === 0) cueListeners.delete(track);
+  };
+}
+
+function notifyCueListeners(track: TextTrackLike): void {
+  const listeners = cueListeners.get(track);
+  if (!listeners) return;
+
+  for (const listener of [...listeners]) listener();
+}
+
+function isNativeMediaElement(media: MediaTextTrackCapability): media is MediaTextTrackCapability & HTMLMediaElement {
+  const MediaElement = globalThis.HTMLMediaElement;
+
+  return Boolean(MediaElement && media instanceof MediaElement);
+}

--- a/packages/utils/src/dom/tests/text-track.test.ts
+++ b/packages/utils/src/dom/tests/text-track.test.ts
@@ -78,4 +78,15 @@ describe('findTrackElement', () => {
     expect(findTrackElement(video, captionsTrack)).toBe(captionsEl);
     expect(findTrackElement(video, chaptersTrack)).toBe(chaptersEl);
   });
+
+  it('finds a track element forwarded through a shadow root', () => {
+    const host = document.createElement('div');
+    const root = host.attachShadow({ mode: 'open' });
+    const el = document.createElement('track');
+    const track = mockTrackProperty(el);
+
+    root.append(el);
+
+    expect(findTrackElement(host, track)).toBe(el);
+  });
 });

--- a/packages/utils/src/dom/text-track.ts
+++ b/packages/utils/src/dom/text-track.ts
@@ -1,15 +1,25 @@
 export type CaptionOrSubtitleKind = 'captions' | 'subtitles';
 
+export interface TextTrackIdentity {
+  readonly kind: string;
+}
+
 /** Whether a text track is a captions or subtitles track. */
 export function isCaptionOrSubtitleTrack(track: { kind: string }): track is { kind: CaptionOrSubtitleKind } {
   return track.kind === 'captions' || track.kind === 'subtitles';
 }
 
 /** Find the `<track>` element that owns the given `TextTrack`. */
-export function findTrackElement(media: EventTarget, track: unknown): HTMLTrackElement | null {
-  if (!(media instanceof HTMLElement)) return null;
+export function findTrackElement(media: EventTarget, track: TextTrackIdentity): HTMLTrackElement | null {
+  // SAFETY: DOM media wrappers may expose the ParentNode query API without inheriting from HTMLElement.
+  const root = media as EventTarget & {
+    querySelectorAll?: (selectors: string) => Iterable<HTMLTrackElement>;
+    shadowRoot?: ShadowRoot | null;
+  };
 
-  for (const el of media.querySelectorAll('track')) {
+  const elements = [...(root.querySelectorAll?.('track') ?? []), ...(root.shadowRoot?.querySelectorAll('track') ?? [])];
+
+  for (const el of elements) {
     if (el.track === track) return el;
   }
 


### PR DESCRIPTION
Refs #2439

## Summary

Extract the framework-neutral foundation from #2439 so the HTML controller and React hooks share one lifecycle-safe text-track implementation.

## Changes

- Create removable native text tracks with queued cue writes and explicit cleanup
- Add active-track and cue snapshot watchers for native and adapter-backed media
- Notify observers when programmatic cues are added or removed
- Extend media contracts with optional active-cue, cue-removal, and text-track-removal capabilities
- Resolve native track elements through wrapped media shadow roots

## Testing

- `pnpm -F @videojs/utils test`
- `pnpm -F @videojs/media test`
- `pnpm build:packages`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:workspace`