### PR TITLE
docs(site): simplify media reference installs

### DIFF
--- a/site/src/components/docs/api-reference/MediaImports.astro
+++ b/site/src/components/docs/api-reference/MediaImports.astro
@@ -13,4 +13,4 @@ interface Props {
 const { media, package: pkg, react } = Astro.props;
 ---
 
-<ModuleImports name={media} package={pkg} react={react} subpath="media" />
+<ModuleImports name={media} package={pkg} packageOnlyInstall={true} react={react} subpath="media" />

--- a/site/src/components/docs/api-reference/ModuleImports.astro
+++ b/site/src/components/docs/api-reference/ModuleImports.astro
@@ -13,22 +13,29 @@ interface Props {
   name: string;
   /** Package that ships the module's adapter or extension, installed beside the framework package. */
   package?: string;
+  /** Whether the install command should include only the module package. */
+  packageOnlyInstall?: boolean;
   /** Named export from the React module. */
   react: string;
   /** Public module family shared by the React, HTML, and CDN imports. */
   subpath: 'extensions' | 'media';
 }
 
-const { name, package: pkg, react, subpath } = Astro.props;
+const { name, package: pkg, packageOnlyInstall = false, react, subpath } = Astro.props;
 
 const cdnCode = `<script type="module" src="${VJS10_CDN_BASE}/${subpath}/${name}.js"></script>`;
 
 const imports: Array<{ code: string; framework: 'react' | 'html'; lang: BundledLanguage }> = [
   ...(pkg
-    ? [
-        { code: `pnpm add @videojs/react ${pkg}`, framework: 'react' as const, lang: 'bash' as const },
-        { code: `pnpm add @videojs/html ${pkg}`, framework: 'html' as const, lang: 'bash' as const },
-      ]
+    ? packageOnlyInstall
+      ? [
+          { code: `pnpm add ${pkg}`, framework: 'react' as const, lang: 'bash' as const },
+          { code: `pnpm add ${pkg}`, framework: 'html' as const, lang: 'bash' as const },
+        ]
+      : [
+          { code: `pnpm add @videojs/react ${pkg}`, framework: 'react' as const, lang: 'bash' as const },
+          { code: `pnpm add @videojs/html ${pkg}`, framework: 'html' as const, lang: 'bash' as const },
+        ]
     : []),
   {
     code: `import { ${react} } from '@videojs/react/${subpath}/${name}';`,


### PR DESCRIPTION
## Summary

Limit the media reference install snippet to the media package itself instead of prepending framework package installs.

## Changes

- add a package-only install mode to the shared module import renderer used by reference pages
- opt media reference imports into that mode while leaving extension import instructions unchanged

## Testing

Not run separately. Verified as part of `pnpm typecheck` during the slider work that shared this workspace state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to install snippet text on the docs site; no runtime or package behavior.
> 
> **Overview**
> **Media API reference pages** now show `pnpm add <media-package>` only, instead of also listing `@videojs/react` and `@videojs/html` on the same install line.
> 
> `ModuleImports` gains an optional **`packageOnlyInstall`** flag (default `false`) that switches install snippets between package-only and framework-plus-package. **`MediaImports`** sets it to `true`; **extension** reference pages keep the previous combined install commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2efb6e1a751c098c29afd8bbae3d8ff235b26bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->