### PR TITLE
ci(cd): attribute release-please to a GitHub App when configured

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,13 +24,25 @@ jobs:
       id-token: write
 
     steps:
+      # release-please needs a token other than GITHUB_TOKEN so the release
+      # branch push, the release PR, and the published releases still trigger
+      # release-pr.yml, CI, and changelog-prose.yml
+      # (see https://github.com/peter-evans/create-pull-request/issues/48).
+      # Prefer a GitHub App installation token so the release PRs and tags are
+      # attributed to the app's bot user rather than a maintainer. Until the
+      # RELEASE_APP_ID variable and RELEASE_APP_PRIVATE_KEY secret exist, fall
+      # back to the fine grained personal token.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        if: ${{ vars.RELEASE_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          # Use a fine grained token for release-please so this workflow
-          # can trigger other workflows like release-pr.yml
-          # see https://github.com/peter-evans/create-pull-request/issues/48
-          token: ${{ secrets.V10_WORKFLOW_TRIGGER_WORKFLOW_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.V10_WORKFLOW_TRIGGER_WORKFLOW_GH_TOKEN }}
           config-file: .github/release-please/release-please-config.json
           manifest-file: .github/release-please/.release-please-manifest.json
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,13 +28,10 @@ jobs:
       # branch push, the release PR, and the published releases still trigger
       # release-pr.yml, CI, and changelog-prose.yml
       # (see https://github.com/peter-evans/create-pull-request/issues/48).
-      # Prefer a GitHub App installation token so the release PRs and tags are
-      # attributed to the app's bot user rather than a maintainer. Until the
-      # RELEASE_APP_ID variable and RELEASE_APP_PRIVATE_KEY secret exist, fall
-      # back to the fine grained personal token.
+      # A GitHub App installation token attributes the release PRs and tags to
+      # the app's bot user rather than a maintainer.
       - uses: actions/create-github-app-token@v2
         id: app-token
-        if: ${{ vars.RELEASE_APP_ID != '' }}
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -42,7 +39,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ steps.app-token.outputs.token || secrets.V10_WORKFLOW_TRIGGER_WORKFLOW_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: .github/release-please/release-please-config.json
           manifest-file: .github/release-please/.release-please-manifest.json
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,7 +73,8 @@ jobs:
 
       - name: Verify release checkout
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        run: node -e "process.exit(require('./packages/html/package.json').version === process.env.VERSION ? 0 : 1)"
+        run: |
+          node -e "process.exit(require('./packages/html/package.json').version === process.env.VERSION ? 0 : 1)"
         env:
           VERSION: ${{ steps.release.outputs['packages/html--version'] }}
 


### PR DESCRIPTION
Split out of #2599 so the release attribution change can merge and be tested on its own.

## What

1. `cd.yml` now mints a GitHub App installation token with `actions/create-github-app-token@v2` from the `RELEASE_APP_ID` variable and `RELEASE_APP_PRIVATE_KEY` secret, and hands that token to `release-please-action`. The personal token (`V10_WORKFLOW_TRIGGER_WORKFLOW_GH_TOKEN`) is no longer referenced; a missing or invalid app credential fails the release job instead of silently releasing under a maintainer's identity.
2. Fixes the "Verify release checkout" step, whose plain-scalar `run:` contained `? 0 : 1` and made `cd.yml` invalid YAML since #2446. Every Deployment run on `main` since Aug 28 has failed at parse time with zero jobs, so release-please has not run at all. Without this fix the app token could not be exercised. (#2599 carries the same two-line change and will merge cleanly on top.)

## Why

Release PRs, tags, and releases are currently attributed to whoever owns the personal token. A GitHub App installation token attributes them to the app's bot user (`videojs-release[bot]`) instead. `GITHUB_TOKEN` is not an option because events it creates do not trigger other workflows, which would break `release-pr.yml`, CI on the release PR, and `changelog-prose.yml`.

## Testing

- `actionlint .github/workflows/cd.yml` passes on this branch and fails on `main` with the YAML parse error.
- `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` are configured on the repository (the app is installed on `videojs/v10` only).
- After this merges, the next Deployment run on `main` should show the `create-github-app-token` step running, and release-please should open or update the release PR as the app's bot user. Closing the current release PR (#2448) makes release-please recreate it under the new author.
- Note: until #2599 merges, release-please will still propose `10.0.0-beta.33`. That is expected; the point of this PR is the author, not the version.
- The `V10_WORKFLOW_TRIGGER_WORKFLOW_GH_TOKEN` secret can be deleted once a bot-authored release PR has been observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ5RTqfnRMiiASH1T7tWVj