### PR TITLE
docs(site): document always-visible controls

### DIFF
--- a/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
+++ b/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
@@ -147,7 +147,7 @@ Media Chrome configures behavior through `<media-controller>` attributes. Video.
 | Media Chrome attribute | Video.js v10 | How |
 |---|---|---|
 | `audio` | the audio preset | Choose an audio player and audio skin rather than toggling at runtime. |
-| `autohide` | `media-controls` (built in) | Controls auto-hide after inactivity automatically. The delay is currently fixed; see [Known gaps](#known-gaps). |
+| `autohide` | `media-controls` (built in) | Controls auto-hide after inactivity automatically. `autohide="-1"` becomes `visibility="always"` on `media-controls`; the delay is currently fixed, see [Known gaps](#known-gaps). |
 | `fullscreenelement` | `media-container` | Fullscreen targets the container element. |
 | `gesturesdisabled` | `media-gesture disabled`, or omit | Disable per gesture element, or leave the gestures out. |
 | `nohotkeys` | `media-hotkey disabled`, or omit | Disable per hotkey element, or leave them out. |
@@ -338,7 +338,7 @@ Put a `ref` on the media component to reach the rendered `HTMLVideoElement`; the
 
 These Media Chrome features have no direct equivalent yet. Several can be approximated; see [Workarounds](#workarounds).
 
-- No configurable `autohide` delay or disable switch (`autohide="-1"`), and no `autohideovercontrols` ([#1728](https://github.com/videojs/v10/issues/1728))
+- No configurable `autohide` delay and no `autohideovercontrols` ([#1728](https://github.com/videojs/v10/issues/1728)). Disabling autohide (`autohide="-1"`) is covered by `visibility="always"` on `media-controls`; see [Workarounds](#workarounds).
 - No `defaultduration` placeholder before the media loads ([#1729](https://github.com/videojs/v10/issues/1729))
 - Volume and muted preferences are not persisted across sessions, so Media Chrome's `novolumepref` and `nomutedpref` opt-outs have nothing to opt out of ([#944](https://github.com/videojs/v10/issues/944)). Video.js can choose an initial subtitle track from the locale, but it does not yet remember the viewer's later language choice ([#1786](https://github.com/videojs/v10/issues/1786)).
 - No `breakpoints` or container-breakpoint attributes; use CSS container queries instead
@@ -352,7 +352,7 @@ Chapters themselves do work. Add a default `<track kind="chapters">` and the pac
 
 ### Disable autohide (`autohide="-1"`)
 
-Packaged skins don't expose an autohide switch. Install the closest skin's source and remove its hidden-control styles. That's safer than overriding internal selectors in a skin you don't own.
+Set `visibility="always"` on `media-controls` (or `Controls.Root` in React) and the controls stay visible regardless of activity. Packaged skins don't expose that attribute; to keep a preset skin's look, <DocsLink slug="how-to/customize-skins" anchor="eject-and-edit-a-skin">eject the skin</DocsLink> and set it on the skin's controls element rather than overriding internal selectors in a skin you don't own.
 
 ### Breakpoints
 

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -797,7 +797,7 @@ Ordered roughly by how many migrations they'll touch.
 
 - Two skins, against Mux Player's five themes, and no runtime theme switch. That's a deliberate trade, fewer looks you can eject, but it's a real difference if you shipped `theme="classic"`.
 - Lazy loading (`loading="viewport|page"`) has no equivalent.
-- The controls auto-hide delay isn't configurable, and there's no disabled state for the controls ([#1728](https://github.com/videojs/v10/issues/1728)).
+- The controls auto-hide delay isn't configurable ([#1728](https://github.com/videojs/v10/issues/1728)). Always-visible controls are available through `visibility="always"` on the controls component in a custom or ejected skin.
 - Nothing persists between sessions: volume, captions language, speed, quality. That's out of scope for GA ([#944](https://github.com/videojs/v10/issues/944)). Default subtitle language is tracked at [#1423](https://github.com/videojs/v10/issues/1423), though Mux users can set `source.playback.defaultSubtitlesLang` and let the HLS playlist decide.
 - Smaller conveniences without homes yet: debug mode ([#1406](https://github.com/videojs/v10/issues/1406)) and autoplay with a muted fallback ([#1039](https://github.com/videojs/v10/issues/1039)). Unmuting from zero volume already restores a sensible level, so Mux Player's smart-unmute behavior carries over.
 

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -375,7 +375,7 @@ Here's a matrix for configuration options in Plyr and how each maps to Video.js 
 | `autoplay`, `muted`, `loop`, `playsinline`, `preload` | These are attributes on your media (e.g. `<video>`) component. |
 | `poster` / `data-poster` | Set `poster` on `<video-player>` or `VideoPlayer`. See [Basic migration](#basic-migration). |
 | `ratio` | Set `aspect-ratio` in CSS on the skin component. |
-| `hideControls` | Preset skins auto-hide controls based on activity. The delay is currently not configurable. |
+| `hideControls` | Preset skins auto-hide controls based on activity. `hideControls: false` maps to `visibility="always"` on the controls component in a custom or ejected skin; the delay is currently not configurable. |
 | `clickToPlay` | Preset video skins include click and tap gestures. [Eject the skin](#eject-a-skin) to remove or change them. |
 | `keyboard` | Preset video skins include common hotkeys. [Eject the skin](#eject-a-skin) to remove or change them. |
 | `tooltips` | Preset skins include tooltips for common controls. [Eject the skin](#eject-a-skin) to customize them. |
@@ -503,5 +503,5 @@ For changes to controls, layout, or icons, eject the skin into your project. Its
 - Plyr's full-window fullscreen fallback has no matching Video.js feature. This was designed as a fallback when the Fullscreen API wasn't supported, but given [browser support for fullscreen is around 96%](https://caniuse.com/fullscreen), it's unlikely to be required.
 - Plain MP4 source arrays with `size` metadata do not automatically create a quality menu. Use Mux, HLS, or DASH for adaptive quality when possible. A simpler source-driven quality menu may be considered later.
 - Preset skins segment the time slider and show chapter titles when the media includes a default `<track kind="chapters">`. Dedicated cue-point APIs are not complete yet; see [#1442](https://github.com/videojs/v10/issues/1442).
-- The controls auto-hide delay and disabled state are not configurable yet ([#1728](https://github.com/videojs/v10/issues/1728)).
+- The controls auto-hide delay is not configurable yet ([#1728](https://github.com/videojs/v10/issues/1728)). Disabling auto-hide is possible with `visibility="always"` on the controls component, but not from a preset skin's attributes.
 - Native controls are not automatically removed when custom controls load; see [#1160](https://github.com/videojs/v10/issues/1160).

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -261,7 +261,7 @@ These are the ones that need a decision rather than a rename, so each has a sect
 | `playbackRates` | not configurable yet ([#1404](https://github.com/videojs/v10/issues/1404)) |
 | `textTrackSettings` | no equivalent; see [Known gaps](#known-gaps) |
 | `spatialNavigation` | no equivalent; see [Known gaps](#known-gaps) |
-| `inactivityTimeout` | not configurable yet ([#1728](https://github.com/videojs/v10/issues/1728)) |
+| `inactivityTimeout` | delay not configurable yet ([#1728](https://github.com/videojs/v10/issues/1728)); `inactivityTimeout: 0` maps to `visibility="always"` on the controls component |
 | `errorDisplay`, `notSupportedMessage` | the skins include an error dialog |
 | `ModalDialog` | compose a <DocsLink slug="reference/dialog">Dialog</DocsLink>; your application controls media playback when it opens and closes |
 
@@ -659,7 +659,7 @@ Ordered roughly by how likely each is to block a v8 migration.
 - Nothing persists between sessions: volume, captions language, speed, quality. That's out of scope for GA ([#944](https://github.com/videojs/v10/issues/944)). Default subtitle language is tracked at [#1423](https://github.com/videojs/v10/issues/1423).
 - No VHS-equivalent tuning surface. Engine settings belong to the engine you chose, and the default HLS component deliberately exposes few of them.
 - Chapters render in the time slider from a `<track kind="chapters">`, and its segments reflect `data-active`. There is no player-level active chapter value or chapter menu, so v8's chapters menu has no equivalent ([#1873](https://github.com/videojs/v10/issues/1873)). Cue points aren't implemented ([#1442](https://github.com/videojs/v10/issues/1442)).
-- The controls auto-hide delay isn't configurable, so v8's `inactivityTimeout` has no equivalent ([#1728](https://github.com/videojs/v10/issues/1728)).
+- The controls auto-hide delay isn't configurable, so arbitrary `inactivityTimeout` values have no equivalent ([#1728](https://github.com/videojs/v10/issues/1728)). The common `inactivityTimeout: 0` case is covered by `visibility="always"` on the controls component in a custom or ejected skin.
 - No full-window fullscreen fallback. v8 had one for browsers without the Fullscreen API; [support is around 96%](https://caniuse.com/fullscreen) now.
 - Multiple `<source>` elements with `size` metadata don't become a quality menu. Use HLS or DASH for adaptive quality; picking renditions by resolution won't be added ([#1415](https://github.com/videojs/v10/issues/1415)).
 - Two skins, and no runtime theme switch.

--- a/site/src/content/docs/how-to/show-and-hide-controls.mdx
+++ b/site/src/content/docs/how-to/show-and-hide-controls.mdx
@@ -74,7 +74,23 @@ The feature needs the player container for activity tracking; without a containe
 
 ### Always-visible controls
 
-Skip the visibility wiring: render your controls without consuming `controlsVisible`. State still tracks activity for anything else that needs it.
+Set `visibility="always"` on <DocsLink slug="reference/controls">Controls</DocsLink>. The controls stay visible and report the user as active while the feature keeps tracking activity for anything else that needs it. The packaged audio skins use this mode.
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Controls.Root visibility="always">
+  <Controls.Content className="controls">...</Controls.Content>
+</Controls.Root>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<media-controls visibility="always">
+  <media-controls-content class="controls">...</media-controls-content>
+</media-controls>
+```
+</FrameworkCase>
 
 ### Custom show/hide styling
 

--- a/site/src/content/docs/reference/controls.mdx
+++ b/site/src/content/docs/reference/controls.mdx
@@ -58,6 +58,24 @@ If the user is active, or if the video is paused, this component will show contr
 
 User activity is tracked via pointer movement, keyboard input, and focus events on the player container. On touch devices, a quick tap toggles visibility. `mouseleave` immediately sets the user as inactive.
 
+`visibility` selects between the two modes. The default, `auto`, follows the player's controls visibility state as described above. `always` keeps the controls visible and reports the user as active regardless of playback or idle state, and works without the controls feature. The idle delay itself is not configurable.
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Controls.Root visibility="always">
+  <Controls.Content>...</Controls.Content>
+</Controls.Root>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<media-controls visibility="always">
+  <media-controls-content>...</media-controls-content>
+</media-controls>
+```
+</FrameworkCase>
+
 ## Styling
 
 `Controls.Root` is a state and context provider. `Controls.Content` / `<media-controls-content>` renders the interactive controls surface and receives its DOM props, ref, and controls state data attributes.


### PR DESCRIPTION
Closes #2619

## Summary

#2527 added `visibility: 'auto' | 'always'` to `Controls.Root` and `<media-controls>`. The Controls reference described auto-hide as unconditional, the show-and-hide guide told readers to bypass the visibility wiring, and four migration guides still claimed there is no way to disable auto-hide.

## Changes

- Controls reference: document the `visibility` modes with React and HTML snippets, including that `always` works without the controls feature and that the idle delay stays fixed.
- Show and hide controls guide: the always-visible variation now uses `visibility="always"` and notes the packaged audio skins rely on it.
- Media Chrome, Mux Player, Plyr, and Video.js 8 migration guides: map `autohide="-1"`, `hideControls: false`, and `inactivityTimeout: 0` to `visibility="always"`, keep the fixed-delay limitation and #1728 link, and point preset-skin users at ejecting a skin to set the attribute.

## Testing

Prose only. Checked against `ControlsCore` in `packages/core/src/core/ui/controls/core.ts` and the audio skins in `packages/skins/src/skins/*/audio/controls.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> Updates site docs so **always-visible controls** are documented end-to-end after `visibility: 'auto' | 'always'` landed on `Controls.Root` / `<media-controls>`.
> 
> The **Controls reference** and **show-and-hide controls** how-to now describe `visibility` (`auto` vs `always`), with React/HTML examples, and note that `always` works without the controls feature while the idle delay stays fixed. The always-visible variation replaces the old “skip visibility wiring” workaround with `visibility="always"` (packaged audio skins are called out).
> 
> **Four migration guides** (Media Chrome, Mux Player, Plyr, Video.js 8) no longer say auto-hide cannot be turned off. They map `autohide="-1"`, `hideControls: false`, and `inactivityTimeout: 0` to `visibility="always"`, keep #1728 for non-configurable delay, and direct preset-skin users to **eject a skin** to set the attribute. Media Chrome’s autohide workaround section is rewritten around `visibility="always"` instead of stripping hidden-control CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59fad41f9dd547c2365828e15b0dac1bd6626110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->