### PR TITLE
fix(site): expand namespace re-exports into nested api reference parts

### DIFF
--- a/.agents/skills/write-api-reference/references/builder-conventions.md
+++ b/.agents/skills/write-api-reference/references/builder-conventions.md
@@ -64,6 +64,8 @@ The same map covers media elements whose PascalCase name doesn't kebab-case to t
 
 **Non-primary parts**: Each gets its own element file at `packages/html/src/ui/{name}/{part}.ts` (e.g., `time/group.ts`). Element class must be `{Name}{Part}Element` (e.g., `TimeGroupElement`). A nested React part source such as `./chapters/title` is honored when the same folder exists on the HTML side; otherwise the part is looked up flat in the component directory.
 
+**Namespace parts**: `export * as Thumbnail from './thumbnail/index.parts'` groups nested parts that render as `Slider.Thumbnail.Root` and `Slider.Thumbnail.Image` (part ids `thumbnail-root`, `thumbnail-image`). The nested index lives in a folder named after the namespace. Its `Root` maps to the element file of the same name (`slider/thumbnail.ts`, class `SliderThumbnailElement`); other nested parts map to `{namespace}-{part}.ts`. Nested exports may point at another component's file (`../../thumbnail/image`); that part is React-only unless an element file matches, and inherits data attributes from the component that owns the file. Domain variants may re-export the namespace (`export { Thumbnail } from '../slider/index.parts'`) and receive the same nested parts.
+
 **Framework-divergent parts**: All parts get `platforms.react`. Parts with a matching HTML element file also get `platforms.html`. The renderer filters parts by framework — React-only parts are hidden in HTML docs.
 
 **Part descriptions**: Extracted from JSDoc on the React component export:

--- a/site/scripts/api-docs-builder/src/parts-handler.ts
+++ b/site/scripts/api-docs-builder/src/parts-handler.ts
@@ -7,6 +7,11 @@ export interface PartExport {
   name: string;
   localName: string;
   source: string;
+  /**
+   * `named` for `export { X as Y } from './y'`; `namespace` for `export * as Y from './y/index.parts'`, whose source is
+   * a nested parts index rather than a component file.
+   */
+  kind: 'named' | 'namespace';
 }
 
 /** Extract value re-exports from a React index.parts.ts file. */
@@ -17,6 +22,15 @@ export function extractParts(filePath: string, project: OxcProject): PartExport[
   const parts: PartExport[] = [];
 
   for (const statement of file.program.body) {
+    if (statement.type === 'ExportAllDeclaration') {
+      if (!statement.exported || statement.exportKind === 'type') continue;
+
+      const name = moduleName(statement.exported);
+
+      parts.push({ name, localName: name, source: statement.source.value, kind: 'namespace' });
+      continue;
+    }
+
     if (statement.type !== 'ExportNamedDeclaration' || !statement.source || statement.exportKind === 'type') continue;
 
     for (const specifier of statement.specifiers) {
@@ -26,6 +40,7 @@ export function extractParts(filePath: string, project: OxcProject): PartExport[
         name: moduleName(specifier.exported),
         localName: moduleName(specifier.local),
         source: statement.source.value,
+        kind: 'named',
       });
     }
   }

--- a/site/scripts/api-docs-builder/src/pipeline.ts
+++ b/site/scripts/api-docs-builder/src/pipeline.ts
@@ -16,7 +16,7 @@ import { extractDataAttrs } from './data-attrs-handler.js';
 import { abbreviateType } from './formatter.js';
 import { extractHtml } from './html-handler.js';
 import { getJSDocTag, OxcProject, staticName } from './oxc-project.js';
-import { extractPartDescription, extractParts, extractSubPartProps } from './parts-handler.js';
+import { extractPartDescription, extractParts, extractSubPartProps, type PartExport } from './parts-handler.js';
 import type {
   ComponentReference,
   ComponentSource,
@@ -313,9 +313,10 @@ export function discoverParts(source: ComponentSource, program: OxcProject, mono
   const partExports = extractParts(source.partsIndexPath, program);
   if (partExports.length === 0) return [];
 
-  const localExports = partExports.filter((p) => p.source.startsWith('./'));
-  const nonLocalExports = partExports.filter((p) => !p.source.startsWith('./'));
-  if (localExports.length === 0 && nonLocalExports.length === 0) return [];
+  const namedExports = partExports.filter((p) => p.kind === 'named');
+  const localExports = namedExports.filter((p) => p.source.startsWith('./'));
+  const nonLocalExports = namedExports.filter((p) => !p.source.startsWith('./'));
+  const namespaceExports = partExports.filter((p) => p.kind === 'namespace' && p.source.startsWith('./'));
 
   const componentKebab = source.kebab;
   const htmlDir = path.join(htmlUiPath, componentKebab);
@@ -358,6 +359,12 @@ export function discoverParts(source: ComponentSource, program: OxcProject, mono
     part.dataAttrsComponentName = source.name;
   }
 
+  for (const namespaceExport of namespaceExports) {
+    parts.push(
+      ...discoverNamespaceParts(namespaceExport, source.partsIndexPath, componentKebab, htmlDir, coreUiPath, program)
+    );
+  }
+
   if (nonLocalExports.length > 0) {
     const bySource = new Map<string, typeof nonLocalExports>();
 
@@ -383,6 +390,13 @@ export function discoverParts(source: ComponentSource, program: OxcProject, mono
       for (const reExport of exports) {
         const originExport = originExports.find((o) => o.name === reExport.name);
         if (!originExport) continue;
+
+        if (originExport.kind === 'namespace') {
+          parts.push(
+            ...discoverNamespaceParts(originExport, originPartsFile, originKebab, originHtmlDir, coreUiPath, program)
+          );
+          continue;
+        }
 
         const kebab = partKebabFromSource(originExport.source, originKebab);
 
@@ -415,6 +429,63 @@ export function discoverParts(source: ComponentSource, program: OxcProject, mono
   }
 
   return parts.sort((a, b) => Number(b.isPrimary) - Number(a.isPrimary));
+}
+
+// A namespace re-export (`export * as Thumbnail from './thumbnail/index.parts'`) groups nested parts that render
+// as `Slider.Thumbnail.Root` and `Slider.Thumbnail.Image`. The nested index sits in a folder named after the
+// namespace; its `Root` maps to the element file of that name (`slider/thumbnail.ts`), other nested parts to
+// `{namespace}-{part}.ts`. Nested exports may point outside the component (`../../thumbnail/image`); those parts
+// take their React file, and any data attributes, from the component that owns that file.
+function discoverNamespaceParts(
+  namespaceExport: PartExport,
+  partsIndexPath: string,
+  componentKebab: string,
+  htmlDir: string,
+  coreUiPath: string,
+  program: OxcProject
+): PartSource[] {
+  const nestedIndexFile = path.resolve(path.dirname(partsIndexPath), `${namespaceExport.source}.ts`);
+  if (!fs.existsSync(nestedIndexFile)) return [];
+
+  const namespaceKebab = pascalToKebab(namespaceExport.name);
+  const nestedDir = path.dirname(nestedIndexFile);
+  const parts: PartSource[] = [];
+
+  for (const nestedExport of extractParts(nestedIndexFile, program)) {
+    if (nestedExport.kind !== 'named') continue;
+
+    const partKebab = partKebabFromSource(nestedExport.source, namespaceKebab);
+    const elementBasename = nestedExport.name === 'Root' ? namespaceKebab : `${namespaceKebab}-${partKebab}`;
+    const partElement = resolvePartElement(
+      htmlDir,
+      componentKebab,
+      `./${namespaceKebab}/${partKebab}`,
+      elementBasename
+    );
+
+    const reactFile = path.resolve(nestedDir, `${nestedExport.source}.tsx`);
+    const reactPath = fs.existsSync(reactFile) ? reactFile : undefined;
+
+    const ownerKebab = reactPath ? path.basename(path.dirname(reactPath)) : componentKebab;
+    const ownerDataAttrsFile = path.join(coreUiPath, ownerKebab, 'data.ts');
+    const ownsDataAttrs = !!reactPath && usesDataAttrs(reactPath) && fs.existsSync(ownerDataAttrsFile);
+
+    parts.push({
+      name: `${namespaceExport.name}.${nestedExport.name}`,
+      localName: nestedExport.localName,
+      kebab: `${namespaceKebab}-${partKebab}`,
+      isPrimary: false,
+      htmlPath: partElement?.path,
+      htmlElementName: partElement?.className,
+      reactPath,
+      dataAttrsPath: ownsDataAttrs ? ownerDataAttrsFile : undefined,
+      dataAttrsComponentName: ownsDataAttrs ? kebabToPascal(ownerKebab) : undefined,
+    });
+  }
+
+  return parts.sort(
+    (a, b) => Number(b.kebab === `${namespaceKebab}-root`) - Number(a.kebab === `${namespaceKebab}-root`)
+  );
 }
 
 // Exactly one local part carries the shared core data and the component's root element. Several parts

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -243,6 +243,10 @@ describe('Component pipeline (end-to-end)', () => {
   //     React props from `{LocalName}Props` interface.
   //   - REACT-ONLY PARTS: Sub-parts with no matching HTML element file.
   //     Get platforms.react but NOT platforms.html.
+  //   - NAMESPACE PARTS: `export * as Preview from './preview/index.parts'`
+  //     expands the nested index into `Preview.Root`, `Preview.Label`, ...
+  //     keyed `preview-root`, `preview-label`. The nested Root maps to the
+  //     element file named after the namespace (`slider/preview.ts`).
   //
   // Non-boolean data-attr types are inferred from StateAttrMap<State>:
   //   - number → type: "number"
@@ -462,6 +466,46 @@ describe('Component pipeline (end-to-end)', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────
+  // MULTI-PART WITH A NAMESPACE RE-EXPORT: Slider
+  // ─────────────────────────────────────────────────────────────────
+  //
+  // slider/index.parts.ts re-exports `./preview/index.parts` as the
+  // `Preview` namespace. Its nested exports become dotted parts:
+  //   - Preview.Root → slider/preview.ts (element named after the namespace)
+  //   - Preview.Label → gauge/label.tsx (nested re-export of another
+  //     component's React-only part)
+
+  describe('Slider (multi-part with a namespace re-export)', () => {
+    it('expands the namespace into dotted parts', () => {
+      const parts = findComponent('Slider')!.reference.parts!;
+
+      expect(Object.keys(parts).sort()).toEqual(['preview-label', 'preview-root', 'root', 'thumb', 'track']);
+    });
+
+    it('nested Root resolves the element named after the namespace', () => {
+      const root = findComponent('Slider')!.reference.parts!['preview-root']!;
+
+      expect(root.name).toBe('Preview.Root');
+      expect(root.description).toBe('Positions preview content at the slider pointer.');
+      expect(root.props.offset).toMatchObject({
+        type: 'number',
+        description: 'Distance between the preview and the track, in pixels.',
+        frameworks: ['react'],
+      });
+      expect(root.platforms.html).toEqual({ tagName: 'media-slider-preview' });
+      expect(root.platforms.react).toEqual({});
+    });
+
+    it('nested re-export of another component stays React-only', () => {
+      const label = findComponent('Slider')!.reference.parts!['preview-label']!;
+
+      expect(label.name).toBe('Preview.Label');
+      expect(label.description).toBe('An accessible label for the gauge value. Renders a `<span>` element.');
+      expect(label.platforms).toEqual({ react: {} });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
   // MULTI-PART WITH RE-EXPORTS: VolumeSlider
   // ─────────────────────────────────────────────────────────────────
   //
@@ -490,6 +534,15 @@ describe('Component pipeline (end-to-end)', () => {
       expect(ref.parts!.root).toBeDefined();
       expect(ref.parts!.thumb).toBeDefined();
       expect(ref.parts!.track).toBeDefined();
+    });
+
+    it('re-exported namespace (Preview) expands from the slider origin', () => {
+      const parts = findComponent('VolumeSlider')!.reference.parts!;
+
+      expect(parts['preview-root']!.name).toBe('Preview.Root');
+      expect(parts['preview-root']!.platforms.html).toEqual({ tagName: 'media-slider-preview' });
+      expect(parts['preview-label']!.name).toBe('Preview.Label');
+      expect(parts['preview-label']!.platforms).toEqual({ react: {} });
     });
 
     it('local primary part (Root) gets VolumeSlider core data', () => {

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/slider/preview.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/slider/preview.ts
@@ -1,0 +1,9 @@
+/**
+ * HTML element fixture for a namespace root part.
+ *
+ * Exercises: `Preview.Root` resolves to the element file named after the namespace.
+ */
+
+export class SliderPreviewElement {
+  static readonly tagName = 'media-slider-preview';
+}

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/slider/index.parts.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/slider/index.parts.ts
@@ -1,8 +1,9 @@
 /**
  * Slider base parts index.
  *
- * All local exports. volume-slider re-exports Thumb and Track from here.
+ * Local exports plus one namespace re-export. volume-slider re-exports Preview, Thumb, and Track from here.
  */
+export * as Preview from './preview/index.parts';
 export { Root, type RootProps } from './root';
 export { Thumb, type ThumbProps } from './thumb';
 export { Track, type TrackProps } from './track';

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/slider/preview/index.parts.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/slider/preview/index.parts.ts
@@ -1,0 +1,10 @@
+/**
+ * Nested parts index, exposed from slider/index.parts.ts as `export * as Preview`.
+ *
+ * Exercises: namespace part discovery.
+ * - Root: nested part whose element file is named after the namespace (slider/preview.ts)
+ * - Label: nested re-export of another component's React-only part (gauge/label.tsx)
+ */
+
+export { Label, type LabelProps } from '../../gauge/label';
+export { SliderPreviewRoot as Root, type SliderPreviewRootProps as RootProps } from './root';

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/slider/preview/root.tsx
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/slider/preview/root.tsx
@@ -1,0 +1,15 @@
+/**
+ * Nested part React component.
+ *
+ * Exercises: description and `{LocalName}Props` extraction for a part reached through a namespace re-export.
+ */
+
+/** Positions preview content at the slider pointer. */
+export function SliderPreviewRoot(_props: SliderPreviewRootProps) {
+  return null;
+}
+
+export interface SliderPreviewRootProps {
+  /** Distance between the preview and the track, in pixels. */
+  offset: number;
+}

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/volume-slider/index.parts.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/volume-slider/index.parts.ts
@@ -5,6 +5,7 @@
  * - Root: local export (primary part, instantiates VolumeSliderCore)
  * - Thumb: re-exported from slider (gets slider's HTML elements + data-attrs)
  * - Track: re-exported from slider (gets slider's HTML elements)
+ * - Preview: re-exported namespace from slider (expands to Preview.Root and Preview.Label)
  *
  * Re-exported parts are NEVER primary. Their element files and data-attrs
  * are resolved from the ORIGIN component (slider), not the consumer (volume-slider).
@@ -13,5 +14,5 @@
  * (no single-part fallback).
  */
 
-export { Thumb, type ThumbProps, Track, type TrackProps } from '../slider/index.parts';
+export { Preview, Thumb, type ThumbProps, Track, type TrackProps } from '../slider/index.parts';
 export { Root, type RootProps } from './root';


### PR DESCRIPTION
Closes #2675

Follows #2682, now merged.

## Summary

The stale-docs report for #2568 said `Slider.Thumbnail.Root`, `Slider.Thumbnail.Image`, and `<media-slider-thumbnail>` had been removed. They still exist; the API docs builder stopped seeing them when #2568 turned the slider thumbnail into a nested namespace (`export * as Thumbnail from './thumbnail/index.parts'`), because part discovery only read named re-exports. The Slider reference page and the seek-preview demos were already correct.

## Changes

- Part discovery now understands `export * as X from './x/index.parts'`. Each nested export becomes a dotted part (`Thumbnail.Root`, `Thumbnail.Image`) keyed `thumbnail-root` / `thumbnail-image`, so the reference renders `Slider.Thumbnail.Root` alongside the other parts.
- The nested `Root` resolves the element file named after the namespace (`slider/thumbnail.ts` → `media-slider-thumbnail`); other nested parts look for `{namespace}-{part}.ts` and are React-only otherwise.
- Nested exports that point at another component's file (`../../thumbnail/image`) take their description and props from that file and inherit that component's data attributes when the file applies them.
- Domain variants that re-export the namespace (`export { Thumbnail } from '../slider/index.parts'`) get the same nested parts.
- Fixtures and e2e coverage for a namespace re-export on Slider and its re-export through VolumeSlider; builder conventions reference updated.

Regenerating the reference against this branch adds exactly two parts to `slider.json` (`Thumbnail.Root` with `media-slider-thumbnail`, and `Thumbnail.Image` with `crossOrigin`, `fetchPriority`, and `loading`); no other component output changes beyond #2682.

Known gap, unchanged from other sub-parts: `Thumbnail.Root` lists only `className`/`render`/`style` because the sub-part prop extractor does not follow the `ThumbnailCore.RootProps` namespace type for `thumbnails`. The standalone Thumbnail reference documents that prop.

## Testing

- `pnpm -F site exec vp test run scripts/api-docs-builder` (197 tests)
- `pnpm exec tsx site/scripts/api-docs-builder/src/index.ts` and diffed the generated JSON against main
- `pnpm check:workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the api-docs-builder part-discovery pipeline and reference docs output; runtime component behavior is unchanged.
> 
> **Overview**
> Fixes API reference generation for multi-part components that expose nested part groups via **`export * as Namespace from './namespace/index.parts'`** (e.g. `Slider.Thumbnail.Root`), which were omitted after part indexes moved to that pattern.
> 
> **`extractParts`** now classifies **`export * as …`** as namespace exports (alongside named re-exports). **`discoverParts`** expands each local namespace into dotted parts (`Preview.Root`, `preview-root`), maps nested **`Root`** to the HTML element file named after the namespace, resolves other nested parts to `{namespace}-{part}.ts` or React-only when there is no element, and follows cross-component nested re-exports for props/descriptions/data-attrs from the owning component. Domain variants that re-export the namespace from a base **`index.parts.ts`** get the same expansion from the origin.
> 
> Builder conventions and e2e fixtures/tests cover Slider **`Preview`** and VolumeSlider re-export behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34690e3765bb2bd2acd6aef627b18d2bbbf12901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->