### PR TITLE
feat(sandbox): add aspect ratio preview option

### DIFF
--- a/apps/e2e/suites/sandbox/tests/sandbox-compare.spec.ts
+++ b/apps/e2e/suites/sandbox/tests/sandbox-compare.spec.ts
@@ -41,6 +41,51 @@ async function playerBox(frame: Frame) {
 }
 
 test.describe('Sandbox compare', () => {
+  for (const platform of ['html', 'react']) {
+    test(`changes the ${platform} aspect ratio in both panels without reloading`, async ({ page }) => {
+      await page.setViewportSize({ width: 1600, height: 1000 });
+      await page.goto(
+        `${SANDBOX_BASE}/?platform=${platform}&media=video&skins=authored&compare=styling&layout=row&width=480&${QUERY}`
+      );
+
+      const frames = await Promise.all([getPanelFrame(page, 'css'), getPanelFrame(page, 'tailwind')]);
+      const urls = frames.map((frame) => frame.url());
+      const options = page.getByRole('button', { name: 'Options', exact: true });
+
+      if ((await options.getAttribute('aria-expanded')) !== 'true') await options.click();
+
+      for (const [label, height] of [
+        ['4:3', 360],
+        ['1:1', 480],
+        ['9:16', 853],
+        ['21:9', 206],
+        ['Intrinsic', 270],
+        ['16:9', 270],
+      ] as const) {
+        await page.getByRole('combobox', { name: 'Aspect ratio', exact: true }).click();
+        await page.getByRole('option', { name: label, exact: true }).click();
+
+        for (const frame of frames) {
+          await expect.poll(async () => Math.round((await playerBox(frame)).height)).toBe(height);
+        }
+
+        expect(frames.map((frame) => frame.url())).toEqual(urls);
+        const ratio = new URL(page.url()).searchParams.get('ratio');
+
+        expect(ratio).toBe(label === '16:9' ? null : label.toLowerCase());
+      }
+
+      await page.getByRole('combobox', { name: 'Aspect ratio', exact: true }).click();
+      await page.getByRole('option', { name: '4:3', exact: true }).click();
+      await page.reload();
+      await expect(page.getByRole('combobox', { name: 'Aspect ratio', exact: true })).toHaveText('4:3');
+
+      for (const id of ['css', 'tailwind']) {
+        await expect.poll(async () => Math.round((await playerBox(await getPanelFrame(page, id))).height)).toBe(360);
+      }
+    });
+  }
+
   test('compares the two stylings side by side with one width', async ({ page }) => {
     await page.setViewportSize({ width: 1600, height: 900 });
     await page.goto(`${SANDBOX_BASE}/?platform=react&media=video&compare=styling&layout=row&width=480&${QUERY}`, {

--- a/apps/sandbox/app/shared/player-frame.ts
+++ b/apps/sandbox/app/shared/player-frame.ts
@@ -10,19 +10,16 @@ export const PLAYER_WIDTH = {
   stops: [384, 512, 672, 960, 1360],
 } as const;
 
+export const ASPECT_RATIOS = ['intrinsic', '16:9', '4:3', '1:1', '9:16', '21:9'] as const;
+export type AspectRatio = (typeof ASPECT_RATIOS)[number];
+
 /** The width a preview opens at before the control is touched: the video skins' `4xl` cap or the audio skins' `xl`. */
 export function defaultPlayerWidth(player: MediaPlayer): number {
   return player === 'audio' ? 576 : 896;
 }
 
-/**
- * How the React skin components frame their player: centred, and capped by the shell's width control through
- * `--sandbox-player-width`, with the skin's own cap when a page is opened without one. The html templates write the
- * plain `max-w-4xl` and `max-w-xl` classes a consumer would, and `styles.css` caps those the same way.
- */
+/** Shared preview framing; `styles.css` applies the video's width and aspect-ratio preferences. */
 export const PLAYER_FRAME_CLASSES = {
-  // Keep centred controls on device pixels instead of the fractional height produced by aspect-ratio.
-  video:
-    'mx-auto aspect-video max-w-[var(--sandbox-player-width,56rem)] h-[round(nearest,calc(min(var(--sandbox-player-width,56rem),100vw-1rem)*9/16),2px)]!',
+  video: 'sandbox-video-frame mx-auto max-w-[var(--sandbox-player-width,56rem)]',
   audio: 'mx-auto w-full max-w-[var(--sandbox-player-width,36rem)]',
 } as const;

--- a/apps/sandbox/app/shared/sandbox-listener.ts
+++ b/apps/sandbox/app/shared/sandbox-listener.ts
@@ -6,6 +6,7 @@ import { isBoolean, isNumber, isString } from '@videojs/utils/predicate';
 
 import { CAPTIONS_MODES, type CaptionsMode } from './captions';
 import { setDocumentDirection } from './i18n/document-locale';
+import { ASPECT_RATIOS, type AspectRatio } from './player-frame';
 import { defaultSkinSource } from './skin-sources';
 import { DEFAULT_SOURCE, SOURCES, type SourceId } from './sources';
 
@@ -200,6 +201,10 @@ function parseWidth(value: unknown): number | undefined {
   return Number.isFinite(width) && width > 0 ? width : undefined;
 }
 
+function parseAspectRatio(value: unknown): AspectRatio | undefined {
+  return isOneOf(ASPECT_RATIOS, value) ? value : undefined;
+}
+
 function parseScheme(value: unknown): ColorScheme | undefined {
   return isOneOf(COLOR_SCHEMES, value) ? value : undefined;
 }
@@ -232,6 +237,13 @@ preference('accent', parseAccent, (accent) => {
 preference('width', parseWidth, (width) => {
   if (width) style.setProperty('--sandbox-player-width', `${width}px`);
   else style.removeProperty('--sandbox-player-width');
+});
+
+preference('ratio', parseAspectRatio, (ratio) => {
+  document.documentElement.dataset.aspectRatio = ratio ?? '16:9';
+
+  if (ratio && ratio !== 'intrinsic') style.setProperty('--sandbox-player-ratio', ratio.replace(':', ' / '));
+  else style.removeProperty('--sandbox-player-ratio');
 });
 
 // `color-scheme` and the `dark:` variant both key off this attribute; see `styles.css`.

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -15,7 +15,7 @@ import { COMPARE_LABELS } from '@app/labels';
 import { hasTailwindSkin, isMediaId, MEDIA, type MediaId, mediaSources } from '@app/media';
 import { CAPTIONS_MODES, type CaptionsMode } from '@app/shared/captions';
 import { DEFAULT_SANDBOX_LOCALE, SANDBOX_LOCALE_TAGS, type SandboxLocaleTag } from '@app/shared/i18n/locale-meta';
-import { defaultPlayerWidth, PLAYER_WIDTH } from '@app/shared/player-frame';
+import { ASPECT_RATIOS, type AspectRatio, defaultPlayerWidth, PLAYER_WIDTH } from '@app/shared/player-frame';
 import {
   COLOR_SCHEMES,
   type ColorScheme,
@@ -86,6 +86,7 @@ function readParams() {
     accentColor: params.get('accent')?.trim() ?? '',
     locale: readOption(SANDBOX_LOCALE_TAGS, params.get('locale'), DEFAULT_SANDBOX_LOCALE),
     width: readWidth(params.get('width')),
+    ratio: readOption(ASPECT_RATIOS, params.get('ratio'), '16:9'),
     scheme: readOption(COLOR_SCHEMES, params.get('scheme'), 'auto'),
     direction: readOption(TEXT_DIRECTIONS, params.get('dir'), 'auto'),
     compare: readOption(COMPARE_AXES, params.get('compare'), 'off'),
@@ -117,6 +118,7 @@ function storeOptionsOpen(open: boolean): void {
 function postPreferences(target: Window, params: FrameParams): void {
   target.postMessage({ type: 'accent-change', accent: params.accentColor }, '*');
   target.postMessage({ type: 'width-change', width: params.width }, '*');
+  target.postMessage({ type: 'ratio-change', ratio: params.ratio }, '*');
   target.postMessage({ type: 'scheme-change', scheme: params.scheme }, '*');
   target.postMessage({ type: 'dir-change', dir: params.direction }, '*');
   target.postMessage({ type: 'mirror-change', mirror: params.mirror }, '*');
@@ -138,6 +140,7 @@ export function App() {
   const [accentColor, setAccentColor] = useState(initial.accentColor);
   const [locale, setLocale] = useState<SandboxLocaleTag>(initial.locale);
   const [width, setWidth] = useState(initial.width);
+  const [ratio, setRatio] = useState<AspectRatio>(initial.ratio);
   const [scheme, setScheme] = useState<ColorScheme>(initial.scheme);
   const [direction, setDirection] = useState<TextDirection>(initial.direction);
   const [compare, setCompare] = useState<CompareMode>(initial.compare);
@@ -190,6 +193,7 @@ export function App() {
     captions,
     accentColor,
     playerWidth,
+    ratio,
     scheme,
     direction,
     mirroring: false,
@@ -208,6 +212,7 @@ export function App() {
     locale,
     accentColor,
     width: playerWidth,
+    ratio,
     scheme,
     direction,
     mirror: mirroring,
@@ -236,6 +241,8 @@ export function App() {
 
     if (width !== undefined) params.set('width', String(width));
 
+    if (ratio !== '16:9') params.set('ratio', ratio);
+
     if (skins !== undefined) params.set('skins', skins);
 
     if (compare !== 'off') {
@@ -262,6 +269,7 @@ export function App() {
     accentColor,
     locale,
     width,
+    ratio,
     scheme,
     direction,
     compare,
@@ -304,6 +312,8 @@ export function App() {
 
     if (previous.playerWidth !== playerWidth) post({ type: 'width-change', width: playerWidth });
 
+    if (previous.ratio !== ratio) post({ type: 'ratio-change', ratio });
+
     if (previous.scheme !== scheme) post({ type: 'scheme-change', scheme });
 
     if (previous.direction !== direction) post({ type: 'dir-change', dir: direction });
@@ -320,11 +330,26 @@ export function App() {
       captions,
       accentColor,
       playerWidth,
+      ratio,
       scheme,
       direction,
       mirroring,
     };
-  }, [skin, source, autoplay, muted, loop, preload, captions, accentColor, playerWidth, scheme, direction, mirroring]);
+  }, [
+    skin,
+    source,
+    autoplay,
+    muted,
+    loop,
+    preload,
+    captions,
+    accentColor,
+    playerWidth,
+    ratio,
+    scheme,
+    direction,
+    mirroring,
+  ]);
 
   // Keep the last few errors the frames relay, tagged with the panel they came from, for the report.
   useEffect(() => {
@@ -506,6 +531,9 @@ export function App() {
           width={playerWidth}
           onWidthChange={setWidth}
           widthDisabled={!resizable}
+          ratio={ratio}
+          onRatioChange={setRatio}
+          ratioDisabled={descriptor.player !== 'video'}
           scheme={scheme}
           onSchemeChange={setScheme}
           direction={direction}

--- a/apps/sandbox/app/shell/options-panel.tsx
+++ b/apps/sandbox/app/shell/options-panel.tsx
@@ -16,7 +16,7 @@ import { Slider } from '@app/components/ui/slider';
 import { Switch } from '@app/components/ui/switch';
 import { CAPTIONS_MODES, type CaptionsMode } from '@app/shared/captions';
 import { SANDBOX_LOCALE_OPTION_GROUPS, type SandboxLocaleTag } from '@app/shared/i18n/locale-meta';
-import { PLAYER_WIDTH } from '@app/shared/player-frame';
+import { ASPECT_RATIOS, type AspectRatio, PLAYER_WIDTH } from '@app/shared/player-frame';
 import {
   COLOR_SCHEMES,
   type ColorScheme,
@@ -38,6 +38,9 @@ export type OptionsPanelProps = {
   width: number;
   onWidthChange: (value: number) => void;
   widthDisabled: boolean;
+  ratio: AspectRatio;
+  onRatioChange: (value: AspectRatio) => void;
+  ratioDisabled: boolean;
   scheme: ColorScheme;
   onSchemeChange: (value: ColorScheme) => void;
   direction: TextDirection;
@@ -87,6 +90,9 @@ export function OptionsPanel({
   width,
   onWidthChange,
   widthDisabled,
+  ratio,
+  onRatioChange,
+  ratioDisabled,
   scheme,
   onSchemeChange,
   direction,
@@ -161,6 +167,13 @@ export function OptionsPanel({
       <SidebarContent className="gap-0">
         <Section title="Preview">
           <WidthControl value={width} onChange={onWidthChange} disabled={widthDisabled} />
+          <SelectField
+            label="Aspect ratio"
+            value={ratio}
+            onChange={(value) => onRatioChange(value as AspectRatio)}
+            disabled={ratioDisabled}
+            options={ASPECT_RATIOS.map((value) => ({ value, label: value === 'intrinsic' ? 'Intrinsic' : value }))}
+          />
           <SelectField
             id={schemeId}
             label="Color scheme"

--- a/apps/sandbox/app/shell/preview.tsx
+++ b/apps/sandbox/app/shell/preview.tsx
@@ -8,6 +8,7 @@ import { LAYOUT_LABELS } from '@app/labels';
 import type { MediaId } from '@app/media';
 import type { CaptionsMode } from '@app/shared/captions';
 import type { SandboxLocaleTag } from '@app/shared/i18n/locale-meta';
+import type { AspectRatio } from '@app/shared/player-frame';
 import type { ColorScheme, PreloadValue, TextDirection } from '@app/shared/sandbox-listener';
 import type { SourceId } from '@app/shared/sources';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/16/solid';
@@ -34,6 +35,7 @@ export interface FrameParams {
   readonly locale: SandboxLocaleTag;
   readonly accentColor: string;
   readonly width: number;
+  readonly ratio: AspectRatio;
   readonly scheme: ColorScheme;
   readonly direction: TextDirection;
   /** Mirror playback between compare panels. */
@@ -75,6 +77,7 @@ function buildUrl(panel: ComparePanel, params: FrameParams, bustCache = false): 
     preload: params.preload,
     locale: params.locale,
     width: String(params.width),
+    ratio: params.ratio,
     scheme: params.scheme,
     dir: params.direction,
   });

--- a/apps/sandbox/app/styles.css
+++ b/apps/sandbox/app/styles.css
@@ -46,18 +46,14 @@
   }
 }
 
-/*
- * The shell's width control sizes the player through `--sandbox-player-width` (see `shared/player-frame.ts`). The html
- * templates frame their player with the classes a consumer would write, `max-w-4xl` and `max-w-xl`, and these unlayered
- * rules cap them at the control's width instead, falling back to those same widths when a page is opened without one.
- * React pages take the equivalent classes through `VideoSkinComponent` and `AudioSkinComponent`. The CDN page puts
- * `<media-i18n>` inside the player rather than around it, hence the second selector.
- */
-#root :is(video-player, live-video-player) > :not(media-i18n),
-#root :is(video-player, live-video-player) > media-i18n > * {
+/* Shared by HTML, React, and CDN previews, including pages opened outside the shell. */
+.sandbox-video-frame {
   max-width: var(--sandbox-player-width, 56rem);
-  /* Keep centred controls on device pixels instead of the fractional height produced by aspect-ratio. */
-  height: round(nearest, calc(min(var(--sandbox-player-width, 56rem), 100vw - 1rem) * 9 / 16), 2px) !important;
+  aspect-ratio: var(--sandbox-player-ratio, 16 / 9);
+}
+
+[data-aspect-ratio="intrinsic"] .sandbox-video-frame {
+  aspect-ratio: auto;
 }
 
 #root :has(> :is(audio-player, live-audio-player)) {

--- a/apps/sandbox/templates/cdn/main.ts
+++ b/apps/sandbox/templates/cdn/main.ts
@@ -379,7 +379,7 @@ async function render() {
   }
 
   const skin = html`
-    <${skinTag} class="mx-auto aspect-video max-w-4xl">
+    <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
       <${mediaTag} ${mediaClassAttr} ${sourceAttr} ${mediaAttrs} playsinline ${crossoriginAttr}>
         ${skinnedVideo ? renderChapters(getChapters(state.source)) : ''}
         ${renderStoryboard(storyboard)}

--- a/apps/sandbox/templates/html-cloudflare-video/main.ts
+++ b/apps/sandbox/templates/html-cloudflare-video/main.ts
@@ -8,7 +8,7 @@ createHtmlSandbox({
   player: 'video',
   render: ({ skinTag }) => html`
     <video-player>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <cloudflare-video class="block h-full w-full" src="${CLOUDFLARE_VIDEO_SRC}" playsinline></cloudflare-video>
       </${skinTag}>
     </video-player>

--- a/apps/sandbox/templates/html-dash-video/main.ts
+++ b/apps/sandbox/templates/html-dash-video/main.ts
@@ -8,7 +8,7 @@ createHtmlSandbox({
   player: 'video',
   render: ({ skinTag, src, attrs, storyboard, poster }) => html`
     <video-player>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <dash-video${src} ${attrs} playsinline crossorigin>${storyboard}</dash-video>
         <!-- Mux Data is an opt-in media component. It hands the dash.js engine to the Mux Data
              SDK, so views carry stream-level detail. These streams aren't Mux-hosted, so the

--- a/apps/sandbox/templates/html-hls-video/main.ts
+++ b/apps/sandbox/templates/html-hls-video/main.ts
@@ -9,7 +9,7 @@ createHtmlSandbox({
   live: true,
   render: ({ playerTag, skinTag, src, attrs, chapters, storyboard, poster }) => html`
     <${playerTag}>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <hls-video${src} ${attrs} playsinline crossorigin>
           ${chapters}
           ${storyboard}

--- a/apps/sandbox/templates/html-hlsjs-video/main.ts
+++ b/apps/sandbox/templates/html-hlsjs-video/main.ts
@@ -14,7 +14,7 @@ createHtmlSandbox({
   playbackOverrides: true,
   render: ({ playerTag, skinTag, src, attrs, chapters, storyboard, poster }) => html`
     <${playerTag}>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <hlsjs-video${src} ${attrs} playsinline crossorigin>
           ${chapters}
           ${storyboard}

--- a/apps/sandbox/templates/html-mux-video-spf/main.ts
+++ b/apps/sandbox/templates/html-mux-video-spf/main.ts
@@ -25,7 +25,7 @@ createHtmlSandbox({
   live: true,
   render: ({ playerTag, skinTag, src, attrs, poster, placeholder }) => html`
     <${playerTag}${poster ? ` poster="${poster}"` : ''}>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <!-- The player fills in the poster; the slotted image paints a blurred placeholder underneath while it loads. -->
         ${placeholder ? html`<img slot="poster" alt="" crossorigin style="background: url('${placeholder}') var(--media-object-position, center) / contain no-repeat" />` : ''}
         <!-- The storyboard track is derived automatically from the Mux src. -->

--- a/apps/sandbox/templates/html-mux-video/main.ts
+++ b/apps/sandbox/templates/html-mux-video/main.ts
@@ -16,7 +16,7 @@ createHtmlSandbox({
   playbackOverrides: true,
   render: ({ playerTag, skinTag, src, attrs, chapters, poster, placeholder }) => html`
     <${playerTag}${poster ? ` poster="${poster}"` : ''}>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <!-- The player fills in the poster; the slotted image paints a blurred placeholder underneath while it loads. -->
         ${placeholder ? html`<img slot="poster" alt="" crossorigin style="background: url('${placeholder}') var(--media-object-position, center) / contain no-repeat" />` : ''}
         <!-- The storyboard track is derived automatically from the Mux src. The slotted image replaces the skin's

--- a/apps/sandbox/templates/html-native-hls-video/main.ts
+++ b/apps/sandbox/templates/html-native-hls-video/main.ts
@@ -9,7 +9,7 @@ createHtmlSandbox({
   live: true,
   render: ({ playerTag, skinTag, src, attrs, chapters, storyboard, poster }) => html`
     <${playerTag}>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <native-hls-video${src} ${attrs} playsinline crossorigin>
           ${chapters}
           ${storyboard}

--- a/apps/sandbox/templates/html-shaka-video/main.ts
+++ b/apps/sandbox/templates/html-shaka-video/main.ts
@@ -7,7 +7,7 @@ createHtmlSandbox({
   player: 'video',
   render: ({ skinTag, src, attrs, storyboard, poster }) => html`
     <video-player>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <!-- Shaka plays DASH and HLS from the same element, so the source list here is not
              narrowed to one manifest format the way the dash.js sandbox is. -->
         <shaka-video${src} ${attrs} playsinline crossorigin>${storyboard}</shaka-video>

--- a/apps/sandbox/templates/html-tiktok-video/main.ts
+++ b/apps/sandbox/templates/html-tiktok-video/main.ts
@@ -8,7 +8,7 @@ createHtmlSandbox({
   player: 'video',
   render: ({ skinTag }) => html`
     <video-player>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <!-- The host element floors itself at TikTok's portrait 325x578; clear that so it fits a landscape box. -->
         <tiktok-video class="block h-full min-h-0 w-full min-w-0" src="${TIKTOK_VIDEO_SRC}" playsinline></tiktok-video>
       </${skinTag}>

--- a/apps/sandbox/templates/html-twitch-video/main.ts
+++ b/apps/sandbox/templates/html-twitch-video/main.ts
@@ -8,7 +8,7 @@ createHtmlSandbox({
   player: 'video',
   render: ({ skinTag }) => html`
     <video-player>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <twitch-video class="block h-full w-full" src="${TWITCH_VIDEO_SRC}" playsinline></twitch-video>
       </${skinTag}>
     </video-player>

--- a/apps/sandbox/templates/html-video/main.ts
+++ b/apps/sandbox/templates/html-video/main.ts
@@ -6,7 +6,7 @@ createHtmlSandbox({
   player: 'video',
   render: ({ skinTag, src, attrs, chapters, storyboard, poster }) => html`
     <video-player>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <video${src} ${attrs} playsinline crossorigin>
           ${chapters}
           ${storyboard}

--- a/apps/sandbox/templates/html-vimeo-video/main.ts
+++ b/apps/sandbox/templates/html-vimeo-video/main.ts
@@ -8,7 +8,7 @@ createHtmlSandbox({
   player: 'video',
   render: ({ skinTag }) => html`
     <video-player>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <vimeo-video class="block h-full w-full" src="${VIMEO_VIDEO_SRC}" playsinline></vimeo-video>
       </${skinTag}>
     </video-player>

--- a/apps/sandbox/templates/html-wistia-video/main.ts
+++ b/apps/sandbox/templates/html-wistia-video/main.ts
@@ -8,7 +8,7 @@ createHtmlSandbox({
   player: 'video',
   render: ({ skinTag }) => html`
     <video-player>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <wistia-video class="block h-full w-full" src="${WISTIA_VIDEO_SRC}" playsinline></wistia-video>
       </${skinTag}>
     </video-player>

--- a/apps/sandbox/templates/html-youtube-video/main.ts
+++ b/apps/sandbox/templates/html-youtube-video/main.ts
@@ -8,7 +8,7 @@ createHtmlSandbox({
   player: 'video',
   render: ({ skinTag }) => html`
     <video-player>
-      <${skinTag} class="mx-auto aspect-video max-w-4xl">
+      <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <youtube-video class="block h-full w-full" src="${YOUTUBE_VIDEO_SRC}" playsinline></youtube-video>
       </${skinTag}>
     </video-player>


### PR DESCRIPTION
## Summary

Add an **Aspect ratio** option to the sandbox preview options so we can discover issues like #2706 before users do. The default is still `16:9`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sandbox preview and styling-only changes with e2e coverage; default remains 16:9 and behavior is isolated to the dev sandbox.
> 
> **Overview**
> Adds an **Aspect ratio** control to the sandbox options panel (video only), with choices including intrinsic, 16:9, 4:3, 1:1, 9:16, and 21:9. The selection syncs to the URL as `?ratio=` (default 16:9 is omitted), flows into preview iframe URLs, and updates both compare panels live via `ratio-change` postMessage without reloading.
> 
> Preview framing moves from fixed `aspect-video` Tailwind on skins to a shared **`sandbox-video-frame`** class driven by `--sandbox-player-ratio` and `data-aspect-ratio` on the document (intrinsic clears forced aspect ratio). HTML, CDN, and React video previews all use this path.
> 
> New Playwright coverage exercises aspect-ratio changes in CSS vs Tailwind compare mode for **html** and **react**, including URL persistence after reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16bf07217ca95c4f2877f45e2886d975482b6d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->