### PR TITLE
ci(ci): run affected package tests in grouped jobs

### DIFF
--- a/.github/scripts/package-test-matrix.js
+++ b/.github/scripts/package-test-matrix.js
@@ -1,0 +1,233 @@
+/**
+ * Selects package tests affected by a pull request and groups them into a small
+ * number of balanced GitHub Actions jobs.
+ *
+ * Changed packages and all of their workspace dependents are selected. Changes
+ * to shared build or toolchain files select every package test. Pushes to main
+ * pass `--all` so the default branch always receives full coverage.
+ *
+ * Usage:
+ *   printf '%s\n' packages/core/src/index.ts | node .github/scripts/package-test-matrix.js
+ *   node .github/scripts/package-test-matrix.js --all
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'];
+const MAX_SHARDS = 4;
+const TARGET_PACKAGES_PER_SHARD = 5;
+
+const GLOBAL_FILES = new Set([
+  '.node-version',
+  '.npmrc',
+  '.nvmrc',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'tsconfig.base.json',
+  'tsconfig.json',
+  'vite.config.ts',
+]);
+
+const TEST_WEIGHTS = new Map([
+  ['@videojs/react', 6],
+  ['@videojs/skins', 5],
+  ['@videojs/core', 4],
+  ['@videojs/html', 4],
+  ['@videojs/utils', 3],
+  ['@videojs/cdn', 2],
+  ['@videojs/icons', 2],
+  ['@videojs/media', 2],
+  ['@videojs/sandbox', 2],
+  ['@videojs/spotify-audio', 2],
+  ['vjsc', 2],
+]);
+
+export const SPECIAL_TEST_PACKAGES = new Set(['@videojs/spf']);
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function normalizePath(path) {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function packageRecord(root, directory) {
+  const packageJson = readJson(join(root, directory, 'package.json'));
+  const dependencies = new Set();
+
+  for (const field of DEPENDENCY_FIELDS) {
+    for (const name of Object.keys(packageJson[field] ?? {})) dependencies.add(name);
+  }
+
+  return {
+    name: packageJson.name,
+    directory: normalizePath(directory),
+    dependencies,
+    scripts: packageJson.scripts ?? {},
+  };
+}
+
+/** Discover the workspace layout without requiring dependencies to be installed. */
+export function discoverWorkspacePackages(root) {
+  const directories = [];
+  const packagesDirectory = join(root, 'packages');
+
+  for (const entry of readdirSync(packagesDirectory, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const directory = join(packagesDirectory, entry.name);
+
+    if (existsSync(join(directory, 'package.json'))) {
+      directories.push(relative(root, directory));
+      continue;
+    }
+
+    for (const child of readdirSync(directory, { withFileTypes: true })) {
+      const childDirectory = join(directory, child.name);
+
+      if (child.isDirectory() && existsSync(join(childDirectory, 'package.json'))) {
+        directories.push(relative(root, childDirectory));
+      }
+    }
+  }
+
+  const appsDirectory = join(root, 'apps');
+
+  for (const entry of readdirSync(appsDirectory, { withFileTypes: true })) {
+    const directory = join(appsDirectory, entry.name);
+
+    if (entry.isDirectory() && existsSync(join(directory, 'package.json'))) {
+      directories.push(relative(root, directory));
+    }
+  }
+
+  if (existsSync(join(root, 'site/package.json'))) directories.push('site');
+
+  return directories.map((directory) => packageRecord(root, directory)).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Workspaces eligible for affected package-test selection in the main CI workflow. */
+export function isMainCiTestPackage(pkg) {
+  return Boolean(pkg.scripts.test) && (pkg.directory.startsWith('packages/') || pkg.directory === 'apps/sandbox');
+}
+
+function selectsEveryPackage(file) {
+  return (
+    GLOBAL_FILES.has(file) ||
+    file.startsWith('build/') ||
+    file === '.github/workflows/ci.yml' ||
+    file === '.github/scripts/package-test-matrix.js'
+  );
+}
+
+/** Select directly changed packages and their transitive workspace dependents. */
+export function selectAffectedPackageNames(workspacePackages, changedFiles, forceAll = false) {
+  const testPackages = workspacePackages.filter(isMainCiTestPackage);
+  const allTestPackageNames = testPackages.map(({ name }) => name).sort((a, b) => a.localeCompare(b));
+  const files = [...new Set(changedFiles.map(normalizePath).filter(Boolean))];
+
+  if (forceAll || files.some(selectsEveryPackage)) return allTestPackageNames;
+
+  const packagesByName = new Map(workspacePackages.map((pkg) => [pkg.name, pkg]));
+  const packagesByDirectory = [...workspacePackages].sort((a, b) => b.directory.length - a.directory.length);
+  const changedPackageNames = new Set();
+
+  for (const file of files) {
+    const owner = packagesByDirectory.find(
+      ({ directory }) => file === directory || file.startsWith(`${directory}/`)
+    );
+
+    if (owner) {
+      changedPackageNames.add(owner.name);
+    } else if (file.startsWith('packages/')) {
+      // A removed or newly nested package cannot be reconstructed from the
+      // checked-out tree, so retain full coverage for that uncommon case.
+      return allTestPackageNames;
+    }
+  }
+
+  const dependents = new Map(workspacePackages.map(({ name }) => [name, new Set()]));
+
+  for (const pkg of workspacePackages) {
+    for (const dependency of pkg.dependencies) {
+      if (packagesByName.has(dependency)) dependents.get(dependency).add(pkg.name);
+    }
+  }
+
+  const affectedPackageNames = new Set(changedPackageNames);
+  const queue = [...changedPackageNames];
+
+  for (let index = 0; index < queue.length; index++) {
+    for (const dependent of dependents.get(queue[index]) ?? []) {
+      if (affectedPackageNames.has(dependent)) continue;
+
+      affectedPackageNames.add(dependent);
+      queue.push(dependent);
+    }
+  }
+
+  return allTestPackageNames.filter((name) => affectedPackageNames.has(name));
+}
+
+/** Balance selected packages while avoiding one runner installation per package. */
+export function createPackageTestShards(packageNames) {
+  if (packageNames.length === 0) return [];
+
+  const shardCount = Math.min(MAX_SHARDS, Math.ceil(packageNames.length / TARGET_PACKAGES_PER_SHARD));
+  const shards = Array.from({ length: shardCount }, () => ({ packages: [], weight: 0 }));
+  const weightedPackages = [...packageNames].sort((a, b) => {
+    const weightDifference = (TEST_WEIGHTS.get(b) ?? 1) - (TEST_WEIGHTS.get(a) ?? 1);
+
+    return weightDifference || a.localeCompare(b);
+  });
+
+  for (const packageName of weightedPackages) {
+    const shard = shards.reduce((lightest, candidate) => {
+      if (candidate.weight !== lightest.weight) return candidate.weight < lightest.weight ? candidate : lightest;
+
+      return candidate.packages.length < lightest.packages.length ? candidate : lightest;
+    });
+
+    shard.packages.push(packageName);
+    shard.weight += TEST_WEIGHTS.get(packageName) ?? 1;
+  }
+
+  return shards.map(({ packages }, index) => ({
+    name: `${index + 1}/${shards.length}`,
+    packages: packages.sort((a, b) => a.localeCompare(b)),
+  }));
+}
+
+export function createPackageTestSelection({ root, changedFiles = [], forceAll = false }) {
+  const workspacePackages = discoverWorkspacePackages(root);
+  const affectedPackageNames = selectAffectedPackageNames(workspacePackages, changedFiles, forceAll);
+  const runSpf = affectedPackageNames.includes('@videojs/spf');
+  const standardPackageNames = affectedPackageNames.filter((name) => !SPECIAL_TEST_PACKAGES.has(name));
+  const shards = createPackageTestShards(standardPackageNames);
+
+  return {
+    affected: affectedPackageNames,
+    hasStandardTests: shards.length > 0,
+    matrix: {
+      // GitHub validates the matrix before evaluating all job fields. Keep a
+      // placeholder for the job-level `if` to skip when no tests are affected.
+      include: shards.length > 0 ? shards : [{ name: 'none', packages: [] }],
+    },
+    runSpf,
+  };
+}
+
+const scriptPath = process.argv[1] ? resolve(process.argv[1]) : '';
+
+if (scriptPath === fileURLToPath(import.meta.url)) {
+  const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+  const forceAll = process.argv.includes('--all');
+  const changedFiles = forceAll ? [] : readFileSync(0, 'utf8').split(/\r?\n/);
+  const selection = createPackageTestSelection({ root, changedFiles, forceAll });
+
+  process.stdout.write(`${JSON.stringify(selection)}\n`);
+}

--- a/.github/scripts/tests/package-test-matrix.test.js
+++ b/.github/scripts/tests/package-test-matrix.test.js
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  createPackageTestSelection,
+  createPackageTestShards,
+  selectAffectedPackageNames,
+} from '../package-test-matrix.js';
+
+function workspacePackage(name, directory, dependencies = [], test = true) {
+  return {
+    name,
+    directory,
+    dependencies: new Set(dependencies),
+    scripts: test ? { test: 'vp test run' } : {},
+  };
+}
+
+const workspacePackages = [
+  workspacePackage('@videojs/utils', 'packages/utils'),
+  workspacePackage('@videojs/media', 'packages/media', ['@videojs/utils']),
+  workspacePackage('@videojs/core', 'packages/core', ['@videojs/media']),
+  workspacePackage('@videojs/react', 'packages/react', ['@videojs/core']),
+  workspacePackage('@videojs/spf', 'packages/spf', ['@videojs/media']),
+  workspacePackage('@videojs/sandbox', 'apps/sandbox', ['@videojs/react']),
+  workspacePackage('@videojs/e2e', 'apps/e2e', ['@videojs/react'], false),
+  workspacePackage('site', 'site', ['@videojs/react'], false),
+];
+
+describe('selectAffectedPackageNames', () => {
+  it('selects a changed package and its transitive dependents', () => {
+    const selected = selectAffectedPackageNames(workspacePackages, ['packages/media/src/index.ts']);
+
+    assert.deepEqual(selected, [
+      '@videojs/core',
+      '@videojs/media',
+      '@videojs/react',
+      '@videojs/sandbox',
+      '@videojs/spf',
+    ]);
+  });
+
+  it('does not select dependency tests when only a dependent changed', () => {
+    const selected = selectAffectedPackageNames(workspacePackages, ['packages/react/src/player.tsx']);
+
+    assert.deepEqual(selected, ['@videojs/react', '@videojs/sandbox']);
+  });
+
+  it('ignores changes owned by separately tested workspaces', () => {
+    const selected = selectAffectedPackageNames(workspacePackages, ['apps/e2e/suites/player/player.test.ts']);
+
+    assert.deepEqual(selected, []);
+  });
+
+  it('selects every test for shared toolchain changes', () => {
+    const selected = selectAffectedPackageNames(workspacePackages, ['build/task.ts']);
+
+    assert.deepEqual(selected, [
+      '@videojs/core',
+      '@videojs/media',
+      '@videojs/react',
+      '@videojs/sandbox',
+      '@videojs/spf',
+      '@videojs/utils',
+    ]);
+  });
+
+  it('falls back to every test for an unknown package path', () => {
+    const selected = selectAffectedPackageNames(workspacePackages, ['packages/removed/src/index.ts']);
+
+    assert.equal(selected.length, 6);
+  });
+});
+
+describe('createPackageTestShards', () => {
+  it('limits fan-out and keeps every package in exactly one shard', () => {
+    const packages = Array.from({ length: 23 }, (_, index) => `package-${index}`);
+    const shards = createPackageTestShards(packages);
+    const selected = shards.flatMap((shard) => shard.packages);
+
+    assert.equal(shards.length, 4);
+    assert.deepEqual(selected.sort(), packages.sort());
+  });
+});
+
+describe('createPackageTestSelection', () => {
+  it('discovers every current package test and separates SPF for its container', () => {
+    const selection = createPackageTestSelection({
+      root: new URL('../../..', import.meta.url).pathname,
+      forceAll: true,
+    });
+    const standardPackages = selection.matrix.include.flatMap((shard) => shard.packages);
+
+    assert.equal(selection.runSpf, true);
+    assert.equal(selection.hasStandardTests, true);
+    assert.ok(selection.affected.includes('@videojs/spf'));
+    assert.ok(standardPackages.includes('@videojs/react'));
+    assert.ok(standardPackages.includes('@videojs/sandbox'));
+    assert.ok(!standardPackages.includes('@videojs/spf'));
+    assert.equal(new Set([...standardPackages, '@videojs/spf']).size, selection.affected.length);
+  });
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
+          package-manager-cache: false
 
       - name: Test package selector
         run: node --test .github/scripts/tests/package-test-matrix.test.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,52 @@ jobs:
       - name: Install dependencies (cache warm-up)
         run: pnpm install --frozen-lockfile
 
+  package_test_selection:
+    name: Select package tests
+    runs-on: ubuntu-latest
+    outputs:
+      has_standard_tests: ${{ steps.selection.outputs.has_standard_tests }}
+      matrix: ${{ steps.selection.outputs.matrix }}
+      run_spf: ${{ steps.selection.outputs.run_spf }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Test package selector
+        run: node --test .github/scripts/tests/package-test-matrix.test.js
+
+      - name: Select affected package tests
+        id: selection
+        env:
+          CHANGED_FILE_COUNT: ${{ github.event.pull_request.changed_files }}
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" && "$CHANGED_FILE_COUNT" -lt 3000 ]]; then
+            selection=$(
+              gh api "repos/$GH_REPO/pulls/$NUMBER/files" --paginate \
+                --jq '.[] | .filename, (.previous_filename // empty)' |
+                node .github/scripts/package-test-matrix.js
+            )
+          else
+            selection=$(node .github/scripts/package-test-matrix.js --all)
+          fi
+
+          jq . <<<"$selection"
+          {
+            echo "has_standard_tests=$(jq -r '.hasStandardTests' <<<"$selection")"
+            echo "matrix=$(jq -c '.matrix' <<<"$selection")"
+            echo "run_spf=$(jq -r '.runSpf' <<<"$selection")"
+          } >> "$GITHUB_OUTPUT"
+
   lint:
     needs: install
     runs-on: ubuntu-latest
@@ -93,42 +139,13 @@ jobs:
         run: pnpm typecheck
 
   test:
-    needs: install
-    name: Test (${{ matrix.package }})
+    needs: [install, package_test_selection]
+    if: needs.package_test_selection.outputs.has_standard_tests == 'true'
+    name: Test packages (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        package:
-          - '@videojs/cli'
-          - '@videojs/cdn'
-          - 'vjsc'
-          - '@videojs/core'
-          - '@videojs/icons'
-          - '@videojs/media'
-          - '@videojs/mux'
-          - '@videojs/cloudflare-video'
-          - '@videojs/spotify-audio'
-          - '@videojs/tiktok-video'
-          - '@videojs/twitch-video'
-          - '@videojs/youtube-video'
-          - '@videojs/native-hls-video'
-          - '@videojs/dash-video'
-          - '@videojs/google-cast'
-          - '@videojs/hlsjs-video'
-          - '@videojs/mux-audio'
-          - '@videojs/mux-data'
-          - '@videojs/mux-video'
-          - '@videojs/shaka-video'
-          - '@videojs/vimeo-video'
-          - '@videojs/wistia-video'
-          - '@videojs/skins'
-          - '@videojs/store'
-          - '@videojs/utils'
-          - '@videojs/element'
-          - '@videojs/html'
-          - '@videojs/react'
-          - '@videojs/sandbox'
+      matrix: ${{ fromJSON(needs.package_test_selection.outputs.matrix) }}
 
     steps:
       - name: Checkout code
@@ -154,10 +171,20 @@ jobs:
           restore-keys: |
             vite-task-${{ runner.os }}-${{ runner.arch }}-packages-
 
-      - name: Test package
-        run: pnpm exec vp run "${{ matrix.package }}#test:ci"
+      - name: Test packages
+        env:
+          PACKAGES: ${{ toJSON(matrix.packages) }}
+        run: |
+          filters=()
+          while IFS= read -r package; do
+            filters+=(--filter "$package")
+          done < <(jq -r '.[]' <<<"$PACKAGES")
+
+          pnpm exec vp run --fail-if-no-match "${filters[@]}" test:ci
 
   test-spf:
+    needs: package_test_selection
+    if: needs.package_test_selection.outputs.run_spf == 'true'
     name: Test (@videojs/spf)
     runs-on: ubuntu-latest
     container:

--- a/build/scripts/check-workspace.mjs
+++ b/build/scripts/check-workspace.mjs
@@ -15,6 +15,12 @@ import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import {
+  discoverWorkspacePackages,
+  isMainCiTestPackage,
+  SPECIAL_TEST_PACKAGES,
+} from '../../.github/scripts/package-test-matrix.js';
+
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const PACKAGES_DIR = join(ROOT, 'packages');
 
@@ -71,14 +77,15 @@ function readPackageJson(dir) {
 function checkCiTestCoverage() {
   const warnings = [];
   const ciText = readText(join(ROOT, '.github/workflows/ci.yml'));
-
-  // Collect package names from the test matrix.
-  const matrixMatch = ciText.match(/matrix:\s*\n\s*package:\s*\n((?:\s*-\s*'[^']+'\s*\n)+)/);
   const testedInCi = new Set();
+  const hasDynamicPackageTests =
+    ciText.includes('node .github/scripts/package-test-matrix.js') &&
+    ciText.includes('matrix.packages') &&
+    ciText.includes('test:ci');
 
-  if (matrixMatch) {
-    for (const m of matrixMatch[1].matchAll(/'([^']+)'/g)) {
-      testedInCi.add(m[1]);
+  if (hasDynamicPackageTests) {
+    for (const pkg of discoverWorkspacePackages(ROOT)) {
+      if (isMainCiTestPackage(pkg) && !SPECIAL_TEST_PACKAGES.has(pkg.name)) testedInCi.add(pkg.name);
     }
   }
 


### PR DESCRIPTION
## Summary

Reduce package-test CI overhead by running only the packages affected by a pull request and their transitive workspace dependents. Full coverage still runs on `main` and for shared build or toolchain changes.

## Changes

- Discover testable workspaces and derive affected tests from changed files plus dependency, dev-dependency, optional-dependency, and peer-dependency edges
- Balance ordinary package tests across at most four jobs instead of starting one runner per package
- Keep SPF isolated in its Playwright container and skip it when it is unaffected
- Fall back to full coverage for shared configuration changes, unknown package paths, and oversized pull requests
- Validate the dynamic CI coverage path in the workspace consistency checker

## Testing

- `node --test .github/scripts/tests/package-test-matrix.test.js`
- Full generated selection of all 29 ordinary package test suites
- `pnpm lint`
- `pnpm check:workspace`
- Actionlint and YAML parsing for `.github/workflows/ci.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI test scope is now computed from changed files and dependency graphs, so incorrect selection could skip needed package tests on PRs despite full-run fallbacks for toolchain and large PRs.
> 
> **Overview**
> Replaces the static per-package CI test matrix with **dynamic affected-package selection** so pull requests only run workspace tests for changed packages and their transitive dependents, while **main** and broad toolchain edits still run everything.
> 
> Adds `package-test-matrix.js` to discover workspaces, map PR file changes through dependency edges, fall back to full coverage for global/build/CI changes or unknown `packages/` paths, and **shard** ordinary tests into at most four weighted jobs. **`test-spf`** is gated separately and stays out of the standard shards.
> 
> The workflow gains a **`package_test_selection`** job (runs unit tests for the selector, then `gh api` changed files or `--all`) that feeds a dynamic matrix; each test job runs **`pnpm exec vp run`** with multiple `--filter` packages. **`check-workspace`** now validates CI coverage via the same discovery helpers instead of parsing a hardcoded matrix list in `ci.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc851c0baa0935f7c9c5a78f23d40a149b1b75c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->