### PR TITLE
ci(preview): skip pnpm's lockfile check when publishing previews

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -116,11 +116,14 @@ jobs:
       - name: Prepare the StackBlitz template
         run: pnpm --filter @videojs/sandbox exec tsx scripts/prepare-template.ts
 
+      # The template step above left apps/sandbox/package.json out of step with the lockfile on purpose. pnpm re-verifies
+      # the lockfile before any root-level `pnpm exec` and, in CI, refuses to continue, so skip that check here.
       - name: Publish preview packages
         env:
           VIDEOJS_SKIP_PACKAGE_DOCS: '1'
         run: >
-          pnpm exec pkg-pr-new publish --pnpm --previewVersion --peerDeps --packageManager=pnpm
+          pnpm --config.verify-deps-before-run=false exec pkg-pr-new publish --pnpm --previewVersion --peerDeps
+          --packageManager=pnpm
           './packages/cdn'
           './packages/core'
           './packages/element'


### PR DESCRIPTION
## What this does

Makes the Preview Releases workflow pass again. It has failed on every run since #2586, on `main` included.

## Why

`prepare-template.ts` rewrites `apps/sandbox/package.json` in place for the StackBlitz upload, so the lockfile stops matching it. pnpm 11 re-verifies the lockfile before a root-level `pnpm exec` and, in CI, aborts with `ERR_PNPM_OUTDATED_LOCKFILE` before `pkg-pr-new` even starts.

| Step | Before | After |
| --- | --- | --- |
| Publish preview packages | `pnpm exec pkg-pr-new publish …` | `pnpm --config.verify-deps-before-run=false exec pkg-pr-new publish …` |

Reproduced locally: after running the template script, `CI=true pnpm exec node -e 1` fails with the same error, and the flag is the only thing that clears it (the `npm_config_*` env form does not). Nothing else changes: dependencies are already installed by the earlier step, and the checkout is disposable.

## Validation

Local reproduction above, workspace check. The workflow run on this PR is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change on a disposable checkout; dependencies are already installed and only the lockfile re-check before `pnpm exec` is skipped for the publish step.
> 
> **Overview**
> Restores the **Preview Releases** workflow after failures from pnpm 11’s pre-run lockfile verification.
> 
> The StackBlitz **Prepare the StackBlitz template** step intentionally rewrites `apps/sandbox/package.json`, which no longer matches the frozen lockfile. The **Publish preview packages** step now runs `pnpm` with `--config.verify-deps-before-run=false` so `pkg-pr-new` can run in CI without `ERR_PNPM_OUTDATED_LOCKFILE`. Workflow comments document that tradeoff; install still uses `--frozen-lockfile` earlier in the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40cb009893ad9bf69df04491a7a77d2c0bcfa89a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->