### PR TITLE
docs(site): document disabled and unavailable time and live button states

### DIFF
--- a/site/src/content/docs/how-to/play-live-streams.mdx
+++ b/site/src/content/docs/how-to/play-live-streams.mdx
@@ -107,7 +107,7 @@ Two features describe liveness:
 
 The <DocsLink slug="reference/feature-time">time feature</DocsLink> adjusts for live playback: `duration` reports the live edge (the end of the seekable range) and keeps growing as the stream continues.
 
-LiveButton reads this state: it renders as an active "go to live" control while playback is behind the edge, seeks to the edge on activation, and goes inactive at the edge.
+LiveButton reads this state: it renders as an active "go to live" control while playback is behind the edge, seeks to the edge on activation, and goes inactive at the edge. Until the media reports a `seekable` range — before metadata loads, or for non-live media — the button is disabled (`data-disabled`) because there is no edge to seek to. Custom live UIs should treat "behind the edge" and "actionable" as separate states.
 
 ## Availability and constraints
 

--- a/site/src/content/docs/reference/live-button.mdx
+++ b/site/src/content/docs/reference/live-button.mdx
@@ -45,6 +45,8 @@ import basicUsageHtmlTs from "@/components/docs/demos/live-button/html/css/Basic
 
 LiveButton indicates whether playback is at the live edge and acts as a "go to live" control. While playback is behind the edge, clicking seeks to the live edge — the end of the last `seekable` range. At the edge the button goes inactive (`aria-disabled`) and clicking is a no-op.
 
+The button is also disabled whenever it has no live edge to seek to: the media is not live, the `seekable` ranges are still empty (before metadata loads, for example), or the last range ends at `Infinity`. It reports `disabled` in its state, sets `data-disabled`, and ignores activation until a seek target exists. Passing `disabled` forces the same state.
+
 The button combines three player features: <DocsLink slug="reference/feature-live">live</DocsLink> for `liveEdgeStart` and `targetLiveWindow`, <DocsLink slug="reference/feature-time">time</DocsLink> for `currentTime` and the `seek()` action, and <DocsLink slug="reference/feature-buffer">buffer</DocsLink> for `seekable`. All three are included in the `liveVideoFeatures` and `liveAudioFeatures` presets, and the packaged live skins include the button.
 
 Media counts as live while `targetLiveWindow` is not `NaN`. That value is how far behind the live edge viewers can seek: `0` means the stream is watchable only at the edge, and `Infinity` means the stream keeps its recording seekable so viewers can rewind and catch up, like a DVR. For on-demand media the button reports neither `live` nor `liveEdge` and stays inert.
@@ -61,13 +63,15 @@ See <DocsLink slug="how-to/play-live-streams">Play live streams</DocsLink> for h
 |-----------|--------|-------------|
 | `data-live` | Present / absent | Present when the stream is live (or DVR) |
 | `data-live-edge` | Present / absent | Present when playback is at the live edge |
+| `data-disabled` | Present / absent | Present when the button is non-interactive (mirrors `aria-disabled`) |
 
-Use `data-live-edge` to color the button red at the edge and gray behind it:
+Use `data-live-edge` to color the button red at the edge and gray behind it, and `data-disabled` to fade it while no live-edge target is available:
 
 <FrameworkCase frameworks={["html"]}>
 ```css
 media-live-button { color: gray; }
 media-live-button[data-live-edge] { color: red; }
+media-live-button[data-disabled] { opacity: 0.5; }
 ```
 </FrameworkCase>
 
@@ -77,12 +81,13 @@ React renders a `<button>` element with the same data attributes. Add a `classNa
 ```css
 .live-button { color: gray; }
 .live-button[data-live-edge] { color: red; }
+.live-button[data-disabled] { opacity: 0.5; }
 ```
 </FrameworkCase>
 
 ## Accessibility
 
-Renders a `<button>` with an automatic `aria-label` that updates based on state: "Playing live" at the live edge, "Seek to live edge" while behind it. Override with the `label` prop, which accepts a text descriptor, literal string, or function returning either. A text descriptor contains an opaque translation key and English fallback, for example `{ key: 'live.playing', text: 'Playing live' }`. When the button is disabled or playback is at the live edge, `aria-disabled="true"` is set. Keyboard activation: <kbd>Enter</kbd> / <kbd>Space</kbd>.
+Renders a `<button>` with an automatic `aria-label` that updates based on state: "Playing live" at the live edge, "Seek to live edge" while behind it. Override with the `label` prop, which accepts a text descriptor, literal string, or function returning either. A text descriptor contains an opaque translation key and English fallback, for example `{ key: 'live.playing', text: 'Playing live' }`. When the button is disabled — explicitly, or because no live-edge seek target is available yet — or playback is at the live edge, `aria-disabled="true"` is set and activation is ignored. Keyboard activation: <kbd>Enter</kbd> / <kbd>Space</kbd>.
 
 ## Examples
 

--- a/site/src/content/docs/reference/time.mdx
+++ b/site/src/content/docs/reference/time.mdx
@@ -92,6 +92,8 @@ Hour display is triggered when either the current value or the duration exceeds 
 
 Use `toggle` to let current displays switch between elapsed and remaining time, or remaining and duration displays switch between those two values. The initial display comes from `type`.
 
+Before the media reports a duration or seekable range — while metadata is still loading, for example — no time value is available. A plain display still renders the formatted zero value but sets `data-unavailable`; a toggleable display is disabled instead: it sets `data-disabled`, leaves the tab order, and ignores activation until a value arrives.
+
 <FrameworkCase frameworks={["react"]}>
 
 ```tsx
@@ -112,11 +114,26 @@ Use `toggle` to let current displays switch between elapsed and remaining time, 
 
 ## Styling
 
+| Attribute | Values | Description |
+|-----------|--------|-------------|
+| `data-type` | `current` / `duration` / `remaining` | The type of time being displayed |
+| `data-disabled` | Present / absent | Present when a toggleable display has no time value yet |
+| `data-unavailable` | Present / absent | Present when a plain display has no time value yet |
+
 The negative sign is rendered inside `<span aria-hidden="true">` and can be hidden with CSS:
 
 ```css
 [data-type="remaining"] > span[aria-hidden] {
   display: none;
+}
+```
+
+Dim a display while its value is unavailable:
+
+```css
+[data-disabled],
+[data-unavailable] {
+  opacity: 0.5;
 }
 ```
 
@@ -137,6 +154,8 @@ Each `<Time.Value>` has:
 No `aria-live` region is used — time updates too frequently and might overwhelm screen readers. The separator and negative sign are `aria-hidden="true"` because the accessible label already describes the value.
 
 Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard support for Enter and Space. Their `aria-label` starts with the action and includes the current value. Their `aria-description` explains which values the control toggles between.
+
+While no time value is available, a toggleable display is disabled: it sets `aria-disabled="true"` and `tabindex="-1"`, drops the `aria-description`, changes its `aria-label` to "Media not loaded, unknown time.", and ignores clicks and key presses. A plain display in the same state omits `datetime` and uses that same label.
 
 ## Examples
 


### PR DESCRIPTION
Closes #2677

## Summary

#2525 taught `Time.Value` and `LiveButton` to handle controls before media metadata, adding `disabled` / `unavailable` state and the matching `data-disabled` / `data-unavailable` attributes. The reference pages still described toggleable time displays as always focusable and the live button as inactive only at the live edge.

## Changes

- Time reference: explain the pre-metadata state (plain displays set `data-unavailable`, toggles become disabled and leave the tab order), add a data-attribute table with `data-type`, `data-disabled`, and `data-unavailable`, and correct the accessibility section so it no longer claims every toggle has `tabindex="0"` and an `aria-description`.
- LiveButton reference: document when the button is disabled (not live, empty `seekable`, or an infinite seekable end), add the `data-disabled` styling hook and example, and clarify the `aria-disabled` conditions.
- Play live streams guide: distinguish "behind the live edge" from "actionable" so custom live UIs do not imply activation before a seek target exists.

## Testing

Prose only. Wording checked against `TimeCore.getState`/`getAttrs` and `LiveButtonCore.getState`/`getAttrs` in `packages/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> Updates site docs so **Time** and **LiveButton** reference pages match behavior added in #2525: controls before metadata load are **disabled** or **unavailable**, with `data-disabled` / `data-unavailable` styling hooks.
> 
> The **Time** reference now documents pre-metadata behavior (plain displays use `data-unavailable`; toggleable displays are disabled, non-focusable, and ignore input), adds a data-attribute table, CSS examples for dimming, and revises accessibility so toggles are not always `tabindex="0"` with an `aria-description`.
> 
> The **LiveButton** reference adds when the button is disabled (no seek target: not live, empty `seekable`, or infinite range end), documents `data-disabled`, and expands `aria-disabled` / activation rules.
> 
> The **Play live streams** guide tells custom UIs to separate “behind the edge” from “actionable” so users are not prompted to seek before a live edge exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 885bece76006149df04847e8205b2d9d5dafe3c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->