### PR TITLE
chore(cd): drop the rc.1 release-as pin and fix the dist-tag workflow

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -4,7 +4,6 @@
   "tag-separator": "@",
   "include-component-in-tag": true,
   "include-v-in-tag": false,
-  "release-as": "10.0.0-rc.1",
   "plugins": [
     {
       "type": "node-workspace",

--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -37,14 +37,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # setup-node reads `packageManager` from package.json and expects pnpm on
-      # PATH for its cache, so install it first even though the job only runs npm.
-      - uses: pnpm/action-setup@v4
-
+      # setup-node reads `packageManager` from package.json and would try to
+      # cache a pnpm store this job never creates. It only runs npm, so opt out.
       - uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       # Mirrors the publish filter in cd.yml (./packages/**): top-level packages
       # plus the adapters/ and extensions/ buckets. Private workspace packages

--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -37,6 +37,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # setup-node reads `packageManager` from package.json and expects pnpm on
+      # PATH for its cache, so install it first even though the job only runs npm.
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'


### PR DESCRIPTION
Release tooling follow-ups from the `10.0.0-rc.1` release, split out of #2658 so they can land before the next breaking change hits main.

**1. Removes `release-as` from the release-please config.** #2599 pinned the release to `10.0.0-rc.1`. It has shipped, so the pin has to go: while it remains, the next Deployment run proposes rc.1 again and cannot tag over the existing tags. With it gone, `prerelease-type: rc` bumps to rc.2 on its own.

**2. Fixes the dist-tag workflow.** Its first run after the rc.1 publish failed at `actions/setup-node`, which reads `packageManager` from package.json and tries to set up pnpm caching. The job only runs `npm dist-tag`, so it now opts out with `package-manager-cache: false` rather than installing pnpm for a store it never fills. `next` still points at `10.0.0-alpha.11`; the rc.2 release moves it, or run the **npm dist-tag** workflow with `version=10.0.0-rc.1`, `tag=next` sooner.

**Merge this before any breaking change lands on main.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ5RTqfnRMiiASH1T7tWVj