### PR TITLE
fix(test): wait for fullscreen thumbnail geometry

### DIFF
--- a/apps/e2e/suites/sandbox/tests/sandbox-skin-styling.spec.ts
+++ b/apps/e2e/suites/sandbox/tests/sandbox-skin-styling.spec.ts
@@ -120,7 +120,7 @@ for (const { platform, skin, styling, skins } of CASES) {
       thumbnail.evaluate((element) => {
         const image = element.shadowRoot?.querySelector('img') ?? element.querySelector('img');
 
-        if (!(element instanceof HTMLElement) || !(image instanceof HTMLElement)) {
+        if (!(element instanceof HTMLElement) || !(image instanceof HTMLImageElement)) {
           throw new Error('Expected the thumbnail host and image to be HTML elements.');
         }
 
@@ -128,6 +128,7 @@ for (const { platform, skin, styling, skins } of CASES) {
         const imageRect = image.getBoundingClientRect();
 
         return {
+          loaded: image.complete && image.naturalWidth > 0,
           width: element.offsetWidth,
           height: element.offsetHeight,
           maxWidth: parseFloat(getComputedStyle(element).maxWidth),
@@ -135,6 +136,16 @@ for (const { platform, skin, styling, skins } of CASES) {
           bottomGap: rect.bottom - imageRect.bottom,
         };
       });
+
+    // No loading attribute also matches the empty state before thumbnail cues arrive.
+    await expect(async () => {
+      const box = await measure();
+
+      expect(box.loaded).toBe(true);
+      expect(box.width).toBeGreaterThan(0);
+      expect(box.height).toBeGreaterThan(0);
+      expect(box.maxWidth - box.width).toBeLessThanOrEqual(2);
+    }).toPass({ timeout: 15_000 });
 
     const before = await measure();
 
@@ -146,23 +157,20 @@ for (const { platform, skin, styling, skins } of CASES) {
 
     // Fullscreen widens the preview through a container query, and the tile has to grow to fill it — less the 1px
     // anti-fringe inset on each edge.
-    await expect.poll(async () => (await measure()).maxWidth).toBeGreaterThan(before.maxWidth);
-    await expect
-      .poll(async () => {
-        const box = await measure();
+    await expect(async () => {
+      const after = await measure();
 
-        return box.maxWidth - box.width;
-      })
-      .toBeLessThanOrEqual(2);
-    await expect.poll(async () => (await measure()).width).toBeGreaterThan(before.width);
-
-    const after = await measure();
-
-    // Aspect ratio survives the resize, so the tile is neither cropped nor letterboxed.
-    expect(Math.abs(after.width / after.height - before.width / before.height)).toBeLessThan(0.02);
-    // The sprite still covers the container that clips it.
-    expect(after.rightGap).toBeLessThanOrEqual(0);
-    expect(after.bottomGap).toBeLessThanOrEqual(0);
+      expect(after.loaded).toBe(true);
+      expect(after.maxWidth).toBeGreaterThan(before.maxWidth);
+      expect(after.maxWidth - after.width).toBeLessThanOrEqual(2);
+      expect(after.width).toBeGreaterThan(before.width);
+      expect(after.height).toBeGreaterThan(0);
+      // Aspect ratio survives the resize, so the tile is neither cropped nor letterboxed.
+      expect(Math.abs(after.width / after.height - before.width / before.height)).toBeLessThan(0.02);
+      // The sprite still covers the container that clips it.
+      expect(after.rightGap).toBeLessThanOrEqual(0);
+      expect(after.bottomGap).toBeLessThanOrEqual(0);
+    }).toPass({ timeout: 10_000 });
   });
 }
 


### PR DESCRIPTION
## Summary

Fix the fullscreen thumbnail test race behind the [failing main E2E run](https://github.com/videojs/v10/actions/runs/34177115306). Before thumbnail cues arrive, the empty image has no `data-loading` attribute, so the test can record a zero-size baseline and later fail its aspect-ratio comparison despite a correctly rendered fullscreen thumbnail.

## Changes

- Wait for a loaded image and nonzero thumbnail dimensions before recording the baseline.
- Retry the fullscreen size, aspect-ratio, and sprite-coverage assertions together while layout settles.

## Testing

- Reproduced the original failure locally, including a controlled metadata delay that recorded a `0×0` baseline followed by a correct `334×187` fullscreen thumbnail.
- Full Sandbox suite: 90 passed, 9 skipped.
- Repeated all ten fullscreen thumbnail variants three times with a two-second metadata delay using a temporary diagnostic test: 30 passed.
- Targeted Vite+ formatting and lint checks; `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in sandbox skin styling E2E; no production player or skin behavior is modified.
> 
> **Overview**
> Hardens the sandbox **fullscreen thumbnail scaling** E2E so geometry is measured only after the seek preview image is actually loaded, not when cues are still missing and `data-loading` is absent.
> 
> The thumbnail `measure()` helper now treats the inner node as an `HTMLImageElement` and exposes a **`loaded`** flag (`complete` plus `naturalWidth > 0`). A **`toPass`** wait runs before the pre-fullscreen baseline so width, height, and max-width are nonzero and stable. Post-fullscreen checks that used separate **`expect.poll`** calls are folded into one **`toPass`** block that retries growth, aspect ratio, and sprite coverage while layout settles after container-query resize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5eee7e4c3001f2e298adecb5bdb96884b3b7fa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->