### PR TITLE
fix(site): keep shared-source react parts in the api reference

### DIFF
--- a/.agents/skills/write-api-reference/references/builder-conventions.md
+++ b/.agents/skills/write-api-reference/references/builder-conventions.md
@@ -58,7 +58,9 @@ The same map covers media elements whose PascalCase name doesn't kebab-case to t
 
 **Single-part fallback**: When filtering leaves only one part (typically Root), the component uses single-part mode — the remaining part's props/state/data-attrs are promoted to the top level, not nested under `parts`.
 
-**Primary part identification**: The part whose React source file instantiates the component's Core class (matches `new \w+Core\(`). The primary part receives the shared core props/state/data-attrs/css-vars.
+**Primary part identification**: The part whose React source file instantiates the component's Core class (matches `new {Name}Core`). When no part does (the parts drive the core through hooks) or several do (they share one source file), the part exported as `Root` is primary. The primary part receives the shared core props/state/data-attrs/css-vars and the component's `element.ts`.
+
+**Shared source files**: Parts may be exported from one file (`export { XRoot as Root, XOptions as Options, XValue as Value } from './component'`). Their kebabs then derive from the export names (`root`, `options`, `value`) rather than the file name, and descriptions and `{LocalName}Props` resolve by local export name inside that file.
 
 **Non-primary parts**: Each gets its own element file at `packages/html/src/ui/{name}/{part}.ts` (e.g., `time/group.ts`). Element class must be `{Name}{Part}Element` (e.g., `TimeGroupElement`). A nested React part source such as `./chapters/title` is honored when the same folder exists on the HTML side; otherwise the part is looked up flat in the component directory.
 

--- a/site/scripts/api-docs-builder/src/pipeline.ts
+++ b/site/scripts/api-docs-builder/src/pipeline.ts
@@ -32,7 +32,7 @@ import type {
   PropDef,
   StateDef,
 } from './types.js';
-import { kebabToPascal, log, partKebabFromSource, sortProps } from './utils.js';
+import { kebabToPascal, log, partKebabFromSource, pascalToKebab, sortProps } from './utils.js';
 
 // ─── Overrides ─────────────────────────────────────────────────────
 
@@ -320,33 +320,42 @@ export function discoverParts(source: ComponentSource, program: OxcProject, mono
   const componentKebab = source.kebab;
   const htmlDir = path.join(htmlUiPath, componentKebab);
 
+  // Parts that share one source file (`./component` exporting Root, Options, and Value) are named after
+  // their export; a file-derived kebab would collide and collapse them into a single part.
+  const sharedSources = new Set(
+    localExports.map((part) => part.source).filter((value, index, all) => all.indexOf(value) !== index)
+  );
+
   const parts: PartSource[] = [];
 
   for (const partExport of localExports) {
-    const kebab = partKebabFromSource(partExport.source, componentKebab);
+    const kebab = sharedSources.has(partExport.source)
+      ? pascalToKebab(partExport.name)
+      : partKebabFromSource(partExport.source, componentKebab);
 
     const partElement = resolvePartElement(htmlDir, componentKebab, partExport.source, kebab);
 
     const reactFile = path.join(path.dirname(source.partsIndexPath!), `${partExport.source.replace('./', '')}.tsx`);
     const reactPath = fs.existsSync(reactFile) ? reactFile : undefined;
 
-    const isPrimary = !!reactPath && instantiatesCore(reactPath, source.name);
-
-    const subPartUsesDataAttrs = !isPrimary && !!reactPath && usesDataAttrs(reactPath);
-
-    const part: PartSource = {
+    parts.push({
       name: partExport.name,
       localName: partExport.localName,
       kebab,
-      isPrimary,
-      htmlPath: partElement?.path ?? (isPrimary ? source.htmlPath : undefined),
+      isPrimary: !!reactPath && instantiatesCore(reactPath, source.name),
+      htmlPath: partElement?.path,
       htmlElementName: partElement?.className,
       reactPath,
-      dataAttrsPath: subPartUsesDataAttrs ? source.dataAttrsPath : undefined,
-      dataAttrsComponentName: subPartUsesDataAttrs ? source.name : undefined,
-    };
+    });
+  }
 
-    parts.push(part);
+  selectPrimaryPart(parts, source);
+
+  for (const part of parts) {
+    if (part.isPrimary || !part.reactPath || !usesDataAttrs(part.reactPath)) continue;
+
+    part.dataAttrsPath = source.dataAttrsPath;
+    part.dataAttrsComponentName = source.name;
   }
 
   if (nonLocalExports.length > 0) {
@@ -405,21 +414,22 @@ export function discoverParts(source: ComponentSource, program: OxcProject, mono
     }
   }
 
-  const primaryCount = parts.filter((p) => p.isPrimary).length;
-
-  if (primaryCount > 1) {
-    let foundFirst = false;
-
-    for (const p of parts) {
-      if (p.isPrimary) {
-        if (foundFirst) p.isPrimary = false;
-
-        foundFirst = true;
-      }
-    }
-  }
-
   return parts.sort((a, b) => Number(b.isPrimary) - Number(a.isPrimary));
+}
+
+// Exactly one local part carries the shared core data and the component's root element. Several parts
+// qualify when they share a source file that constructs the core; none qualifies when the React parts
+// drive the core through hooks instead of constructing it. Both cases fall back to the `Root` part.
+function selectPrimaryPart(parts: PartSource[], source: ComponentSource): void {
+  const primaries = parts.filter((part) => part.isPrimary);
+  const root = parts.find((part) => part.name === 'Root');
+
+  const primary = primaries.length === 0 ? root : (primaries.find((part) => part.name === 'Root') ?? primaries[0]);
+  if (!primary) return;
+
+  for (const part of parts) part.isPrimary = part === primary;
+
+  primary.htmlPath ??= source.htmlPath;
 }
 
 // ─── Component Reference Building ──────────────────────────────────

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -234,7 +234,8 @@ describe('Component pipeline (end-to-end)', () => {
   //
   // Parts are discovered from index.parts.ts exports:
   //   - PRIMARY PART: The part whose React source instantiates the
-  //     component's own Core class (matches `new {Name}Core\b`).
+  //     component's own Core class (matches `new {Name}Core\b`). When
+  //     no part does, or several do, the part named `Root` is chosen.
   //     Gets: shared core Props/State, data-attrs, CSS vars, root tagName.
   //   - SUB-PARTS: All other parts. Get: their own tagName (if element
   //     file exists), description from React JSDoc, shared data-attrs
@@ -401,6 +402,62 @@ describe('Component pipeline (end-to-end)', () => {
       // parts not listed in @parts are untouched
       expect(parts.track!.dataAttributes).toEqual({});
       expect(parts.indicator!.dataAttributes['data-emphasized']).toBeUndefined();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // MULTI-PART WITH A SHARED SOURCE FILE: OptionGroup
+  // ─────────────────────────────────────────────────────────────────
+  //
+  // Option groups export Root, Options, and Value from one `component.tsx`
+  // and drive the core through hooks, so no React source constructs it.
+  //   - Part kebabs derive from the export names instead of the shared
+  //     file name, so the parts do not collapse into one record.
+  //   - `Root` becomes the primary part by fallback and gets the core
+  //     data plus the component's `element.ts` (tag name and events).
+  //   - Descriptions and sub-part props resolve by local export name
+  //     inside the shared file.
+
+  describe('OptionGroup (multi-part, shared source file)', () => {
+    it('keeps one part per export', () => {
+      const ref = findComponent('OptionGroup')!.reference;
+
+      expect(ref.props).toEqual({});
+      expect(ref.platforms).toEqual({});
+      expect(Object.keys(ref.parts!).sort()).toEqual(['options', 'root', 'value']);
+    });
+
+    it('falls back to Root as the primary part', () => {
+      const root = findComponent('OptionGroup')!.reference.parts!.root!;
+
+      expect(root.name).toBe('Root');
+      expect(root.description).toBe(
+        'Owns option state and shares it with an enclosing menu. Does not render a DOM element.'
+      );
+      expect(root.props.label).toMatchObject({ type: 'string', default: "''" });
+      expect(root.props.formatOption).toMatchObject({ type: 'function' });
+      expect(root.state.value).toMatchObject({ type: 'string' });
+      expect(root.dataAttributes['data-value']).toMatchObject({ description: 'The selected option value.' });
+      expect(root.platforms.html).toEqual({
+        tagName: 'media-option-group',
+        events: [{ name: 'value-change', description: 'Emitted when the selected option changes.' }],
+      });
+      expect(root.platforms.react).toEqual({});
+    });
+
+    it('resolves sub-parts by export name inside the shared file', () => {
+      const parts = findComponent('OptionGroup')!.reference.parts!;
+
+      expect(parts.options!.description).toBe('Renders items for the available options.');
+      expect(parts.options!.props.renderItem).toMatchObject({
+        type: '((value: string) => unknown)',
+        frameworks: ['react'],
+      });
+      expect(parts.options!.platforms).toEqual({ react: {} });
+
+      expect(parts.value!.description).toBe('Displays the selected option label.');
+      expect(parts.value!.props.className).toMatchObject({ type: 'string' });
+      expect(parts.value!.platforms).toEqual({ react: {} });
     });
   });
 

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/core/ui/option-group/core.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/core/ui/option-group/core.ts
@@ -1,0 +1,26 @@
+/**
+ * Multi-part component fixture whose React parts share one source file (core).
+ *
+ * Exercises: core Props/State for a component whose React parts never construct the core themselves.
+ */
+
+export interface OptionGroupProps {
+  /** Accessible label for the group. */
+  label: string;
+  /** Formats an option value for display. */
+  formatOption: (value: string) => string;
+}
+
+export interface OptionGroupState {
+  /** The selected option value. */
+  value: string;
+  /** Whether the group is disabled. */
+  disabled: boolean;
+}
+
+export class OptionGroupCore {
+  static readonly defaultProps = {
+    label: '',
+    formatOption: (value: string) => value,
+  };
+}

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/core/ui/option-group/data.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/core/ui/option-group/data.ts
@@ -1,0 +1,17 @@
+/**
+ * Data attributes fixture for the shared-source multi-part component.
+ */
+
+type StateAttrMap<State> = { [Key in keyof State]?: string };
+
+interface OptionGroupState {
+  value: string;
+  disabled: boolean;
+}
+
+export const OptionGroupDataAttrs = {
+  /** The selected option value. */
+  value: 'data-value',
+  /** Present when the group is disabled. */
+  disabled: 'data-disabled',
+} as const satisfies StateAttrMap<OptionGroupState>;

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/option-group/element.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/option-group/element.ts
@@ -1,0 +1,18 @@
+/**
+ * HTML element fixture for the shared-source multi-part component.
+ *
+ * Exercises: the `Root` part falls back to the component's `element.ts` when no React part constructs the core.
+ */
+
+export class OptionGroupElement extends EventTarget {
+  static readonly tagName = 'media-option-group';
+
+  static readonly properties = {
+    label: { type: String },
+  };
+
+  /** @fires value-change - Emitted when the selected option changes. */
+  announceValue(value: string) {
+    this.dispatchEvent(new CustomEvent('value-change', { detail: { value }, bubbles: true }));
+  }
+}

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/option-group/component.tsx
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/option-group/component.tsx
@@ -1,0 +1,36 @@
+/**
+ * Shared React source for every OptionGroup part.
+ *
+ * Exercises: part descriptions and sub-part props resolved by local export name inside one file. Nothing here
+ * constructs `OptionGroupCore`, so primary detection falls back to `Root`.
+ */
+
+export interface OptionGroupRootProps {
+  label?: string;
+  children?: unknown;
+}
+
+/** Owns option state and shares it with an enclosing menu. Does not render a DOM element. */
+export function OptionGroupRoot(_props: OptionGroupRootProps) {
+  return null;
+}
+
+export interface OptionGroupOptionsProps {
+  /** Render one consumer-owned item for every option. */
+  renderItem: (value: string) => unknown;
+}
+
+/** Renders items for the available options. */
+export function OptionGroupOptions(_props: OptionGroupOptionsProps) {
+  return null;
+}
+
+export interface OptionGroupValueProps {
+  /** Additional class name. */
+  className?: string;
+}
+
+/** Displays the selected option label. */
+export function OptionGroupValue(_props: OptionGroupValueProps) {
+  return null;
+}

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/option-group/index.parts.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/option-group/index.parts.ts
@@ -1,0 +1,19 @@
+/**
+ * Parts index whose exports all come from one source file.
+ *
+ * Exercises: shared-source part discovery.
+ * - Root: primary by fallback (no part constructs OptionGroupCore); gets core data and the root element
+ * - Options: React-only sub-part with custom props
+ * - Value: React-only sub-part
+ *
+ * Part kebabs derive from the export names because a file-derived kebab (`component`) would collide.
+ */
+
+export {
+  OptionGroupOptions as Options,
+  type OptionGroupOptionsProps as OptionsProps,
+  OptionGroupRoot as Root,
+  type OptionGroupRootProps as RootProps,
+  OptionGroupValue as Value,
+  type OptionGroupValueProps as ValueProps,
+} from './component';

--- a/site/scripts/api-docs-builder/src/utils.ts
+++ b/site/scripts/api-docs-builder/src/utils.ts
@@ -16,6 +16,10 @@ export function kebabToPascal(str: string): string {
     .join('');
 }
 
+export function pascalToKebab(str: string): string {
+  return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
 /**
  * Derive the kebab-case part segment from an `index.parts.ts` source path.
  *


### PR DESCRIPTION
Closes #2678

## Summary

The stale-docs report for #2673 said the HTML platform (tag names and the `value-change` event) had disappeared from the API reference for the four radio groups. The custom elements still exist; the API docs builder lost them. The React radio groups export `Root`, `Options`, and `Value` from a single `component.tsx` and drive their core through hooks, so the builder derived the same `component` kebab for all three parts (collapsing them into one record) and found no primary part to attach `element.ts` to.

## Changes

- Parts exported from a shared source file are keyed by their export name (`root`, `options`, `value`) instead of the file name, so they no longer overwrite each other.
- When no local part constructs the component's core, or several do, the `Root` part becomes the primary part and receives the core props/state/data attributes and the component's `element.ts` (tag name and events). Sub-part data-attribute detection now runs after that selection.
- New `OptionGroup` fixture and e2e coverage for the shared-source layout; builder conventions reference updated to describe it.

Regenerating the reference against this branch changes only the four radio-group JSON files. Each now has `Root` with `media-*-radio-group`, the `value-change` event, core props and data attributes, plus React-only `Options` and `Value` parts with their own props and descriptions. Every other component's output is byte-identical.

## Testing

- `pnpm -F site exec vp test run scripts/api-docs-builder` (193 tests)
- `pnpm exec tsx site/scripts/api-docs-builder/src/index.ts` and diffed the generated JSON against main
- `pnpm check:workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reference-generation logic for all multi-part components (primary selection and part keys), though the PR reports only radio-group JSON diffs in production output.
> 
> **Overview**
> Fixes **api-docs-builder** multi-part discovery when **Root**, **Options**, and **Value** are re-exported from one `component.tsx` (hook-driven core, no `new {Name}Core` in React).
> 
> **Shared-source parts** no longer share one file-derived kebab (`component`); when several exports point at the same `./` source, part slugs come from export names via new **`pascalToKebab`** (`root`, `options`, `value`) so they stay separate in generated JSON.
> 
> **Primary part** selection is centralized in **`selectPrimaryPart`**: if zero or multiple parts “instantiate core,” **`Root`** wins (or the first core-instantiator when `Root` isn’t among them). The primary gets the component **`element.ts`** (`htmlPath` fallback), restoring HTML tag names and events on docs that had lost them (e.g. radio groups). Sub-part **data-attrs** wiring runs after that choice.
> 
> Docs (**builder-conventions.md**), an **OptionGroup** fixture, and e2e tests lock in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 770f34b1728aad8812aa426a141af501fb681a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->