### PR TITLE
ci(release-pr): cancel superseded changelog runs

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -7,9 +7,10 @@ on:
 
 # release-please force-pushes the release branch on every merge to main, and each
 # push starts a fresh run here that rewrites the changelog for the branch as it
-# now stands. Back-to-back merges used to queue runs behind each other, and the
-# stale one could land its changelog commit last. Only the newest run matters, so
-# cancel any run still going when a new push arrives.
+# now stands. Each run regenerates everything from scratch, so only the run for
+# the newest push can produce the right changelog: cancel any run still going
+# when a new push arrives, rather than letting a run for an older branch state
+# finish after it and commit a stale changelog.
 concurrency:
   group: release-pr
   cancel-in-progress: true

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -5,9 +5,14 @@ on:
     branches:
       - 'release-please--branches--main'
 
+# release-please force-pushes the release branch on every merge to main, and each
+# push starts a fresh run here that rewrites the changelog for the branch as it
+# now stands. Back-to-back merges used to queue runs behind each other, and the
+# stale one could land its changelog commit last. Only the newest run matters, so
+# cancel any run still going when a new push arrives.
 concurrency:
   group: release-pr
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   changelog:


### PR DESCRIPTION
## Why

release-please force-pushes `release-please--branches--main` on every merge to `main`, and each push triggers `release-pr.yml`, which regenerates the changelog and commits it to the release branch. The `release-pr` concurrency group had `cancel-in-progress: false`, so back-to-back merges queue one run per push. A run started against an older branch state can finish after the newer one and commit a stale changelog. This is a latent race read from the workflow, not something we caught in the act during rc.2.

## What

Set `cancel-in-progress: true` on the `release-pr` concurrency group, with a comment explaining why. Only the newest push is worth finishing, and a cancelled run's work is redone in full by the run that replaced it, so nothing is lost.

## Verification

- `actionlint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ5RTqfnRMiiASH1T7tWVj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only concurrency change; aligns release-pr with other workflows and reduces changelog race risk without touching runtime code.
> 
> **Overview**
> Enables **in-progress cancellation** on the `release-pr` workflow’s concurrency group so only the latest push to `release-please--branches--main` can finish and commit the regenerated changelog.
> 
> Adds workflow comments documenting that release-please force-pushes the release branch on each merge to `main`, that every run rebuilds the changelog from scratch, and that an older run finishing after a newer one could write a **stale** `CHANGELOG.md` / site changelog commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 329d446234fa1c7f8c4fcaca7b8f1f90a387bed9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->