### PR TITLE
docs(design): fix common-media-library upstream links

### DIFF
--- a/internal/design/spf/presentation-modeling.md
+++ b/internal/design/spf/presentation-modeling.md
@@ -91,7 +91,7 @@ Format — Hypothetical Application Model). The framing is explicit in
 the code:
 
 > Protocol-agnostic representation of streaming media content.
-> See https://github.com/AcademySoftwareFoundation/common-media-library
+> See https://github.com/streaming-video-technology-alliance/common-media-library
 
 All types live in `packages/spf/src/media/types/index.ts`.
 
@@ -567,5 +567,5 @@ file format-specific architectural docs as siblings to this one
   case study for the opposite direction: hardcoded, but should be
   config)
 - `packages/spf/src/media/types/index.ts` — canonical type definitions
-- [common-media-library upstream](https://github.com/AcademySoftwareFoundation/common-media-library)
+- [common-media-library upstream](https://github.com/streaming-video-technology-alliance/common-media-library)
   — the CMAF-HAM model this layer is based on


### PR DESCRIPTION
Refs #1814

## Summary

Two links in the SPF presentation-modeling design doc pointed at `AcademySoftwareFoundation/common-media-library`, which does not exist (GitHub returns 404). The Common Media Library lives under `streaming-video-technology-alliance`, the URL the SPF media types header has used since #1814.

## Changes

- Point both Common Media Library references in the presentation-modeling design doc at the streaming-video-technology-alliance repository.
- No other content changes. A repo-wide search found no other occurrences of the old org.

## Testing

- `git grep -i academysoftwarefoundation` returns nothing.
- Confirmed via the GitHub API that the new repository resolves and the old path returns 404.
- `git diff --check` clean. Docs-only change, no code or tests affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL correction with no runtime, API, or test impact.
> 
> **Overview**
> **Fixes broken Common Media Library links** in `internal/design/spf/presentation-modeling.md` so they point at the correct upstream org.
> 
> Both references (the inline CMAF-HAM citation and the “See also” link) are updated from `github.com/AcademySoftwareFoundation/common-media-library` (404) to `github.com/streaming-video-technology-alliance/common-media-library`, matching the URL already used in the SPF media types header per #1814. No other doc or code content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd51e4bb3404a0ec66e7784c6a28e55e15fd3dc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->