### PR TITLE
fix(packages): adopt cn for class name merging

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -34,8 +34,7 @@
     "@videojs/vimeo-video": "workspace:*",
     "@videojs/wistia-video": "workspace:*",
     "@videojs/youtube-video": "workspace:*",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^3.5.0"
+    "cn": "^0.2.5"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",

--- a/apps/sandbox/scripts/sync-source-owned-skins.ts
+++ b/apps/sandbox/scripts/sync-source-owned-skins.ts
@@ -20,9 +20,6 @@ const presets = ['video', 'audio', 'live-video', 'live-audio'] as const;
 const variants = ['', '-minimal'] as const;
 
 const inWorkspace = existsSync(resolve(workspaceDir, 'pnpm-workspace.yaml'));
-/** The Shadcn `cn` helper on the packages the Sandbox depends on, kept even after the registry's `utils` item runs. */
-const CN_UTILS = `import { clsx, type ClassValue } from 'clsx';\nimport { twMerge } from 'tailwind-merge';\n\nexport function cn(...inputs: ClassValue[]) {\n  return twMerge(clsx(inputs));\n}\n`;
-
 const localRegistry = existsSync(resolve(registryDir, 'react/registry.json'));
 const server = localRegistry ? createServer() : undefined;
 const address = server
@@ -116,9 +113,6 @@ async function installCatalog(install: (typeof installs)[number], address: strin
     await cp(resolve(root, 'src/components/videojs'), destination, { recursive: true });
 
     if (install.catalog.startsWith('react')) {
-      // The registry's `utils` item overwrites the fixture's `cn` with whatever Shadcn ships today, and that may
-      // import a package the Sandbox never installs. The copied helpers keep the `cn` built from what it does.
-      await writeFile(resolve(root, 'src/lib/utils.ts'), CN_UTILS);
       await cp(resolve(root, 'src/lib'), resolve(destination, '../../lib'), { recursive: true });
     }
 
@@ -138,9 +132,8 @@ async function writeFixture(root: string, address: string, alias: string): Promi
       '@videojs/core': '*',
       '@videojs/html': '10.0.0-beta.32',
       '@videojs/react': '10.0.0-beta.32',
-      clsx: '*',
+      cn: '*',
       react: '*',
-      'tailwind-merge': '*',
     },
   };
   const components = {
@@ -185,7 +178,7 @@ async function writeFixture(root: string, address: string, alias: string): Promi
   await writeFile(resolve(root, 'components.json'), `${JSON.stringify(components, null, 2)}\n`);
   await writeFile(resolve(root, 'tsconfig.json'), `${JSON.stringify(tsconfig, null, 2)}\n`);
   await writeFile(resolve(root, 'src/index.css'), '@import "./components/videojs/styles/theme.css";\n');
-  await writeFile(resolve(root, 'src/lib/utils.ts'), CN_UTILS);
+  await writeFile(resolve(root, 'src/lib/utils.ts'), "export { cn } from 'cn';\n");
 }
 
 async function runCommand(

--- a/apps/sandbox/scripts/sync-source-owned-skins.ts
+++ b/apps/sandbox/scripts/sync-source-owned-skins.ts
@@ -20,6 +20,9 @@ const presets = ['video', 'audio', 'live-video', 'live-audio'] as const;
 const variants = ['', '-minimal'] as const;
 
 const inWorkspace = existsSync(resolve(workspaceDir, 'pnpm-workspace.yaml'));
+/** The Shadcn `cn` helper on the packages the Sandbox depends on, kept even after the registry's `utils` item runs. */
+const CN_UTILS = `import { clsx, type ClassValue } from 'clsx';\nimport { twMerge } from 'tailwind-merge';\n\nexport function cn(...inputs: ClassValue[]) {\n  return twMerge(clsx(inputs));\n}\n`;
+
 const localRegistry = existsSync(resolve(registryDir, 'react/registry.json'));
 const server = localRegistry ? createServer() : undefined;
 const address = server
@@ -113,6 +116,9 @@ async function installCatalog(install: (typeof installs)[number], address: strin
     await cp(resolve(root, 'src/components/videojs'), destination, { recursive: true });
 
     if (install.catalog.startsWith('react')) {
+      // The registry's `utils` item overwrites the fixture's `cn` with whatever Shadcn ships today, and that may
+      // import a package the Sandbox never installs. The copied helpers keep the `cn` built from what it does.
+      await writeFile(resolve(root, 'src/lib/utils.ts'), CN_UTILS);
       await cp(resolve(root, 'src/lib'), resolve(destination, '../../lib'), { recursive: true });
     }
 
@@ -179,10 +185,7 @@ async function writeFixture(root: string, address: string, alias: string): Promi
   await writeFile(resolve(root, 'components.json'), `${JSON.stringify(components, null, 2)}\n`);
   await writeFile(resolve(root, 'tsconfig.json'), `${JSON.stringify(tsconfig, null, 2)}\n`);
   await writeFile(resolve(root, 'src/index.css'), '@import "./components/videojs/styles/theme.css";\n');
-  await writeFile(
-    resolve(root, 'src/lib/utils.ts'),
-    `import { clsx, type ClassValue } from 'clsx';\nimport { twMerge } from 'tailwind-merge';\n\nexport function cn(...inputs: ClassValue[]) {\n  return twMerge(clsx(inputs));\n}\n`
-  );
+  await writeFile(resolve(root, 'src/lib/utils.ts'), CN_UTILS);
 }
 
 async function runCommand(

--- a/packages/skins/build/packages/react.ts
+++ b/packages/skins/build/packages/react.ts
@@ -173,7 +173,7 @@ function collectSharedSourcePaths(skins: readonly SkinRoot[]): ReadonlySet<strin
 }
 
 function reactFrameworkImport(specifier: string): string | undefined {
-  if (specifier === '@videojs/react' || radioGroupImports.has(specifier) || specifier === 'clsx') {
+  if (specifier === '@videojs/react' || radioGroupImports.has(specifier) || specifier === 'cn') {
     return `${packageRoot}/internal/skin-primitives.ts`;
   }
 

--- a/packages/skins/build/target/react.tsx
+++ b/packages/skins/build/target/react.tsx
@@ -139,7 +139,7 @@ export const reactComponentTarget: ComponentTarget<CoreSchema> = defineComponent
       },
     },
     types: {
-      ClassNameValue: { from: 'clsx', name: 'ClassValue' },
+      ClassNameValue: { from: 'cn', name: 'ClassValue' },
       PropsOf: { from: 'react', name: 'ComponentProps' },
       VjscNode: { from: 'react', name: 'ReactNode' },
       VjscElement: { from: 'react', name: 'ReactElement' },

--- a/packages/skins/package.json
+++ b/packages/skins/package.json
@@ -33,7 +33,7 @@
     "@videojs/icons": "workspace:*",
     "@videojs/utils": "workspace:*",
     "@vitejs/plugin-react": "^6.0.4",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.5",
     "dashjs": "^5.2.0",
     "hls.js": "^1.6.7",
     "mux-embed": "5.17.10",

--- a/packages/skins/src/utils.ts
+++ b/packages/skins/src/utils.ts
@@ -1,4 +1,4 @@
-import type { ClassValue } from 'clsx';
+import type { ClassValue } from 'cn';
 
 export { cn } from '@videojs/utils/style';
 

--- a/packages/vjsc/package.json
+++ b/packages/vjsc/package.json
@@ -87,13 +87,13 @@
     "@oxc-project/types": "0.146.0",
     "@tailwindcss/node": "4.2.1",
     "@videojs/utils": "workspace:*",
+    "cn": "^0.2.5",
     "lightningcss": "^1.32.0",
     "magic-string": "^1.2.2",
     "oxc-parser": "0.146.0",
     "oxc-walker": "^1.1.1",
     "rolldown": "~1.2.5",
     "shadcn": "^4.16.2",
-    "tailwind-merge": "^3.5.0",
     "tailwindcss": "4.2.1"
   },
   "devDependencies": {

--- a/packages/vjsc/src/styles/resolved.ts
+++ b/packages/vjsc/src/styles/resolved.ts
@@ -2,8 +2,8 @@ import { realpath } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { twMerge } from 'cn';
 import { type OutputChunk, rolldown } from 'rolldown';
-import { twMerge } from 'tailwind-merge';
 
 import { toArray } from '../utils/array';
 import { splitClassNames } from './class-names';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,12 +210,9 @@ importers:
       '@videojs/youtube-video':
         specifier: workspace:*
         version: link:../../packages/adapters/youtube-video
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
-      tailwind-merge:
-        specifier: ^3.5.0
-        version: 3.5.0
+      cn:
+        specifier: ^0.2.5
+        version: 0.2.5
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.3
@@ -1035,9 +1032,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.4
         version: 6.0.4(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)(yaml@2.9.0))(babel-plugin-react-compiler@1.0.0)
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cn:
+        specifier: ^0.2.5
+        version: 0.2.5
       dashjs:
         specifier: ^5.2.0
         version: 5.2.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
@@ -1160,6 +1157,9 @@ importers:
       '@videojs/utils':
         specifier: workspace:*
         version: link:../utils
+      cn:
+        specifier: ^0.2.5
+        version: 0.2.5
       lightningcss:
         specifier: ^1.32.0
         version: 1.32.0
@@ -1178,9 +1178,6 @@ importers:
       shadcn:
         specifier: ^4.16.2
         version: 4.16.2(supports-color@8.1.1)(typescript@6.0.2)
-      tailwind-merge:
-        specifier: ^3.5.0
-        version: 3.5.0
       tailwindcss:
         specifier: 4.2.1
         version: 4.2.1
@@ -6035,6 +6032,11 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cn@0.2.5:
+    resolution: {integrity: sha512-OCjZtMeQfXbI4Es1+EIjkd77gvWzaE689gD8KhfexlqjClC06qR1MQBR+Z35ZMSPNEBWyHiItW1Soy0UvwNv9w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -15396,6 +15398,8 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  cn@0.2.5: {}
 
   code-block-writer@13.0.3: {}
 


### PR DESCRIPTION
## Summary

The Sandbox build broke because Shadcn's `utils` registry item now ships `export { cn } from "cn"`, and the Sandbox copied that helper without the `cn` package. Rather than keep a private `clsx` + `tailwind-merge` helper, this adopts [`cn`](https://github.com/shadcn-ui/cn) as the class-merging engine across the registry, the compiler, and the Sandbox.

## Changes

- React registry items import `ClassValue` from `cn`, so consumers only need the package Shadcn already installs for `@/lib/utils`; `clsx` drops out of every item's dependency list
- vjsc merges authored utility groups with `cn`'s `twMerge`; the emitted registry output is byte-identical to the `tailwind-merge` build
- The Sandbox depends on `cn` and installs the registry skins with Shadcn's own helper instead of rewriting `lib/utils.ts` after `shadcn add`
- `clsx` and `tailwind-merge` are removed from `@videojs/skins`, `vjsc`, and the Sandbox; the site keeps its own themed `twMerge` for now

`cn` is pinned to `^0.2.5` because the workspace's 24-hour `minimumReleaseAge` still blocks `0.2.6`.

## Why it looked green elsewhere

The Sandbox `setup` task is cached on its scripts, templates, and the built registry. Branches that touch none of those restore the pre-`cn` generated tree and never run the CLI, which is why CI and most Vercel deploys still passed. Any skins, template, or sandbox-script change busts that cache and hits the failure, as PR #2640 did.

## Testing

- `pnpm build:sandbox` passes; both generated `lib/utils.ts` files are `export { cn } from "cn"` and no generated file imports `clsx`
- Registry output built with `cn`'s `twMerge` hashes identically to the `tailwind-merge` build across all React and HTML items
- `pnpm -F vjsc test`, `pnpm -F @videojs/skins test`, `pnpm -F @videojs/sandbox test`, `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches style compilation (`twMerge` in vjsc) and generated registry/Sandbox install paths; behavior is intended to stay equivalent to the prior merge stack.
> 
> **Overview**
> Replaces the **`clsx` + `tailwind-merge`** stack with the **`cn`** package in the Sandbox, `@videojs/skins`, and **`vjsc`**, matching current Shadcn registry **`@/lib/utils`** (`export { cn } from "cn"`).
> 
> The Sandbox sync fixture now depends on **`cn`** and seeds **`src/lib/utils.ts`** with that re-export instead of generating a local **`twMerge(clsx(...))`** helper. Registry React build wiring treats **`cn`** like the old **`clsx`** import (primitives bundling, **`ClassNameValue`** typed from **`cn`**). **`vjsc`** merges authored utility groups via **`twMerge`** from **`cn`** rather than **`tailwind-merge`**. **`packages/skins/src/utils.ts`** sources **`ClassValue`** from **`cn`** while still re-exporting runtime **`cn`** from **`@videojs/utils/style`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bfa7c30d00283b661b6619937fd5b620541c161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->