### PR TITLE
refactor(skin): harden style reset

### DIFF
--- a/packages/html/src/define/shared.css
+++ b/packages/html/src/define/shared.css
@@ -16,6 +16,11 @@ media-controls {
   width: 100%;
 }
 
+:host(:focus) {
+  /* The host matches :focus when a shadow control is focused; keep page styles from adding a second ring. */
+  outline: none !important;
+}
+
 media-container {
   min-width: 0;
   min-height: 0;

--- a/packages/skins/src/styles/base.css
+++ b/packages/skins/src/styles/base.css
@@ -8,15 +8,25 @@
 
 @layer base {
   @scope (.media-skin) {
+    :scope {
+      font-style: normal;
+      font-weight: 400;
+      text-align: start;
+      text-transform: none;
+      letter-spacing: normal;
+    }
+
     :scope,
     *,
     ::before,
     ::after {
       box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+      border: 0 solid;
     }
 
     button {
-      margin: 0;
       font: inherit;
       color: inherit;
       text-transform: none;
@@ -30,7 +40,6 @@
     media-icon {
       display: block;
       max-width: 100%;
-      margin: 0;
     }
 
     svg[fill="currentColor"] {
@@ -50,7 +59,6 @@
       width: 100%;
       height: 100%;
       max-width: 100%;
-      margin: 0;
       border-radius: inherit;
       object-fit: var(--media-object-fit, contain);
       object-position: var(--media-object-position, center);

--- a/packages/skins/src/styles/buttons/button.styles.ts
+++ b/packages/skins/src/styles/buttons/button.styles.ts
@@ -6,7 +6,7 @@ export default styles({
   rules: {
     root: {
       utilities: [
-        'grid size-media-control min-h-0 shrink-0 touch-manipulation select-none place-items-center rounded-media-control border-0 bg-transparent p-0 text-center text-inherit [corner-shape:var(--media-control-corner-shape)] [text-shadow:inherit]',
+        'grid size-media-control min-h-0 shrink-0 touch-manipulation select-none place-items-center rounded-media-control border-0 bg-transparent p-0 text-center text-inherit [corner-shape:var(--media-control-corner-shape)]',
         'cursor-pointer focus-ring-media',
         'will-change-[scale] duration-media-base ease-out [transition-property:background-color,color,outline-offset,scale]',
         'media-highlighted:highlight-media',
@@ -21,7 +21,7 @@ export default styles({
     },
     icon: {
       utilities: [
-        'col-start-1 row-start-1 size-media-icon drop-shadow-media-icon',
+        'col-start-1 row-start-1 size-media-icon drop-shadow-media-icon [text-shadow:inherit]',
         'transition-[opacity,scale] duration-media-base ease-out',
       ],
     },

--- a/packages/skins/src/styles/popups/dialog.styles.ts
+++ b/packages/skins/src/styles/popups/dialog.styles.ts
@@ -10,7 +10,7 @@ export default styles({
     },
     backdrop: {
       utilities: [
-        'absolute inset-0 z-40 bg-media-backdrop/20 opacity-100 backdrop-filter-media-dialog',
+        'absolute inset-0 z-40 bg-media-backdrop/20 opacity-100 backdrop-filter-media-dialog rounded-[inherit]',
         'not-data-open:hidden transition-opacity delay-media-dialog duration-media-dialog ease-out',
         'media-transitioning:opacity-0 data-ending-style:delay-0',
       ],


### PR DESCRIPTION
While testing in WordPress I noticed that the HTML skins receive focus on the skin element when clicking the play button. This removes the resulting outline from the skin while retaining focus styling on the play button itself (when `:focus-visible`). 

Also fixes an issue with the missing dialog backdrop radius and superfluous text shadows in the primary button style. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 572df92dea005bc2523407f10f8d49394852c775. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->