### PR TITLE
feat(skin): slot the slider thumbnail image

### DIFF
--- a/apps/sandbox/app/shared/react/skins.tsx
+++ b/apps/sandbox/app/shared/react/skins.tsx
@@ -188,6 +188,7 @@ type VideoSkinComponentProps = { live?: boolean } & VideoSkinProps;
 export function VideoSkinComponent({
   live = false,
   className = PLAYER_FRAME_CLASSES.video,
+  renderThumbnail,
   ...props
 }: VideoSkinComponentProps) {
   const { skin, styling, skins, source, captions } = useSandbox();
@@ -203,8 +204,17 @@ export function VideoSkinComponent({
 
   if (!Component) return null;
 
+  // The live skin has no time slider, so it takes no thumbnail override; the prop would land on its container.
+  const thumbnailProps: Pick<VideoSkinProps, 'renderThumbnail'> = live ? {} : { renderThumbnail };
+
   // SAFETY: React 19 hands `ref` to a function component as a prop, and every skin spreads its props onto the container.
-  return createElement(Component, { ...props, ...directionProps, className, ref: rootRef } as VideoSkinProps);
+  return createElement(Component, {
+    ...props,
+    ...thumbnailProps,
+    ...directionProps,
+    className,
+    ref: rootRef,
+  } as VideoSkinProps);
 }
 
 type AudioSkinComponentProps = { live?: boolean } & AudioSkinProps;

--- a/apps/sandbox/templates/html-mux-video/main.ts
+++ b/apps/sandbox/templates/html-mux-video/main.ts
@@ -19,7 +19,9 @@ createHtmlSandbox({
       <${skinTag} class="mx-auto aspect-video max-w-4xl">
         <!-- The player fills in the poster; the slotted image paints a blurred placeholder underneath while it loads. -->
         ${placeholder ? html`<img slot="poster" alt="" crossorigin style="background: url('${placeholder}') var(--media-object-position, center) / contain no-repeat" />` : ''}
-        <!-- The storyboard track is derived automatically from the Mux src. -->
+        <!-- The storyboard track is derived automatically from the Mux src. The slotted image replaces the skin's
+             preview image so it can carry its own loading hints; the skin still fills in the frame under the pointer. -->
+        <img slot="thumbnail" alt="" decoding="async" fetchpriority="low" />
         <mux-video${src} ${attrs} playsinline crossorigin>${chapters}</mux-video>
         <!-- Mux Data and Cast are opt-in media components; no env key is needed for Mux-hosted sources. -->
         <mux-data player-software-name="mux-video"></mux-data>

--- a/apps/sandbox/templates/react-mux-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-video/main.tsx
@@ -38,6 +38,8 @@ function App() {
               />
             ) : undefined
           }
+          // Replaces the skin's preview image so it can carry its own loading hints; the skin still fills in the frame.
+          renderThumbnail={<img alt="" decoding="async" fetchPriority="low" />}
           live={live}
         >
           {/* The storyboard track is derived automatically from the Mux src. */}

--- a/internal/decisions/ui/skin-images-are-authorable.md
+++ b/internal/decisions/ui/skin-images-are-authorable.md
@@ -1,0 +1,25 @@
+---
+status: decided
+date: 2026-09-09
+---
+
+# Every image a skin renders can be supplied by the author
+
+## Decision
+
+Any `<img>` a packaged skin renders internally is fallback content, not a private detail. The author can replace it from inside the skin tag — an `<img slot="poster">` or `<img slot="thumbnail">` in HTML, `renderPoster` or `renderThumbnail` in React — and the component that owns the image fills in only what the author left off. The poster and slider thumbnail follow this rule today; any image a skin adds later must too.
+
+## Why
+
+The attributes that make an image good — `srcset`, `sizes`, `loading`, `fetchpriority`, `crossorigin`, `alt`, a `<picture>` wrapper, or a framework component such as Next.js `<Image>` — cannot be exposed one by one through a shadow boundary or a skin prop without reinventing the `<img>` API. Handing the author the element is the only surface that stays complete as browsers add attributes. This is the same reasoning the [poster design](/internal/design/ui/poster.md#component-managed-image-src-prop) used to reject a component-managed `src` prop, generalized to every skin image.
+
+The skin's own image is the slot's fallback content in light DOM rather than something drawn in a component's shadow root, so the skin styles it by class and an author's image through `::slotted(img)`, and there is never a hidden duplicate beside the author's. In React the same source becomes a `render` override because there is no slot to fill; the vjsc React target maps authored children of every image part to `render` so skin source needs no target-specific code.
+
+Because the component still has to write to an image it did not create — the poster fills `src`, the thumbnail owns `src`/`srcset` and mirrors `crossorigin`, `loading`, and `fetchpriority` — ownership is settled once, when the image is adopted. What the image already carries is the author's and is left alone; what the component writes it also removes when the image steps aside. Deciding later would misread the component's own writes as authored. The thumbnail cannot simply leave a supplied image untouched, because the skin's own image is also a supplied image from the element's point of view and relies on it for `crossorigin` inheritance from the media element.
+
+## Consequences
+
+- A new skin image needs three things: a named slot around it in skin source, an owning component that respects authored attributes, and a `shadow-dom` style variant so a slotted image is sized and transitioned like the skin's own.
+- Ejected HTML strips every named slot, since without a shadow root the author edits the image directly.
+
+See [`packages/skins/src/components/layout/poster.tsx`](/packages/skins/src/components/layout/poster.tsx), [`packages/skins/src/components/sliders/time-slider.tsx`](/packages/skins/src/components/sliders/time-slider.tsx), and the adoption logic in [`packages/html/src/ui/thumbnail/element.ts`](/packages/html/src/ui/thumbnail/element.ts).

--- a/packages/html/src/ui/thumbnail/element.ts
+++ b/packages/html/src/ui/thumbnail/element.ts
@@ -25,6 +25,14 @@ img,
   display: block;
 }`;
 
+/**
+ * Image attributes the element fills in from its own properties. Ones already on an image when it is adopted are the
+ * author's and are left alone, so an `<img slot="thumbnail" loading="lazy">` keeps its settings inside a skin.
+ */
+const IMAGE_ATTRIBUTES = ['crossorigin', 'loading', 'fetchpriority'] as const;
+
+type ImageAttribute = (typeof IMAGE_ATTRIBUTES)[number];
+
 /** The image the element draws when none is supplied, reachable from outside as `::part(image)`. */
 function createFallbackImage(): HTMLImageElement {
   const img = document.createElement('img');
@@ -42,7 +50,9 @@ function createFallbackImage(): HTMLImageElement {
  *
  * The element owns `src` and `srcset` on the active image. Left empty, it draws an image of its own in its shadow root.
  * Supply an `<img>` child instead — `<media-thumbnail time="12"><img alt=""></media-thumbnail>` — to compose overlays
- * or loading indicators beside the image the element controls.
+ * or loading indicators beside the image the element controls. Any `crossorigin`, `loading`, or `fetchpriority` the
+ * child already carries wins over the element's own; the rest are filled in. Inside a skin, an `<img slot="thumbnail">`
+ * of yours replaces the one the skin carries.
  */
 export class ThumbnailElement extends UIElement {
   static readonly tagName = 'media-thumbnail';
@@ -70,6 +80,8 @@ export class ThumbnailElement extends UIElement {
 
   #slots: AbortController | null = null;
   #img: HTMLImageElement | null = null;
+  /** Attributes `#img` already carried when adopted, which the author owns. */
+  #authored = new Set<ImageAttribute>();
   #thumbnails: ThumbnailImage[] = [];
   #externalThumbnails: ThumbnailImage[] | undefined;
   #lastTextTrack: MediaTextTrackState | undefined;
@@ -160,13 +172,7 @@ export class ThumbnailElement extends UIElement {
     const img = findComposedElement(this, isHTMLImageElement) ?? this.#fallback;
 
     this.#adopt(img);
-
-    // Sync img attributes from element properties.
-    applyElementProps(img, {
-      crossorigin: this.#core.resolveCrossOrigin(this.crossOrigin, this.#inheritedCrossOrigin(textTrack)),
-      loading: this.loading,
-      fetchpriority: this.fetchPriority,
-    });
+    this.#applyImageAttributes(img, textTrack);
 
     // Track src changes via the thumbnail API.
     this.#api?.updateSrc(thumbnail?.url);
@@ -208,6 +214,19 @@ export class ThumbnailElement extends UIElement {
     return this.#externalThumbnails ? undefined : textTrack?.thumbnailTrackCrossOrigin;
   }
 
+  /** Sync image attributes from element properties, leaving the ones the author put on the image alone. */
+  #applyImageAttributes(img: HTMLImageElement, textTrack: MediaTextTrackState | undefined): void {
+    const props: Partial<Record<ImageAttribute, string | undefined>> = {
+      crossorigin: this.#core.resolveCrossOrigin(this.crossOrigin, this.#inheritedCrossOrigin(textTrack)),
+      loading: this.loading,
+      fetchpriority: this.fetchPriority,
+    };
+
+    for (const name of this.#authored) delete props[name];
+
+    applyElementProps(img, props);
+  }
+
   #applyResize(result: ThumbnailResizeResult): void {
     this.style.width = `${result.containerWidth}px`;
     this.style.height = `${result.containerHeight}px`;
@@ -245,9 +264,16 @@ export class ThumbnailElement extends UIElement {
       this.#resetStyles();
       previous.removeAttribute('src');
       previous.removeAttribute('srcset');
+
+      for (const name of IMAGE_ATTRIBUTES) {
+        if (!this.#authored.has(name)) previous.removeAttribute(name);
+      }
     }
 
+    // Ownership is settled once, when an image becomes active: after the first
+    // sync the attributes we set would themselves look authored.
     this.#img = next;
+    this.#authored = new Set(next ? IMAGE_ATTRIBUTES.filter((name) => next.hasAttribute(name)) : []);
     this.#imageAttributes.disconnect();
 
     if (next && next !== this.#fallback) {

--- a/packages/html/src/ui/thumbnail/tests/element.test.ts
+++ b/packages/html/src/ui/thumbnail/tests/element.test.ts
@@ -237,6 +237,70 @@ describe('ThumbnailElement', () => {
     expect(first.hasAttribute('src')).toBe(false);
   });
 
+  describe('image attributes', () => {
+    it('fills loading and fetchpriority in from its own properties', async () => {
+      const thumbnail = document.createElement(ThumbnailElement.tagName) as ThumbnailElement;
+      const img = document.createElement('img');
+
+      Object.defineProperty(img, 'complete', { value: false, configurable: true });
+      thumbnail.setAttribute('loading', 'lazy');
+      thumbnail.setAttribute('fetchpriority', 'low');
+      thumbnail.append(img);
+      document.body.append(thumbnail);
+      await thumbnail.updateComplete;
+
+      expect(img.getAttribute('loading')).toBe('lazy');
+      expect(img.getAttribute('fetchpriority')).toBe('low');
+    });
+
+    it('leaves attributes the supplied image already carries alone', async () => {
+      const thumbnail = document.createElement(ThumbnailElement.tagName) as ThumbnailElement;
+      const img = document.createElement('img');
+
+      Object.defineProperty(img, 'complete', { value: false, configurable: true });
+      img.setAttribute('crossorigin', 'use-credentials');
+      img.setAttribute('loading', 'lazy');
+      img.setAttribute('fetchpriority', 'low');
+      thumbnail.setAttribute('crossorigin', 'anonymous');
+      thumbnail.append(img);
+      document.body.append(thumbnail);
+      await thumbnail.updateComplete;
+
+      expect(img.getAttribute('crossorigin')).toBe('use-credentials');
+      expect(img.getAttribute('loading')).toBe('lazy');
+      expect(img.getAttribute('fetchpriority')).toBe('low');
+
+      // Ownership is settled at adoption, so a later property change still yields to the author.
+      thumbnail.loading = 'eager';
+      await thumbnail.updateComplete;
+
+      expect(img.getAttribute('loading')).toBe('lazy');
+    });
+
+    it('removes only the attributes it set when an image steps aside', async () => {
+      const thumbnail = document.createElement(ThumbnailElement.tagName) as ThumbnailElement;
+      const first = document.createElement('img');
+
+      Object.defineProperty(first, 'complete', { value: false, configurable: true });
+      first.setAttribute('loading', 'lazy');
+      thumbnail.setAttribute('fetchpriority', 'low');
+      thumbnail.append(first);
+      document.body.append(thumbnail);
+      await thumbnail.updateComplete;
+
+      expect(first.getAttribute('fetchpriority')).toBe('low');
+
+      const second = document.createElement('img');
+
+      Object.defineProperty(second, 'complete', { value: false, configurable: true });
+      first.replaceWith(second);
+
+      await vi.waitFor(() => expect(second.getAttribute('fetchpriority')).toBe('low'));
+      expect(first.hasAttribute('fetchpriority')).toBe(false);
+      expect(first.getAttribute('loading')).toBe('lazy');
+    });
+  });
+
   describe('crossorigin', () => {
     it('inherits the media element CORS mode when unset', async () => {
       await expect(renderCrossOrigin('anonymous')).resolves.toBe('anonymous');
@@ -273,6 +337,25 @@ describe('ThumbnailElement', () => {
       });
 
       expect(attribute).toBe('');
+    });
+
+    it('prefers a value the supplied image carries over the inherited one', async () => {
+      const provider = document.createElement('test-thumbnail-player') as TestPlayerProviderElement;
+      const thumbnail = document.createElement(ThumbnailElement.tagName) as ThumbnailElement;
+      const img = document.createElement('img');
+
+      img.setAttribute('crossorigin', 'use-credentials');
+      provider.setStore(createTextTrackStore('anonymous'));
+      thumbnail.append(img);
+      provider.append(thumbnail);
+      document.body.append(provider);
+
+      for (let index = 0; index < 5; index++) {
+        await thumbnail.updateComplete;
+        await nextFrame();
+      }
+
+      expect(img.getAttribute('crossorigin')).toBe('use-credentials');
     });
 
     it('does not inherit for thumbnails supplied directly', async () => {

--- a/packages/react/src/presets/types.ts
+++ b/packages/react/src/presets/types.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties, PropsWithChildren } from 'react';
 
 import type { Poster } from '@/ui/poster';
+import type { Slider } from '@/ui/slider';
 
 /** Shared layout props for React skins, combined with any skin-specific props in `T`. */
 export type BaseSkinProps<T = unknown> = PropsWithChildren<
@@ -29,4 +30,19 @@ export type BaseVideoSkinProps<T = unknown> = BaseSkinProps<T> & {
    *   ```;
    */
   renderPoster?: Poster.ImageProps['render'];
+};
+
+/** Props for on-demand video skins, which add a thumbnail preview to the time slider. */
+export type OnDemandVideoSkinProps<T = unknown> = BaseVideoSkinProps<T> & {
+  /**
+   * Draws the thumbnail preview image in place of the `<img>` the skin renders while scrubbing. The skin still resolves
+   * the storyboard frame and passes `src`, sizing styles, and the rest of the image props; use it to set `crossOrigin`,
+   * `loading`, or `fetchPriority`, or to render through your own image component.
+   *
+   * @example
+   *   ```tsx
+   *   <VideoSkin renderThumbnail={<img alt="" loading="lazy" fetchPriority="low" />} />
+   *   ```;
+   */
+  renderThumbnail?: Slider.Thumbnail.ImageProps['render'];
 };

--- a/packages/react/src/presets/video/tests/skin.test.tsx
+++ b/packages/react/src/presets/video/tests/skin.test.tsx
@@ -71,6 +71,33 @@ describe('VideoSkin', () => {
     expect(custom?.getAttribute('style')).toContain('poster-placeholder.jpg');
   });
 
+  it('lets renderThumbnail draw the slider preview image', () => {
+    const { container } = render(
+      <VideoSkin renderThumbnail={<img data-testid="custom" fetchPriority="low" loading="lazy" alt="" />} />,
+      {
+        // The time slider only renders with the time and buffer features present.
+        wrapper: wrapper({
+          controlsVisible: true,
+          userActive: true,
+          requestControlsLock: () => () => {},
+          currentTime: 0,
+          duration: 100,
+          seeking: false,
+          seek: async () => {},
+          buffered: [],
+          seekable: [],
+        }),
+      }
+    );
+
+    const custom = container.querySelector('.media-slider-thumbnail > [data-testid="custom"]');
+
+    expect(container.querySelectorAll('.media-slider-thumbnail > img')).toHaveLength(1);
+    expect(custom?.getAttribute('fetchpriority')).toBe('low');
+    expect(custom?.getAttribute('loading')).toBe('lazy');
+    expect(custom?.classList.contains('media-slider-thumbnail-image')).toBe(true);
+  });
+
   it('lets renderPoster draw something that is not an image', () => {
     const { container } = render(<VideoSkin renderPoster={(props) => <div {...props} data-testid="custom" />} />, {
       wrapper: wrapper(),

--- a/packages/skins/build/packages/html.ts
+++ b/packages/skins/build/packages/html.ts
@@ -183,7 +183,7 @@ export function createSourceOwnedHtml(template: string): string {
 
   return template
     .replace(mediaSlot, '<!-- Add a compatible media element here. -->')
-    .replace(/<slot name="poster">\s*([\s\S]*?)\s*<\/slot>/, '$1')
+    .replace(/<slot name="[^"]+">\s*([\s\S]*?)\s*<\/slot>/g, '$1')
     .replaceAll('&amp;', '&')
     .replaceAll('&gt;', '>')
     .replaceAll('&lt;', '<');

--- a/packages/skins/build/packages/react.ts
+++ b/packages/skins/build/packages/react.ts
@@ -76,6 +76,7 @@ export async function createReactPackageSkins(
         generatedComponent,
         importSource: relativeImport(`${publicRoot}/${publicName}.tsx`, generatedRoot),
         video: skin.preset.endsWith('video'),
+        live: skin.preset.startsWith('live'),
       })
     );
     addGenerated(
@@ -189,9 +190,11 @@ function reactSkinWrapper(options: {
   readonly generatedComponent: string;
   readonly importSource: string;
   readonly video: boolean;
+  /** Live skins have no time slider, so they take no thumbnail render override. */
+  readonly live: boolean;
 }): string {
   const props = `${options.component}Props`;
-  const base = options.video ? 'BaseVideoSkinProps' : 'BaseSkinProps';
+  const base = options.video ? (options.live ? 'BaseVideoSkinProps' : 'OnDemandVideoSkinProps') : 'BaseSkinProps';
 
   return `'use client';
 

--- a/packages/skins/build/target/react.tsx
+++ b/packages/skins/build/target/react.tsx
@@ -50,6 +50,10 @@ export const reactComponentTarget: ComponentTarget<CoreSchema> = defineComponent
     },
   };
 
+  // Image parts take their authored children as the `render` override, so a skin can draw its own image.
+  const rendersImageChildren = (component: string, path: readonly string[]) =>
+    path.at(-1) === 'Image' && (component === 'Poster' || component === 'Slider' || component === 'Thumbnail');
+
   return {
     source: '@videojs/core/vjsc',
     components: {
@@ -66,7 +70,7 @@ export const reactComponentTarget: ComponentTarget<CoreSchema> = defineComponent
             from: source,
             name: component,
             path: propsPath,
-            children: component === 'Poster' && path.at(-1) === 'Image' ? 'render' : undefined,
+            children: rendersImageChildren(component, path) ? 'render' : undefined,
           },
         });
       },
@@ -88,6 +92,14 @@ export const reactComponentTarget: ComponentTarget<CoreSchema> = defineComponent
         },
         Poster: {
           Image: ({ props, children }) => <target.Poster.Image render={children} {...props} />,
+        },
+        Slider: {
+          Thumbnail: {
+            Image: ({ props, children }) => <target.Slider.Thumbnail.Image render={children} {...props} />,
+          },
+        },
+        Thumbnail: {
+          Image: ({ props, children }) => <target.Thumbnail.Image render={children} {...props} />,
         },
         Tooltip: {
           Trigger: ({ props, children }) => <target.Tooltip.Trigger render={children} {...props} />,

--- a/packages/skins/build/tests/vite.test.ts
+++ b/packages/skins/build/tests/vite.test.ts
@@ -248,6 +248,8 @@ describe('Skins Vite workflow', () => {
     expect(html?.code).toContain('[&[data-loading]>slot::slotted(img)]:opacity-0');
     expect(react?.code).not.toContain('::slotted');
     expect(react?.code).not.toContain('"thumbnail"');
+    // React has no slot to fill, so the same override arrives as the image's `render` prop instead.
+    expect(react?.code).toMatch(/_jsxDEV\(SliderPrimitive\.Thumbnail\.Image, \{\s+render: renderThumbnail/);
   }, 30_000);
 
   it('hides source-less poster images for both targets', async () => {

--- a/packages/skins/build/tests/vite.test.ts
+++ b/packages/skins/build/tests/vite.test.ts
@@ -22,6 +22,8 @@ const htmlAudioSettingsMenuUrl =
 const volumePopoverUrl = `/../src/components/controls/volume-popover.tsx${reactTarget}`;
 const htmlPosterUrl = '/../src/components/layout/poster.tsx?style=tailwind&target=html&skin=default-video';
 const reactPosterUrl = '/../src/components/layout/poster.tsx?style=tailwind&target=react&skin=default-video';
+const htmlTimeSliderUrl = '/../src/components/sliders/time-slider.tsx?style=tailwind&target=html&skin=default-video';
+const reactTimeSliderUrl = '/../src/components/sliders/time-slider.tsx?style=tailwind&target=react&skin=default-video';
 // The Minimal controls reach across to the volume popover trigger with `group-has-*`, a tracked parity gap.
 const minimalControlsUrl = '/../src/skins/minimal/video/controls.tsx?style=tailwind&target=react&skin=minimal-video';
 const buttonStyles = resolve(packageDir, 'src/styles/buttons/button.styles.ts');
@@ -235,6 +237,17 @@ describe('Skins Vite workflow', () => {
 
     expect(html?.code).toContain('[&>slot::slotted(img)]:layer-media');
     expect(react?.code).not.toContain('::slotted');
+  }, 30_000);
+
+  it('slots the thumbnail image and styles a slotted one only for HTML targets', async () => {
+    const html = await server.transformRequest(htmlTimeSliderUrl);
+    const react = await server.transformRequest(reactTimeSliderUrl);
+
+    expect(html?.code).toMatch(/name:\s*"thumbnail"/);
+    expect(html?.code).toContain('[&>slot::slotted(img)]:block');
+    expect(html?.code).toContain('[&[data-loading]>slot::slotted(img)]:opacity-0');
+    expect(react?.code).not.toContain('::slotted');
+    expect(react?.code).not.toContain('"thumbnail"');
   }, 30_000);
 
   it('hides source-less poster images for both targets', async () => {

--- a/packages/skins/src/components/sliders/time-slider.tsx
+++ b/packages/skins/src/components/sliders/time-slider.tsx
@@ -1,7 +1,7 @@
 import type { SliderPreviewOverflow, TimeSliderProps as CoreProps } from '@videojs/core';
 import * as $ from '@videojs/core/vjsc';
 import { SpinnerIcon } from '@videojs/icons/vjsc';
-import { Box, type Props, Slot, Template } from 'vjsc/components';
+import { Box, type Props, type PropsOf, Slot, Template } from 'vjsc/components';
 
 import type { SkinComponentDescription } from '../../meta';
 import popupStyles from '../../styles/popups/popup.styles';
@@ -12,9 +12,16 @@ import { SliderBuffer, SliderFill, SliderThumb, SliderTrack } from './slider';
 
 export interface TimeSliderProps extends CoreProps {
   previewOverflow?: SliderPreviewOverflow | undefined;
+  /** Draws the thumbnail preview image in place of the one the skin renders. */
+  renderThumbnail?: PropsOf<typeof $.Slider.Thumbnail.Image>['children'];
 }
 
-export function TimeSlider({ className, previewOverflow = 'visible', ...props }: Props<TimeSliderProps> = {}) {
+export function TimeSlider({
+  className,
+  previewOverflow = 'visible',
+  renderThumbnail,
+  ...props
+}: Props<TimeSliderProps> = {}) {
   return (
     <$.TimeSlider.Root className={[sliderStyles.root, styles.root, className]} {...props}>
       <$.TimeSlider.Chapters className={styles.chapters}>
@@ -29,7 +36,7 @@ export function TimeSlider({ className, previewOverflow = 'visible', ...props }:
       <$.TimeSlider.Preview className={sliderStyles.preview} overflow={previewOverflow}>
         <$.Slider.Thumbnail.Root className={[sliderStyles.previewContent, popupStyles.surface, thumbnailStyles.root]}>
           <Slot name="thumbnail">
-            <$.Slider.Thumbnail.Image className={thumbnailStyles.image} />
+            <$.Slider.Thumbnail.Image className={thumbnailStyles.image}>{renderThumbnail}</$.Slider.Thumbnail.Image>
           </Slot>
           <SpinnerIcon className={thumbnailStyles.spinnerIcon} />
         </$.Slider.Thumbnail.Root>

--- a/packages/skins/src/components/sliders/time-slider.tsx
+++ b/packages/skins/src/components/sliders/time-slider.tsx
@@ -1,7 +1,7 @@
 import type { SliderPreviewOverflow, TimeSliderProps as CoreProps } from '@videojs/core';
 import * as $ from '@videojs/core/vjsc';
 import { SpinnerIcon } from '@videojs/icons/vjsc';
-import { Box, type Props, Template } from 'vjsc/components';
+import { Box, type Props, Slot, Template } from 'vjsc/components';
 
 import type { SkinComponentDescription } from '../../meta';
 import popupStyles from '../../styles/popups/popup.styles';
@@ -28,7 +28,9 @@ export function TimeSlider({ className, previewOverflow = 'visible', ...props }:
       <$.TimeSlider.Thumb $render={SliderThumb} className={styles.thumb} />
       <$.TimeSlider.Preview className={sliderStyles.preview} overflow={previewOverflow}>
         <$.Slider.Thumbnail.Root className={[sliderStyles.previewContent, popupStyles.surface, thumbnailStyles.root]}>
-          <$.Slider.Thumbnail.Image className={thumbnailStyles.image} />
+          <Slot name="thumbnail">
+            <$.Slider.Thumbnail.Image className={thumbnailStyles.image} />
+          </Slot>
           <SpinnerIcon className={thumbnailStyles.spinnerIcon} />
         </$.Slider.Thumbnail.Root>
         <Box className={[sliderStyles.previewContent, styles.previewContent]}>

--- a/packages/skins/src/skins/default/video/controls.tsx
+++ b/packages/skins/src/skins/default/video/controls.tsx
@@ -1,4 +1,5 @@
 import * as $ from '@videojs/core/vjsc';
+import type { PropsOf } from 'vjsc/components';
 
 import { AirPlayButton } from '../../../components/buttons/airplay-button';
 import { ButtonTooltip } from '../../../components/buttons/button-tooltip';
@@ -14,7 +15,11 @@ import timeStyles from '../../../styles/layout/time.styles';
 import { VideoSettingsMenu } from '../../shared/video/settings-menu';
 import styles from './controls.styles';
 
-export function DefaultVideoControls() {
+export interface DefaultVideoControlsProps {
+  renderThumbnail?: PropsOf<typeof TimeSlider>['renderThumbnail'];
+}
+
+export function DefaultVideoControls({ renderThumbnail }: DefaultVideoControlsProps = {}) {
   return (
     <$.Controls.Root>
       <$.Controls.Backdrop className={controlsStyles.backdrop} />
@@ -28,7 +33,7 @@ export function DefaultVideoControls() {
 
             <$.Controls.Group className={styles.timeSliderGroup}>
               <$.Time.Value className={[timeStyles.value, styles.timeValue]} type="current" />
-              <TimeSlider />
+              <TimeSlider renderThumbnail={renderThumbnail} />
               <$.Time.Value className={[timeStyles.toggle, styles.timeValue]} type="remaining" toggle />
             </$.Controls.Group>
 

--- a/packages/skins/src/skins/default/video/skin.tsx
+++ b/packages/skins/src/skins/default/video/skin.tsx
@@ -14,9 +14,16 @@ import { DefaultVideoControls } from './controls';
 export interface DefaultVideoSkinProps extends Omit<PropsOf<typeof Container>, 'children'> {
   children?: VjscNode;
   renderPoster?: PropsOf<typeof Poster>['renderImage'];
+  renderThumbnail?: PropsOf<typeof DefaultVideoControls>['renderThumbnail'];
 }
 
-export function DefaultVideoSkin({ children, className, renderPoster, ...props }: DefaultVideoSkinProps = {}) {
+export function DefaultVideoSkin({
+  children,
+  className,
+  renderPoster,
+  renderThumbnail,
+  ...props
+}: DefaultVideoSkinProps = {}) {
   return (
     <Container className={[videoSkinStyles.root, className]} data-theme="default" data-preset="video" {...props}>
       <Slot>{children}</Slot>
@@ -24,7 +31,7 @@ export function DefaultVideoSkin({ children, className, renderPoster, ...props }
       <BufferingIndicator />
       <ErrorDialog />
 
-      <DefaultVideoControls />
+      <DefaultVideoControls renderThumbnail={renderThumbnail} />
 
       <VideoHotkeys />
       <VideoGestures />

--- a/packages/skins/src/skins/minimal/video/controls.tsx
+++ b/packages/skins/src/skins/minimal/video/controls.tsx
@@ -1,4 +1,5 @@
 import * as $ from '@videojs/core/vjsc';
+import type { PropsOf } from 'vjsc/components';
 
 import { AirPlayButton } from '../../../components/buttons/airplay-button';
 import { ButtonTooltip } from '../../../components/buttons/button-tooltip';
@@ -14,7 +15,11 @@ import timeStyles from '../../../styles/layout/time.styles';
 import { VideoSettingsMenu } from '../../shared/video/settings-menu';
 import styles from './controls.styles';
 
-export function MinimalVideoControls() {
+export interface MinimalVideoControlsProps {
+  renderThumbnail?: PropsOf<typeof TimeSlider>['renderThumbnail'];
+}
+
+export function MinimalVideoControls({ renderThumbnail }: MinimalVideoControlsProps = {}) {
   return (
     <$.Controls.Root>
       <$.Controls.Backdrop className={controlsStyles.backdrop} />
@@ -33,7 +38,7 @@ export function MinimalVideoControls() {
               <$.Time.Separator className={timeStyles.separator} />
               <$.Time.Value className={timeStyles.durationValue} type="duration" />
             </$.Time.Group>
-            <TimeSlider previewOverflow="clamp" />
+            <TimeSlider previewOverflow="clamp" renderThumbnail={renderThumbnail} />
           </$.Controls.Group>
 
           <$.Controls.Group className={styles.end}>

--- a/packages/skins/src/skins/minimal/video/skin.tsx
+++ b/packages/skins/src/skins/minimal/video/skin.tsx
@@ -14,9 +14,16 @@ import { MinimalVideoControls } from './controls';
 export interface MinimalVideoSkinProps extends Omit<PropsOf<typeof Container>, 'children'> {
   children?: VjscNode;
   renderPoster?: PropsOf<typeof Poster>['renderImage'];
+  renderThumbnail?: PropsOf<typeof MinimalVideoControls>['renderThumbnail'];
 }
 
-export function MinimalVideoSkin({ children, className, renderPoster, ...props }: MinimalVideoSkinProps = {}) {
+export function MinimalVideoSkin({
+  children,
+  className,
+  renderPoster,
+  renderThumbnail,
+  ...props
+}: MinimalVideoSkinProps = {}) {
   return (
     <Container className={[videoSkinStyles.root, className]} data-theme="minimal" data-preset="video" {...props}>
       <Slot>{children}</Slot>
@@ -24,7 +31,7 @@ export function MinimalVideoSkin({ children, className, renderPoster, ...props }
       <BufferingIndicator />
       <ErrorDialog />
 
-      <MinimalVideoControls />
+      <MinimalVideoControls renderThumbnail={renderThumbnail} />
 
       <VideoHotkeys />
       <VideoGestures />

--- a/packages/skins/src/styles/sliders/thumbnail.styles.ts
+++ b/packages/skins/src/styles/sliders/thumbnail.styles.ts
@@ -19,6 +19,12 @@ export default styles({
           'after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:bg-(image:--media-thumbnail-gradient)',
         ],
         minimal: '[left:var(--media-preview-left,var(--media-slider-pointer))]',
+        // An image slotted in from outside the skin cannot carry the image class, so the root styles it.
+        'shadow-dom': [
+          '[&>slot::slotted(img)]:block [&>slot::slotted(img)]:transition-opacity',
+          '[&>slot::slotted(img)]:duration-media-base [&>slot::slotted(img)]:ease-out',
+          '[&[data-loading]>slot::slotted(img)]:opacity-0',
+        ],
       },
     },
     image: {

--- a/site/src/content/docs/how-to/show-timeline-thumbnail-previews.mdx
+++ b/site/src/content/docs/how-to/show-timeline-thumbnail-previews.mdx
@@ -34,7 +34,11 @@ With <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, the storyboard tr
 Add a `kind="metadata"` track labeled `thumbnails` whose cues reference storyboard images, then put a slider thumbnail inside the <DocsLink slug="reference/time-slider">TimeSlider</DocsLink>. Scrubbing shows the frame under the pointer. The slider thumbnail reads the pointer time from the slider, so you never pass `time`; it otherwise accepts the same props as the standalone <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink>.
 
 <FrameworkCase frameworks={["react"]}>
-Compose `Slider.Thumbnail.Root` around `Slider.Thumbnail.Image`, and put image settings such as `crossOrigin`, `loading`, and `fetchPriority` on the image part.
+Compose `Slider.Thumbnail.Root` around `Slider.Thumbnail.Image`, and put image settings such as `crossOrigin`, `loading`, and `fetchPriority` on the image part. Inside a packaged skin, pass `renderThumbnail` to draw the image yourself; the skin still supplies `src` and sizing:
+
+```tsx
+<VideoSkin renderThumbnail={<img alt="" loading="lazy" fetchPriority="low" />} />
+```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/how-to/show-timeline-thumbnail-previews.mdx
+++ b/site/src/content/docs/how-to/show-timeline-thumbnail-previews.mdx
@@ -38,7 +38,18 @@ Compose `Slider.Thumbnail.Root` around `Slider.Thumbnail.Image`, and put image s
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-`<media-slider-thumbnail>` draws its own image unless you supply an `<img>` child; set `crossorigin`, `loading`, or `fetchpriority` on the element itself.
+`<media-slider-thumbnail>` draws its own image unless you supply an `<img>` child; set `crossorigin`, `loading`, or `fetchpriority` on the element itself, or on the image you supply. Inside a packaged skin, an `<img slot="thumbnail">` replaces the image the skin carries, so those attributes go on it:
+
+```html
+<video-player>
+  <video-skin>
+    <video src="video.mp4" crossorigin="anonymous">
+      <track kind="metadata" label="thumbnails" src="storyboard.vtt" default />
+    </video>
+    <img slot="thumbnail" alt="" loading="lazy" fetchpriority="low" />
+  </video-skin>
+</video-player>
+```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>

--- a/site/src/content/docs/reference/thumbnail.mdx
+++ b/site/src/content/docs/reference/thumbnail.mdx
@@ -98,7 +98,7 @@ A same-origin track needs none of this.
 
 ## Behavior
 
-The thumbnail root resolves an image for the current `time`, owns `src` and `srcset` on it, and reports its loading lifecycle. In React, render that image with `Thumbnail.Image`. In HTML, the `<img>` child is optional: leave it out and `<media-thumbnail>` draws an image of its own in its shadow DOM; supply one to replace it and compose overlays or loading indicators beside it.
+The thumbnail root resolves an image for the current `time`, owns `src` and `srcset` on it, and reports its loading lifecycle. In React, render that image with `Thumbnail.Image`. In HTML, the `<img>` child is optional: leave it out and `<media-thumbnail>` draws an image of its own in its shadow DOM; supply one to replace it and compose overlays or loading indicators beside it. Any `crossorigin`, `loading`, or `fetchpriority` the supplied image already carries is yours and wins over the element's own attributes; the rest are filled in.
 
 Supported source formats:
 

--- a/site/src/content/docs/reference/video-minimal-skin.mdx
+++ b/site/src/content/docs/reference/video-minimal-skin.mdx
@@ -55,7 +55,7 @@ See <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster an
 ## Thumbnail
 
 <FrameworkCase frameworks={["react"]}>
-The skin renders a storyboard preview image while scrubbing the time slider. Eject the skin to change the image it renders.
+The skin renders a storyboard preview image while scrubbing the time slider. Pass `renderThumbnail` to replace it with your own image, for example to set `crossOrigin`, `loading`, or `fetchPriority`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/reference/video-minimal-skin.mdx
+++ b/site/src/content/docs/reference/video-minimal-skin.mdx
@@ -52,6 +52,18 @@ The skin renders a poster image before playback starts. An element with `slot="p
 
 See <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink> for complete examples.
 
+## Thumbnail
+
+<FrameworkCase frameworks={["react"]}>
+The skin renders a storyboard preview image while scrubbing the time slider. Eject the skin to change the image it renders.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+The skin renders a storyboard preview image while scrubbing the time slider. An `<img slot="thumbnail">` replaces it, so image attributes such as `crossorigin`, `loading`, and `fetchpriority` go on it.
+</FrameworkCase>
+
+See <DocsLink slug="how-to/show-timeline-thumbnail-previews">Show timeline thumbnail previews</DocsLink> for complete examples.
+
 ## Styling
 
 Packaged skins style themselves and expose a small set of public CSS custom properties. Everything else inside the skin is private and may change between releases. <DocsLink slug="how-to/customize-skins" anchor="style-a-packaged-skin">Customize skins</DocsLink> documents the properties. When you need deeper changes, eject the skin.

--- a/site/src/content/docs/reference/video-skin.mdx
+++ b/site/src/content/docs/reference/video-skin.mdx
@@ -55,7 +55,7 @@ See <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster an
 ## Thumbnail
 
 <FrameworkCase frameworks={["react"]}>
-The skin renders a storyboard preview image while scrubbing the time slider. Eject the skin to change the image it renders.
+The skin renders a storyboard preview image while scrubbing the time slider. Pass `renderThumbnail` to replace it with your own image, for example to set `crossOrigin`, `loading`, or `fetchPriority`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/reference/video-skin.mdx
+++ b/site/src/content/docs/reference/video-skin.mdx
@@ -52,6 +52,18 @@ The skin renders a poster image before playback starts. An element with `slot="p
 
 See <DocsLink slug="how-to/add-a-poster-and-loading-placeholder">Add a poster and loading placeholder</DocsLink> for complete examples.
 
+## Thumbnail
+
+<FrameworkCase frameworks={["react"]}>
+The skin renders a storyboard preview image while scrubbing the time slider. Eject the skin to change the image it renders.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+The skin renders a storyboard preview image while scrubbing the time slider. An `<img slot="thumbnail">` replaces it, so image attributes such as `crossorigin`, `loading`, and `fetchpriority` go on it.
+</FrameworkCase>
+
+See <DocsLink slug="how-to/show-timeline-thumbnail-previews">Show timeline thumbnail previews</DocsLink> for complete examples.
+
 ## Styling
 
 Packaged skins style themselves and expose a small set of public CSS custom properties. Everything else inside the skin is private and may change between releases. <DocsLink slug="how-to/customize-skins" anchor="style-a-packaged-skin">Customize skins</DocsLink> documents the properties. When you need deeper changes, eject the skin.


### PR DESCRIPTION
## Summary

Let authors supply the slider thumbnail preview image themselves, the way they already can for the poster, so they can put `crossorigin`, `loading`, or `fetchpriority` on it inside a packaged skin. HTML gets an `<img slot="thumbnail">`; React gets `renderThumbnail` on `VideoSkin` and `MinimalVideoSkin`. The skin still resolves the storyboard frame and supplies `src` and sizing.

## Changes

- Video skins (default and minimal) wrap the slider thumbnail image in `<slot name="thumbnail">`; an author's image displaces the skin's. Ejected HTML strips the slot like it does `poster`.
- The HTML skin styles a slotted thumbnail image through `::slotted()` (block display and the loading fade), since it cannot carry the skin's image class.
- `<media-thumbnail>` / `<media-slider-thumbnail>` keep `crossorigin`, `loading`, and `fetchpriority` that a supplied image already carries. Previously the element re-synced those from its own properties on every update, so an unset property removed whatever the author had set.
- React `VideoSkin` and `MinimalVideoSkin` take `renderThumbnail`, mirroring `renderPoster`. Live skins have no time slider and do not take it.
- The Mux sandbox templates slot the image on both platforms.
- Docs: packaged-skin examples in the thumbnail how-to, a Thumbnail section on the video skin references, and the authored-attribute rule on the Thumbnail reference.

```html
<video-skin>
  <video src="video.mp4" crossorigin="anonymous">
    <track kind="metadata" label="thumbnails" src="storyboard.vtt" default />
  </video>
  <img slot="thumbnail" alt="" loading="lazy" fetchpriority="low" />
</video-skin>
```

```tsx
<VideoSkin renderThumbnail={<img alt="" loading="lazy" fetchPriority="low" />} />
```

<details>
<summary>Implementation details</summary>

Attribute ownership on the thumbnail image is settled once at adoption, mirroring how the poster settles `src`: attributes the image already carries are the author's and are left alone; the element fills in the rest and removes only what it wrote when the image steps aside. Per-attribute rather than per-image because the thumbnail always owns `src`/`srcset`, and because the skin's own `<img>` is also a light-DOM image that still relies on the element for `crossorigin` inheritance from the media element.

The React target now hands authored children of every image part (`Poster`, `Thumbnail`, `Slider.Thumbnail`) to `render`, so the skin source threads the override through the controls and time slider without target-specific code. The generated preset wrappers pick `OnDemandVideoSkinProps` for on-demand video skins and keep `BaseVideoSkinProps` for live ones.

</details>

## Testing

- `pnpm -F @videojs/html test` — new cases for authored attributes and cleanup on image replacement
- `pnpm -F @videojs/skins test` — new build test asserting the slot and `::slotted` styles are HTML-only and that React threads `render`
- `pnpm -F @videojs/react test` — new `renderThumbnail` case on `VideoSkin`
- `pnpm -F @videojs/sandbox test`, `pnpm typecheck` (after rebuilding `@videojs/react` declarations)
- Regenerated skins and inspected the emitted template, CSS, ejected registry HTML, and React output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive skin and docs APIs plus thumbnail attribute handling for preview images; no auth, billing, or playback security changes.
> 
> **Overview**
> Packaged **on-demand** video skins now treat the time-slider storyboard preview like the poster: authors can supply their own `<img>` so they control `crossorigin`, `loading`, `fetchpriority`, or a framework image component. **HTML** uses `<img slot="thumbnail">` inside the skin; **React** adds **`renderThumbnail`** on generated video skins (wired through `VideoSkinComponent`, omitted for live skins with no scrubber).
> 
> The time slider wraps its preview image in a named slot with `::slotted` styling for HTML; the vjsc React target maps image-part children to `render` for poster and slider thumbnail alike. Ejected HTML strips **all** named slots, not just `poster`.
> 
> **`<media-thumbnail>`** now records which `crossorigin` / `loading` / `fetchpriority` values were on the image at adoption and leaves those alone on later updates, instead of clearing author settings when element properties are unset. Sandbox Mux templates, docs, and an ADR generalize “every skin image is authorable.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 140906f234f5324862166e01f18f0f56968a9adc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->