### PR TITLE
docs(site): use playback adapter terminology in react media hooks

### DIFF
--- a/site/src/content/docs/reference/use-attach-media.mdx
+++ b/site/src/content/docs/reference/use-attach-media.mdx
@@ -27,6 +27,6 @@ function CustomHlsVideo() {
 }
 ```
 
-The callback attaches a non-null element and detaches the host when React clears or cleans up the ref.
+The callback attaches a non-null element to the playback adapter and detaches it when React clears or cleans up the ref.
 
 <UtilReference util="useAttachMedia" />

--- a/site/src/content/docs/reference/use-media-extension.mdx
+++ b/site/src/content/docs/reference/use-media-extension.mdx
@@ -27,6 +27,6 @@ function CustomMuxData() {
 }
 ```
 
-The hook creates one instance, follows media changes, and destroys the extension on unmount. A plain `<video>` element is not a media-extension host, so registration is skipped for it.
+The hook creates one instance, registers it when a media adapter is available, follows media changes, and destroys the extension on unmount. A plain `<video>` element is not a media adapter and cannot carry extensions, so registration is skipped for it.
 
 <UtilReference util="useMediaExtension" />


### PR DESCRIPTION
Closes #2631

## Summary

#2602 renamed media engine hosts to playback adapters. The `useAttachMedia` and `useMediaExtension` reference pages still called the value a "host".

## Changes

- `useAttachMedia`: the cleanup sentence now says the callback detaches the playback adapter.
- `useMediaExtension`: the fallback sentence now says a plain `<video>` is not a media adapter and cannot carry extensions, matching the hook's JSDoc.

## Testing

Prose only. Wording matches the JSDoc in `packages/react/src/utils/use-attach-media.ts` and `use-media-extension.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime or API impact.
> 
> **Overview**
> Updates the **`useAttachMedia`** and **`useMediaExtension`** reference prose so it matches the post-#2602 vocabulary instead of calling the media value a **host**.
> 
> For **`useAttachMedia`**, the cleanup sentence now states that the callback attaches the element **to the playback adapter** and detaches on ref cleanup. For **`useMediaExtension`**, the description now mentions **registering when a media adapter is available** and explains that a plain `<video>` is **not a media adapter** and cannot carry extensions—aligned with the hooks’ JSDoc in `packages/react`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1467c1ad439e545e3a1f686980b9ba784115b1f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->