### PR TITLE
feat(site): add baseline PostHog analytics instrumentation

### DIFF
--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -62,6 +62,22 @@ pnpm -F site astro check
 - React context does not cross Astro islands.
 - Never expose `context.locals.accessToken` to client code. Auth and Mux integration are only for the installation uploader; trace the middleware and server actions before changing that flow.
 
+## Analytics
+
+PostHog loads production-only from `src/components/Posthog.astro`. It runs cookieless, so there is no durable person:
+never call `identify`, `alias`, or any person-property API. `register()` super properties last for one page load, so
+`Posthog.astro` re-registers `docs_framework` and `docs_style` from storage on every load, and components re-register
+after a change.
+
+- Custom events go through `src/utils/analytics.ts`. Add a name to `ANALYTICS_EVENTS` and its properties to
+  `AnalyticsEventProperties` rather than passing a bare string.
+- Tag clickable markup declaratively with three `data-ph-capture-attribute-*` names, which PostHog reads from the
+  clicked element or any ancestor: `location` for the region (`nav`, `footer-docs`, `hero`, `docs-sidebar`,
+  `install-page`, `mux-uploader`, …), `cta` for a specific call-to-action (`get-started`, `edit-page`, `mux-login`, …),
+  and `destination` for outbound or cross-section links (`mux`, `github`, `discord`, `docs`, `blog`, `external`).
+- Put `location` on a container and `cta`/`destination` on the individual anchor or button.
+- Never send upload IDs, playback IDs, tokens, or free-form user text beyond a search query.
+
 ## API references
 
 Generated reference JSON is gitignored and rebuilt by `pnpm -F site api-docs`, dev, and build. Do not hand-edit it. Change the TypeScript/JSDoc input or the builder, run the generator, and inspect the output. Keep the builder E2E suite passing.

--- a/site/src/components/CopyButton.tsx
+++ b/site/src/components/CopyButton.tsx
@@ -1,5 +1,7 @@
 import { useRef, useState } from 'react';
 
+import type { AnalyticsEventProperties } from '@/utils/analytics';
+import { ANALYTICS_EVENTS, trackEvent } from '@/utils/analytics';
 import useIsHydrated from '@/utils/useIsHydrated';
 
 export interface CopyButtonProps {
@@ -12,9 +14,19 @@ export interface CopyButtonProps {
   className?: string;
   style?: React.CSSProperties;
   timeout?: number;
+  /** Names this block in the `code_copied` event. Defaults to a generic id. */
+  analytics?: AnalyticsEventProperties['code_copied'];
 }
 
-export default function CopyButton({ children, copied, copyFrom, className, style, timeout = 2000 }: CopyButtonProps) {
+export default function CopyButton({
+  children,
+  copied,
+  copyFrom,
+  className,
+  style,
+  timeout = 2000,
+  analytics = { block: 'code-tabs' },
+}: CopyButtonProps) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [isCopied, setIsCopied] = useState(false);
   const isHydrated = useIsHydrated();
@@ -49,6 +61,8 @@ export default function CopyButton({ children, copied, copyFrom, className, styl
 
       if (text) {
         await navigator.clipboard.writeText(text.trim());
+        trackEvent(ANALYTICS_EVENTS.codeCopied, analytics);
+
         setIsCopied(true);
         setTimeout(() => {
           setIsCopied(false);

--- a/site/src/components/CopyMarkdownButton.tsx
+++ b/site/src/components/CopyMarkdownButton.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import { CheckIcon } from 'lucide-react';
 import { useState } from 'react';
 
+import { ANALYTICS_EVENTS, trackEvent } from '@/utils/analytics';
 import useIsHydrated from '@/utils/useIsHydrated';
 
 export interface CopyMarkdownButtonProps {
@@ -68,6 +69,8 @@ export default function CopyMarkdownButton({ className, style }: CopyMarkdownBut
 
         await navigator.clipboard.write([clipboardItem]);
       }
+
+      trackEvent(ANALYTICS_EVENTS.codeCopied, { block: 'page-markdown' });
 
       setState({ status: 'success' });
       setTimeout(() => {

--- a/site/src/components/DialNav.tsx
+++ b/site/src/components/DialNav.tsx
@@ -5,7 +5,13 @@ import DialInner from '@/assets/icons/dial-inner.svg?react';
 import DialOuter from '@/assets/icons/dial-outer.svg?react';
 import GetStartedLink from '@/components/NavBar/GetStartedLink';
 
-type Link = { href: string; label: string; angle: number };
+type Link = {
+  href: string;
+  label: string;
+  angle: number;
+  /** Analytics `destination` for autocaptured clicks. */
+  destination?: 'mux' | 'docs' | 'blog' | 'external';
+};
 
 export interface DialNavProps {
   left: [Link, Link];
@@ -55,6 +61,7 @@ export default function DialNav({ left, right }: DialNavProps) {
               key={link.href}
               href={link.href}
               onClick={(e) => handleClick(e, link)}
+              data-ph-capture-attribute-destination={link.destination}
               className={clsx(
                 'flex rounded-xs min-w-44 items-center gap-2 px-6 py-6 text-h5 font-display-compact font-bold uppercase text-faded-black dark:text-manila-light',
                 'justify-end pr-15 -mr-12 bg-manila-50 dark:bg-black'
@@ -104,6 +111,7 @@ export default function DialNav({ left, right }: DialNavProps) {
               key={link.href}
               href={link.href}
               onClick={(e) => handleClick(e, link)}
+              data-ph-capture-attribute-destination={link.destination}
               className={clsx(
                 'flex rounded-xs min-w-44 items-center gap-2 px-6 py-6 text-h5 font-display-compact font-bold uppercase text-faded-black dark:text-manila-light',
                 'pl-15 -ml-12 bg-manila-50 dark:bg-black'

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -11,12 +11,14 @@ type NavLink = {
   href: string;
   label: string;
   external?: boolean;
+  /** Analytics `destination` for autocaptured clicks; omitted for same-section pages. */
+  destination?: 'blog' | 'external';
 };
 const navLinks: NavLink[] = [
-  { href: '/blog', label: 'Blog' },
+  { href: '/blog', label: 'Blog', destination: 'blog' },
   { href: '/changelog', label: 'Changelog' },
   { href: '/privacy', label: 'Privacy' },
-  { href: 'https://legacy.videojs.org', label: 'V8', external: true },
+  { href: 'https://legacy.videojs.org', label: 'V8', external: true, destination: 'external' },
 ];
 
 type Props = {
@@ -26,6 +28,7 @@ const { class: className } = Astro.props;
 ---
 
 <footer
+  data-ph-capture-attribute-location="footer"
   class:list={[
     "mx-auto mt-30 grid w-full max-w-305 gap-3 px-5 pb-11 md:mt-32 md:pt-0",
     className,
@@ -42,6 +45,8 @@ const { class: className } = Astro.props;
       >
         <GetStartedLink
           client:idle
+          data-ph-capture-attribute-cta="view-docs"
+          data-ph-capture-attribute-destination="docs"
           className="flex items-center rounded-xs px-2 py-2 font-display font-bold uppercase md:px-5 intent:bg-manila-dark dark:intent:bg-warm-gray"
         >
           Docs
@@ -50,6 +55,7 @@ const { class: className } = Astro.props;
           navLinks.map((link) => (
             <a
               href={link.href}
+              data-ph-capture-attribute-destination={link.destination}
               class="flex items-center gap-1.5 rounded-xs px-2 py-2 font-display font-bold uppercase md:px-5 intent:bg-manila-dark dark:intent:bg-warm-gray"
             >
               {link.label}{" "}
@@ -65,6 +71,7 @@ const { class: className } = Astro.props;
             href={DISCORD_INVITE_URL}
             class="flex items-center rounded-xs px-2 py-2 font-display font-bold uppercase md:px-5 intent:bg-manila-dark dark:intent:bg-warm-gray"
             aria-label="Discord"
+            data-ph-capture-attribute-destination="discord"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -74,6 +81,7 @@ const { class: className } = Astro.props;
             href={GITHUB_REPO_URL}
             class="flex items-center rounded-xs px-2 py-2 font-display font-bold uppercase md:px-5 intent:bg-manila-dark dark:intent:bg-warm-gray"
             aria-label="GitHub"
+            data-ph-capture-attribute-destination="github"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -89,6 +97,7 @@ const { class: className } = Astro.props;
           href={DISCORD_INVITE_URL}
           class="flex items-center rounded-xs px-2 py-2 font-display font-bold uppercase md:hidden intent:bg-manila-dark dark:intent:bg-warm-gray"
           aria-label="Discord"
+          data-ph-capture-attribute-destination="discord"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -98,6 +107,7 @@ const { class: className } = Astro.props;
           href={GITHUB_REPO_URL}
           class="flex items-center rounded-xs px-2 py-2 font-display font-bold uppercase md:hidden intent:bg-manila-dark dark:intent:bg-warm-gray"
           aria-label="GitHub"
+          data-ph-capture-attribute-destination="github"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -125,6 +135,7 @@ const { class: className } = Astro.props;
         <br />
         Video hosting and streaming <a
           href={MUX_URL}
+          data-ph-capture-attribute-destination="mux"
           class="underline intent:decoration-gold"
           >sponsored by Mux
         </a>

--- a/site/src/components/FooterDocs.astro
+++ b/site/src/components/FooterDocs.astro
@@ -11,12 +11,14 @@ type NavLink = {
   href: string;
   label: string;
   external?: boolean;
+  /** Analytics `destination` for autocaptured clicks; omitted for same-section pages. */
+  destination?: 'blog' | 'external';
 };
 const navLinks: NavLink[] = [
-  { href: '/blog', label: 'Blog' },
+  { href: '/blog', label: 'Blog', destination: 'blog' },
   { href: '/changelog', label: 'Changelog' },
   { href: '/privacy', label: 'Privacy' },
-  { href: 'https://legacy.videojs.org', label: 'V8', external: true },
+  { href: 'https://legacy.videojs.org', label: 'V8', external: true, destination: 'external' },
 ];
 
 type Props = {
@@ -26,6 +28,7 @@ const { class: className } = Astro.props;
 ---
 
 <footer
+  data-ph-capture-attribute-location="footer-docs"
   class:list={[
     "@container mt-30 grid gap-3 pb-11 @4xl:mt-32 @4xl:pt-0",
     className,
@@ -42,6 +45,8 @@ const { class: className } = Astro.props;
       >
         <GetStartedLink
           client:idle
+          data-ph-capture-attribute-cta="view-docs"
+          data-ph-capture-attribute-destination="docs"
           className="flex items-center rounded-xs px-2 py-2 font-display font-bold uppercase @4xl:px-5 intent:bg-manila-dark dark:intent:bg-warm-gray"
         >
           Docs
@@ -50,6 +55,7 @@ const { class: className } = Astro.props;
           navLinks.map((link) => (
             <a
               href={link.href}
+              data-ph-capture-attribute-destination={link.destination}
               class="flex items-center gap-1.5 rounded-xs px-2 py-2 font-display font-bold uppercase @4xl:px-5 intent:bg-manila-dark dark:intent:bg-warm-gray"
             >
               {link.label}{" "}
@@ -65,6 +71,7 @@ const { class: className } = Astro.props;
             href={DISCORD_INVITE_URL}
             class="flex items-center rounded-xs px-2 py-2 font-display font-bold uppercase @4xl:px-5 intent:bg-manila-dark dark:intent:bg-warm-gray"
             aria-label="Discord"
+            data-ph-capture-attribute-destination="discord"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -74,6 +81,7 @@ const { class: className } = Astro.props;
             href={GITHUB_REPO_URL}
             class="flex items-center rounded-xs px-2 py-2 font-display font-bold uppercase @4xl:px-5 intent:bg-manila-dark dark:intent:bg-warm-gray"
             aria-label="GitHub"
+            data-ph-capture-attribute-destination="github"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -89,6 +97,7 @@ const { class: className } = Astro.props;
           href={DISCORD_INVITE_URL}
           class="flex items-center rounded-xs px-2 py-2 font-display font-bold uppercase @4xl:hidden intent:bg-manila-dark dark:intent:bg-warm-gray"
           aria-label="Discord"
+          data-ph-capture-attribute-destination="discord"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -98,6 +107,7 @@ const { class: className } = Astro.props;
           href={GITHUB_REPO_URL}
           class="flex items-center rounded-xs px-2 py-2 font-display font-bold uppercase @4xl:hidden intent:bg-manila-dark dark:intent:bg-warm-gray"
           aria-label="GitHub"
+          data-ph-capture-attribute-destination="github"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -120,6 +130,7 @@ const { class: className } = Astro.props;
       <br class="@5xl:hidden" />
       Video hosting and streaming <a
         href={MUX_URL}
+        data-ph-capture-attribute-destination="mux"
         class="underline intent:decoration-gold"
         >sponsored by Mux.
       </a>

--- a/site/src/components/NavBar/MobileNav.tsx
+++ b/site/src/components/NavBar/MobileNav.tsx
@@ -14,6 +14,8 @@ interface NavLink {
   label: string;
   matchPath: string | null;
   external?: boolean;
+  /** Analytics `destination` for autocaptured clicks. */
+  destination: 'docs' | 'blog';
 }
 
 export interface MobileNavProps {
@@ -50,6 +52,7 @@ export default function MobileNav({ navLinks, currentPath, children, compact, pi
       <Dialog.Portal>
         {/* Popup container */}
         <Dialog.Popup
+          data-ph-capture-attribute-location="nav-mobile"
           className={clsx(
             'fixed inset-0 z-50 flex flex-col',
             'bg-manila-light dark:bg-faded-black text-faded-black dark:text-manila-light'
@@ -107,7 +110,13 @@ export default function MobileNav({ navLinks, currentPath, children, compact, pi
 
                 if (link.href === '/docs') {
                   return (
-                    <GetStartedLink key={link.href} className={className} aria-current={isActive ? 'page' : undefined}>
+                    <GetStartedLink
+                      key={link.href}
+                      className={className}
+                      aria-current={isActive ? 'page' : undefined}
+                      data-ph-capture-attribute-cta="view-docs"
+                      data-ph-capture-attribute-destination="docs"
+                    >
                       {link.label}
                     </GetStartedLink>
                   );
@@ -119,6 +128,7 @@ export default function MobileNav({ navLinks, currentPath, children, compact, pi
                     href={link.href}
                     className={className}
                     aria-current={isActive ? 'page' : undefined}
+                    data-ph-capture-attribute-destination={link.destination}
                   >
                     {link.label} {link.external ? <ArrowUpRight size="1em" aria-hidden="true" /> : null}
                   </a>
@@ -131,6 +141,7 @@ export default function MobileNav({ navLinks, currentPath, children, compact, pi
                 )}
                 target="_blank"
                 rel="noopener"
+                data-ph-capture-attribute-destination="discord"
               >
                 Discord
               </a>
@@ -142,6 +153,7 @@ export default function MobileNav({ navLinks, currentPath, children, compact, pi
                 )}
                 target="_blank"
                 rel="noopener"
+                data-ph-capture-attribute-destination="github"
               >
                 GitHub
               </a>

--- a/site/src/components/NavBar/NavBar.astro
+++ b/site/src/components/NavBar/NavBar.astro
@@ -19,10 +19,12 @@ type NavLink = {
   label: string;
   matchPath: string | null;
   external?: boolean;
+  /** Analytics `destination` for autocaptured clicks. */
+  destination: 'docs' | 'blog';
 };
 const navLinks: NavLink[] = [
-  { href: '/docs', label: 'Docs', matchPath: '/docs' },
-  { href: '/blog', label: 'Blog', matchPath: '/blog' },
+  { href: '/docs', label: 'Docs', matchPath: '/docs', destination: 'docs' },
+  { href: '/blog', label: 'Blog', matchPath: '/blog', destination: 'blog' },
 ];
 
 const currentPath = Astro.url.pathname;
@@ -33,6 +35,7 @@ const { class: className } = Astro.props;
 
 <nav
   aria-label="Video.js"
+  data-ph-capture-attribute-location="nav"
   class:list={[
     "flex justify-between",
     "mx-auto w-full max-w-305 items-center px-5 py-7 md:py-10",
@@ -53,6 +56,8 @@ const { class: className } = Astro.props;
         "flex items-center rounded-xs px-5 py-2 font-display font-bold uppercase intent:bg-manila-dark dark:intent:bg-warm-gray",
       )}
       aria-current={isDocsActive ? "page" : undefined}
+      data-ph-capture-attribute-cta="view-docs"
+      data-ph-capture-attribute-destination="docs"
     >
       Docs
     </GetStartedLink>
@@ -60,6 +65,7 @@ const { class: className } = Astro.props;
       otherNavLinks.map((link) => (
         <a
           href={link.href}
+          data-ph-capture-attribute-destination={link.destination}
           class:list={[
             "flex items-center rounded-xs px-5 py-2 font-display font-bold uppercase intent:bg-manila-dark dark:intent:bg-warm-gray",
           ]}
@@ -77,6 +83,7 @@ const { class: className } = Astro.props;
         "flex items-center rounded-xs px-3 py-2 font-display font-bold uppercase intent:bg-manila-dark dark:intent:bg-warm-gray",
       )}
       aria-label="Discord"
+      data-ph-capture-attribute-destination="discord"
       target="_blank"
       rel="noopener noreferrer"
     >
@@ -88,6 +95,7 @@ const { class: className } = Astro.props;
         "flex items-center rounded-xs px-3 py-2 font-display font-bold uppercase intent:bg-manila-dark dark:intent:bg-warm-gray",
       )}
       aria-label="GitHub"
+      data-ph-capture-attribute-destination="github"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/site/src/components/NavBar/NavBarDocs.astro
+++ b/site/src/components/NavBar/NavBarDocs.astro
@@ -20,10 +20,12 @@ type NavLink = {
   label: string;
   matchPath: string | null;
   external?: boolean;
+  /** Analytics `destination` for autocaptured clicks. */
+  destination: 'docs' | 'blog';
 };
 const navLinks: NavLink[] = [
-  { href: '/docs', label: 'Docs', matchPath: '/docs' },
-  { href: '/blog', label: 'Blog', matchPath: '/blog' },
+  { href: '/docs', label: 'Docs', matchPath: '/docs', destination: 'docs' },
+  { href: '/blog', label: 'Blog', matchPath: '/blog', destination: 'blog' },
 ];
 
 const currentPath = Astro.url.pathname;
@@ -34,6 +36,7 @@ const { class: className } = Astro.props;
 
 <nav
   aria-label="Video.js"
+  data-ph-capture-attribute-location="nav-docs"
   class:list={[
     "sticky top-0 z-30 mx-auto flex w-full items-center justify-between border-b border-b-manila-75 bg-manila-light px-5 dark:border-warm-gray dark:bg-faded-black",
     className,
@@ -56,6 +59,8 @@ const { class: className } = Astro.props;
         isDocsActive ? "relative z-10 text-orange" : "",
       )}
       aria-current={isDocsActive ? "page" : undefined}
+      data-ph-capture-attribute-cta="view-docs"
+      data-ph-capture-attribute-destination="docs"
     >
       Docs
       <hr
@@ -67,6 +72,7 @@ const { class: className } = Astro.props;
       otherNavLinks.map((link) => (
         <a
           href={link.href}
+          data-ph-capture-attribute-destination={link.destination}
           class:list={[
             "flex items-center rounded-xs px-5 py-2 font-display text-h3 uppercase intent:bg-manila-dark dark:intent:bg-warm-gray",
           ]}
@@ -84,6 +90,7 @@ const { class: className } = Astro.props;
         "my-1 flex items-center rounded-xs px-3 py-2 font-display font-bold uppercase intent:bg-manila-dark dark:intent:bg-warm-gray",
       )}
       aria-label="Discord"
+      data-ph-capture-attribute-destination="discord"
       target="_blank"
       rel="noopener noreferrer"
     >
@@ -95,6 +102,7 @@ const { class: className } = Astro.props;
         "my-1 flex items-center rounded-xs px-3 py-2 font-display font-bold uppercase intent:bg-manila-dark dark:intent:bg-warm-gray",
       )}
       aria-label="GitHub"
+      data-ph-capture-attribute-destination="github"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/site/src/components/Posthog.astro
+++ b/site/src/components/Posthog.astro
@@ -4,13 +4,26 @@
  * Idle-loaded to minimize impact on page performance.
  *
  * Requires "Cookieless server hash mode" enabled in PostHog project settings.
+ *
+ * Cookieless mode means there is no durable person: never call `identify`,
+ * `alias`, or any person-property API. Super properties registered in `loaded`
+ * below last for this page load only, which is why every page re-registers.
+ * Custom events go through `src/utils/analytics.ts`.
  */
+
+import { FRAMEWORK_COOKIE, STYLE_STORAGE_KEY_PREFIX } from '@/utils/docs/preferences';
 ---
 
 <link rel="dns-prefetch" href="/" />
 <link rel="preconnect" href="/" crossorigin />
 
-<script is:inline>
+<script
+  is:inline
+  define:vars={{
+    frameworkCookie: FRAMEWORK_COOKIE,
+    styleKeyPrefix: STYLE_STORAGE_KEY_PREFIX,
+  }}
+>
   (function () {
     function load() {
       !(function (t, e) {
@@ -73,6 +86,36 @@
         ui_host: "https://us.posthog.com",
         defaults: "2026-01-30",
         cookieless_mode: "always",
+        capture_dead_clicks: true,
+        capture_heatmaps: true,
+        // `loaded` runs before the initial $pageview, so the docs context is
+        // attached to every event on this page load. Keys come from
+        // `src/utils/docs/preferences.ts` via define:vars above.
+        loaded: function (ph) {
+          try {
+            var framework = null;
+
+            document.cookie.split(";").forEach(function (cookie) {
+              var parts = cookie.trim().split("=");
+
+              if (parts[0] === frameworkCookie) framework = parts[1] || null;
+            });
+
+            var context = {};
+
+            if (framework) {
+              context.docs_framework = framework;
+
+              var style = localStorage.getItem(styleKeyPrefix + framework);
+
+              if (style) context.docs_style = style;
+            }
+
+            if (Object.keys(context).length) ph.register(context);
+          } catch (error) {
+            // Storage can throw in private modes; analytics must never break the page.
+          }
+        },
       });
     }
 

--- a/site/src/components/Search.tsx
+++ b/site/src/components/Search.tsx
@@ -1,5 +1,6 @@
 import { DocSearch } from '@docsearch/react';
 import { useStore } from '@nanostores/react';
+import { useEffect, useRef } from 'react';
 
 import { GITHUB_REPO_URL } from '@/consts';
 import {
@@ -10,16 +11,81 @@ import {
   DOCSEARCH_DOCS_INDEX,
 } from '@/search.config';
 import { currentFramework } from '@/stores/preferences';
+import { ANALYTICS_EVENTS, trackEvent } from '@/utils/analytics';
 
 interface SearchProps {
   className?: string;
 }
 
+/**
+ * Tags the portaled DocSearch modal for autocapture and reports when it opens.
+ *
+ * DocSearch exposes no open/close callbacks, and it portals the modal to `document.body`, outside this component's
+ * markup — so the attributes cannot be written declaratively and the open has to be observed. Watching for the modal
+ * element covers every entry point (button, `Ctrl/Cmd+K`, `/`) in one place. If DocSearch renames these classes the
+ * events simply stop firing; nothing breaks.
+ */
+function useSearchModalAnalytics(): void {
+  useEffect(() => {
+    let modalObserver: MutationObserver | null = null;
+
+    const tagModal = (container: HTMLElement) => {
+      container.dataset.phCaptureAttributeLocation = 'search';
+
+      const reportLink = container.querySelector<HTMLAnchorElement>('.DocSearch-NoResults-Help a');
+      if (!reportLink) return;
+
+      reportLink.dataset.phCaptureAttributeCta = 'report-search-issue';
+      reportLink.dataset.phCaptureAttributeDestination = 'github';
+    };
+
+    const openObserver = new MutationObserver(() => {
+      const container = document.querySelector<HTMLElement>('.DocSearch-Container');
+
+      if (!container) {
+        modalObserver?.disconnect();
+        modalObserver = null;
+        return;
+      }
+
+      if (modalObserver) return;
+
+      trackEvent(ANALYTICS_EVENTS.searchOpened);
+      tagModal(container);
+
+      // The no-results screen mounts after the first query, so keep tagging while the modal is open.
+      modalObserver = new MutationObserver(() => tagModal(container));
+      modalObserver.observe(container, { childList: true, subtree: true });
+    });
+
+    openObserver.observe(document.body, { childList: true });
+
+    return () => {
+      openObserver.disconnect();
+      modalObserver?.disconnect();
+    };
+  }, []);
+}
+
 export default function Search({ className }: SearchProps) {
   const framework = useStore(currentFramework);
+  const reportedQueryRef = useRef<string | null>(null);
+
+  useSearchModalAnalytics();
+
+  // DocSearch calls this while rendering the "no results" screen, so it re-runs on every render of that screen.
+  // Reporting once per query keeps one event per dead-end search rather than one per keystroke.
+  const getMissingResultsUrl = ({ query }: { query: string }) => {
+    if (reportedQueryRef.current !== query) {
+      reportedQueryRef.current = query;
+      trackEvent(ANALYTICS_EVENTS.searchNoResults, { query });
+    }
+
+    return `${GITHUB_REPO_URL}issues/new?title=${encodeURIComponent(`Search: no results for "${query}"`)}&labels=search`;
+  };
 
   return (
-    <div className={className}>
+    <div className={className} data-ph-capture-attribute-location="search">
       <DocSearch
         appId={DOCSEARCH_APP_ID}
         apiKey={DOCSEARCH_API_KEY}
@@ -37,9 +103,7 @@ export default function Search({ className }: SearchProps) {
             name: DOCSEARCH_CHANGELOG_INDEX,
           },
         ]}
-        getMissingResultsUrl={({ query }) =>
-          `${GITHUB_REPO_URL}issues/new?title=${encodeURIComponent(`Search: no results for "${query}"`)}&labels=search`
-        }
+        getMissingResultsUrl={getMissingResultsUrl}
       />
     </div>
   );

--- a/site/src/components/Tabs.tsx
+++ b/site/src/components/Tabs.tsx
@@ -16,6 +16,7 @@ import { Check } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import CopyIcon from '@/assets/icons/copy.svg?react';
+import type { AnalyticsEventProperties } from '@/utils/analytics';
 import { twMerge } from '@/utils/twMerge';
 import useIsHydrated from '@/utils/useIsHydrated';
 
@@ -91,8 +92,10 @@ interface TabsListProps {
   label: string;
   children: React.ReactNode;
   variant?: TabsVariant;
+  /** Names this tab set's code in the `code_copied` event. */
+  analytics?: AnalyticsEventProperties['code_copied'];
 }
-export function TabsList({ label, children, variant = 'compact' }: TabsListProps) {
+export function TabsList({ label, children, variant = 'compact', analytics }: TabsListProps) {
   return (
     <div className={clsx('w-full flex items-center p-0 h-12', variant === 'compact' ? 'p-0' : 'px-2.5')}>
       <div
@@ -115,6 +118,7 @@ export function TabsList({ label, children, variant = 'compact' }: TabsListProps
           'ml-auto sticky right-0 h-7 px-2.5 flex items-center justify-center cursor-pointer disabled:cursor-wait intent:bg-manila-dark dark:intent:bg-warm-gray rounded-xs'
         )}
         copied={<Check size={20} />}
+        analytics={analytics}
       >
         <CopyIcon width="1.25rem" height="1.25rem" />
       </CopyButton>

--- a/site/src/components/docs/DocsLinkCard.astro
+++ b/site/src/components/docs/DocsLinkCard.astro
@@ -30,6 +30,8 @@ const href = anchor ? `${url}#${anchor}` : url;
 >
   <a
     href={href}
+    data-ph-capture-attribute-location="docs-link-card"
+    data-ph-capture-attribute-destination="docs"
     class="flex items-center justify-between gap-4 rounded-xs border border-manila-dark p-4 no-underline md:pl-6 dark:border-warm-gray intent:bg-manila-75 dark:intent:bg-warm-gray"
   >
     {

--- a/site/src/components/docs/DocsSidebar.astro
+++ b/site/src/components/docs/DocsSidebar.astro
@@ -20,7 +20,11 @@ const filteredSidebar = filterSidebar(framework);
 <div class={clsx("bg-manila-light dark:bg-faded-black", className)}>
   <slot />
   <PreferenceUpdater client:idle currentFramework={framework} />
-  <nav aria-label="Docs sidebar" class="p-6">
+  <nav
+    aria-label="Docs sidebar"
+    data-ph-capture-attribute-location="docs-sidebar"
+    class="p-6"
+  >
     {
       filteredSidebar.map((item) => (
         <SidebarItem item={item} framework={framework} docTitles={docTitles} docStabilities={docStabilities} />

--- a/site/src/components/docs/EditPageButton.astro
+++ b/site/src/components/docs/EditPageButton.astro
@@ -13,6 +13,8 @@ const editUrl = `${GITHUB_REPO_URL}edit/main/${filePath}`;
 <div class="mx-auto w-full max-w-3xl">
   <a
     href={editUrl}
+    data-ph-capture-attribute-cta="edit-page"
+    data-ph-capture-attribute-destination="github"
     target="_blank"
     rel="noopener noreferrer"
     class="text-p3 underline intent:decoration-gold"

--- a/site/src/components/docs/Selectors.tsx
+++ b/site/src/components/docs/Selectors.tsx
@@ -11,6 +11,7 @@ import {
   STYLE_LABELS,
   SUPPORTED_FRAMEWORKS,
 } from '@/types/docs';
+import { ANALYTICS_EVENTS, registerAnalyticsContext, trackEvent } from '@/utils/analytics';
 import { setStylePreferenceClient, updateStyleAttribute } from '@/utils/docs/preferences';
 import { resolveFrameworkChange } from '@/utils/docs/routing';
 import useIsHydrated from '@/utils/useIsHydrated';
@@ -29,6 +30,15 @@ export function Selectors({ currentFramework, currentSlug }: SelectorProps) {
     if (newFramework === null) return;
 
     if (!isValidFramework(newFramework)) return;
+
+    if (newFramework !== currentFramework) {
+      registerAnalyticsContext({ docs_framework: newFramework });
+      trackEvent(ANALYTICS_EVENTS.docsPreferenceChanged, {
+        preference: 'framework',
+        value: newFramework,
+        previous: currentFramework,
+      });
+    }
 
     const { url, shouldReplace } = resolveFrameworkChange({
       currentFramework,
@@ -60,6 +70,15 @@ export function Selectors({ currentFramework, currentSlug }: SelectorProps) {
     if (newStyle === null) return;
 
     if (!isValidStyleForFramework(currentFramework, newStyle)) return;
+
+    if (newStyle !== currentStyle) {
+      registerAnalyticsContext({ docs_style: newStyle });
+      trackEvent(ANALYTICS_EVENTS.docsPreferenceChanged, {
+        preference: 'style',
+        value: newStyle,
+        previous: currentStyle,
+      });
+    }
 
     // Update localStorage for this framework
     setStylePreferenceClient(currentFramework, newStyle);

--- a/site/src/components/docs/TableOfContents/TableOfContents.desktop.tsx
+++ b/site/src/components/docs/TableOfContents/TableOfContents.desktop.tsx
@@ -22,7 +22,12 @@ export function TableOfContentsDesktop({ headings, activeId, onNavigate, classNa
   };
 
   return (
-    <nav ref={navRef} aria-label="On this page" className={clsx('', className)}>
+    <nav
+      ref={navRef}
+      aria-label="On this page"
+      data-ph-capture-attribute-location="docs-toc"
+      className={clsx('', className)}
+    >
       <div className="py-8 pr-6">
         <h2 className="text-p3 mb-3 font-bold">On this page</h2>
         <ul className="space-y-3">

--- a/site/src/components/home/GetStartedBanner.astro
+++ b/site/src/components/home/GetStartedBanner.astro
@@ -4,7 +4,10 @@ import ArrowIcon from '@/assets/icons/arrow.svg?react';
 import GetStartedLink from '../NavBar/GetStartedLink';
 ---
 
-<section class="mx-auto w-full max-w-305 px-5">
+<section
+  data-ph-capture-attribute-location="get-started-banner"
+  class="mx-auto w-full max-w-305 px-5"
+>
   <div
     class="group relative mb-34 items-center bg-faded-black py-2.5 text-center text-manila-light transition-colors duration-200 has-[a:hover]:text-faded-black lg:mb-40 lg:flex lg:text-left lg:duration-300 dark:bg-manila-light dark:text-faded-black dark:has-[a:hover]:text-manila-light"
   >
@@ -41,6 +44,8 @@ import GetStartedLink from '../NavBar/GetStartedLink';
     <GetStartedLink
       client:idle
       aria-label="Get started"
+      data-ph-capture-attribute-cta="get-started"
+      data-ph-capture-attribute-destination="docs"
       className={clsx(
         "relative z-10 ml-auto flex h-15 items-center justify-center text-faded-black lg:h-25 lg:w-40 lg:pr-2.5 dark:text-orange",
       )}

--- a/site/src/components/home/Header.astro
+++ b/site/src/components/home/Header.astro
@@ -12,6 +12,7 @@ const { poster } = Astro.props;
 ---
 
 <header
+  data-ph-capture-attribute-location="hero"
   class="relative mx-auto mb-25 grid w-full max-w-305 grid-cols-1 px-5 pt-19 [grid-template-areas:var(--grid-template-areas)] md:py-0 md:[grid-template-areas:var(--md-grid-template-areas)]"
   style="--grid-template-areas: 'pill' 'title' 'description' 'video' 'mux'; --md-grid-template-areas: 'video' 'mux' 'description'"
 >
@@ -50,6 +51,7 @@ const { poster } = Astro.props;
     Video hosting sponsored by <a
       class="relative inline-flex w-11 items-center justify-center md:w-12.5"
       href={MUX_URL}
+      data-ph-capture-attribute-destination="mux"
       target="_blank"
       rel="noopener"
       aria-label="Mux"

--- a/site/src/components/home/Sponsors.astro
+++ b/site/src/components/home/Sponsors.astro
@@ -38,6 +38,7 @@ const sponsors: SponsorItem[] = [
 ---
 
 <section
+  data-ph-capture-attribute-location="sponsors"
   class="row-span-2 mx-auto grid w-full max-w-305 grid-rows-subgrid px-5"
 >
   <header class="border-t border-faded-black py-4 dark:border-manila-light">
@@ -52,6 +53,7 @@ const sponsors: SponsorItem[] = [
   >
     <a
       href={MUX_URL}
+      data-ph-capture-attribute-destination="mux"
       target="_blank"
       rel="noopener"
       aria-label="Mux"
@@ -93,6 +95,7 @@ const sponsors: SponsorItem[] = [
           >
             <a
               href={href}
+              data-ph-capture-attribute-destination="external"
               target="_blank"
               rel="noopener"
               aria-label={name}

--- a/site/src/components/installation/HTMLInstallTabsClient.tsx
+++ b/site/src/components/installation/HTMLInstallTabsClient.tsx
@@ -6,6 +6,7 @@ import ClientCode from '@/components/Code/ClientCode';
 import { Tab, TabsList, TabsPanel, TabsRoot } from '@/components/Tabs';
 import { shared } from '@/components/typography/styles';
 import { installMethod, renderer, skin, useCase } from '@/stores/installation';
+import { ANALYTICS_EVENTS, trackEvent } from '@/utils/analytics';
 import { rendererSupportsCdn } from '@/utils/installation/cdn-code';
 import { generateHTMLInstallCode } from '@/utils/installation/codegen';
 import type { InstallMethod } from '@/utils/installation/types';
@@ -22,6 +23,7 @@ export default function HTMLInstallTabs({ cdnMedia }: HTMLInstallTabsProps) {
   const $renderer = useStore(renderer);
   const $skin = useStore(skin);
   const $useCase = useStore(useCase);
+  const $installMethod = useStore(installMethod);
 
   const supportsCdn = rendererSupportsCdn($renderer, cdnMedia);
   const install = generateHTMLInstallCode({ renderer: $renderer, skin: $skin, useCase: $useCase }, cdnMedia);
@@ -35,9 +37,17 @@ export default function HTMLInstallTabs({ cdnMedia }: HTMLInstallTabsProps) {
     if (!el) return;
 
     const observer = new MutationObserver(() => {
-      const value = el.querySelector('[role="tab"][data-tab-active="true"]')?.getAttribute('data-value');
+      const active = el.querySelector('[role="tab"][data-tab-active="true"]')?.getAttribute('data-value');
+      if (!active) return;
 
-      if (value) installMethod.set(value as InstallMethod);
+      // SAFETY: every tab below is rendered with an InstallMethod as its value.
+      const value = active as InstallMethod;
+
+      const previous = installMethod.get();
+      if (value === previous) return;
+
+      installMethod.set(value);
+      trackEvent(ANALYTICS_EVENTS.installOptionChanged, { option: 'install_method', value, previous });
     });
 
     observer.observe(el, { subtree: true, attributes: true, attributeFilter: ['data-tab-active'] });
@@ -62,7 +72,10 @@ export default function HTMLInstallTabs({ cdnMedia }: HTMLInstallTabsProps) {
           `initial` while the CDN tab mounts/unmounts can leave two tabs active
           at once and desync installMethod from the visible tab. */}
       <TabsRoot key={supportsCdn ? 'with-cdn' : 'without-cdn'}>
-        <TabsList label="Installation">
+        <TabsList
+          label="Installation"
+          analytics={{ block: 'html-install', framework: 'html', install_method: $installMethod }}
+        >
           {supportsCdn && (
             <Tab value="cdn" initial>
               cdn

--- a/site/src/components/installation/HTMLUsageCodeBlock.tsx
+++ b/site/src/components/installation/HTMLUsageCodeBlock.tsx
@@ -24,7 +24,10 @@ export default function HTMLUsageCodeBlock() {
     <>
       {result.imports && (
         <TabsRoot maxWidth={false}>
-          <TabsList label="HTML implementation">
+          <TabsList
+            label="HTML implementation"
+            analytics={{ block: 'html-usage', framework: 'html', install_method: $installMethod }}
+          >
             <Tab value="typescript" initial>
               TypeScript
             </Tab>
@@ -35,7 +38,10 @@ export default function HTMLUsageCodeBlock() {
         </TabsRoot>
       )}
       <TabsRoot maxWidth={false}>
-        <TabsList label="HTML implementation">
+        <TabsList
+          label="HTML implementation"
+          analytics={{ block: 'html-usage', framework: 'html', install_method: $installMethod }}
+        >
           <Tab value="html" initial>
             HTML
           </Tab>

--- a/site/src/components/installation/MuxUploaderPanel.tsx
+++ b/site/src/components/installation/MuxUploaderPanel.tsx
@@ -9,6 +9,7 @@ import { actions } from 'astro:actions';
 import { useCallback, useRef, useState } from 'react';
 
 import { muxPlaybackId, renderer, sourceUrl } from '@/stores/installation';
+import { ANALYTICS_EVENTS, trackEvent } from '@/utils/analytics';
 import { initiateAuthPopup } from '@/utils/mux/auth-flow';
 import { pollForPlaybackId } from '@/utils/mux/polling';
 
@@ -16,6 +17,11 @@ import type { UploaderState } from './UploaderOverlay';
 import UploaderOverlay from './UploaderOverlay';
 
 // import './MuxUploaderPanel.module.css';
+
+/** Server action errors carry a short code; fall back to a trimmed message. Never includes ids or tokens. */
+function failureReason(error: { code?: string; message: string }): string {
+  return error.code ?? error.message.slice(0, 100);
+}
 
 /**
  * Mux video uploader with auth-gated flow.
@@ -59,20 +65,28 @@ export default function MuxUploaderPanel() {
       }
 
       // Other error - throw and let MuxUploader display its native error UI
+      trackEvent(ANALYTICS_EVENTS.muxUploadFailed, {
+        stage: 'create_upload',
+        reason: failureReason(result.error),
+      });
       throw new Error(result.error.message);
     }
 
     // Authenticated - store upload ID and proceed
     setUploadId(result.data.uploadId);
     setState('uploading');
+    trackEvent(ANALYTICS_EVENTS.muxUploadStarted);
     return result.data.uploadUrl;
   }, []);
 
   /** Handles OAuth login via popup. On success: fetches upload URL and resolves the pending Promise. */
   const handleLogin = useCallback(async () => {
+    trackEvent(ANALYTICS_EVENTS.muxLoginClicked);
+
     const result = await actions.auth.initiateLogin();
 
     if (result.error) {
+      trackEvent(ANALYTICS_EVENTS.muxAuthFailed, { reason: failureReason(result.error) });
       setError(result.error.message);
       setState('polling_error');
       return;
@@ -81,12 +95,18 @@ export default function MuxUploaderPanel() {
     initiateAuthPopup({
       authorizationUrl: result.data.authorizationUrl,
       onSuccess: async () => {
+        trackEvent(ANALYTICS_EVENTS.muxAuthSucceeded);
+
         // Now authenticated - fetch upload URL
         const uploadResult = await actions.mux.createDirectUpload({
           corsOrigin: window.location.origin,
         });
 
         if (uploadResult.error) {
+          trackEvent(ANALYTICS_EVENTS.muxUploadFailed, {
+            stage: 'create_upload',
+            reason: failureReason(uploadResult.error),
+          });
           setError(uploadResult.error.message);
           setState('polling_error');
           return;
@@ -95,9 +115,11 @@ export default function MuxUploaderPanel() {
         // Store upload ID and resolve the pending Promise
         setUploadId(uploadResult.data.uploadId);
         setState('uploading');
+        trackEvent(ANALYTICS_EVENTS.muxUploadStarted);
         loginResolverRef.current?.(uploadResult.data.uploadUrl);
       },
       onError: (errorMessage) => {
+        trackEvent(ANALYTICS_EVENTS.muxAuthFailed, { reason: errorMessage.slice(0, 100) });
         setError(errorMessage);
         setState('polling_error');
       },
@@ -108,6 +130,7 @@ export default function MuxUploaderPanel() {
   const handleUploadSuccess = useCallback(async () => {
     if (!uploadId) return;
 
+    trackEvent(ANALYTICS_EVENTS.muxUploadCompleted);
     setState('preparing');
 
     const result = await pollForPlaybackId({
@@ -137,10 +160,16 @@ export default function MuxUploaderPanel() {
     });
 
     if (result.status === 'error') {
+      trackEvent(ANALYTICS_EVENTS.muxUploadFailed, {
+        stage: 'polling',
+        reason: result.message.slice(0, 100),
+      });
       setError(result.message);
       setState('polling_error');
       return;
     }
+
+    trackEvent(ANALYTICS_EVENTS.muxPlaybackIdResolved);
 
     // Success! Update local state and nanostores (for cross-island use)
     setPlaybackId(result.playbackId);

--- a/site/src/components/installation/ReactCreateCodeBlock.tsx
+++ b/site/src/components/installation/ReactCreateCodeBlock.tsx
@@ -18,7 +18,7 @@ export default function ReactCreateCodeBlock() {
 
   return (
     <TabsRoot maxWidth={false}>
-      <TabsList label="React implementation">
+      <TabsList label="React implementation" analytics={{ block: 'react-create', framework: 'react' }}>
         <Tab value="react" initial>
           ./components/player/index.tsx
         </Tab>

--- a/site/src/components/installation/ReactInstallTabs.tsx
+++ b/site/src/components/installation/ReactInstallTabs.tsx
@@ -10,7 +10,7 @@ export default function ReactInstallTabs() {
 
   return (
     <TabsRoot>
-      <TabsList label="Installation">
+      <TabsList label="Installation" analytics={{ block: 'react-install', framework: 'react' }}>
         <Tab value="npm" initial>
           npm
         </Tab>

--- a/site/src/components/installation/ReactUsageCodeBlock.tsx
+++ b/site/src/components/installation/ReactUsageCodeBlock.tsx
@@ -18,7 +18,7 @@ export default function ReactUsageCodeBlock() {
 
   return (
     <TabsRoot maxWidth={false}>
-      <TabsList label="React usage">
+      <TabsList label="React usage" analytics={{ block: 'react-usage', framework: 'react' }}>
         <Tab value="react" initial>
           ./app/page.tsx
         </Tab>

--- a/site/src/components/installation/RendererPicker.tsx
+++ b/site/src/components/installation/RendererPicker.tsx
@@ -5,7 +5,7 @@ import RendererSelect from './RendererSelect';
 
 export default function RendererPicker() {
   return (
-    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2" data-ph-capture-attribute-location="install-page">
       <div className="flex flex-col gap-4">
         <p className="font-bold">Select your source</p>
         <RendererSelect />
@@ -13,7 +13,13 @@ export default function RendererPicker() {
       <div className="flex flex-col gap-4">
         <p className="font-bold">
           Or upload your media for free to{' '}
-          <a href={MUX_URL} target="_blank" rel="noopener" className="intent:decoration-gold underline">
+          <a
+            href={MUX_URL}
+            target="_blank"
+            rel="noopener"
+            data-ph-capture-attribute-destination="mux"
+            className="intent:decoration-gold underline"
+          >
             Mux
           </a>
         </p>

--- a/site/src/components/installation/RendererSelect.tsx
+++ b/site/src/components/installation/RendererSelect.tsx
@@ -3,9 +3,10 @@ import { useEffect } from 'react';
 
 import { Select } from '@/components/Select';
 import { renderer, sourceUrl, useCase } from '@/stores/installation';
+import { ANALYTICS_EVENTS, registerAnalyticsContext, trackEvent } from '@/utils/analytics';
 import { articleFor, detectRenderer } from '@/utils/installation/detect-renderer';
 import { buildOptions } from '@/utils/installation/renderer-options';
-import { getInstallationPreset } from '@/utils/installation/types';
+import { getInstallationPreset, type Renderer } from '@/utils/installation/types';
 
 export default function RendererSelect() {
   const $renderer = useStore(renderer);
@@ -33,6 +34,20 @@ export default function RendererSelect() {
       }
     }
   }, [detectedRenderer, $useCase]);
+
+  // Covers every path that changes the renderer — manual pick, URL auto-detection, and a finished Mux upload — so the
+  // super property never drifts from the store. Super properties are per page load, so re-registering is cheap.
+  useEffect(() => {
+    registerAnalyticsContext({ install_renderer: $renderer });
+  }, [$renderer]);
+
+  const selectRenderer = (value: Renderer) => {
+    const previous = renderer.get();
+    if (value === previous) return;
+
+    renderer.set(value);
+    trackEvent(ANALYTICS_EVENTS.installOptionChanged, { option: 'renderer', value, previous });
+  };
 
   const showDetectionMatch = $sourceUrl.trim() && detection && detection.renderer === $renderer;
   const showDetectionSuggestion = $sourceUrl.trim() && detection && detection.renderer !== $renderer;
@@ -65,7 +80,7 @@ export default function RendererSelect() {
               This looks like {articleFor(detection.renderer)} {detection.label} link.
               <button
                 type="button"
-                onClick={() => renderer.set(detection.renderer)}
+                onClick={() => selectRenderer(detection.renderer)}
                 className="intent:decoration-gold cursor-pointer underline"
               >
                 Select {detection.label}
@@ -80,7 +95,7 @@ export default function RendererSelect() {
         <Select
           value={$renderer}
           onChange={(value) => {
-            if (value) renderer.set(value);
+            if (value) selectRenderer(value);
           }}
           options={options}
           aria-label="Select renderer"

--- a/site/src/components/installation/SkinPicker.tsx
+++ b/site/src/components/installation/SkinPicker.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import type { ImageRadioOption } from '@/components/ImageRadioGroup';
 import ImageRadioGroup from '@/components/ImageRadioGroup';
 import { skin, useCase } from '@/stores/installation';
+import { ANALYTICS_EVENTS, trackEvent } from '@/utils/analytics';
 import { getInstallationPreset, type Skin } from '@/utils/installation/types';
 
 const VIDEO_SKINS: ImageRadioOption<Skin>[] = [
@@ -34,7 +35,13 @@ export default function SkinPicker() {
     }
   }, [options]);
 
-  return (
-    <ImageRadioGroup value={$skin} onChange={(value) => skin.set(value)} options={options} aria-label="Select skin" />
-  );
+  const selectSkin = (value: Skin) => {
+    const previous = skin.get();
+    if (value === previous) return;
+
+    skin.set(value);
+    trackEvent(ANALYTICS_EVENTS.installOptionChanged, { option: 'skin', value, previous });
+  };
+
+  return <ImageRadioGroup value={$skin} onChange={selectSkin} options={options} aria-label="Select skin" />;
 }

--- a/site/src/components/installation/UploaderOverlay.tsx
+++ b/site/src/components/installation/UploaderOverlay.tsx
@@ -17,6 +17,7 @@ interface UploaderOverlayProps {
 function OverlayWrapper({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
     <div
+      data-ph-capture-attribute-location="mux-uploader"
       className={clsx(
         'absolute inset-0 flex flex-col items-center justify-center gap-3',
         'bg-manila-light dark:bg-faded-black',
@@ -47,7 +48,13 @@ export default function UploaderOverlay({ state, error, playbackId, onLogin, onR
       <OverlayWrapper>
         <p className="text-p3 font-bold">
           To upload this video to{' '}
-          <a href={MUX_URL} target="_blank" rel="noopener" className="intent:decoration-gold underline">
+          <a
+            href={MUX_URL}
+            target="_blank"
+            rel="noopener"
+            data-ph-capture-attribute-destination="mux"
+            className="intent:decoration-gold underline"
+          >
             Mux
           </a>
           &hellip;
@@ -55,6 +62,8 @@ export default function UploaderOverlay({ state, error, playbackId, onLogin, onR
         <button
           type="button"
           onClick={onLogin}
+          data-ph-capture-attribute-cta="mux-login"
+          data-ph-capture-attribute-destination="mux"
           className="bg-bright-yellow text-faded-black text-p3 intent:bg-bright-yellow/70 inline-flex cursor-pointer items-center gap-2 rounded-xs px-4 py-2 font-bold"
         >
           Sign up or log in
@@ -86,6 +95,8 @@ export default function UploaderOverlay({ state, error, playbackId, onLogin, onR
             target="_blank"
             className="intent:decoration-gold underline"
             rel="noopener"
+            data-ph-capture-attribute-cta="mux-dashboard"
+            data-ph-capture-attribute-destination="mux"
           >
             manage on Mux
           </a>
@@ -102,7 +113,12 @@ export default function UploaderOverlay({ state, error, playbackId, onLogin, onR
           Error preparing video:
           {error}
         </p>
-        <button type="button" onClick={onRetry} className="text-p3 intent:decoration-gold underline">
+        <button
+          type="button"
+          onClick={onRetry}
+          data-ph-capture-attribute-cta="mux-upload-retry"
+          className="text-p3 intent:decoration-gold underline"
+        >
           Try again
         </button>
       </OverlayWrapper>

--- a/site/src/components/installation/UseCasePicker.tsx
+++ b/site/src/components/installation/UseCasePicker.tsx
@@ -3,6 +3,7 @@ import { Globe, Image, RadioTower } from 'lucide-react';
 
 import ImageRadioGroup from '@/components/ImageRadioGroup';
 import { useCase } from '@/stores/installation';
+import { ANALYTICS_EVENTS, trackEvent } from '@/utils/analytics';
 import { getInstallationPreset, USE_CASES, type UseCase } from '@/utils/installation/types';
 
 function getPresetIcon(useCase: UseCase) {
@@ -16,10 +17,18 @@ function getPresetIcon(useCase: UseCase) {
 export default function UseCasePicker() {
   const $useCase = useStore(useCase);
 
+  const selectUseCase = (value: UseCase) => {
+    const previous = useCase.get();
+    if (value === previous) return;
+
+    useCase.set(value);
+    trackEvent(ANALYTICS_EVENTS.installOptionChanged, { option: 'use_case', value, previous });
+  };
+
   return (
     <ImageRadioGroup
       value={$useCase}
-      onChange={(value) => useCase.set(value as UseCase)}
+      onChange={selectUseCase}
       options={USE_CASES.map((value) => ({
         value,
         label: getInstallationPreset(value).label,

--- a/site/src/layouts/ErrorPage.astro
+++ b/site/src/layouts/ErrorPage.astro
@@ -19,7 +19,11 @@ const { title, description, code = '404', message = 'NOT FOUND' } = Astro.props;
 <Base {title} {description} withCompact>
   <div class="flex flex-col" style={{ minHeight: "80dvh" }}>
     <NavBar />
-    <main id="main-content" class="w-full">
+    <main
+      id="main-content"
+      data-ph-capture-attribute-location="error-page"
+      class="w-full"
+    >
       <div
         class="mx-auto grid w-full max-w-305 justify-between gap-8 px-5 py-10 md:flex md:pt-32 md:pb-16"
       >
@@ -39,15 +43,21 @@ const { title, description, code = '404', message = 'NOT FOUND' } = Astro.props;
           client:load
           left={[
             { href: "/", label: "Home", angle: -60 },
-            { href: "/docs", label: "Docs", angle: -120 },
+            {
+              href: "/docs",
+              label: "Docs",
+              angle: -120,
+              destination: "docs",
+            },
           ]}
           right={[
             {
               href: MUX_URL,
               label: "mux.com",
               angle: 60,
+              destination: "mux",
             },
-            { href: "/blog", label: "Blog", angle: 120 },
+            { href: "/blog", label: "Blog", angle: 120, destination: "blog" },
           ]}
         />
       </div>

--- a/site/src/utils/analytics.ts
+++ b/site/src/utils/analytics.ts
@@ -1,0 +1,128 @@
+/**
+ * PostHog event vocabulary and safe capture helpers.
+ *
+ * The snippet in `src/components/Posthog.astro` is production-only and idle-loaded, so `window.posthog` is absent in
+ * development and is the queueing stub until the real script arrives. Every helper here no-ops rather than throwing so
+ * call sites never need their own guards.
+ *
+ * PostHog runs in `cookieless_mode: "always"`. Never call `identify`, `alias`, or any person-property API — there is no
+ * durable person to attach them to. Super properties registered here live for one page load only, so they must be
+ * re-registered whenever the underlying preference changes.
+ */
+
+import type { AnySupportedStyle, SupportedFramework } from '@/types/docs';
+import type { InstallMethod, Renderer, Skin, UseCase } from '@/utils/installation/types';
+
+declare global {
+  interface Window {
+    /**
+     * Minimal surface of the PostHog snippet. The pre-load stub exposes the same two methods and queues their calls, so
+     * both are safe to invoke before `array.js` finishes loading.
+     */
+    posthog?: {
+      capture?: (event: string, properties?: Record<string, unknown>) => void;
+      register?: (properties: Record<string, unknown>) => void;
+    };
+  }
+}
+
+/**
+ * Every custom event the site captures. Autocaptured clicks are described declaratively with
+ * `data-ph-capture-attribute-*` instead — see `site/AGENTS.md`.
+ */
+export const ANALYTICS_EVENTS = {
+  docsPreferenceChanged: 'docs_preference_changed',
+  installOptionChanged: 'install_option_changed',
+  codeCopied: 'code_copied',
+  searchOpened: 'search_opened',
+  searchNoResults: 'search_no_results',
+  muxLoginClicked: 'mux_login_clicked',
+  muxAuthSucceeded: 'mux_auth_succeeded',
+  muxAuthFailed: 'mux_auth_failed',
+  muxUploadStarted: 'mux_upload_started',
+  muxUploadCompleted: 'mux_upload_completed',
+  muxPlaybackIdResolved: 'mux_playback_id_resolved',
+  muxUploadFailed: 'mux_upload_failed',
+} as const;
+
+export type AnalyticsEventName = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
+
+/** Which docs preference changed. */
+export type DocsPreference = 'framework' | 'style';
+
+/** Which installation picker changed. */
+export type InstallOption = 'renderer' | 'skin' | 'use_case' | 'install_method';
+
+/** Properties each event carries. Keep these stable: dashboards filter on them. */
+export interface AnalyticsEventProperties {
+  docs_preference_changed: {
+    preference: DocsPreference;
+    value: SupportedFramework | AnySupportedStyle;
+    previous: SupportedFramework | AnySupportedStyle | null;
+  };
+  install_option_changed: {
+    option: InstallOption;
+    value: Renderer | Skin | UseCase | InstallMethod;
+    previous: Renderer | Skin | UseCase | InstallMethod | null;
+  };
+  /** `block` is a short, stable id for the copied code block. */
+  code_copied: {
+    block: string;
+    framework?: SupportedFramework;
+    install_method?: InstallMethod;
+  };
+  search_opened: undefined;
+  search_no_results: { query: string };
+  mux_login_clicked: undefined;
+  mux_auth_succeeded: undefined;
+  mux_auth_failed: { reason: string };
+  mux_upload_started: undefined;
+  mux_upload_completed: undefined;
+  mux_playback_id_resolved: undefined;
+  /** Never carries upload ids, playback ids, or tokens — only the step and a short reason. */
+  mux_upload_failed: { stage: string; reason: string };
+}
+
+/**
+ * Super properties describing the reader's current context, attached to every subsequent event on this page load.
+ * Cookieless mode drops them on navigation, so re-register whenever the source preference changes.
+ */
+export type AnalyticsContext = {
+  docs_framework?: SupportedFramework | null;
+  docs_style?: AnySupportedStyle | null;
+  install_renderer?: Renderer | null;
+};
+
+function getPosthog(): Window['posthog'] | null {
+  if (typeof window === 'undefined') return null;
+
+  return window.posthog ?? null;
+}
+
+/** Capture a custom event. No-ops when PostHog is absent, and never throws. */
+export function trackEvent<E extends AnalyticsEventName>(name: E, properties?: AnalyticsEventProperties[E]): void {
+  if (import.meta.env.DEV) console.debug('[analytics] capture', name, properties);
+
+  const posthog = getPosthog();
+  if (typeof posthog?.capture !== 'function') return;
+
+  try {
+    posthog.capture(name, properties);
+  } catch (error) {
+    if (import.meta.env.DEV) console.debug('[analytics] capture failed', name, error);
+  }
+}
+
+/** Register super properties for the rest of this page load. No-ops when PostHog is absent, and never throws. */
+export function registerAnalyticsContext(properties: AnalyticsContext): void {
+  if (import.meta.env.DEV) console.debug('[analytics] register', properties);
+
+  const posthog = getPosthog();
+  if (typeof posthog?.register !== 'function') return;
+
+  try {
+    posthog.register(properties);
+  } catch (error) {
+    if (import.meta.env.DEV) console.debug('[analytics] register failed', error);
+  }
+}

--- a/site/src/utils/tests/analytics.test.ts
+++ b/site/src/utils/tests/analytics.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { ANALYTICS_EVENTS, registerAnalyticsContext, trackEvent } from '../analytics';
+
+beforeEach(() => {
+  // The helpers log through console.debug in dev, which vitest also runs as.
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  delete window.posthog;
+  vi.restoreAllMocks();
+});
+
+describe('trackEvent', () => {
+  it('no-ops when PostHog is absent', () => {
+    expect(() => trackEvent(ANALYTICS_EVENTS.searchOpened)).not.toThrow();
+  });
+
+  it('no-ops when the snippet has not attached capture yet', () => {
+    window.posthog = {};
+
+    expect(() => trackEvent(ANALYTICS_EVENTS.searchOpened)).not.toThrow();
+  });
+
+  it('forwards the event name and properties to capture', () => {
+    const capture = vi.fn();
+
+    window.posthog = { capture };
+
+    trackEvent(ANALYTICS_EVENTS.searchNoResults, { query: 'chapters' });
+
+    expect(capture).toHaveBeenCalledWith('search_no_results', { query: 'chapters' });
+  });
+
+  it('captures property-less events with undefined properties', () => {
+    const capture = vi.fn();
+
+    window.posthog = { capture };
+
+    trackEvent(ANALYTICS_EVENTS.muxLoginClicked);
+
+    expect(capture).toHaveBeenCalledWith('mux_login_clicked', undefined);
+  });
+
+  it('swallows errors thrown by capture', () => {
+    const capture = vi.fn(() => {
+      throw new Error('posthog exploded');
+    });
+
+    window.posthog = { capture };
+
+    expect(() => trackEvent(ANALYTICS_EVENTS.searchOpened)).not.toThrow();
+    expect(capture).toHaveBeenCalled();
+  });
+});
+
+describe('registerAnalyticsContext', () => {
+  it('no-ops when PostHog is absent', () => {
+    expect(() => registerAnalyticsContext({ docs_framework: 'react' })).not.toThrow();
+  });
+
+  it('forwards super properties to register', () => {
+    const register = vi.fn();
+
+    window.posthog = { register };
+
+    registerAnalyticsContext({ docs_framework: 'react', docs_style: 'css' });
+
+    expect(register).toHaveBeenCalledWith({ docs_framework: 'react', docs_style: 'css' });
+  });
+
+  it('swallows errors thrown by register', () => {
+    const register = vi.fn(() => {
+      throw new Error('posthog exploded');
+    });
+
+    window.posthog = { register };
+
+    expect(() => registerAnalyticsContext({ install_renderer: 'hls' })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Establishes a stable PostHog event and property vocabulary on videojs.org so future engagement and videojs.org → Mux funnel questions can be answered with filters rather than new code. Site-only change; no package code touched.

### Declarative click tagging

Clickable markup is tagged with three `data-ph-capture-attribute-*` names that PostHog autocapture promotes to top-level event properties (the PostHog analogue of Heap's `data-analytics-selector`):

- `location` on containers: `nav`, `nav-docs`, `nav-mobile`, `footer`, `footer-docs`, `hero`, `get-started-banner`, `sponsors`, `docs-sidebar`, `docs-toc`, `docs-link-card`, `install-page`, `mux-uploader`, `search`, `error-page`
- `cta` on specific calls to action: `get-started`, `view-docs`, `edit-page`, `mux-login`, `mux-dashboard`, `report-search-issue`, …
- `destination` on outbound / cross-section links: `mux`, `github`, `discord`, `docs`, `blog`, `external`

### Custom events (`site/src/utils/analytics.ts`)

Typed `ANALYTICS_EVENTS` vocabulary plus `trackEvent` and `registerAnalyticsContext`, both of which no-op when PostHog is absent and never throw. Dev builds log through `console.debug`.

| Event | Properties |
|---|---|
| `docs_preference_changed` | `preference`, `value`, `previous` |
| `install_option_changed` | `option`, `value`, `previous` |
| `code_copied` | `block`, `framework?`, `install_method?` |
| `search_opened` | |
| `search_no_results` | `query` |
| `mux_login_clicked`, `mux_auth_succeeded`, `mux_upload_started`, `mux_upload_completed`, `mux_playback_id_resolved` | |
| `mux_auth_failed` | `reason` |
| `mux_upload_failed` | `stage`, `reason` |

Failure events carry only a step name and a short reason, never upload IDs, playback IDs, or tokens.

Super properties `docs_framework` and `docs_style` are registered from the snippet's `loaded` callback (before the initial `$pageview`) using the storage keys from `preferences.ts` via `define:vars`, and re-registered on change. `install_renderer` is registered from `RendererSelect` whenever the renderer store changes.

### Snippet config

`capture_dead_clicks: true` and `capture_heatmaps: true` added. Cookieless mode unchanged; `identify` / `alias` / person properties are deliberately not used and `site/AGENTS.md` now documents that constraint along with the tagging vocabulary.

## Notes for review

- `install_option_changed` fires from user handlers, not store setters, so the `useEffect` auto-corrections that follow a use-case change don't register as user choices.
- DocSearch v4 exposes no open/close callbacks and portals its modal to `document.body`, so `Search.tsx` observes for `.DocSearch-Container` to fire `search_opened` and tag the no-results issue link. If DocSearch renames those classes the events stop firing but nothing breaks.
- `analytics.ts` has a few `anti-slop` lint warnings (`Record<string, unknown>`, `typeof === 'function'`) inherent to describing an untyped third-party global; `pnpm lint` runs `--quiet` so they don't fail.

## Test plan

- [x] `pnpm -F site test` — 37 files, 589 tests pass (8 new for `analytics.ts`)
- [x] `pnpm typecheck`, `pnpm -F site exec astro check` — clean
- [x] `pnpm lint` (site scope) and `pnpm lint:fix:file` on each changed file
- [x] `pnpm check:workspace` — pass (site/AGENTS.md changed)
- [x] `pnpm build:site` — pass; verified rendered HTML carries the attributes on home, docs, and install pages and that `define:vars` injected the real storage keys
- [ ] After deploy: confirm in PostHog that autocaptured clicks show `location` / `cta` / `destination` and that the initial `$pageview` carries `docs_framework`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cu2LJFbVDVaAZohbBwPgkD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu2LJFbVDVaAZohbBwPgkD)_