### PR TITLE
docs(site): describe slider thumbnail props in the timeline previews guide

### DIFF
--- a/site/src/content/docs/how-to/show-timeline-thumbnail-previews.mdx
+++ b/site/src/content/docs/how-to/show-timeline-thumbnail-previews.mdx
@@ -31,7 +31,7 @@ With <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, the storyboard tr
 
 ## Recommended approach
 
-Add a `kind="metadata"` track labeled `thumbnails` whose cues reference storyboard images, then put a slider thumbnail inside the <DocsLink slug="reference/time-slider">TimeSlider</DocsLink>. Scrubbing shows the frame under the pointer; the thumbnail reads the pointer time from the slider, so it takes no props.
+Add a `kind="metadata"` track labeled `thumbnails` whose cues reference storyboard images, then put a slider thumbnail inside the <DocsLink slug="reference/time-slider">TimeSlider</DocsLink>. Scrubbing shows the frame under the pointer. The slider thumbnail reads the pointer time from the slider, so you never pass `time`; it otherwise accepts the same props as the standalone <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink>. In React, compose `Slider.Thumbnail.Root` around `Slider.Thumbnail.Image` and put image settings such as `crossOrigin`, `loading`, and `fetchPriority` on the image part. In HTML, `<media-slider-thumbnail>` draws its own image unless you supply an `<img>` child.
 
 <FrameworkCase frameworks={["react"]}>
   <StyleCase styles={["css"]}>
@@ -94,6 +94,7 @@ Regenerate the storyboard with a larger frame size, or split giant sprite sheets
 ## Related components
 
 - <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink>
+- <DocsLink slug="reference/slider">Slider</DocsLink>
 - <DocsLink slug="reference/time-slider">Time slider</DocsLink>
 
 ## Related API

--- a/site/src/content/docs/how-to/show-timeline-thumbnail-previews.mdx
+++ b/site/src/content/docs/how-to/show-timeline-thumbnail-previews.mdx
@@ -31,7 +31,15 @@ With <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, the storyboard tr
 
 ## Recommended approach
 
-Add a `kind="metadata"` track labeled `thumbnails` whose cues reference storyboard images, then put a slider thumbnail inside the <DocsLink slug="reference/time-slider">TimeSlider</DocsLink>. Scrubbing shows the frame under the pointer. The slider thumbnail reads the pointer time from the slider, so you never pass `time`; it otherwise accepts the same props as the standalone <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink>. In React, compose `Slider.Thumbnail.Root` around `Slider.Thumbnail.Image` and put image settings such as `crossOrigin`, `loading`, and `fetchPriority` on the image part. In HTML, `<media-slider-thumbnail>` draws its own image unless you supply an `<img>` child.
+Add a `kind="metadata"` track labeled `thumbnails` whose cues reference storyboard images, then put a slider thumbnail inside the <DocsLink slug="reference/time-slider">TimeSlider</DocsLink>. Scrubbing shows the frame under the pointer. The slider thumbnail reads the pointer time from the slider, so you never pass `time`; it otherwise accepts the same props as the standalone <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink>.
+
+<FrameworkCase frameworks={["react"]}>
+Compose `Slider.Thumbnail.Root` around `Slider.Thumbnail.Image`, and put image settings such as `crossOrigin`, `loading`, and `fetchPriority` on the image part.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+`<media-slider-thumbnail>` draws its own image unless you supply an `<img>` child; set `crossorigin`, `loading`, or `fetchpriority` on the element itself.
+</FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
   <StyleCase styles={["css"]}>


### PR DESCRIPTION
Closes #2672

## Summary

The timeline thumbnail guide said the slider thumbnail "takes no props". Since #2566 the slider thumbnail is composable: `Slider.Thumbnail.Root` accepts every `Thumbnail.Root` prop except `time`, and `Slider.Thumbnail.Image` carries the image settings (`crossOrigin`, `loading`, `fetchPriority`).

## Changes

- Reword the recommended approach so it says only `time` is supplied by the slider, points at the standalone Thumbnail reference for the remaining props, and names the `Root`/`Image` composition in React and the optional `<img>` child in HTML.
- Link the Slider reference from the related components list.

## Testing

Prose only. Checked against `SliderThumbnailRoot` in `packages/react/src/ui/slider/thumbnail/root.tsx` and `SliderThumbnailElement` in `packages/html/src/ui/slider/thumbnail.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **Show timeline thumbnail previews** how-to so it matches the composable slider thumbnail API instead of saying the component takes no props.
> 
> The recommended approach now clarifies that only **`time`** comes from the slider and other options mirror the standalone **Thumbnail** reference. New **React** and **HTML** notes describe **`Slider.Thumbnail.Root` / `Slider.Thumbnail.Image`** (image props on the image part) and **`<media-slider-thumbnail>`** with an optional **`<img>`** child. **Related components** adds a link to the **Slider** reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a43b7017377b91d6af3b4d7f1890af0a6a91c96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->