### PR TITLE
ci: run vp through a file so forwarding output cannot hit EAGAIN

### DIFF
--- a/.github/scripts/run-logged.sh
+++ b/.github/scripts/run-logged.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run a command with its output in a regular file, then print that file.
+#
+# Vite Task forwards task output to its own stdout. When that stdout is a
+# pipe, the Node processes it spawns for tasks set O_NONBLOCK on the shared
+# file description for as long as they run (Node does this to every pipe it
+# touches; vp clears it at startup but cannot stop its children re-setting
+# it). A large burst of forwarded output while such a child is alive then
+# fills the pipe and the write fails with
+#   "Failed to forward task process output: Resource temporarily unavailable
+#   (os error 11)"
+# which Vite Task records as a failed task even though the task finished.
+# Node only makes pipes non-blocking, and writes to a regular file never
+# return EAGAIN, so route the output through a file and replay it afterwards.
+#
+# Usage: run-logged.sh <log-name> <command> [args...]
+set -u
+
+name=$1
+shift
+log="${RUNNER_TEMP:-/tmp}/${name}.log"
+
+"$@" >"$log" 2>&1
+status=$?
+
+cat "$log"
+exit "$status"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,15 +89,15 @@ jobs:
 
       - name: Clean
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        run: pnpm clean
+        run: .github/scripts/run-logged.sh clean pnpm clean
 
       - name: Build
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        run: pnpm build:packages
+        run: .github/scripts/run-logged.sh build-packages pnpm build:packages
 
       - name: Build CDN bundles
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        run: pnpm build:cdn
+        run: .github/scripts/run-logged.sh build-cdn pnpm build:cdn
 
       # Fail before publishing rather than ship bundles that reach out to a public
       # CDN at runtime, which would break self-hosted and archive installs.
@@ -115,11 +115,11 @@ jobs:
       # The site task and CLI dependency graph let Vite Task reuse the package builds here.
       - name: Build site (required by html/react prepack and CLI)
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        run: pnpm build:site
+        run: .github/scripts/run-logged.sh build-site pnpm build:site
 
       - name: Build CLI
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        run: pnpm build:cli
+        run: .github/scripts/run-logged.sh build-cli pnpm build:cli
 
       - name: Publish
         if: ${{ steps.release.outputs.releases_created == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
             filters+=(--filter "$package")
           done < <(jq -r '.[]' <<<"$PACKAGES")
 
-          pnpm exec vp run --fail-if-no-match "${filters[@]}" test:ci
+          .github/scripts/run-logged.sh test-packages pnpm exec vp run --fail-if-no-match "${filters[@]}" test:ci
 
   test-spf:
     needs: package_test_selection
@@ -217,7 +217,7 @@ jobs:
             vite-task-${{ runner.os }}-${{ runner.arch }}-packages-
 
       - name: Test SPF
-        run: pnpm exec vp run @videojs/spf#test:ci
+        run: .github/scripts/run-logged.sh test-spf pnpm exec vp run @videojs/spf#test:ci
 
   workspace:
     needs: install


### PR DESCRIPTION
## Why

Six `Test packages` shards across three CI runs on 2026-09-09 failed with no failing test:

```
✗ Failed to forward task process output: Resource temporarily unavailable (os error 11)
vp run: 0/25 cache hit (0%), 4 failed.
```

Runs: [34411239444](https://github.com/videojs/v10/actions/runs/34411239444) (release branch, pnpm 12), [34412176604](https://github.com/videojs/v10/actions/runs/34412176604) (pnpm 11), [34406370628](https://github.com/videojs/v10/actions/runs/34406370628) (`chore/pnpm-12`). Every vitest suite in those jobs passed; vp gave up while children were still printing passing results.

Mechanism, verified by two independent reviews of the logs and of `vite-plus@0.2.8`:

- The message is `SavedExecutionError::ForwardTaskProcessOutput` in the Rust core, a failed write of forwarded output to vp's own stdout. Not a read.
- vp calls `ensureBlockingStdio()` at startup, but the Node processes it spawns for tasks set `O_NONBLOCK` on the shared stdout file description while they run (observed by sampling `/proc/<pid>/fdinfo/1` during a real `vp run`). Node does this to any pipe it touches, never to a regular file.
- A large burst of forwarded output (a `vp pack` dumping ~1,400 `dist/...` lines in ~60 ms) while such a child is alive fills the pipe; the write returns EAGAIN; vp marks the task failed.
- A cold task cache makes the bursts bigger and more frequent but is not the cause: a passing shard on main had 0% cache hits and 3× the output.
- Not pnpm-version related; it reproduced under 11.17.0 and 12.3.4.

Release exposure: cd.yml's `release` job builds every package with vp before `pnpm -r publish`, and release-please has already tagged the release by then. A re-run would find nothing to release and skip publish. That build has passed cold twice (rc.1 and today), so the risk is probabilistic, not observed.

## What

- `.github/scripts/run-logged.sh <name> <command...>`: runs the command with stdout and stderr in `$RUNNER_TEMP/<name>.log`, prints the log, exits with the command's status.
- cd.yml: `clean`, `build:packages`, `build:cdn`, `build:site`, `build:cli` run through it.
- ci.yml: `Test packages` and `Test SPF` run through it. These are the steps that actually failed.

Cost: step output appears when the step ends instead of streaming, and stdout/stderr are merged.

## Verified

- `actionlint` passes on both workflows; script is `100755`.
- Wrapper preserves exit status (0 and 7 tested) and captures both streams; child sees a regular file on fd 1 with `O_NONBLOCK` clear.
- Reviewer check: `node flags.js | cat` reports `O_NONBLOCK=true`; `node flags.js > out.txt` reports `O_NONBLOCK=false`.

## Follow-ups

- Report upstream to Vite+: vp should retry on `EAGAIN` or re-clear `O_NONBLOCK` while forwarding.
- Consider `vp run --last-details` in a failure path so failed tasks are attributable from the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ5RTqfnRMiiASH1T7tWVj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/CD workflow and helper-script changes only; no application runtime behavior, aside from non-streaming GitHub Actions logs.
> 
> **Overview**
> Adds **`.github/scripts/run-logged.sh`** so `vp` and related `pnpm` tasks write stdout/stderr to a temp log file (avoiding pipe `EAGAIN` when Node sets non-blocking mode on forwarded output), then replay the log and preserve the exit code.
> 
> **CI** routes `Test packages` and **Test SPF** through the wrapper; **CD** routes release `clean`, package/CDN/site/CLI builds the same way. Step logs show up when the step finishes and streams are merged.
> 
> Also adds temporary **“Drop task cache (experiment, do not merge)”** steps in `ci.yml` that delete `node_modules/.vite/task-cache` before those tests—likely for debugging and probably should be removed before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c660ef28438f3768a4bdd6539928be73a2e0bed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->