### PR TITLE
docs(site): document compound react radio group parts

### DIFF
--- a/site/src/components/docs/api-reference/ComponentImports.astro
+++ b/site/src/components/docs/api-reference/ComponentImports.astro
@@ -8,13 +8,15 @@ import FrameworkCase from '../FrameworkCase.astro';
 interface Props {
   component: string;
   html: string;
+  /** React entry point to import from when the component is not exported from the package root. */
+  reactFrom?: string;
 }
 
-const { component, html } = Astro.props;
+const { component, html, reactFrom = '@videojs/react' } = Astro.props;
 
 const imports: Array<{ code: string; framework: 'react' | 'html'; lang: BundledLanguage }> = [
   {
-    code: `import { ${component} } from '@videojs/react';`,
+    code: `import { ${component} } from '${reactFrom}';`,
     framework: 'react',
     lang: 'tsx',
   },

--- a/site/src/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.css
@@ -22,6 +22,15 @@
   backdrop-filter: blur(10px);
 }
 
+.menu-hint {
+  margin-left: 8px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.menu-hint:empty {
+  display: none;
+}
+
 .menu {
   --media-menu-side-offset: 8px;
   box-sizing: border-box;

--- a/site/src/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.tsx
@@ -1,5 +1,6 @@
-import { AudioTrackRadioGroup, Container, createPlayer, Menu } from '@videojs/react';
+import { Container, createPlayer, Menu } from '@videojs/react';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
+import { AudioTrackRadioGroup } from '@videojs/react/ui/audio-track-radio-group';
 import { videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
@@ -9,24 +10,27 @@ const src = '{{VJS10_MULTI_AUDIO_DEMO_VIDEO_HLS}}';
 function AudioMenu(): ReactNode {
   return (
     <Menu.Root side="top" align="end">
-      <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
-        Audio
-      </Menu.Trigger>
-      <Menu.Popup className="menu">
-        <Menu.Content>
-          <AudioTrackRadioGroup
-            className="menu-group"
-            renderItem={(props, item) => (
-              <Menu.RadioItem {...props} className="menu-item">
-                {item.label}
-                <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
-                  ✓
-                </Menu.ItemIndicator>
-              </Menu.RadioItem>
-            )}
-          />
-        </Menu.Content>
-      </Menu.Popup>
+      <AudioTrackRadioGroup.Root>
+        <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
+          Audio
+          <AudioTrackRadioGroup.Value className="menu-hint" />
+        </Menu.Trigger>
+        <Menu.Popup className="menu">
+          <Menu.Content>
+            <AudioTrackRadioGroup.Options
+              className="menu-group"
+              renderItem={(props, item) => (
+                <Menu.RadioItem {...props} className="menu-item">
+                  {item.label}
+                  <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
+                    ✓
+                  </Menu.ItemIndicator>
+                </Menu.RadioItem>
+              )}
+            />
+          </Menu.Content>
+        </Menu.Popup>
+      </AudioTrackRadioGroup.Root>
     </Menu.Root>
   );
 }

--- a/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.css
@@ -22,6 +22,15 @@
   backdrop-filter: blur(10px);
 }
 
+.menu-hint {
+  margin-left: 8px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.menu-hint:empty {
+  display: none;
+}
+
 .menu {
   --media-menu-side-offset: 8px;
   box-sizing: border-box;

--- a/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx
@@ -1,4 +1,5 @@
-import { CaptionsRadioGroup, Container, createPlayer, Menu } from '@videojs/react';
+import { Container, createPlayer, Menu } from '@videojs/react';
+import { CaptionsRadioGroup } from '@videojs/react/ui/captions-radio-group';
 import { Video, videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
@@ -7,24 +8,27 @@ const { Player } = createPlayer({ features: videoFeatures });
 function CaptionsMenu(): ReactNode {
   return (
     <Menu.Root side="top" align="end">
-      <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
-        Captions
-      </Menu.Trigger>
-      <Menu.Popup className="menu">
-        <Menu.Content>
-          <CaptionsRadioGroup
-            className="menu-group"
-            renderItem={(props, item) => (
-              <Menu.RadioItem {...props} className="menu-item">
-                {item.label}
-                <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
-                  ✓
-                </Menu.ItemIndicator>
-              </Menu.RadioItem>
-            )}
-          />
-        </Menu.Content>
-      </Menu.Popup>
+      <CaptionsRadioGroup.Root>
+        <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
+          Captions
+          <CaptionsRadioGroup.Value className="menu-hint" />
+        </Menu.Trigger>
+        <Menu.Popup className="menu">
+          <Menu.Content>
+            <CaptionsRadioGroup.Options
+              className="menu-group"
+              renderItem={(props, item) => (
+                <Menu.RadioItem {...props} className="menu-item">
+                  {item.label}
+                  <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
+                    ✓
+                  </Menu.ItemIndicator>
+                </Menu.RadioItem>
+              )}
+            />
+          </Menu.Content>
+        </Menu.Popup>
+      </CaptionsRadioGroup.Root>
     </Menu.Root>
   );
 }

--- a/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.css
@@ -22,6 +22,15 @@
   backdrop-filter: blur(10px);
 }
 
+.menu-hint {
+  margin-left: 8px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.menu-hint:empty {
+  display: none;
+}
+
 .menu {
   --media-menu-side-offset: 8px;
   box-sizing: border-box;

--- a/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx
@@ -1,4 +1,5 @@
-import { Container, createPlayer, Menu, PlaybackRateRadioGroup } from '@videojs/react';
+import { Container, createPlayer, Menu } from '@videojs/react';
+import { PlaybackRateRadioGroup } from '@videojs/react/ui/playback-rate-radio-group';
 import { Video, videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
@@ -7,24 +8,27 @@ const { Player } = createPlayer({ features: videoFeatures });
 function SpeedMenu(): ReactNode {
   return (
     <Menu.Root side="top" align="end">
-      <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
-        Speed
-      </Menu.Trigger>
-      <Menu.Popup className="menu">
-        <Menu.Content>
-          <PlaybackRateRadioGroup
-            className="menu-group"
-            renderItem={(props, item) => (
-              <Menu.RadioItem {...props} className="menu-item">
-                {item.label}
-                <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
-                  ✓
-                </Menu.ItemIndicator>
-              </Menu.RadioItem>
-            )}
-          />
-        </Menu.Content>
-      </Menu.Popup>
+      <PlaybackRateRadioGroup.Root>
+        <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
+          Speed
+          <PlaybackRateRadioGroup.Value className="menu-hint" />
+        </Menu.Trigger>
+        <Menu.Popup className="menu">
+          <Menu.Content>
+            <PlaybackRateRadioGroup.Options
+              className="menu-group"
+              renderItem={(props, item) => (
+                <Menu.RadioItem {...props} className="menu-item">
+                  {item.label}
+                  <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
+                    ✓
+                  </Menu.ItemIndicator>
+                </Menu.RadioItem>
+              )}
+            />
+          </Menu.Content>
+        </Menu.Popup>
+      </PlaybackRateRadioGroup.Root>
     </Menu.Root>
   );
 }

--- a/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.css
@@ -22,6 +22,15 @@
   backdrop-filter: blur(10px);
 }
 
+.menu-hint {
+  margin-left: 8px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.menu-hint:empty {
+  display: none;
+}
+
 .menu {
   --media-menu-side-offset: 8px;
   box-sizing: border-box;

--- a/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
@@ -1,5 +1,6 @@
-import { Container, createPlayer, Menu, QualityRadioGroup } from '@videojs/react';
+import { Container, createPlayer, Menu } from '@videojs/react';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
+import { QualityRadioGroup } from '@videojs/react/ui/quality-radio-group';
 import { videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
@@ -9,28 +10,31 @@ const src = '{{VJS8_DEMO_VIDEO_HLS}}';
 function QualityMenu(): ReactNode {
   return (
     <Menu.Root side="top" align="end">
-      <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
-        Quality
-      </Menu.Trigger>
-      <Menu.Popup className="menu">
-        <Menu.Content>
-          <QualityRadioGroup
-            className="menu-group"
-            renderItem={(props, item) => (
-              <Menu.RadioItem {...props} className="menu-item">
-                <span>
-                  {item.label}
-                  {item.tier ? <sup className="menu-tier">{item.tier}</sup> : null}
-                </span>
-                {item.badge ? <span className="menu-badge">{item.badge}</span> : null}
-                <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
-                  ✓
-                </Menu.ItemIndicator>
-              </Menu.RadioItem>
-            )}
-          />
-        </Menu.Content>
-      </Menu.Popup>
+      <QualityRadioGroup.Root>
+        <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
+          Quality
+          <QualityRadioGroup.Value className="menu-hint" />
+        </Menu.Trigger>
+        <Menu.Popup className="menu">
+          <Menu.Content>
+            <QualityRadioGroup.Options
+              className="menu-group"
+              renderItem={(props, item) => (
+                <Menu.RadioItem {...props} className="menu-item">
+                  <span>
+                    {item.label}
+                    {item.tier ? <sup className="menu-tier">{item.tier}</sup> : null}
+                  </span>
+                  {item.badge ? <span className="menu-badge">{item.badge}</span> : null}
+                  <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
+                    ✓
+                  </Menu.ItemIndicator>
+                </Menu.RadioItem>
+              )}
+            />
+          </Menu.Content>
+        </Menu.Popup>
+      </QualityRadioGroup.Root>
     </Menu.Root>
   );
 }

--- a/site/src/content/docs/reference/audio-track-radio-group.mdx
+++ b/site/src/content/docs/reference/audio-track-radio-group.mdx
@@ -27,20 +27,27 @@ Creates radio items from the player audio track state and selects the enabled tr
 
 ## Import
 
-<ComponentImports component="AudioTrackRadioGroup" html="audio-track-radio-group" />
+<ComponentImports component="AudioTrackRadioGroup" html="audio-track-radio-group" reactFrom="@videojs/react/ui/audio-track-radio-group" />
 
 ## Anatomy
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <AudioTrackRadioGroup
-    renderItem={(props, item) => (
-      <Menu.RadioItem {...props}>
-        {item.label}
-        <Menu.ItemIndicator checked={item.checked} />
-      </Menu.RadioItem>
-    )}
-  />
+  <AudioTrackRadioGroup.Root>
+    <Menu.Trigger>
+      <AudioTrackRadioGroup.Value />
+    </Menu.Trigger>
+    <Menu.Content>
+      <AudioTrackRadioGroup.Options
+        renderItem={(props, item) => (
+          <Menu.RadioItem {...props}>
+            {item.label}
+            <Menu.ItemIndicator checked={item.checked} />
+          </Menu.RadioItem>
+        )}
+      />
+    </Menu.Content>
+  </AudioTrackRadioGroup.Root>
   ```
 </FrameworkCase>
 
@@ -62,7 +69,9 @@ Creates radio items from the player audio track state and selects the enabled tr
 The group is available when the configured media exposes more than one audio track. Labels use the track label, then language, then kind. Pass `formatTrack` to customize the visible labels.
 
 <FrameworkCase frameworks={["react"]}>
-`AudioTrackRadioGroup` uses <DocsLink slug="reference/use-audio-track-options">`useAudioTrackOptions`</DocsLink> to own selection and generate each item. Its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label` and current `checked` value. It returns `null` when the <DocsLink slug="reference/feature-audio-track">audio track feature</DocsLink> is not configured.
+`AudioTrackRadioGroup.Root` uses <DocsLink slug="reference/use-audio-track-options">`useAudioTrackOptions`</DocsLink> to own selection and renders no element. Wrap the menu's `Menu.Trigger` and `Menu.Content` in it so the trigger inherits the group's disabled and hidden state and exposes `data-availability`. `AudioTrackRadioGroup.Options` renders the items: its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label` and current `checked` value. `AudioTrackRadioGroup.Value` displays the selected label, typically inside the trigger. `Options` and `Value` render `null` when the <DocsLink slug="reference/feature-audio-track">audio track feature</DocsLink> is not configured.
+
+The `AudioTrackRadioGroup` export from the `@videojs/react` root is a compatibility component that composes `Root` and `Options` behind the former single-component props. Prefer the parts for new code.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -85,7 +94,7 @@ Unavailable groups receive the native `hidden` attribute.
 The group uses the menu radio group pattern.
 
 <FrameworkCase frameworks={["react"]}>
-The component receives an accessible label from the `label` prop or defaults to `Audio`. Override it with `aria-label` or `aria-labelledby`.
+`AudioTrackRadioGroup.Options` receives its accessible label from the `label` prop on `AudioTrackRadioGroup.Root` or defaults to `Audio`. Override it with `aria-label` or `aria-labelledby` on `AudioTrackRadioGroup.Options`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/reference/captions-radio-group.mdx
+++ b/site/src/content/docs/reference/captions-radio-group.mdx
@@ -27,20 +27,27 @@ Creates radio items from the player text track state and selects the showing cap
 
 ## Import
 
-<ComponentImports component="CaptionsRadioGroup" html="captions-radio-group" />
+<ComponentImports component="CaptionsRadioGroup" html="captions-radio-group" reactFrom="@videojs/react/ui/captions-radio-group" />
 
 ## Anatomy
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <CaptionsRadioGroup
-    renderItem={(props, item) => (
-      <Menu.RadioItem {...props}>
-        {item.label}
-        <Menu.ItemIndicator checked={item.checked} />
-      </Menu.RadioItem>
-    )}
-  />
+  <CaptionsRadioGroup.Root>
+    <Menu.Trigger>
+      <CaptionsRadioGroup.Value />
+    </Menu.Trigger>
+    <Menu.Content>
+      <CaptionsRadioGroup.Options
+        renderItem={(props, item) => (
+          <Menu.RadioItem {...props}>
+            {item.label}
+            <Menu.ItemIndicator checked={item.checked} />
+          </Menu.RadioItem>
+        )}
+      />
+    </Menu.Content>
+  </CaptionsRadioGroup.Root>
   ```
 </FrameworkCase>
 
@@ -62,7 +69,9 @@ Creates radio items from the player text track state and selects the showing cap
 The group is available when the configured media exposes at least one caption or subtitle track. The first generated option is `Off`; selecting it hides captions. Track labels use the track label, then language, then kind. Pass `formatTrack` to customize the visible labels.
 
 <FrameworkCase frameworks={["react"]}>
-`CaptionsRadioGroup` uses <DocsLink slug="reference/use-captions-options">`useCaptionsOptions`</DocsLink> to own selection and generate each item, including `Off`. Its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label` and current `checked` value. It returns `null` when the <DocsLink slug="reference/feature-text-tracks">text tracks feature</DocsLink> is not configured.
+`CaptionsRadioGroup.Root` uses <DocsLink slug="reference/use-captions-options">`useCaptionsOptions`</DocsLink> to own selection and renders no element. Wrap the menu's `Menu.Trigger` and `Menu.Content` in it so the trigger inherits the group's disabled and hidden state and exposes `data-availability`. `CaptionsRadioGroup.Options` renders the items, including `Off`: its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label` and current `checked` value. `CaptionsRadioGroup.Value` displays the selected label, typically inside the trigger. `Options` and `Value` render `null` when the <DocsLink slug="reference/feature-text-tracks">text tracks feature</DocsLink> is not configured.
+
+The `CaptionsRadioGroup` export from the `@videojs/react` root is a compatibility component that composes `Root` and `Options` behind the former single-component props. Prefer the parts for new code.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -85,7 +94,7 @@ Unavailable groups receive the native `hidden` attribute.
 The group uses the menu radio group pattern.
 
 <FrameworkCase frameworks={["react"]}>
-The component receives an accessible label from the `label` prop or defaults to `Captions`. Override it with `aria-label` or `aria-labelledby`.
+`CaptionsRadioGroup.Options` receives its accessible label from the `label` prop on `CaptionsRadioGroup.Root` or defaults to `Captions`. Override it with `aria-label` or `aria-labelledby` on `CaptionsRadioGroup.Options`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/reference/menu.mdx
+++ b/site/src/content/docs/reference/menu.mdx
@@ -111,7 +111,36 @@ Root menus inside a <DocsLink slug="reference/player-container">Container</DocsL
 
 In React, create a submenu by nesting another `Menu.Root` in the parent `Menu.Content`; its `Menu.Trigger` behaves as a parent item and its `Menu.Content` becomes the active Content. In HTML, add another `<media-menu-content>` as a sibling, give it an `id`, and point the parent `<media-menu-item>` at it with `commandfor`.
 
-Media option groups can render the current selection beside a submenu trigger. See <DocsLink slug="reference/playback-rate-radio-group">PlaybackRateRadioGroup</DocsLink>, <DocsLink slug="reference/quality-radio-group">QualityRadioGroup</DocsLink>, <DocsLink slug="reference/audio-track-radio-group">AudioTrackRadioGroup</DocsLink>, and <DocsLink slug="reference/captions-radio-group">CaptionsRadioGroup</DocsLink>.
+Media option groups share their option state with the enclosing menu: the selected value, and whether the options are disabled, hidden, or available. The menu's trigger inherits the disabled and hidden state and exposes `data-availability`, and the menu closes if its options disappear while open. See <DocsLink slug="reference/playback-rate-radio-group">PlaybackRateRadioGroup</DocsLink>, <DocsLink slug="reference/quality-radio-group">QualityRadioGroup</DocsLink>, <DocsLink slug="reference/audio-track-radio-group">AudioTrackRadioGroup</DocsLink>, and <DocsLink slug="reference/captions-radio-group">CaptionsRadioGroup</DocsLink>.
+
+<FrameworkCase frameworks={["react"]}>
+Wrap a submenu's `Menu.Trigger` and `Menu.Content` in the group's `Root` part, and render its `Value` part inside the trigger to show the current selection:
+
+```tsx
+<Menu.Root>
+  <QualityRadioGroup.Root>
+    <Menu.Trigger>
+      Quality
+      <QualityRadioGroup.Value />
+    </Menu.Trigger>
+    <Menu.Content>
+      <QualityRadioGroup.Options renderItem={...} />
+    </Menu.Content>
+  </QualityRadioGroup.Root>
+</Menu.Root>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+The generated radio group publishes its state to the `<media-menu>` that contains it. Add an element with `data-part="hint"` inside the parent `<media-menu-item>` and the menu writes the selected label into it:
+
+```html
+<media-menu-item commandfor="quality-menu">
+  Quality
+  <span data-part="hint"></span>
+</media-menu-item>
+```
+</FrameworkCase>
 
 ## Styling
 

--- a/site/src/content/docs/reference/playback-rate-radio-group.mdx
+++ b/site/src/content/docs/reference/playback-rate-radio-group.mdx
@@ -27,20 +27,27 @@ Creates radio items from the player playback rate state and selects the playback
 
 ## Import
 
-<ComponentImports component="PlaybackRateRadioGroup" html="playback-rate-radio-group" />
+<ComponentImports component="PlaybackRateRadioGroup" html="playback-rate-radio-group" reactFrom="@videojs/react/ui/playback-rate-radio-group" />
 
 ## Anatomy
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <PlaybackRateRadioGroup
-    renderItem={(props, item) => (
-      <Menu.RadioItem {...props}>
-        {item.label}
-        <Menu.ItemIndicator checked={item.checked} />
-      </Menu.RadioItem>
-    )}
-  />
+  <PlaybackRateRadioGroup.Root>
+    <Menu.Trigger>
+      <PlaybackRateRadioGroup.Value />
+    </Menu.Trigger>
+    <Menu.Content>
+      <PlaybackRateRadioGroup.Options
+        renderItem={(props, item) => (
+          <Menu.RadioItem {...props}>
+            {item.label}
+            <Menu.ItemIndicator checked={item.checked} />
+          </Menu.RadioItem>
+        )}
+      />
+    </Menu.Content>
+  </PlaybackRateRadioGroup.Root>
   ```
 </FrameworkCase>
 
@@ -62,7 +69,9 @@ Creates radio items from the player playback rate state and selects the playback
 The group is available when the configured media exposes playback rates. Option labels default to the rate followed by a multiplication sign (e.g. `1.5×`); pass `formatRate` to customize them.
 
 <FrameworkCase frameworks={["react"]}>
-`PlaybackRateRadioGroup` uses <DocsLink slug="reference/use-playback-rate-options">`usePlaybackRateOptions`</DocsLink> to own selection and generate each item. Its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label` and current `checked` value. It returns `null` when the <DocsLink slug="reference/feature-playback-rate">playback rate feature</DocsLink> is not configured.
+`PlaybackRateRadioGroup.Root` uses <DocsLink slug="reference/use-playback-rate-options">`usePlaybackRateOptions`</DocsLink> to own selection and renders no element. Wrap the menu's `Menu.Trigger` and `Menu.Content` in it so the trigger inherits the group's disabled and hidden state and exposes `data-availability`. `PlaybackRateRadioGroup.Options` renders the items: its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label` and current `checked` value. `PlaybackRateRadioGroup.Value` displays the selected label, typically inside the trigger. `Options` and `Value` render `null` when the <DocsLink slug="reference/feature-playback-rate">playback rate feature</DocsLink> is not configured.
+
+The `PlaybackRateRadioGroup` export from the `@videojs/react` root is a compatibility component that composes `Root` and `Options` behind the former single-component props. Prefer the parts for new code.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -85,7 +94,7 @@ Unavailable groups receive the native `hidden` attribute.
 The group uses the menu radio group pattern.
 
 <FrameworkCase frameworks={["react"]}>
-The component receives an accessible label from the `label` prop or defaults to `Playback rate`. Override it with `aria-label` or `aria-labelledby`.
+`PlaybackRateRadioGroup.Options` receives its accessible label from the `label` prop on `PlaybackRateRadioGroup.Root` or defaults to `Playback rate`. Override it with `aria-label` or `aria-labelledby` on `PlaybackRateRadioGroup.Options`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/reference/quality-radio-group.mdx
+++ b/site/src/content/docs/reference/quality-radio-group.mdx
@@ -27,20 +27,27 @@ Creates radio items from the player video rendition state and selects automatic 
 
 ## Import
 
-<ComponentImports component="QualityRadioGroup" html="quality-radio-group" />
+<ComponentImports component="QualityRadioGroup" html="quality-radio-group" reactFrom="@videojs/react/ui/quality-radio-group" />
 
 ## Anatomy
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <QualityRadioGroup
-    renderItem={(props, item) => (
-      <Menu.RadioItem {...props}>
-        {item.label}
-        <Menu.ItemIndicator checked={item.checked} />
-      </Menu.RadioItem>
-    )}
-  />
+  <QualityRadioGroup.Root>
+    <Menu.Trigger>
+      <QualityRadioGroup.Value />
+    </Menu.Trigger>
+    <Menu.Content>
+      <QualityRadioGroup.Options
+        renderItem={(props, item) => (
+          <Menu.RadioItem {...props}>
+            {item.label}
+            <Menu.ItemIndicator checked={item.checked} />
+          </Menu.RadioItem>
+        )}
+      />
+    </Menu.Content>
+  </QualityRadioGroup.Root>
   ```
 </FrameworkCase>
 
@@ -64,7 +71,9 @@ Creates radio items from the player video rendition state and selects automatic 
 The group is available when the configured media exposes more than one video rendition. The first generated option is `Auto`; selecting it returns control to adaptive bitrate selection. Pass `formatRendition` to customize visible rendition labels.
 
 <FrameworkCase frameworks={["react"]}>
-`QualityRadioGroup` uses <DocsLink slug="reference/use-quality-options">`useQualityOptions`</DocsLink> to own selection and generate each item. Its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label`, optional `tier` and `badge`, and current `checked` value. It returns `null` when the <DocsLink slug="reference/feature-quality">quality feature</DocsLink> is not configured.
+`QualityRadioGroup.Root` uses <DocsLink slug="reference/use-quality-options">`useQualityOptions`</DocsLink> to own selection and renders no element. Wrap the menu's `Menu.Trigger` and `Menu.Content` in it so the trigger inherits the group's disabled and hidden state and exposes `data-availability`. `QualityRadioGroup.Options` renders the items: its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label`, optional `tier` and `badge`, and current `checked` value. `QualityRadioGroup.Value` displays the selected label, typically inside the trigger. `Options` and `Value` render `null` when the <DocsLink slug="reference/feature-quality">quality feature</DocsLink> is not configured.
+
+The `QualityRadioGroup` export from the `@videojs/react` root is a compatibility component that composes `Root` and `Options` behind the former single-component props. Prefer the parts for new code.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -87,7 +96,7 @@ Unavailable groups receive the native `hidden` attribute.
 The group uses the menu radio group pattern.
 
 <FrameworkCase frameworks={["react"]}>
-The component receives an accessible label from the `label` prop or defaults to `Quality`. Override it with `aria-label` or `aria-labelledby`.
+`QualityRadioGroup.Options` receives its accessible label from the `label` prop on `QualityRadioGroup.Root` or defaults to `Quality`. Override it with `aria-label` or `aria-labelledby` on `QualityRadioGroup.Options`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/utils/docs/__tests__/component-reference-imports.test.ts
+++ b/site/src/utils/docs/__tests__/component-reference-imports.test.ts
@@ -20,7 +20,9 @@ describe('component reference imports', () => {
 
     for (const { file, source } of componentReferences) {
       expect(source, file).toContain(componentImport);
-      expect(source, file).toMatch(/## Import\n\n<ComponentImports component="[^"]+" html="[^"]+" \/>/);
+      expect(source, file).toMatch(
+        /## Import\n\n<ComponentImports component="[^"]+" html="[^"]+"( reactFrom="[^"]+")? \/>/
+      );
       expect(source.indexOf('## Import'), file).toBeLessThan(source.indexOf('## Anatomy'));
       expect(source.indexOf('## Anatomy'), file).toBeLessThan(source.indexOf('<ComponentReference component="'));
     }


### PR DESCRIPTION
Closes #2620

## Summary

#2528 split the React audio-track, captions, playback-rate, and quality radio groups into `Root`, `Options`, and `Value` parts that share option state with the enclosing menu. The four reference pages and their React demos still showed the single-component form, and the Menu reference did not explain how option groups drive submenu triggers.

## Changes

- The four reference pages import the compound parts from `@videojs/react/ui/<name>-radio-group`, show a `Root` → `Trigger`/`Value` → `Content`/`Options` anatomy, explain what each part owns and when `Options`/`Value` render nothing, and label the `@videojs/react` root export as a compatibility component.
- The four React demos compose the parts inside a menu and render `Value` in the trigger; a small `.menu-hint` style hides the hint while empty.
- Menu reference: describe shared option state (disabled, hidden, `data-availability`, auto-close) with a React composition snippet and the HTML `data-part="hint"` element.
- `ComponentImports` accepts an optional `reactFrom` so pages can show a subpath import.

Pairs with #2682, which restores the `Root`/`Options`/`Value` parts in the generated API reference on these pages.

## Testing

- `pnpm -F site exec astro check` (0 errors)
- `pnpm exec vp check --fix` on the demo files
- Demo composition mirrors `packages/skins/src/components/menus/audio-track-menu.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, demo, and test-only changes on the site with no runtime library or auth/data impact.
> 
> **Overview**
> Updates the docs site to match the **compound React API** (`Root`, `Options`, `Value`) for audio, captions, playback-rate, and quality radio groups, and how those groups integrate with menus.
> 
> Reference pages now show subpath imports (`@videojs/react/ui/...`), the `Root` → trigger/`Value` → `Options` anatomy, and note that the package-root export is a compatibility wrapper. The Menu reference explains shared option state (disabled, hidden, `data-availability`, auto-close) with React and HTML hint patterns.
> 
> React demos import from the UI subpaths, wrap menus with `*.Root`, render `*.Value` in the trigger (with `.menu-hint` styling), and use `*.Options` for items. **`ComponentImports`** gains an optional **`reactFrom`** prop so Import snippets can show subpath imports; the reference import test allows that attribute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d0d93aef2d07497b2c20f6fe534dab97e1aee5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->