### PR TITLE
ci(dist-tag): tag every package before failing on the ones npm rejected

### DIFF
--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -55,8 +55,17 @@ jobs:
               continue
             fi
             name=$(jq -r '.name' "$manifest")
-            npm dist-tag add "${name}@${VERSION}" "$TAG"
+            if ! npm dist-tag add "${name}@${VERSION}" "$TAG"; then
+              failed="${failed} ${name}"
+            fi
           done
+
+          # One package rejecting the tag (usually an npm ownership gap on that
+          # package alone) must not leave the rest of the release untagged.
+          if [ -n "$failed" ]; then
+            echo "::error::Failed to move '${TAG}' to ${VERSION} on:${failed}"
+            exit 1
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Why

The first live run of `npm-dist-tag.yml` ([run 34290762018](https://github.com/videojs/v10/actions/runs/34290762018), `version=10.0.0-rc.1 tag=next`) proved the workflow plumbing from #2660 works: setup-node, token auth, and `npm dist-tag add` all succeeded for the first 7 packages. It then hit a 404 on `@videojs/spf` and the loop aborted, leaving 17 packages behind it untagged.

The 404 is an npm ownership gap, not a workflow bug: `@videojs/spf` has a different maintainer list on npm than every other `@videojs/*` package, and the `NPM_TOKEN` owner isn't on it. Publishing still works because `cd.yml` publishes with `--provenance` (OIDC trusted publishing); `npm dist-tag` has no OIDC path. That needs an existing spf maintainer to run `npm owner add`.

## What

Keep looping on a per-package failure, then fail once at the end with `::error::` naming the packages that still need attention. One bad package no longer blocks the rest of the release's `next` tag.

actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ5RTqfnRMiiASH1T7tWVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ5RTqfnRMiiASH1T7tWVj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to error handling in the dist-tag loop; no runtime or publish path changes.
> 
> **Overview**
> The **npm dist-tag** workflow no longer stops at the first `npm dist-tag add` failure. Each public package is still attempted in the loop; failures are collected and the job only fails **after** every package has been processed.
> 
> When any packages fail (e.g. npm 404 from an ownership gap on one scope), the step emits a GitHub Actions **`::error::`** listing those package names and exits with code 1, so one bad package does not leave the rest of the release untagged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e5290e8cffba8337a861baa4693dbd0c24c2be6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->