### PR TITLE
ci(changelog-prose): give the prose job 60 minutes

### DIFF
--- a/.github/workflows/changelog-prose.yml
+++ b/.github/workflows/changelog-prose.yml
@@ -44,7 +44,7 @@ jobs:
   prose:
     if: github.event_name == 'workflow_dispatch' && startsWith(inputs.tag_name, '@videojs/core@')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       actions: read
       contents: write


### PR DESCRIPTION
## Why

The Changelog Prose run for `@videojs/core@10.0.0-rc.1` ([run 34276259531](https://github.com/videojs/v10/actions/runs/34276259531)) was cancelled 35 minutes after the job started, before Codex pushed a branch or opened a PR. Same shape as the cancelled run on Aug 26 ([run 33011688746](https://github.com/videojs/v10/actions/runs/33011688746)). The job has `timeout-minutes: 30`, and rc.1's raw changelog spans 85 PRs, so the agent needs longer than a beta-sized release.

## What

`timeout-minutes: 30` → `60` on the `prose` job. Nothing else changes.

After merge, re-dispatch the workflow with `tag_name=@videojs/core@10.0.0-rc.1` to produce the rc.1 prose PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ5RTqfnRMiiASH1T7tWVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ5RTqfnRMiiASH1T7tWVj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI configuration tweak with no runtime or application behavior impact.
> 
> **Overview**
> Raises the **`prose` job** timeout in the Changelog Prose workflow from **30 to 60 minutes** so long-running Codex changelog generation (e.g. large RC releases with many PRs) is less likely to be cancelled before it can push a branch and open a PR.
> 
> No other workflow steps, triggers, or permissions change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b90d72132c5e99b610ca7d8fc6ff2ba28ae9ab68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->