### PR TITLE
fix(skin): restore intrinsic height

### DIFF
--- a/apps/e2e/suites/player/tests/skin-container.spec.ts
+++ b/apps/e2e/suites/player/tests/skin-container.spec.ts
@@ -47,6 +47,48 @@ for (const { framework, path } of SOURCE_SKINS) {
 }
 
 for (const { framework, path, selector } of POSTER_SKINS) {
+  test(`fits a supplied poster despite a page image reset — ${framework}`, async ({ page }) => {
+    await page.route('https://image.mux.com/**/thumbnail*', (route) =>
+      route.fulfill({
+        contentType: 'image/svg+xml',
+        headers: { 'Access-Control-Allow-Origin': '*' },
+        body: '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="200"><rect width="100" height="200" fill="red"/></svg>',
+      })
+    );
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+    await page.addStyleTag({ content: '@layer base { img { max-width: 100%; height: auto; } }' });
+
+    const image = page.locator(selector).first();
+    const skin = page.locator('video-skin, [data-source-skin], .media-skin').first();
+
+    await expect.poll(() => image.evaluate((element: HTMLImageElement) => element.naturalWidth)).toBeGreaterThan(0);
+    await expect(image).toHaveCSS('object-fit', 'contain');
+    await expect(image).toHaveCSS('object-position', '50% 50%');
+    expect(await image.boundingBox()).toEqual(await skin.boundingBox());
+  });
+
+  test(`sizes the skin from the media without an explicit aspect ratio — ${framework}`, async ({ page }) => {
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+
+    const skin = page.locator('video-skin, [data-source-skin], .media-skin').first();
+    const video = page.locator('video').first();
+
+    await expect.poll(() => video.evaluate((element: HTMLVideoElement) => element.videoWidth)).toBeGreaterThan(0);
+    await skin.evaluate((element: HTMLElement) => {
+      element.style.aspectRatio = 'auto';
+      element.style.height = 'auto';
+    });
+
+    await expect
+      .poll(async () => {
+        const box = await skin.boundingBox();
+        const ratio = await video.evaluate((element: HTMLVideoElement) => element.videoWidth / element.videoHeight);
+
+        return Math.abs((box?.height ?? 0) - (box?.width ?? 0) / ratio);
+      })
+      .toBeLessThan(1);
+  });
+
   test(`hides a source-less poster image — ${framework}`, async ({ page }) => {
     await page.goto(path, { waitUntil: 'domcontentloaded' });
 

--- a/apps/e2e/suites/skin-parity/tests/vjsc-video-skin-styling.spec.ts
+++ b/apps/e2e/suites/skin-parity/tests/vjsc-video-skin-styling.spec.ts
@@ -27,6 +27,26 @@ const BUFFERING_INDICATOR_SELECTOR =
 const CONTROLS_SELECTOR = '.video-controls';
 
 for (const variant of CASES) {
+  test(`${variant.framework} ${variant.skin} keeps poster sizing and fit in sync`, async ({ page }) => {
+    const { panels } = await openComparison(page, { ...variant, width: 800 }, async () => {});
+
+    for (const { root } of panels) {
+      const image = root.locator('img').first();
+
+      await image.evaluate((element: HTMLImageElement) => {
+        element.removeAttribute('srcset');
+        element.src = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="100" height="200"><rect width="100" height="200" fill="red"/></svg>')}`;
+      });
+      await expect.poll(() => image.evaluate((element: HTMLImageElement) => element.naturalHeight)).toBe(200);
+      await expect(image).toHaveCSS('object-fit', 'contain');
+      await expect(image).toHaveCSS('object-position', '50% 50%');
+      expect(await frameRect(image)).toEqual(await frameRect(root));
+
+      await root.evaluate((element: HTMLElement) => element.style.setProperty('--media-object-fit', 'cover'));
+      await expect(image).toHaveCSS('object-fit', 'cover');
+    }
+  });
+
   test(`${variant.framework} ${variant.skin} keeps CSS and Tailwind layout in sync`, async ({ page }) => {
     for (const width of WIDTHS) {
       const { css, tailwind } = await openVariants(page, variant, width);

--- a/apps/sandbox/app/shared/html/registry-skins.ts
+++ b/apps/sandbox/app/shared/html/registry-skins.ts
@@ -117,7 +117,9 @@ export function defineTemplateSkin(tagName: string, source: SkinTemplate): strin
         poster.removeAttribute('slot');
 
         // The template's image carries the skin's image class, which a slotted poster takes over.
-        if (posterTarget) poster.classList.add(...posterTarget.classList);
+        const image = posterTarget instanceof HTMLSlotElement ? posterTarget.querySelector('img') : posterTarget;
+
+        if (image) poster.classList.add(...image.classList);
 
         posterTarget?.replaceWith(poster);
       } else if (posterTarget instanceof HTMLSlotElement) {

--- a/packages/skins/src/skins/shared/audio/skin.styles.ts
+++ b/packages/skins/src/skins/shared/audio/skin.styles.ts
@@ -6,7 +6,7 @@ export default styles({
   rules: {
     root: {
       scopeRoot: true,
-      utilities: 'h-auto! overflow-visible! bg-transparent! [container-type:inline-size]! after:hidden',
+      utilities: 'h-auto! overflow-visible! bg-transparent! after:hidden',
     },
   },
 });

--- a/packages/skins/src/styles/layout/container.styles.ts
+++ b/packages/skins/src/styles/layout/container.styles.ts
@@ -11,7 +11,7 @@ export default styles({
       className: 'media-container',
       scopeRoot: true,
       utilities: [
-        'relative isolate block h-full w-full overflow-clip rounded-media-player bg-media-background @container/media-root [container-type:size]',
+        'relative isolate block h-full w-full overflow-clip rounded-media-player bg-media-background @container/media-root',
         '[--spacing:var(--media-spacing)] font-media text-media leading-normal subpixel-antialiased',
         'outline-2 -outline-offset-4 outline-transparent transition-[outline-offset,outline-color] duration-media-fast ease-out',
         'focus-visible:outline-media-ring focus-visible:outline-offset-2',

--- a/packages/skins/src/styles/layout/poster.styles.ts
+++ b/packages/skins/src/styles/layout/poster.styles.ts
@@ -16,6 +16,8 @@ export default styles({
         'shadow-dom': [
           '[&>slot::slotted(img:not([src]):not([srcset]))]:invisible',
           '[&>slot::slotted(img)]:layer-media [&>slot::slotted(img)]:object-media',
+          // Page resets such as Tailwind's `img { height: auto }` outrank normal slotted styles.
+          '[&>slot::slotted(img)]:h-full!',
         ],
       },
     },


### PR DESCRIPTION
## Summary

### Container Fix

`container-type: size` makes an element a query container for both width and height. Descendants can respond to either dimension using container queries.

It also applies **size containment**: the element is sized as though its children weren’t there. Its dimensions must come from things like explicit sizing, an aspect ratio, or its surrounding layout. That’s why our player collapsed to zero height: the video could no longer determine the container’s height.

`container-type: inline-size` only contains the inline dimension, normally width. It supports our width-based responsive queries while allowing the video to determine the player’s height.

Closes #2706 

### Poster fix

This PR also fixes issues with the HTML skins rendering poster images incorrectly: 

- The CSS/HTML skin was stretching the image to the container size. 
- The Tailwind/HTML skin was displaying the image in the top-left corner. 

Both issues can be observed here:
https://v10-sandbox.vercel.app/?platform=html&styling=css&media=video&skin=default&source=hls-7&autoplay=0&muted=0&loop=0&preload=metadata&locale=en&scheme=auto&dir=auto&compare=styling
(until this PR is merged, of course)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Layout and poster CSS affect all video/HTML skins and shadow-DOM slotted content; changes are targeted but user-visible sizing regressions are possible across frameworks.
> 
> **Overview**
> Restores **intrinsic player height** by dropping `container-type: size` (and related `container-type` utilities on the audio skin) from layout styles so the media element can size the container again instead of size containment collapsing height to zero.
> 
> Fixes **HTML poster rendering** when posters are slotted from the page: adds `h-full!` on shadow-DOM slotted images so global `img` resets (e.g. Tailwind `height: auto`) don’t win, and updates sandbox registry skin wiring to copy poster **image** classes from the template slot’s inner `img`, not the slot node.
> 
> Adds **Playwright coverage** for poster fit under page image resets, skin height derived from video without an explicit aspect ratio, and CSS/Tailwind poster sizing parity across skin variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ea65ed011a7cef5ce3a0d0ef9121b9ce0357d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->