### PR TITLE
fix(cdn): keep the light-DOM global rules out of the skin sheets

### DIFF
--- a/build/plugins/copy-css-plugin.ts
+++ b/build/plugins/copy-css-plugin.ts
@@ -21,6 +21,11 @@ interface CopyCssPluginOptions {
   rename?: (file: string) => string | null;
   /** Drop an `@import`ed file, by resolved absolute path, instead of inlining it. */
   omitImport?: (file: string) => boolean;
+  /**
+   * Rewrite a sheet's resolved content before it is minified and written. `file` is the source path relative to
+   * `rootDir`.
+   */
+  transform?: (content: string, file: string) => string;
   minify?: boolean;
 }
 
@@ -37,6 +42,7 @@ export function copyCssPlugin(options: CopyCssPluginOptions): BuildPlugin {
     rebuild = true,
     rename = mirrorSrcTree,
     omitImport,
+    rewrite,
     minify = false,
   } = options;
   let poll: ReturnType<typeof setInterval> | undefined;
@@ -68,6 +74,8 @@ export function copyCssPlugin(options: CopyCssPluginOptions): BuildPlugin {
       const source = join(rootDir, file);
       const content = readFileSync(source, 'utf-8');
       let output = inline ? resolveImports(content, dirname(source), omitImport) : content;
+
+      if (rewrite) output = rewrite(output, file);
 
       if (minify) {
         output = transform({ filename: source, code: Buffer.from(output), minify: true }).code.toString();

--- a/packages/cdn/scripts/check-cdn-skins.ts
+++ b/packages/cdn/scripts/check-cdn-skins.ts
@@ -15,6 +15,8 @@ const HTML_DIST_DIR = resolve(
 );
 const PREFIX = '\x1b[35m[check-cdn-skins]\x1b[0m';
 const forbiddenRuntime = /(?:virtual:vjsc|vjsc\/components|vjsc\/target|@videojs\/core\/vjsc)/;
+// A light-DOM rule that lives only in `global.css`; a skin sheet is linked inside a shadow root and must not carry it.
+const globalOnlyRule = 'media-container video::-webkit-media-text-track-container';
 const skins = [
   {
     entry: 'video',
@@ -77,11 +79,14 @@ const skins = [
 function main(): void {
   if (!existsSync(CDN_DIR)) fail(`CDN build not found at ${CDN_DIR}. Run \`pnpm build:cdn\` first.`);
 
+  assert(readCdn('global.css').includes(globalOnlyRule), 'global.css lost its light-DOM rules');
+
   for (const skin of skins) {
     const stylesheet = readCdn(`${skin.entry}.css`);
 
     assert(stylesheet.length > 10_000, `${skin.entry}.css is unexpectedly incomplete`);
     assert(stylesheet.includes(skin.scope), `${skin.entry}.css is missing its skin scope`);
+    assert(!stylesheet.includes(globalOnlyRule), `${skin.entry}.css embeds the light-DOM global.css rules`);
 
     const registration = readSource(`internal/skins/${skin.generated}/register.js`);
     const expectedSources = registrationImports(registration);

--- a/packages/cdn/vite.config.ts
+++ b/packages/cdn/vite.config.ts
@@ -1,4 +1,4 @@
-import { globSync, rmSync, writeFileSync } from 'node:fs';
+import { globSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -74,6 +74,21 @@ export const entries = [
   ...cdnMediaEntries,
   ...cdnExtensionEntries,
 ];
+
+/**
+ * Html's build inlines every `@import` into its published sheets, so each preset skin sheet carries `global.css`. Those
+ * rules are for the light DOM and ship on their own as `global.css`; a skin sheet is linked inside a declarative shadow
+ * root, where `media-container video` and the caption-track rules would otherwise apply too. Strip the exact inlined
+ * text, which is the same resolved content html wrote to `define/global.css`.
+ */
+function stripGlobalSheet(content: string, file: string): string {
+  if (!/^define\/[\w-]+\/[\w-]+\.css$/.test(file)) return content;
+
+  // The background skin is light DOM only and never imports the global sheet; `check-cdn-skins` asserts the rest lost it.
+  const globalSheet = readFileSync(resolve(htmlDistDir, 'define/global.css'), 'utf-8').trim();
+
+  return content.replace(globalSheet, '');
+}
 
 function cdnStylesheetName(file: string): string | null {
   const match = /^define\/(?:([\w-]+)\/)?([\w-]+)\.css$/.exec(file);
@@ -168,6 +183,7 @@ for (const mode of ['dev', 'prod'] satisfies CdnBuildMode[]) {
               outDir: packageDir,
               rename: cdnStylesheetName,
               inline: false,
+              rewrite: stripGlobalSheet,
               minify: true,
             }),
           ]


### PR DESCRIPTION
## What this does

Restores the shadow-sheet behavior the old html cdn build had: preset skin sheets on the CDN no longer embed `global.css`.

## Why

html inlines every `@import` into its published `define/**/*.css`, so `skin.css` carries `global.css` verbatim. `@videojs/cdn` copies those sheets as-is, which put the light-DOM rules (`media-container video`, caption-track tweaks) into `video.css` and friends. Linked inside a declarative shadow root, they applied there. Flagged by Bugbot on #2598.

| Sheet | Before | After |
| --- | --- | --- |
| `video.css`, `audio.css`, `live-*.css`, `*-minimal.css` | skin rules + `global.css` | skin rules only |
| `global.css` | light-DOM rules | unchanged |
| `background.css` | never imported the global sheet | unchanged |

## How

- `copyCssPlugin` gains a `rewrite(content, file)` hook applied after inlining and before minifying.
- The cdn strips the exact resolved text of `define/global.css` from `define/<preset>/*.css`, the same content html wrote to `global.css`.
- `check-cdn-skins` asserts every skin sheet lacks a global-only rule and `global.css` keeps it.

## Validation

`pnpm build:cdn`, `pnpm -F @videojs/cdn check:cdn` (self-contained + 8 skins), cdn tests, lint, workspace check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
