### PR TITLE
fix(skin): resolve blurry slider rendering

### DIFF
--- a/apps/e2e/suites/sandbox/tests/sandbox-skin-styling.spec.ts
+++ b/apps/e2e/suites/sandbox/tests/sandbox-skin-styling.spec.ts
@@ -68,7 +68,7 @@ for (const { platform, skin, styling, skins } of CASES) {
     const styles = await root.evaluate((element) => {
       const accent = 'rgb(18, 52, 86)';
       const fillUsesAccent = [...element.querySelectorAll<HTMLElement>('[data-orientation]')].some(
-        (part) => getComputedStyle(part).backgroundColor === accent
+        (part) => getComputedStyle(part, '::before').backgroundColor === accent
       );
       const style = getComputedStyle(element);
 

--- a/apps/e2e/suites/skin-parity/tests/vjsc-video-skin-styling.spec.ts
+++ b/apps/e2e/suites/skin-parity/tests/vjsc-video-skin-styling.spec.ts
@@ -485,7 +485,7 @@ test('React chapter segments match across styles and retain their generated rang
             orientation: element.getAttribute('data-orientation'),
             segment: getComputedStyle(element).clipPath,
             start: element.style.getPropertyValue('--media-slider-chapter-start'),
-            track: track && getComputedStyle(track).clipPath !== 'none' ? 'clipped' : 'none',
+            track: track && getComputedStyle(track, '::before').clipPath !== 'none' ? 'clipped' : 'none',
           };
         })
       )

--- a/apps/sandbox/app/shared/player-frame.ts
+++ b/apps/sandbox/app/shared/player-frame.ts
@@ -21,8 +21,6 @@ export function defaultPlayerWidth(player: MediaPlayer): number {
  * plain `max-w-4xl` and `max-w-xl` classes a consumer would, and `styles.css` caps those the same way.
  */
 export const PLAYER_FRAME_CLASSES = {
-  // Keep centred controls on device pixels instead of the fractional height produced by aspect-ratio.
-  video:
-    'mx-auto aspect-video max-w-[var(--sandbox-player-width,56rem)] h-[round(nearest,calc(min(var(--sandbox-player-width,56rem),100vw-1rem)*9/16),2px)]!',
+  video: 'mx-auto aspect-video max-w-[var(--sandbox-player-width,56rem)]',
   audio: 'mx-auto w-full max-w-[var(--sandbox-player-width,36rem)]',
 } as const;

--- a/apps/sandbox/app/styles.css
+++ b/apps/sandbox/app/styles.css
@@ -56,8 +56,6 @@
 #root :is(video-player, live-video-player) > :not(media-i18n),
 #root :is(video-player, live-video-player) > media-i18n > * {
   max-width: var(--sandbox-player-width, 56rem);
-  /* Keep centred controls on device pixels instead of the fractional height produced by aspect-ratio. */
-  height: round(nearest, calc(min(var(--sandbox-player-width, 56rem), 100vw - 1rem) * 9 / 16), 2px) !important;
 }
 
 #root :has(> :is(audio-player, live-audio-player)) {

--- a/packages/skins/src/styles/sliders/slider.styles.ts
+++ b/packages/skins/src/styles/sliders/slider.styles.ts
@@ -1,7 +1,10 @@
 import { styles } from 'vjsc/styles';
 
 const trackLayer = [
-  'pointer-events-none absolute rounded-[inherit]',
+  'pointer-events-none absolute inset-0 before:absolute before:inset-0 before:rounded-media-control',
+  'data-[orientation=horizontal]:before:left-(--media-slider-layer-start) data-[orientation=horizontal]:before:right-(--media-slider-layer-end)',
+  'data-[orientation=vertical]:before:top-(--media-slider-layer-end) data-[orientation=vertical]:before:bottom-(--media-slider-layer-start)',
+  'before:transition-[left,right,top,bottom] before:duration-[inherit] before:ease-out',
   'transition-[clip-path] duration-media-slider ease-out',
   'group-data-dragging/slider:duration-0 group-data-seeking/slider:duration-0 group-focus-within/slider:duration-0',
 ] as const;
@@ -25,18 +28,16 @@ export default styles({
     },
     track: {
       utilities: [
-        'relative isolate w-full select-none overflow-hidden rounded-media-pill bg-current/20',
+        'relative isolate w-full select-none rounded-media-pill before:pointer-events-none before:absolute before:inset-0 before:rounded-media-control before:bg-current/20',
         'data-[orientation=horizontal]:h-1 data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1',
       ],
     },
     fill: {
       utilities: [
         ...trackLayer,
-        'bg-media-primary',
-        'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
+        'before:bg-media-primary',
         'data-[orientation=horizontal]:clip-media-x-[--media-slider-fill]',
         'group-data-dragging/slider:data-[orientation=horizontal]:clip-media-x-[--media-slider-pointer]',
-        'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
         'data-[orientation=vertical]:clip-media-y-[--media-slider-fill]',
         'group-data-dragging/slider:data-[orientation=vertical]:clip-media-y-[--media-slider-pointer]',
       ],
@@ -44,10 +45,8 @@ export default styles({
     buffer: {
       utilities: [
         ...trackLayer,
-        'bg-current/20',
-        'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
+        'before:bg-current/20',
         'data-[orientation=horizontal]:clip-media-x-[--media-slider-buffer]',
-        'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
         'data-[orientation=vertical]:clip-media-y-[--media-slider-buffer]',
       ],
     },

--- a/packages/skins/src/styles/sliders/time-slider.styles.ts
+++ b/packages/skins/src/styles/sliders/time-slider.styles.ts
@@ -21,7 +21,7 @@ export default styles({
     chapterTrack: {
       utilities: [
         'transition-[height,width] duration-media-slow ease-out',
-        'data-[orientation=horizontal]:clip-media-chapter-track-x data-[orientation=vertical]:clip-media-chapter-track-y',
+        'data-[orientation=horizontal]:before:clip-media-chapter-track-x data-[orientation=vertical]:before:clip-media-chapter-track-y',
         'group-data-highlighted/chapter:data-[orientation=horizontal]:h-1.75',
         'group-data-highlighted/chapter:data-[orientation=vertical]:w-1.75',
       ],

--- a/packages/skins/src/styles/tailwind.css
+++ b/packages/skins/src/styles/tailwind.css
@@ -333,12 +333,26 @@
 
 /* Horizontal slider layer clipped to a progress variable, for example `clip-media-x-[--media-slider-fill]`. */
 @utility clip-media-x-* {
-  clip-path: inset(0 calc(100% - var(--value([*]))) 0 0 round var(--media-control-radius));
+  --media-slider-layer-start: calc(
+    var(--media-slider-chapter-start, 0%) + var(--media-spacing) * var(--media-chapter-inset-start, 0)
+  );
+  --media-slider-layer-end: max(
+    calc(100% - var(--value([*]))),
+    calc(100% - var(--media-slider-chapter-end, 100%) + var(--media-spacing) * var(--media-chapter-inset-end, 0))
+  );
+  clip-path: inset(-1px calc(var(--media-slider-layer-end) - 1px) -1px calc(var(--media-slider-layer-start) - 1px));
 }
 
 /* Vertical slider layer clipped to a progress variable. */
 @utility clip-media-y-* {
-  clip-path: inset(calc(100% - var(--value([*]))) 0 0 0 round var(--media-control-radius));
+  --media-slider-layer-start: calc(
+    var(--media-slider-chapter-start, 0%) + var(--media-spacing) * var(--media-chapter-inset-start, 0)
+  );
+  --media-slider-layer-end: max(
+    calc(100% - var(--value([*]))),
+    calc(100% - var(--media-slider-chapter-end, 100%) + var(--media-spacing) * var(--media-chapter-inset-end, 0))
+  );
+  clip-path: inset(calc(var(--media-slider-layer-end) - 1px) -1px calc(var(--media-slider-layer-start) - 1px) -1px);
 }
 
 /* Horizontal chapter segment clipped to its start and end. */
@@ -353,18 +367,14 @@
 
 /* Horizontal chapter track with the inter-chapter gap and rounded ends. */
 @utility clip-media-chapter-track-x {
-  clip-path: inset(
-    0 calc(100% - var(--media-slider-chapter-end) + var(--media-spacing) * var(--media-chapter-inset-end)) 0
-      calc(var(--media-slider-chapter-start) + var(--media-spacing) * var(--media-chapter-inset-start)) round
-      var(--media-control-radius)
-  );
+  left: calc(var(--media-slider-chapter-start) + var(--media-spacing) * var(--media-chapter-inset-start));
+  right: calc(100% - var(--media-slider-chapter-end) + var(--media-spacing) * var(--media-chapter-inset-end));
+  clip-path: inset(-1px);
 }
 
 /* Vertical chapter track with the inter-chapter gap and rounded ends. */
 @utility clip-media-chapter-track-y {
-  clip-path: inset(
-    calc(100% - var(--media-slider-chapter-end) + var(--media-spacing) * var(--media-chapter-inset-end)) 0
-      calc(var(--media-slider-chapter-start) + var(--media-spacing) * var(--media-chapter-inset-start)) 0 round
-      var(--media-control-radius)
-  );
+  top: calc(100% - var(--media-slider-chapter-end) + var(--media-spacing) * var(--media-chapter-inset-end));
+  bottom: calc(var(--media-slider-chapter-start) + var(--media-spacing) * var(--media-chapter-inset-start));
+  clip-path: inset(-1px);
 }

--- a/packages/skins/src/styles/vars.ts
+++ b/packages/skins/src/styles/vars.ts
@@ -428,6 +428,14 @@ export const vars = {
     kind: 'runtime',
     description: 'Buffered percentage published by Slider and consumed by the Skin.',
   },
+  '--media-slider-layer-start': {
+    kind: 'internal',
+    description: 'Start inset of a painted slider layer, including its chapter gap.',
+  },
+  '--media-slider-layer-end': {
+    kind: 'internal',
+    description: 'End inset of a painted slider layer, limited by progress and its chapter gap.',
+  },
   '--media-slider-chapter-end': {
     kind: 'runtime',
     description: 'Chapter end percentage published by Time Slider and consumed by the Skin.',


### PR DESCRIPTION
## Summary

Previously, `clip-path` did two jobs: **hide the unfilled portion** and **draw the rounded shape**. At fractional screen positions, the rounded clip antialiased the top edge. Nested clips made that edge darker still.

The fix separates those jobs:

- **A `::before` element paints each layer**—empty track, buffer, and progress—with normal `border-radius`. Its dimensions include the chapter boundaries and gaps.
- **A rectangular `clip-path` controls visibility.** It sits 1px outside the painted shape, so it doesn’t cut through the rounded edges and antialias them again.

That 1px clearance changes only the invisible clipping boundary. The painted track remains 4px tall, with its original radius. Our earlier experiment expanded the *rounded shape itself*, which is why its caps looked wrong.

The player can now retain its natural fractional height. We’re fixing how the track is painted rather than rounding the container to hide the problem.

### Before

<img width="614" alt="CleanShot 2026-09-10 at 6 59 03 PM@2x" src="https://github.com/user-attachments/assets/eef5756b-39b4-4bb5-b893-b16bfad7f772" />

### After

<img width="616" alt="CleanShot 2026-09-10 at 6 59 52 PM@2x" src="https://github.com/user-attachments/assets/8a42dad6-1f9d-4355-8ce7-29632a2f243c" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared slider styling and clip utilities used by seek and volume controls across skins; visual parity is covered by updated e2e tests but chapter/progress edge cases depend on the new layer model.
> 
> **Overview**
> Fixes **blurry seek/volume slider edges** by splitting **painting** from **visibility**: track, buffer, and progress now render on **`::before`** layers with normal `border-radius`, while parent elements use a **rectangular `clip-path` inset 1px outside** the painted shape so clipping no longer antialiases rounded caps. `clip-media-x/y` utilities compute new internal tokens **`--media-slider-layer-start`** and **`--media-slider-layer-end`** (chapter gaps included); chapter track clipping moves to **`::before`** with positioning via `left`/`right` or `top`/`bottom` instead of rounded clip-path alone.
> 
> The sandbox **drops the forced `round(nearest, …)` video height** in `PLAYER_FRAME_CLASSES` and `styles.css`, since fractional `aspect-video` height is acceptable once the slider is fixed.
> 
> E2E contracts now assert accent fill and chapter track clipping on **`::before`** pseudo-elements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf8607d50852198da02ab2a3c1a5ceec9ec1352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->