### PR TITLE
fix(skin): use finite radius to fix Safari clip-path bug

### DIFF
--- a/apps/sandbox/app/shared/player-frame.ts
+++ b/apps/sandbox/app/shared/player-frame.ts
@@ -20,6 +20,8 @@ export function defaultPlayerWidth(player: MediaPlayer): number {
  * with the skin's own cap when a page is opened without one.
  */
 export const PLAYER_FRAME_CLASSES = {
-  video: 'mx-auto aspect-video max-w-[var(--sandbox-player-width,56rem)]',
+  // Keep centred controls on device pixels instead of the fractional height produced by aspect-ratio.
+  video:
+    'mx-auto aspect-video max-w-[var(--sandbox-player-width,56rem)] h-[round(nearest,calc(min(var(--sandbox-player-width,56rem),100vw-1rem)*9/16),2px)]!',
   audio: 'mx-auto w-full max-w-[var(--sandbox-player-width,36rem)]',
 } as const;

--- a/apps/sandbox/app/shell/select.tsx
+++ b/apps/sandbox/app/shell/select.tsx
@@ -57,14 +57,16 @@ export function SelectField({
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {optionGroups
-            ? optionGroups.map((group) => (
-                <SelectGroup key={group.label}>
-                  <SelectLabel>{group.label}</SelectLabel>
-                  {items(group.options)}
-                </SelectGroup>
-              ))
-            : items(options)}
+          {optionGroups ? (
+            optionGroups.map((group) => (
+              <SelectGroup key={group.label}>
+                <SelectLabel>{group.label}</SelectLabel>
+                {items(group.options)}
+              </SelectGroup>
+            ))
+          ) : (
+            <SelectGroup>{items(options)}</SelectGroup>
+          )}
         </SelectContent>
       </Select>
     </>

--- a/packages/skins/src/styles/themes/theme.css
+++ b/packages/skins/src/styles/themes/theme.css
@@ -40,7 +40,7 @@
 
     /* Controls. */
     --media-control-corner-shape: round;
-    --media-control-radius: calc(infinity * 1px);
+    --media-control-radius: 99px;
     --media-control-size: calc(var(--media-spacing) * 9);
     --media-controls-radius: var(--media-control-radius);
     --media-default-accent-color: oklch(1 0 0);


### PR DESCRIPTION
- Safari doesn't like `Infinity * 1px` so clip-path's don't work on the slider. It slipped through the compiled skin testing. 
- Restore missing spacing on sandbox `Select` components. 
- Fix rounding weirdness in the sandbox. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CSS and sandbox UI fixes with no auth, data, or API changes; skin radius change is visually equivalent for pill controls.
> 
> **Overview**
> Fixes **Safari slider rendering** by replacing `--media-control-radius: calc(infinity * 1px)` with a finite **`99px`** value so `clip-path` rounding on sliders works again (Safari rejects the infinite radius).
> 
> In the **sandbox**, flat `Select` options are wrapped in a **`SelectGroup`** again for correct spacing, and the **video preview frame** gets an explicit height rounded to **2px** so controls stay on device pixels instead of fractional `aspect-ratio` heights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240b2a7f266f8a9231dbeb1e2889ddd39b8f119e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->