### PR TITLE
perf(site): faster docs dev server start

### DIFF
--- a/build/pack.ts
+++ b/build/pack.ts
@@ -26,7 +26,10 @@ export function packageBuildConfig(mode: PackageBuildMode, platform: 'browser' |
     ...baseConfig,
     platform,
     format: 'es' as const,
-    sourcemap: true,
+    // The default build is unminified, so source maps add ~1,400 files to the
+    // published packages for little debugging value. Bundlers pick the `dev`
+    // build through the `development` condition, which keeps its maps.
+    sourcemap: mode === 'dev',
     clean: !isWatchMode,
     hash: false,
     unbundle: true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "vp run -r build",
     "clean": "vp run -r --no-cache clean",
     "commitlint": "commitlint --config ./commitlint.config.js --edit",
-    "dev:site": "vp run site#dev",
+    "dev:site": "node --import tsx site/scripts/dev.ts",
     "dev": "pnpm dev:prepare && VP_PACK_WATCH=true vp run --fail-if-no-match --filter='./packages/**' --filter='./apps/*' --filter='./site' --parallel --ignore-depends-on --no-cache dev",
     "dev:prepare": "vp run -w prepare:dev",
     "dev:packages": "vp run --fail-if-no-match --filter='./packages/**' --filter='!@videojs/cli' build && VP_PACK_WATCH=true vp run --fail-if-no-match --filter='./packages/**' --parallel --ignore-depends-on --no-cache dev",

--- a/packages/adapters/cloudflare-video/tsconfig.dts.json
+++ b/packages/adapters/cloudflare-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/dash-video/tsconfig.dts.json
+++ b/packages/adapters/dash-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/hlsjs-video/tsconfig.dts.json
+++ b/packages/adapters/hlsjs-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/mux-audio/tsconfig.dts.json
+++ b/packages/adapters/mux-audio/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/mux-video/tsconfig.dts.json
+++ b/packages/adapters/mux-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/mux/tsconfig.dts.json
+++ b/packages/adapters/mux/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/native-hls-video/tsconfig.dts.json
+++ b/packages/adapters/native-hls-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/shaka-video/tsconfig.dts.json
+++ b/packages/adapters/shaka-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/spotify-audio/tsconfig.dts.json
+++ b/packages/adapters/spotify-audio/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/tiktok-video/tsconfig.dts.json
+++ b/packages/adapters/tiktok-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/twitch-video/tsconfig.dts.json
+++ b/packages/adapters/twitch-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/vimeo-video/tsconfig.dts.json
+++ b/packages/adapters/vimeo-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/wistia-video/tsconfig.dts.json
+++ b/packages/adapters/wistia-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/adapters/youtube-video/tsconfig.dts.json
+++ b/packages/adapters/youtube-video/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/core/tsconfig.dts.json
+++ b/packages/core/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/element/tsconfig.dts.json
+++ b/packages/element/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/extensions/google-cast/tsconfig.dts.json
+++ b/packages/extensions/google-cast/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false,
     "types": ["chromecast-caf-sender"]

--- a/packages/extensions/mux-data/tsconfig.dts.json
+++ b/packages/extensions/mux-data/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/html/tsconfig.dts.json
+++ b/packages/html/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/media/tsconfig.dts.json
+++ b/packages/media/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "useDefineForClassFields": false
   },

--- a/packages/react/tsconfig.dts.json
+++ b/packages/react/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],

--- a/packages/spf/tsconfig.dts.json
+++ b/packages/spf/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/store/tsconfig.dts.json
+++ b/packages/store/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/utils/tsconfig.dts.json
+++ b/packages/utils/tsconfig.dts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "incremental": false,
+    "declarationMap": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"]
   },
   "include": ["src/**/*.ts"]

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -64,7 +64,7 @@ pnpm -F site astro check
 
 ## API references
 
-Generated reference JSON is gitignored and rebuilt by `pnpm -F site api-docs`, dev, and build. Do not hand-edit it. Change the TypeScript/JSDoc input or the builder, run the generator, and inspect the output. Keep the builder E2E suite passing.
+Generated reference JSON is gitignored and rebuilt by `pnpm -F site api-docs`, `pnpm dev:site --prepare`, the root `pnpm dev`, and build. `pnpm dev:site` reuses existing output and only generates it when missing, so refresh it after changing package source or JSDoc. Do not hand-edit it. Change the TypeScript/JSDoc input or the builder, run the generator, and inspect the output. Keep the builder E2E suite passing.
 
 ## Verification
 

--- a/site/README.md
+++ b/site/README.md
@@ -46,17 +46,18 @@ Mostly a standard [Astro](https://astro.build/) project.
 
 If you're in the monorepo's root...
 
-| Command           | Action                                      |
-| :---------------- | :------------------------------------------ |
-| `pnpm dev:site`   | Starts local dev server at `localhost:4321` |
-| `pnpm build:site` | Build the production site to `site/dist/`   |
+| Command                   | Action                                                                                                                                  |
+| :------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm dev:site`           | Starts local dev server at `localhost:4321`; generates API references, the CDN manifest, and package builds only when they are missing |
+| `pnpm dev:site --prepare` | Same, but regenerates API references and rebuilds packages first (after changing package source or JSDoc)                            |
+| `pnpm build:site`         | Build the production site to `site/dist/`                                                                                            |
 
 If you're in `site/`...
 
 | Command              | Action                                           |
 | :------------------- | :----------------------------------------------- |
 | `pnpm install`       | Installs dependencies                            |
-| `pnpm exec vp run dev`   | Starts local dev server at `localhost:4321`  |
+| `pnpm exec vp run dev`   | Starts local dev server at `localhost:4321` (expects generated content; run `pnpm exec vp run dev:prepare` first) |
 | `pnpm exec vp run build` | Build your production site to `./dist/`      |
 | `pnpm astro preview`     | Preview your build locally, before deploying |
 | `pnpm api-docs`      | Regenerate API reference JSON from TypeScript    |

--- a/site/scripts/api-docs-builder/README.md
+++ b/site/scripts/api-docs-builder/README.md
@@ -24,19 +24,20 @@ TypeScript Sources (core/html/media/react/store packages)
 
 ### Building
 
-The builder runs automatically before dev/build through the site's Vite+ tasks:
+The builder runs through the site's Vite+ tasks:
 
 ```bash
 # Run manually
 pnpm -F site api-docs
 
 # Runs automatically on:
-pnpm dev:site
 pnpm build:site
+pnpm dev                   # root dev, via dev:prepare
+pnpm dev:site --prepare    # or plain dev:site when the output is missing
 ```
 
 The manual command also runs the required package builds. `api-docs:generate` is
-the internal generation task used by Turbo after those dependencies are ready.
+the internal generation task Vite+ runs after those dependencies are ready.
 
 ### In MDX
 

--- a/site/scripts/dev.ts
+++ b/site/scripts/dev.ts
@@ -1,0 +1,81 @@
+/**
+ * Start the docs site dev server without replaying the whole workspace task graph.
+ *
+ * `vp run site#dev` used to depend on `api-docs:generate` and `cdn-manifest`, which depend on every workspace package
+ * build. Even with every task cached, Vite+ spent ~16s discovering configs and replaying 34 cache hits before `astro
+ * dev` ran. Astro itself is ready in a few seconds, so this launcher only runs that graph (`site#dev:prepare`) when
+ * generated content or the workspace builds Astro imports are missing, or when asked to with `--prepare`.
+ *
+ * Any other arguments are forwarded to `astro dev`, for example `pnpm dev:site --port 4399`.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SITE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKSPACE_ROOT = resolve(SITE_ROOT, '..');
+const PREPARE_FLAG = '--prepare';
+
+/** Collections written by the `api-docs:generate` task; keep in sync with its `output` in `vite.config.ts`. */
+const GENERATED_REFERENCE_DIRS = ['component', 'util', 'feature', 'media', 'preset'].map(
+  (kind) => `src/content/generated-${kind}-reference`
+);
+
+/** Written by the `cdn-manifest` task. */
+const CDN_MANIFEST = 'src/content/cdn-media.json';
+
+/** Workspace packages Astro imports through their built `dist` exports. */
+const WORKSPACE_PACKAGES = ['@videojs/html', '@videojs/react'];
+
+const PREFIX = '\x1b[36m[dev:site]\x1b[0m';
+
+function hasJsonFiles(directory: string): boolean {
+  return existsSync(directory) && readdirSync(directory).some((file) => file.endsWith('.json'));
+}
+
+/** Site-relative descriptions of everything `astro dev` needs that is not present under `siteRoot`. */
+export function missingPrerequisites(siteRoot = SITE_ROOT): string[] {
+  const missing: string[] = [];
+
+  for (const directory of GENERATED_REFERENCE_DIRS) {
+    if (!hasJsonFiles(join(siteRoot, directory))) missing.push(directory);
+  }
+
+  if (!existsSync(join(siteRoot, CDN_MANIFEST))) missing.push(CDN_MANIFEST);
+
+  for (const name of WORKSPACE_PACKAGES) {
+    if (!existsSync(join(siteRoot, 'node_modules', name, 'dist'))) missing.push(`${name} build`);
+  }
+
+  return missing;
+}
+
+function run(command: string, args: string[], cwd: string, env = process.env): number {
+  const result = spawnSync(command, args, { cwd, env, stdio: 'inherit' });
+  if (result.error) throw result.error;
+
+  return result.status ?? 1;
+}
+
+export function main(argv = process.argv.slice(2)): number {
+  const prepare = argv.includes(PREPARE_FLAG);
+  const astroArgs = argv.filter((arg) => arg !== PREPARE_FLAG);
+  const missing = prepare ? [] : missingPrerequisites();
+
+  if (prepare || missing.length > 0) {
+    if (missing.length > 0) console.log(PREFIX, `Missing ${missing.join(', ')}; running site#dev:prepare first.`);
+
+    const status = run('pnpm', ['exec', 'vp', 'run', 'site#dev:prepare'], WORKSPACE_ROOT);
+    if (status !== 0) return status;
+  } else {
+    console.log(PREFIX, `Reusing generated content. Run \`pnpm dev:site ${PREPARE_FLAG}\` to rebuild it.`);
+  }
+
+  return run('pnpm', ['exec', 'astro', 'dev', ...astroArgs], SITE_ROOT, { ...process.env, NETLIFY_DEV: '1' });
+}
+
+const isEntrypoint = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isEntrypoint) process.exitCode = main();

--- a/site/scripts/dev.ts
+++ b/site/scripts/dev.ts
@@ -1,10 +1,10 @@
 /**
- * Start the docs site dev server without replaying the whole workspace task graph.
+ * Start the docs site dev server.
  *
- * `vp run site#dev` used to depend on `api-docs:generate` and `cdn-manifest`, which depend on every workspace package
- * build. Even with every task cached, Vite+ spent ~16s discovering configs and replaying 34 cache hits before `astro
- * dev` ran. Astro itself is ready in a few seconds, so this launcher only runs that graph (`site#dev:prepare`) when
- * generated content or the workspace builds Astro imports are missing, or when asked to with `--prepare`.
+ * Astro is ready in a few seconds, while the Vite+ graph behind `site#dev:prepare` (API reference JSON, the CDN
+ * manifest, and every workspace package build) costs several seconds even when fully cached, because each hit restores
+ * its outputs. This launcher runs that graph only when generated content or the workspace builds Astro imports are
+ * missing, or when asked to with `--prepare`, and otherwise starts `astro dev` directly.
  *
  * Any other arguments are forwarded to `astro dev`, for example `pnpm dev:site --port 4399`.
  */

--- a/site/scripts/tests/dev.test.ts
+++ b/site/scripts/tests/dev.test.ts
@@ -1,0 +1,69 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+
+import { missingPrerequisites } from '../dev.ts';
+
+const temporaryDirectories: string[] = [];
+
+function createSiteRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'site-dev-'));
+
+  temporaryDirectories.push(root);
+  return root;
+}
+
+function populate(root: string): void {
+  for (const kind of ['component', 'util', 'feature', 'media', 'preset']) {
+    const directory = join(root, `src/content/generated-${kind}-reference`);
+
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, 'entry.json'), '{}');
+  }
+
+  writeFileSync(join(root, 'src/content/cdn-media.json'), '[]');
+
+  for (const name of ['@videojs/html', '@videojs/react']) {
+    mkdirSync(join(root, 'node_modules', name, 'dist'), { recursive: true });
+  }
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('missingPrerequisites', () => {
+  it('lists every generated collection and workspace build when nothing exists', () => {
+    expect(missingPrerequisites(createSiteRoot())).toEqual([
+      'src/content/generated-component-reference',
+      'src/content/generated-util-reference',
+      'src/content/generated-feature-reference',
+      'src/content/generated-media-reference',
+      'src/content/generated-preset-reference',
+      'src/content/cdn-media.json',
+      '@videojs/html build',
+      '@videojs/react build',
+    ]);
+  });
+
+  it('returns nothing once generated content and package builds are present', () => {
+    const root = createSiteRoot();
+
+    populate(root);
+
+    expect(missingPrerequisites(root)).toEqual([]);
+  });
+
+  it('treats a reference directory without JSON files as missing', () => {
+    const root = createSiteRoot();
+
+    populate(root);
+    rmSync(join(root, 'src/content/generated-util-reference/entry.json'));
+
+    expect(missingPrerequisites(root)).toEqual(['src/content/generated-util-reference']);
+  });
+});

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { file, glob } from 'astro/loaders';
 import { z } from 'astro/zod';
 import { defineCollection, reference } from 'astro:content';
@@ -8,8 +10,13 @@ import { FeatureReferenceSchema } from './types/feature-reference';
 import { MediaReferenceSchema } from './types/media-reference';
 import { PresetReferenceSchema } from './types/preset-reference';
 import { UtilReferenceSchema } from './types/util-reference';
-import { defaultGitService } from './utils/gitService';
+import { createGitService } from './utils/gitService';
 import { globWithParser } from './utils/globWithParser';
+
+// One history walk of the content directory serves every entry. Lookups use the absolute `filePath` the loader
+// passes to `parseData`, so they do not depend on the working directory Astro runs from or on `generateId` rewrites.
+const CONTENT_ROOT = fileURLToPath(new URL('./content/', import.meta.url));
+const gitService = createGitService(CONTENT_ROOT);
 
 /**
  * Extract date from filename in format: YYYY-MM-DD-slug.mdx Throws an error if the filename doesn't match the expected
@@ -38,8 +45,7 @@ const blog = defineCollection({
       const pubDate = extractDateFromFilename(originalEntry);
 
       // Get updatedDate from git history (last modification date)
-      const filePath = `site/src/content/blog/${originalEntry}`;
-      const updatedDate = await defaultGitService.getLastModifiedDate(filePath);
+      const updatedDate = entry.filePath ? await gitService.getLastModifiedDate(entry.filePath) : null;
 
       // Return transformed entry with added fields
       return {
@@ -72,10 +78,9 @@ const docs = defineCollection({
   loader: globWithParser({
     base: './src/content/docs',
     pattern: '**/*.mdx',
-    parser: async (entry, originalEntry) => {
+    parser: async (entry) => {
       // Get updatedDate from git history
-      const filePath = `site/src/content/docs/${originalEntry}`;
-      const updatedDate = await defaultGitService.getLastModifiedDate(filePath);
+      const updatedDate = entry.filePath ? await gitService.getLastModifiedDate(entry.filePath) : null;
 
       // Return transformed entry with added field if updatedDate exists
       return {

--- a/site/src/utils/gitService.ts
+++ b/site/src/utils/gitService.ts
@@ -43,9 +43,8 @@ export function parseLastModifiedDates(log: string): Map<string, Date> {
 /**
  * Create a git service that answers per-file lookups from one history walk of `scope`.
  *
- * A separate `git log -1 -- <file>` per content entry walks the full history hundreds of times and dominated a cold
- * Astro content sync. One `--name-only` log over the content directory costs a single walk, and results are keyed by
- * absolute path so the lookup does not depend on the process working directory (Vite+ runs Astro from `site/`).
+ * One `--name-only` log over `scope` costs a single history walk no matter how many entries ask. Results are keyed by
+ * absolute path, so lookups do not depend on the working directory Astro is launched from.
  *
  * @param scope Absolute directory whose history should be loaded. Files outside it resolve to `null`.
  * @param git Git client; defaults to simple-git in the current working directory, which only needs to be inside the

--- a/site/src/utils/gitService.ts
+++ b/site/src/utils/gitService.ts
@@ -1,3 +1,5 @@
+import * as path from 'node:path';
+
 import { simpleGit } from 'simple-git';
 
 /** Git service interface for dependency injection (testability). */
@@ -5,23 +7,77 @@ export interface GitService {
   getLastModifiedDate: (filePath: string) => Promise<Date | null>;
 }
 
-/** Create a git service instance using simple-git. */
-export function createGitService(): GitService {
-  const git = simpleGit();
+/** The slice of simple-git the service drives, so tests can inject a fake client. */
+export interface GitClient {
+  raw: (args: string[]) => Promise<string>;
+  revparse: (args: string[]) => Promise<string>;
+}
+
+// ASCII record separator: prefixes each commit's date so it cannot be confused with a path line.
+const COMMIT_MARKER = '\u001e';
+
+/**
+ * Parse `git log --format=<marker>%aI --name-only` output into the most recent author date per path.
+ *
+ * Git prints commits newest first, so the first date seen for a path is its last modification. Paths are repo-relative,
+ * exactly as git prints them.
+ */
+export function parseLastModifiedDates(log: string): Map<string, Date> {
+  const dates = new Map<string, Date>();
+  let current: Date | null = null;
+
+  for (const line of log.split('\n')) {
+    if (line.startsWith(COMMIT_MARKER)) {
+      current = new Date(line.slice(COMMIT_MARKER.length));
+      continue;
+    }
+
+    if (!line || !current || dates.has(line)) continue;
+
+    dates.set(line, current);
+  }
+
+  return dates;
+}
+
+/**
+ * Create a git service that answers per-file lookups from one history walk of `scope`.
+ *
+ * A separate `git log -1 -- <file>` per content entry walks the full history hundreds of times and dominated a cold
+ * Astro content sync. One `--name-only` log over the content directory costs a single walk, and results are keyed by
+ * absolute path so the lookup does not depend on the process working directory (Vite+ runs Astro from `site/`).
+ *
+ * @param scope Absolute directory whose history should be loaded. Files outside it resolve to `null`.
+ * @param git Git client; defaults to simple-git in the current working directory, which only needs to be inside the
+ *   repo.
+ */
+export function createGitService(scope: string, git: GitClient = simpleGit()): GitService {
+  let dates: Promise<Map<string, Date>> | undefined;
+
+  async function loadDates(): Promise<Map<string, Date>> {
+    const [toplevel, log] = await Promise.all([
+      git.revparse(['--show-toplevel']),
+      // Non-ASCII filenames would otherwise arrive C-quoted and never match a real path.
+      git.raw(['-c', 'core.quotePath=false', 'log', `--format=${COMMIT_MARKER}%aI`, '--name-only', '--', scope]),
+    ]);
+    const root = toplevel.trim();
+
+    return new Map(
+      Array.from(parseLastModifiedDates(log), ([relativePath, date]) => [path.resolve(root, relativePath), date])
+    );
+  }
 
   return {
     async getLastModifiedDate(filePath: string): Promise<Date | null> {
       try {
-        const log = await git.log({ file: filePath, maxCount: 1 });
-        if (!log.latest) return null;
+        dates ??= loadDates();
 
-        return new Date(log.latest.date);
+        return (await dates).get(path.resolve(filePath)) ?? null;
       } catch {
+        dates = undefined;
+
         return null;
       }
     },
   };
 }
-
-/** Default git service instance for production use. */
-export const defaultGitService = createGitService();

--- a/site/src/utils/tests/gitService.test.ts
+++ b/site/src/utils/tests/gitService.test.ts
@@ -1,0 +1,99 @@
+import * as path from 'node:path';
+
+import { describe, expect, it, type Mock, vi } from 'vite-plus/test';
+
+import { createGitService, type GitClient, parseLastModifiedDates } from '../gitService';
+
+// ASCII record separator, matching the marker the service puts in front of each commit date.
+const MARKER = String.fromCharCode(0x1e);
+
+const LOG = [
+  `${MARKER}2026-09-03T16:22:59-07:00`,
+  'site/src/content/docs/how-to/installation.mdx',
+  'site/src/content/docs/concepts/overview.mdx',
+  '',
+  `${MARKER}2026-08-01T10:00:00+00:00`,
+  'site/src/content/docs/concepts/overview.mdx',
+  'site/src/content/blog/2026-07-01-hello.mdx',
+  '',
+].join('\n');
+
+interface FakeGitClient extends GitClient {
+  raw: Mock<GitClient['raw']>;
+  revparse: Mock<GitClient['revparse']>;
+}
+
+function createClient(root = '/repo'): FakeGitClient {
+  return {
+    raw: vi.fn<GitClient['raw']>(async () => LOG),
+    revparse: vi.fn<GitClient['revparse']>(async () => `${root}\n`),
+  };
+}
+
+describe('parseLastModifiedDates', () => {
+  it('keeps the newest date for a path touched by several commits', () => {
+    const dates = parseLastModifiedDates(LOG);
+
+    expect(dates.get('site/src/content/docs/concepts/overview.mdx')).toEqual(new Date('2026-09-03T16:22:59-07:00'));
+    expect(dates.get('site/src/content/blog/2026-07-01-hello.mdx')).toEqual(new Date('2026-08-01T10:00:00+00:00'));
+    expect(dates.size).toBe(3);
+  });
+
+  it('ignores blank lines and paths before any commit marker', () => {
+    expect(parseLastModifiedDates('\nsite/orphan.mdx\n')).toEqual(new Map());
+  });
+});
+
+describe('createGitService', () => {
+  it('resolves absolute paths against the repository root reported by git', async () => {
+    const service = createGitService('/repo/site/src/content', createClient('/repo'));
+
+    await expect(service.getLastModifiedDate('/repo/site/src/content/docs/how-to/installation.mdx')).resolves.toEqual(
+      new Date('2026-09-03T16:22:59-07:00')
+    );
+    await expect(service.getLastModifiedDate('/repo/site/src/content/docs/missing.mdx')).resolves.toBeNull();
+  });
+
+  it('walks the history once for every lookup', async () => {
+    const client = createClient();
+    const service = createGitService('/repo/site/src/content', client);
+
+    await Promise.all([
+      service.getLastModifiedDate('/repo/site/src/content/docs/how-to/installation.mdx'),
+      service.getLastModifiedDate('/repo/site/src/content/docs/concepts/overview.mdx'),
+      service.getLastModifiedDate('/repo/site/src/content/blog/2026-07-01-hello.mdx'),
+    ]);
+
+    expect(client.raw).toHaveBeenCalledTimes(1);
+    expect(client.raw).toHaveBeenCalledWith([
+      '-c',
+      'core.quotePath=false',
+      'log',
+      `--format=${MARKER}%aI`,
+      '--name-only',
+      '--',
+      '/repo/site/src/content',
+    ]);
+    expect(client.revparse).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes the queried path before matching', async () => {
+    const service = createGitService('/repo/site/src/content', createClient());
+
+    await expect(
+      service.getLastModifiedDate(path.join('/repo/site/src/content/docs/how-to/../how-to/installation.mdx'))
+    ).resolves.toEqual(new Date('2026-09-03T16:22:59-07:00'));
+  });
+
+  it('returns null and retries later when git fails', async () => {
+    const client = createClient();
+
+    client.raw.mockRejectedValueOnce(new Error('not a git repository'));
+    const service = createGitService('/repo/site/src/content', client);
+    const file = '/repo/site/src/content/docs/how-to/installation.mdx';
+
+    await expect(service.getLastModifiedDate(file)).resolves.toBeNull();
+    await expect(service.getLastModifiedDate(file)).resolves.toEqual(new Date('2026-09-03T16:22:59-07:00'));
+    expect(client.raw).toHaveBeenCalledTimes(2);
+  });
+});

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -87,9 +87,10 @@ const config: ViteUserConfig = {
         ],
       },
       dev: {
-        // Serves whatever generated content and package builds already exist. Depending on the
-        // generators here would replay every workspace build task (~16s cached) on each start;
-        // the root `dev:site` script (`scripts/dev.ts`) runs `dev:prepare` only when they are missing.
+        // Serves whatever generated content and package builds already exist. Depending on
+        // the generators here would replay every workspace build task on each start, several
+        // seconds even when fully cached, so the root `dev:site` script (`scripts/dev.ts`)
+        // runs `dev:prepare` only when they are missing or explicitly requested.
         command: 'NETLIFY_DEV=1 astro dev',
         cache: false,
       },

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -87,7 +87,14 @@ const config: ViteUserConfig = {
         ],
       },
       dev: {
+        // Serves whatever generated content and package builds already exist. Depending on the
+        // generators here would replay every workspace build task (~16s cached) on each start;
+        // the root `dev:site` script (`scripts/dev.ts`) runs `dev:prepare` only when they are missing.
         command: 'NETLIFY_DEV=1 astro dev',
+        cache: false,
+      },
+      'dev:prepare': {
+        command: 'node -e ""',
         cache: false,
         dependsOn: ['api-docs:generate', 'cdn-manifest'],
       },


### PR DESCRIPTION
## Summary

`pnpm dev:site` took ~21s to serve a page with every cache warm, and ~50s on a fresh checkout, while Astro itself is ready in ~3s. Two changes remove the overhead: the dev server no longer replays the whole workspace task graph on every start, and content sync no longer runs one `git log` per MDX entry.

## Changes

- `pnpm dev:site` starts `astro dev` directly and only runs the generators and package builds (`site#dev:prepare`) when generated reference JSON, the CDN manifest, or the `@videojs/html` / `@videojs/react` builds are missing. `pnpm dev:site --prepare` forces a refresh; other arguments such as `--port` are forwarded to Astro. The root `pnpm dev` is unchanged.
- The content `updatedDate` lookup runs a single `git log --name-only` over `src/content` instead of 263 separate `git log -1` calls, cutting a cold content sync from ~20s to ~0.3s.
- That lookup also never matched anything before: Vite+ runs Astro from `site/` while the code passed `site/`-prefixed pathspecs, and docs ids had no `.mdx` extension. Both parsers now use the absolute `filePath` the loader provides, so docs and blog pages start emitting JSON-LD `dateModified`. This is a visible (metadata-only) change on the deployed site.
- Package builds no longer emit `.d.ts.map` files (published packages ship no `src` for them to point at) or `.js.map` files for the unminified `default` build; the `dev` build keeps its maps. Output drops from 9,314 files / 64 MB to 7,022 / 40 MB, which also shortens every Vite+ cache restore by about 1.5s.

| Scenario | Before | After |
| --- | --- | --- |
| Warm start to `astro ready` | ~21s | ~3s |
| Cold content sync | ~20s | ~0.3s |
| Fresh checkout to `astro ready` | ~51s | ~35s (package builds still run once) |

<details>
<summary>Implementation details</summary>

- Cached Vite+ tasks are not free: the `dev` graph cost ~5s of config discovery across 33 projects plus ~11s replaying 34 cache hits (64 MB of `dist`). Nothing else in the repo uses `--ignore-depends-on` for a single package, so a small launcher script owns the "prepare only when missing" decision and keeps the `dev` task usable by the root parallel `dev`.
- The git service keys results by absolute path via `git rev-parse --show-toplevel`, and passes `-c core.quotePath=false` so a blog post with a curly apostrophe in its filename still matches.

</details>

## Testing

- `pnpm -F site test` (597 tests, including new `gitService` and `dev` launcher tests), `pnpm typecheck`, `pnpm lint`, `pnpm check:workspace`.
- Timed `pnpm dev:site` warm and with the content data store deleted; verified all 263 docs and blog entries receive `updatedDate` by decoding `.astro/data-store.json`.
- Removed `src/content/cdn-media.json` and confirmed `pnpm dev:site` runs `site#dev:prepare`, regenerates it, and then starts Astro.
- Rebuilt every package after the source-map change; utils, html, react, and site test suites pass and `pnpm typecheck` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dev workflow and published package artifacts (maps removed from default builds); git-based content metadata now applies site-wide, which is a visible SEO/metadata change but not auth or data handling.
> 
> **Overview**
> **Faster `pnpm dev:site`** by routing the root script through a new `site/scripts/dev.ts` launcher that starts Astro directly when API reference JSON, the CDN manifest, and required `@videojs/html` / `@videojs/react` builds already exist; `site#dev:prepare` (Vite+ generators) runs only when those artifacts are missing or with `--prepare`. The site `dev` task no longer depends on the full generator graph on every start.
> 
> **Content `updatedDate` sync** replaces per-MDX `git log` calls with one scoped `git log --name-only` walk keyed by absolute paths from the loader’s `filePath`, fixing previously broken path matching so docs/blog can emit `dateModified` metadata.
> 
> **Smaller published package output**: default (non-`dev`) builds disable JS source maps in `packageBuildConfig`, and package `tsconfig.dts.json` files set `declarationMap: false`, cutting thousands of map files from npm tarballs and speeding Vite+ cache restores.
> 
> Docs (`site/README.md`, `AGENTS.md`, api-docs builder README) and unit tests cover the launcher prerequisite checks and git parsing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b01309eef0c54df56eb37a266a30ba33b4dd9d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->