### PR TITLE
docs(site): describe container-scoped error dialog modality

### DIFF
--- a/site/src/content/docs/reference/error-dialog.mdx
+++ b/site/src/content/docs/reference/error-dialog.mdx
@@ -98,7 +98,11 @@ React renders the backdrop and popup as separate DOM elements. Add a `className`
 
 ## Accessibility
 
-The popup uses `role="alertdialog"` and `aria-modal="true"`. Its title and description are connected with `aria-labelledby` and `aria-describedby`. Focus stays within the popup and content outside it is inert while the error is open. Pressing <kbd>Escape</kbd> or activating the close part dismisses the error.
+The popup uses `role="alertdialog"`. Its title and description are connected with `aria-labelledby` and `aria-describedby`.
+
+Modality is scoped to the player container rather than the page. While the error is open, the rest of the container is inert and focus that lands elsewhere inside it returns to the popup, but content outside the player stays interactive and `aria-modal` is omitted. Only when the popup renders outside the container does the dialog fall back to document-wide modality: `aria-modal="true"`, <kbd>Tab</kbd> cycling within the popup, and everything outside it inert.
+
+Pressing <kbd>Escape</kbd> or activating the close part dismisses the error.
 
 ## Examples
 


### PR DESCRIPTION
Closes #2452

## Summary

#2449 scoped error dialogs to the player container: the dialog registers the container as its interaction root, so only the container becomes inert and `aria-modal` is omitted. The ErrorDialog accessibility section still claimed `aria-modal="true"` and page-wide inertness.

## Changes

- Accessibility section now explains container-scoped modality (inert container, focus returned to the popup, page outside the player stays interactive, no `aria-modal`) and the document-wide fallback that applies only when the popup renders outside the container.

## Testing

Prose only. Checked against `setInteractionRoot`/`resolveInteractionRoot` in `packages/core/src/dom/ui/dialog.ts` and `getPopupAttrs` in `packages/core/src/core/ui/dialog/core.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the ErrorDialog accessibility prose; no runtime or API changes.
> 
> **Overview**
> Updates the **ErrorDialog** reference **Accessibility** section so it matches container-scoped modality from #2449 instead of describing page-wide alert behavior.
> 
> The docs now state that `role="alertdialog"` remains, but **`aria-modal` is omitted** when the popup lives in the player: only the container goes inert, stray focus inside the container returns to the popup, and the rest of the page stays usable. They also document the **fallback** when the popup renders outside the container—`aria-modal="true"`, Tab trapping, and document-wide inertness—plus unchanged dismiss behavior (Escape and close).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8694f75eb8a4e764a579c2dc0c8de3c03010a63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->