### PR TITLE
ci(cd): restore the GitHub App token and valid YAML in the release workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,13 +24,22 @@ jobs:
       id-token: write
 
     steps:
+      # release-please needs a token other than GITHUB_TOKEN so the release
+      # branch push, the release PR, and the published releases still trigger
+      # release-pr.yml, CI, and changelog-prose.yml
+      # (see https://github.com/peter-evans/create-pull-request/issues/48).
+      # A GitHub App installation token attributes the release PRs and tags to
+      # the app's bot user rather than a maintainer.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          # Use a fine grained token for release-please so this workflow
-          # can trigger other workflows like release-pr.yml
-          # see https://github.com/peter-evans/create-pull-request/issues/48
-          token: ${{ secrets.V10_WORKFLOW_TRIGGER_WORKFLOW_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: .github/release-please/release-please-config.json
           manifest-file: .github/release-please/.release-please-manifest.json
 
@@ -61,7 +70,8 @@ jobs:
 
       - name: Verify release checkout
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        run: node -e "process.exit(require('./packages/cdn/package.json').version === process.env.VERSION ? 0 : 1)"
+        run: |
+          node -e "process.exit(require('./packages/cdn/package.json').version === process.env.VERSION ? 0 : 1)"
         env:
           VERSION: ${{ steps.release.outputs['packages/cdn--version'] }}
 


### PR DESCRIPTION
## Summary

#2598 moved the release workflow's `@videojs/html` references to the new `@videojs/cdn` package from a branch that predated #2616, so it undid both of #2616's changes to `cd.yml`:

- It dropped the `actions/create-github-app-token` step and put release-please back on the old `V10_WORKFLOW_TRIGGER_WORKFLOW_GH_TOKEN` personal token.
- It rewrote the "Verify release checkout" step as a plain scalar. That command contains `? 0 : 1`, which YAML rejects (`mapping values are not allowed here`).

Because the file no longer parses, every `cd.yml` run since 21:02 UTC today has failed at startup with zero jobs, on every branch, and release-please has not run. The open release PR #2617 was produced by the last good run, which straddled the CDN commit: it is missing `@videojs/cdn` and the five commits that landed after it, so it should be regenerated by the first green run of this workflow before it is merged.

## Change

Re-apply both #2616 changes on top of the `cdn` rename. The resulting file differs from #2616's `cd.yml` only in the `html` → `cdn` lines from #2598.

## Verification

- `cd.yml` at this commit parses with PyYAML; `origin/main` and `4c57edfa` do not.
- `git diff 865e167b -- .github/workflows/cd.yml` shows only `html`/`cdn` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fy1FGmbbNsyZeC34PpEd85

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fy1FGmbbNsyZeC34PpEd85)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production release automation and secrets used for tagging and release PRs; a misconfigured app token would block releases until fixed.
> 
> **Overview**
> **Fixes the production `cd.yml` workflow** so it parses again and release-please can run after a bad merge dropped prior CI fixes.
> 
> The workflow **reintroduces** `actions/create-github-app-token@v2` (using `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) and wires **release-please** to that installation token instead of the personal `V10_WORKFLOW_TRIGGER_WORKFLOW_GH_TOKEN`, so release branch pushes and tags still trigger downstream workflows and releases are attributed to the app bot.
> 
> The **Verify release checkout** step is changed to a **block `run:`** so the inline `node -e` command with `? 0 : 1` is valid YAML (the previous single-line form caused workflow startup failures on every branch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d30733be892092c3aac36e0de28ea0efd9565f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->