### PR TITLE
fix(react): route media event props on embed medias

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -176,6 +176,12 @@ export { useAttachMedia } from './utils/use-attach-media';
 export { composeRefs, useComposedRefs } from './utils/use-composed-refs';
 export { useDestroy } from './utils/use-destroy';
 export { useLatestRef } from './utils/use-latest-ref';
+export {
+  type MediaEventHandler,
+  type MediaEventPropName,
+  type MediaEventProps,
+  useMediaEvents,
+} from './utils/use-media-events';
 export { useMediaExtension } from './utils/use-media-extension';
 export { useMediaInstance } from './utils/use-media-instance';
 export { renderElement } from './utils/use-render';

--- a/packages/react/src/media/cloudflare-video/adapter.tsx
+++ b/packages/react/src/media/cloudflare-video/adapter.tsx
@@ -5,10 +5,11 @@ import { forwardRef, type ReactNode, useState } from 'react';
 
 import { useAttachIframe } from '../../utils/use-attach-iframe';
 import { useComposedRefs } from '../../utils/use-composed-refs';
+import { type MediaEventProps, useMediaEvents } from '../../utils/use-media-events';
 import { useMediaInstance } from '../../utils/use-media-instance';
 import { useSyncProps } from '../../utils/use-sync-props';
 
-export interface CloudflareVideoProps extends Partial<CloudflareAdapterProps> {
+export interface CloudflareVideoProps extends Partial<CloudflareAdapterProps>, MediaEventProps<CloudflareAdapter> {
   children?: ReactNode;
 }
 
@@ -31,10 +32,9 @@ export const CloudflareVideo = forwardRef<HTMLIFrameElement, CloudflareVideoProp
       defaultMuted: !!(props.defaultMuted || props.muted),
     })
   );
-  const iframeProps = useSyncProps<CloudflareAdapterProps, Record<string, unknown>>(
+  const iframeProps = useMediaEvents(
     media,
-    props,
-    CloudflareAdapter.defaultProps
+    useSyncProps<CloudflareAdapterProps, Record<string, unknown>>(media, props, CloudflareAdapter.defaultProps)
   );
 
   return (

--- a/packages/react/src/media/cloudflare-video/adapter.tsx
+++ b/packages/react/src/media/cloudflare-video/adapter.tsx
@@ -19,8 +19,6 @@ export const CloudflareVideo = forwardRef<HTMLIFrameElement, CloudflareVideoProp
 ) {
   const media = useMediaInstance(CloudflareAdapter);
   const props: Partial<CloudflareAdapterProps> & Record<string, unknown> = { ...rawProps };
-  const attachRef = useAttachIframe(media);
-  const composedRef = useComposedRefs(attachRef, ref);
   const [initialSrc] = useState(() =>
     // `source.src` is the only other way to name a video, so honor it when `src` is absent.
     buildCloudflareIframeSrc(props.src || props.source?.src || '', {
@@ -32,10 +30,13 @@ export const CloudflareVideo = forwardRef<HTMLIFrameElement, CloudflareVideoProp
       defaultMuted: !!(props.defaultMuted || props.muted),
     })
   );
-  const iframeProps = useMediaEvents(
-    media,
-    useSyncProps<CloudflareAdapterProps, Record<string, unknown>>(media, props, CloudflareAdapter.defaultProps)
+  const { ref: eventsRef, props: iframeProps } = useMediaEvents(
+    useSyncProps<CloudflareAdapterProps, Record<string, unknown>>(media, props, CloudflareAdapter.defaultProps),
+    media
   );
+  const attachRef = useAttachIframe(media);
+  // Listeners first: `attach()` dispatches `loadstart` synchronously.
+  const composedRef = useComposedRefs(eventsRef, attachRef, ref);
 
   return (
     <iframe

--- a/packages/react/src/media/spotify-audio/adapter.tsx
+++ b/packages/react/src/media/spotify-audio/adapter.tsx
@@ -19,16 +19,18 @@ export const SpotifyAudio = forwardRef<HTMLIFrameElement, SpotifyAudioProps>(fun
 ) {
   const media = useMediaInstance(SpotifyAdapter);
   const props: Partial<SpotifyAdapterProps> & Record<string, unknown> = { ...rawProps };
-  const attachRef = useAttachIframe(media);
-  const composedRef = useComposedRefs(attachRef, ref);
   const [initialSrc] = useState(() =>
     // `source.src` is the only other way to name an entity, so honor it when `src` is absent.
     buildSpotifyIframeSrc(props.src || props.source?.src || '', { ...SpotifyAdapter.defaultProps, ...props })
   );
-  const { style, ...iframeProps } = useMediaEvents(
-    media,
-    useSyncProps<SpotifyAdapterProps, Record<string, unknown>>(media, props, SpotifyAdapter.defaultProps)
-  ) as Record<string, unknown> & { style?: CSSProperties };
+  const { ref: eventsRef, props: elementProps } = useMediaEvents(
+    useSyncProps<SpotifyAdapterProps, Record<string, unknown>>(media, props, SpotifyAdapter.defaultProps),
+    media
+  );
+  const { style, ...iframeProps } = elementProps as Record<string, unknown> & { style?: CSSProperties };
+  const attachRef = useAttachIframe(media);
+  // Listeners first: `attach()` dispatches `loadstart` synchronously.
+  const composedRef = useComposedRefs(eventsRef, attachRef, ref);
 
   return (
     <iframe

--- a/packages/react/src/media/spotify-audio/adapter.tsx
+++ b/packages/react/src/media/spotify-audio/adapter.tsx
@@ -5,10 +5,11 @@ import { type CSSProperties, forwardRef, type ReactNode, useState } from 'react'
 
 import { useAttachIframe } from '../../utils/use-attach-iframe';
 import { useComposedRefs } from '../../utils/use-composed-refs';
+import { type MediaEventProps, useMediaEvents } from '../../utils/use-media-events';
 import { useMediaInstance } from '../../utils/use-media-instance';
 import { useSyncProps } from '../../utils/use-sync-props';
 
-export interface SpotifyAudioProps extends Partial<SpotifyAdapterProps> {
+export interface SpotifyAudioProps extends Partial<SpotifyAdapterProps>, MediaEventProps<SpotifyAdapter> {
   children?: ReactNode;
 }
 
@@ -24,10 +25,9 @@ export const SpotifyAudio = forwardRef<HTMLIFrameElement, SpotifyAudioProps>(fun
     // `source.src` is the only other way to name an entity, so honor it when `src` is absent.
     buildSpotifyIframeSrc(props.src || props.source?.src || '', { ...SpotifyAdapter.defaultProps, ...props })
   );
-  const { style, ...iframeProps } = useSyncProps<SpotifyAdapterProps, Record<string, unknown>>(
+  const { style, ...iframeProps } = useMediaEvents(
     media,
-    props,
-    SpotifyAdapter.defaultProps
+    useSyncProps<SpotifyAdapterProps, Record<string, unknown>>(media, props, SpotifyAdapter.defaultProps)
   ) as Record<string, unknown> & { style?: CSSProperties };
 
   return (

--- a/packages/react/src/media/tests/vimeo-video.test.tsx
+++ b/packages/react/src/media/tests/vimeo-video.test.tsx
@@ -1,5 +1,7 @@
 import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vite-plus/test';
+import { VimeoAdapter } from '@videojs/vimeo-video';
+import type { ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vite-plus/test';
 
 import { VimeoVideo } from '../vimeo-video';
 
@@ -7,6 +9,16 @@ import { VimeoVideo } from '../vimeo-video';
 async function flushDeferredEmbed(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
+}
+
+/** Render and capture the media instance the component attached its iframe to. */
+function renderWithMedia(ui: ReactElement) {
+  const attach = vi.spyOn(VimeoAdapter.prototype, 'attach');
+  const result = render(ui);
+  const media = attach.mock.contexts[0] as VimeoAdapter;
+
+  attach.mockRestore();
+  return { ...result, media };
 }
 
 describe('VimeoVideo', () => {
@@ -29,5 +41,21 @@ describe('VimeoVideo', () => {
     await flushDeferredEmbed();
 
     expect(iframe.getAttribute('src')).toContain('https://player.vimeo.com/video/1181503036');
+  });
+
+  it('routes media event props to the media rather than the iframe', () => {
+    const onPlay = vi.fn((event: Event) => event.currentTarget);
+    const onTimeUpdate = vi.fn();
+    const { container, media } = renderWithMedia(
+      <VimeoVideo src="https://vimeo.com/1181503036" onPlay={onPlay} onTimeUpdate={onTimeUpdate} />
+    );
+
+    media.dispatchEvent(new Event('play'));
+    media.dispatchEvent(new Event('timeupdate'));
+
+    expect(onPlay).toHaveBeenCalledTimes(1);
+    expect(onPlay).toHaveReturnedWith(media);
+    expect(onTimeUpdate).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('iframe')!.hasAttribute('onplay')).toBe(false);
   });
 });

--- a/packages/react/src/media/tests/vimeo-video.test.tsx
+++ b/packages/react/src/media/tests/vimeo-video.test.tsx
@@ -58,4 +58,12 @@ describe('VimeoVideo', () => {
     expect(onTimeUpdate).toHaveBeenCalledTimes(1);
     expect(container.querySelector('iframe')!.hasAttribute('onplay')).toBe(false);
   });
+
+  it('delivers the loadstart the media dispatches while attaching', () => {
+    const onLoadStart = vi.fn();
+
+    render(<VimeoVideo src="https://vimeo.com/1181503036" onLoadStart={onLoadStart} />);
+
+    expect(onLoadStart).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react/src/media/tests/wistia-video.test.tsx
+++ b/packages/react/src/media/tests/wistia-video.test.tsx
@@ -29,6 +29,19 @@ function renderPlayer(ui: React.ReactElement): HTMLElement {
 }
 
 describe('WistiaVideo', () => {
+  it('routes media event props to the element, which React wires only for <video> and <audio>', () => {
+    const onPlay = vi.fn((event: Event) => event.currentTarget);
+    const onTimeUpdate = vi.fn();
+    const player = renderPlayer(<WistiaVideo src={SRC} onPlay={onPlay} onTimeUpdate={onTimeUpdate} />);
+
+    player.dispatchEvent(new Event('play'));
+    player.dispatchEvent(new Event('timeupdate'));
+
+    expect(onPlay).toHaveBeenCalledTimes(1);
+    expect(onPlay).toHaveReturnedWith(player);
+    expect(onTimeUpdate).toHaveBeenCalledTimes(1);
+  });
+
   it('resolves a Wistia URL to the media id the player wants', () => {
     expect(renderPlayer(<WistiaVideo src={SRC} />).getAttribute('media-id')).toBe('oifkgmxnkb');
   });

--- a/packages/react/src/media/tiktok-video/adapter.tsx
+++ b/packages/react/src/media/tiktok-video/adapter.tsx
@@ -5,10 +5,11 @@ import { forwardRef, type ReactNode, useState } from 'react';
 
 import { useAttachIframe } from '../../utils/use-attach-iframe';
 import { useComposedRefs } from '../../utils/use-composed-refs';
+import { type MediaEventProps, useMediaEvents } from '../../utils/use-media-events';
 import { useMediaInstance } from '../../utils/use-media-instance';
 import { useSyncProps } from '../../utils/use-sync-props';
 
-export interface TikTokVideoProps extends Partial<TikTokAdapterProps> {
+export interface TikTokVideoProps extends Partial<TikTokAdapterProps>, MediaEventProps<TikTokAdapter> {
   children?: ReactNode;
 }
 
@@ -31,10 +32,9 @@ export const TikTokVideo = forwardRef<HTMLIFrameElement, TikTokVideoProps>(funct
       defaultMuted: !!(props.defaultMuted || props.muted),
     })
   );
-  const iframeProps = useSyncProps<TikTokAdapterProps, Record<string, unknown>>(
+  const iframeProps = useMediaEvents(
     media,
-    props,
-    TikTokAdapter.defaultProps
+    useSyncProps<TikTokAdapterProps, Record<string, unknown>>(media, props, TikTokAdapter.defaultProps)
   );
 
   return (

--- a/packages/react/src/media/tiktok-video/adapter.tsx
+++ b/packages/react/src/media/tiktok-video/adapter.tsx
@@ -19,8 +19,6 @@ export const TikTokVideo = forwardRef<HTMLIFrameElement, TikTokVideoProps>(funct
 ) {
   const media = useMediaInstance(TikTokAdapter);
   const props: Partial<TikTokAdapterProps> & Record<string, unknown> = { ...rawProps };
-  const attachRef = useAttachIframe(media);
-  const composedRef = useComposedRefs(attachRef, ref);
   const [initialSrc] = useState(() =>
     // `source.src` is the only other way to name a video, so honor it when `src` is absent.
     buildTikTokIframeSrc(props.src || props.source?.src || '', {
@@ -32,10 +30,13 @@ export const TikTokVideo = forwardRef<HTMLIFrameElement, TikTokVideoProps>(funct
       defaultMuted: !!(props.defaultMuted || props.muted),
     })
   );
-  const iframeProps = useMediaEvents(
-    media,
-    useSyncProps<TikTokAdapterProps, Record<string, unknown>>(media, props, TikTokAdapter.defaultProps)
+  const { ref: eventsRef, props: iframeProps } = useMediaEvents(
+    useSyncProps<TikTokAdapterProps, Record<string, unknown>>(media, props, TikTokAdapter.defaultProps),
+    media
   );
+  const attachRef = useAttachIframe(media);
+  // Listeners first: `attach()` dispatches `loadstart` synchronously.
+  const composedRef = useComposedRefs(eventsRef, attachRef, ref);
 
   return (
     <iframe

--- a/packages/react/src/media/twitch-video/adapter.tsx
+++ b/packages/react/src/media/twitch-video/adapter.tsx
@@ -19,8 +19,6 @@ export const TwitchVideo = forwardRef<HTMLIFrameElement, TwitchVideoProps>(funct
 ) {
   const media = useMediaInstance(TwitchAdapter);
   const props: Partial<TwitchAdapterProps> & Record<string, unknown> = { ...rawProps };
-  const attachRef = useAttachIframe(media);
-  const composedRef = useComposedRefs(attachRef, ref);
   const [initialSrc] = useState(() =>
     // Server rendering has no `location` to name as the embed's parent, and Twitch
     // refuses to play in a page its URL never named. Rendering no `src` leaves the
@@ -30,10 +28,13 @@ export const TwitchVideo = forwardRef<HTMLIFrameElement, TwitchVideoProps>(funct
         buildTwitchIframeSrc(props.src || props.source?.src || '', { ...TwitchAdapter.defaultProps, ...props })
       : ''
   );
-  const iframeProps = useMediaEvents(
-    media,
-    useSyncProps<TwitchAdapterProps, Record<string, unknown>>(media, props, TwitchAdapter.defaultProps)
+  const { ref: eventsRef, props: iframeProps } = useMediaEvents(
+    useSyncProps<TwitchAdapterProps, Record<string, unknown>>(media, props, TwitchAdapter.defaultProps),
+    media
   );
+  const attachRef = useAttachIframe(media);
+  // Listeners first: `attach()` dispatches `loadstart` synchronously.
+  const composedRef = useComposedRefs(eventsRef, attachRef, ref);
 
   return (
     <iframe

--- a/packages/react/src/media/twitch-video/adapter.tsx
+++ b/packages/react/src/media/twitch-video/adapter.tsx
@@ -5,10 +5,11 @@ import { forwardRef, type ReactNode, useState } from 'react';
 
 import { useAttachIframe } from '../../utils/use-attach-iframe';
 import { useComposedRefs } from '../../utils/use-composed-refs';
+import { type MediaEventProps, useMediaEvents } from '../../utils/use-media-events';
 import { useMediaInstance } from '../../utils/use-media-instance';
 import { useSyncProps } from '../../utils/use-sync-props';
 
-export interface TwitchVideoProps extends Partial<TwitchAdapterProps> {
+export interface TwitchVideoProps extends Partial<TwitchAdapterProps>, MediaEventProps<TwitchAdapter> {
   children?: ReactNode;
 }
 
@@ -29,10 +30,9 @@ export const TwitchVideo = forwardRef<HTMLIFrameElement, TwitchVideoProps>(funct
         buildTwitchIframeSrc(props.src || props.source?.src || '', { ...TwitchAdapter.defaultProps, ...props })
       : ''
   );
-  const iframeProps = useSyncProps<TwitchAdapterProps, Record<string, unknown>>(
+  const iframeProps = useMediaEvents(
     media,
-    props,
-    TwitchAdapter.defaultProps
+    useSyncProps<TwitchAdapterProps, Record<string, unknown>>(media, props, TwitchAdapter.defaultProps)
   );
 
   return (

--- a/packages/react/src/media/vimeo-video/adapter.tsx
+++ b/packages/react/src/media/vimeo-video/adapter.tsx
@@ -5,10 +5,11 @@ import { forwardRef, type ReactNode, useState } from 'react';
 
 import { useAttachIframe } from '../../utils/use-attach-iframe';
 import { useComposedRefs } from '../../utils/use-composed-refs';
+import { type MediaEventProps, useMediaEvents } from '../../utils/use-media-events';
 import { useMediaInstance } from '../../utils/use-media-instance';
 import { useSyncProps } from '../../utils/use-sync-props';
 
-export interface VimeoVideoProps extends Partial<VimeoAdapterProps> {
+export interface VimeoVideoProps extends Partial<VimeoAdapterProps>, MediaEventProps<VimeoAdapter> {
   children?: ReactNode;
 }
 
@@ -24,7 +25,10 @@ export const VimeoVideo = forwardRef<HTMLIFrameElement, VimeoVideoProps>(functio
     // `source.src` is the only other way to name a video, so honor it when `src` is absent.
     buildVimeoIframeSrc(props.src || props.source?.src || '', { ...VimeoAdapter.defaultProps, ...props })
   );
-  const iframeProps = useSyncProps<VimeoAdapterProps, Record<string, unknown>>(media, props, VimeoAdapter.defaultProps);
+  const iframeProps = useMediaEvents(
+    media,
+    useSyncProps<VimeoAdapterProps, Record<string, unknown>>(media, props, VimeoAdapter.defaultProps)
+  );
 
   return (
     <iframe

--- a/packages/react/src/media/vimeo-video/adapter.tsx
+++ b/packages/react/src/media/vimeo-video/adapter.tsx
@@ -19,16 +19,17 @@ export const VimeoVideo = forwardRef<HTMLIFrameElement, VimeoVideoProps>(functio
 ) {
   const media = useMediaInstance(VimeoAdapter);
   const props: Partial<VimeoAdapterProps> & Record<string, unknown> = { ...rawProps };
-  const attachRef = useAttachIframe(media);
-  const composedRef = useComposedRefs(attachRef, ref);
   const [initialSrc] = useState(() =>
     // `source.src` is the only other way to name a video, so honor it when `src` is absent.
     buildVimeoIframeSrc(props.src || props.source?.src || '', { ...VimeoAdapter.defaultProps, ...props })
   );
-  const iframeProps = useMediaEvents(
-    media,
-    useSyncProps<VimeoAdapterProps, Record<string, unknown>>(media, props, VimeoAdapter.defaultProps)
+  const { ref: eventsRef, props: iframeProps } = useMediaEvents(
+    useSyncProps<VimeoAdapterProps, Record<string, unknown>>(media, props, VimeoAdapter.defaultProps),
+    media
   );
+  const attachRef = useAttachIframe(media);
+  // Listeners first: `attach()` dispatches `loadstart` synchronously.
+  const composedRef = useComposedRefs(eventsRef, attachRef, ref);
 
   return (
     <iframe

--- a/packages/react/src/media/wistia-video/adapter.tsx
+++ b/packages/react/src/media/wistia-video/adapter.tsx
@@ -75,21 +75,19 @@ export const WistiaVideo: ForwardRefExoticComponent<WistiaVideoProps & RefAttrib
   ref
 ) {
   const setMedia = useMediaAttach();
-  // The element is the media, so it is what the event props listen to, once there is one.
-  const [player, setPlayer] = useState<WistiaPlayer | null>(null);
 
   const attachRef = useCallback<RefCallback<WistiaPlayer>>(
     (element) => {
       // No cast: this is where Wistia's real class is held to the contract the normalizer describes.
       if (element) normalizeWistiaPlayer(element);
 
-      setPlayer(element);
       setMedia?.(element as never);
     },
     [setMedia]
   );
-  const composedRef = useComposedRefs(attachRef, ref);
-  const elementProps = useMediaEvents(player, rest);
+  // The element is the media, so it is what the event props listen to.
+  const { ref: eventsRef, props: elementProps } = useMediaEvents(rest);
+  const composedRef = useComposedRefs(eventsRef, attachRef, ref);
 
   // A Wistia URL is accepted where a media id is expected, the way every other media here accepts a `src`.
   const { mediaId, ...options } = source ?? {};

--- a/packages/react/src/media/wistia-video/adapter.tsx
+++ b/packages/react/src/media/wistia-video/adapter.tsx
@@ -28,8 +28,15 @@ import {
 
 import { useMediaAttach } from '../../player/context';
 import { useComposedRefs } from '../../utils/use-composed-refs';
+import { type MediaEventPropName, type MediaEventProps, useMediaEvents } from '../../utils/use-media-events';
 
-export interface WistiaVideoProps extends Partial<Omit<WistiaAdapterProps, 'source'>>, HTMLAttributes<WistiaPlayer> {
+// React only wires `onPlay` and friends to `<video>` and `<audio>`, so on a custom element they are routed by hand and
+// carry the element's own `Event` rather than a synthetic one.
+export interface WistiaVideoProps
+  extends
+    Partial<Omit<WistiaAdapterProps, 'source'>>,
+    Omit<HTMLAttributes<WistiaPlayer>, MediaEventPropName>,
+    MediaEventProps<WistiaPlayer> {
   /** Wistia's own options, `mediaId` among them: everything the player understands that a media does not. */
   source?: WistiaSource | null;
 }
@@ -68,17 +75,21 @@ export const WistiaVideo: ForwardRefExoticComponent<WistiaVideoProps & RefAttrib
   ref
 ) {
   const setMedia = useMediaAttach();
+  // The element is the media, so it is what the event props listen to, once there is one.
+  const [player, setPlayer] = useState<WistiaPlayer | null>(null);
 
   const attachRef = useCallback<RefCallback<WistiaPlayer>>(
     (element) => {
       // No cast: this is where Wistia's real class is held to the contract the normalizer describes.
       if (element) normalizeWistiaPlayer(element);
 
+      setPlayer(element);
       setMedia?.(element as never);
     },
     [setMedia]
   );
   const composedRef = useComposedRefs(attachRef, ref);
+  const elementProps = useMediaEvents(player, rest);
 
   // A Wistia URL is accepted where a media id is expected, the way every other media here accepts a `src`.
   const { mediaId, ...options } = source ?? {};
@@ -103,7 +114,7 @@ export const WistiaVideo: ForwardRefExoticComponent<WistiaVideoProps & RefAttrib
       // Wistia's own options last, so a source reaches anything the props above do not name.
       ...options,
     }),
-    ...rest,
+    ...elementProps,
     style: { ...wistiaPlayerStyle(controls), ...style },
     ref: composedRef,
     children,

--- a/packages/react/src/media/youtube-video/adapter.tsx
+++ b/packages/react/src/media/youtube-video/adapter.tsx
@@ -19,16 +19,17 @@ export const YouTubeVideo = forwardRef<HTMLIFrameElement, YouTubeVideoProps>(fun
 ) {
   const media = useMediaInstance(YouTubeAdapter);
   const props: Partial<YouTubeAdapterProps> & Record<string, unknown> = { ...rawProps };
-  const attachRef = useAttachIframe(media);
-  const composedRef = useComposedRefs(attachRef, ref);
   const [initialSrc] = useState(() =>
     // `source.src` is the only other way to name a video, so honor it when `src` is absent.
     buildYouTubeIframeSrc(props.src || props.source?.src || '', { ...YouTubeAdapter.defaultProps, ...props })
   );
-  const iframeProps = useMediaEvents(
-    media,
-    useSyncProps<YouTubeAdapterProps, Record<string, unknown>>(media, props, YouTubeAdapter.defaultProps)
+  const { ref: eventsRef, props: iframeProps } = useMediaEvents(
+    useSyncProps<YouTubeAdapterProps, Record<string, unknown>>(media, props, YouTubeAdapter.defaultProps),
+    media
   );
+  const attachRef = useAttachIframe(media);
+  // Listeners first: `attach()` dispatches `loadstart` synchronously.
+  const composedRef = useComposedRefs(eventsRef, attachRef, ref);
 
   return (
     <iframe

--- a/packages/react/src/media/youtube-video/adapter.tsx
+++ b/packages/react/src/media/youtube-video/adapter.tsx
@@ -5,10 +5,11 @@ import { forwardRef, type ReactNode, useState } from 'react';
 
 import { useAttachIframe } from '../../utils/use-attach-iframe';
 import { useComposedRefs } from '../../utils/use-composed-refs';
+import { type MediaEventProps, useMediaEvents } from '../../utils/use-media-events';
 import { useMediaInstance } from '../../utils/use-media-instance';
 import { useSyncProps } from '../../utils/use-sync-props';
 
-export interface YouTubeVideoProps extends Partial<YouTubeAdapterProps> {
+export interface YouTubeVideoProps extends Partial<YouTubeAdapterProps>, MediaEventProps<YouTubeAdapter> {
   children?: ReactNode;
 }
 
@@ -24,10 +25,9 @@ export const YouTubeVideo = forwardRef<HTMLIFrameElement, YouTubeVideoProps>(fun
     // `source.src` is the only other way to name a video, so honor it when `src` is absent.
     buildYouTubeIframeSrc(props.src || props.source?.src || '', { ...YouTubeAdapter.defaultProps, ...props })
   );
-  const iframeProps = useSyncProps<YouTubeAdapterProps, Record<string, unknown>>(
+  const iframeProps = useMediaEvents(
     media,
-    props,
-    YouTubeAdapter.defaultProps
+    useSyncProps<YouTubeAdapterProps, Record<string, unknown>>(media, props, YouTubeAdapter.defaultProps)
   );
 
   return (

--- a/packages/react/src/utils/tests/use-media-events.test.tsx
+++ b/packages/react/src/utils/tests/use-media-events.test.tsx
@@ -1,9 +1,27 @@
-import { cleanup, renderHook } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
+import { type RefCallback, useCallback } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
+import { useComposedRefs } from '../use-composed-refs';
 import { useMediaEvents } from '../use-media-events';
 
 afterEach(cleanup);
+
+/**
+ * Render the hook against a `<div>`, composed the way a media component does: events ref first, then the ref that
+ * attaches the media (`onMount` stands in for it).
+ */
+function Harness({
+  media,
+  onMount,
+  ...props
+}: Record<string, unknown> & { media?: EventTarget | null; onMount?: (node: HTMLDivElement) => void }) {
+  const { ref: eventsRef, props: rest } = useMediaEvents(props, media);
+  const attachRef = useCallback<RefCallback<HTMLDivElement>>((node) => void (node && onMount?.(node)), [onMount]);
+  const composedRef = useComposedRefs(eventsRef, attachRef);
+
+  return <div ref={composedRef} {...(rest as Record<string, unknown>)} />;
+}
 
 describe('useMediaEvents', () => {
   it('calls media event handlers when the adapter dispatches the event', () => {
@@ -11,7 +29,7 @@ describe('useMediaEvents', () => {
     const onPlay = vi.fn((event: Event) => event.currentTarget);
     const onTimeUpdate = vi.fn();
 
-    renderHook(() => useMediaEvents(media, { onPlay, onTimeUpdate }));
+    render(<Harness media={media} onPlay={onPlay} onTimeUpdate={onTimeUpdate} />);
 
     media.dispatchEvent(new Event('play'));
     media.dispatchEvent(new Event('timeupdate'));
@@ -22,14 +40,39 @@ describe('useMediaEvents', () => {
     expect(onPlay).toHaveReturnedWith(media);
   });
 
-  it('strips media event props and returns the rest', () => {
-    const media = new EventTarget();
+  it('listens on the rendered element when no media is given', () => {
+    const onPlay = vi.fn((event: Event) => event.currentTarget);
+    const { container } = render(<Harness onPlay={onPlay} />);
+    const element = container.firstElementChild!;
 
-    const { result } = renderHook(() =>
-      useMediaEvents(media, { onPlay: vi.fn(), onError: vi.fn(), id: 'player', onLoad: vi.fn() })
+    element.dispatchEvent(new Event('play'));
+
+    expect(onPlay).toHaveBeenCalledTimes(1);
+    expect(onPlay).toHaveReturnedWith(element);
+  });
+
+  it('binds from the ref so an event dispatched by a later ref is delivered', () => {
+    const media = new EventTarget();
+    const onLoadStart = vi.fn();
+
+    // Stands in for `attach()`, which dispatches `loadstart` synchronously from the ref composed after this one.
+    render(
+      <Harness media={media} onLoadStart={onLoadStart} onMount={() => media.dispatchEvent(new Event('loadstart'))} />
     );
 
-    expect(Object.keys(result.current)).toEqual(['id', 'onLoad']);
+    expect(onLoadStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips media event props and returns the rest', () => {
+    const media = new EventTarget();
+    const { container } = render(
+      <Harness media={media} onPlay={vi.fn()} onError={vi.fn()} id="player" data-kept="yes" />
+    );
+    const element = container.firstElementChild!;
+
+    expect(element.id).toBe('player');
+    expect(element.getAttribute('data-kept')).toBe('yes');
+    expect(element.hasAttribute('onplay')).toBe(false);
   });
 
   it('calls the latest handler without resubscribing', () => {
@@ -38,12 +81,10 @@ describe('useMediaEvents', () => {
     const second = vi.fn();
     const addEventListener = vi.spyOn(media, 'addEventListener');
 
-    const { rerender } = renderHook(({ onPause }) => useMediaEvents(media, { onPause }), {
-      initialProps: { onPause: first as (() => void) | undefined },
-    });
+    const { rerender } = render(<Harness media={media} onPause={first} />);
     const subscriptions = addEventListener.mock.calls.length;
 
-    rerender({ onPause: second });
+    rerender(<Harness media={media} onPause={second} />);
     media.dispatchEvent(new Event('pause'));
 
     expect(first).not.toHaveBeenCalled();
@@ -55,23 +96,56 @@ describe('useMediaEvents', () => {
     const media = new EventTarget();
     const onEnded = vi.fn();
 
-    const { rerender } = renderHook(({ onEnded }) => useMediaEvents(media, { onEnded }), {
-      initialProps: { onEnded: onEnded as (() => void) | undefined },
-    });
+    const { rerender } = render(<Harness media={media} onEnded={onEnded} />);
 
-    rerender({ onEnded: undefined });
+    rerender(<Harness media={media} onEnded={undefined} />);
     media.dispatchEvent(new Event('ended'));
 
     expect(onEnded).not.toHaveBeenCalled();
+  });
+
+  it('moves the listeners when the media changes', () => {
+    const first = new EventTarget();
+    const second = new EventTarget();
+    const onPlay = vi.fn((event: Event) => event.currentTarget);
+
+    const { rerender } = render(<Harness media={first} onPlay={onPlay} />);
+
+    rerender(<Harness media={second} onPlay={onPlay} />);
+    first.dispatchEvent(new Event('play'));
+    second.dispatchEvent(new Event('play'));
+
+    expect(onPlay).toHaveBeenCalledTimes(1);
+    expect(onPlay).toHaveReturnedWith(second);
   });
 
   it('unsubscribes from the adapter on unmount', () => {
     const media = new EventTarget();
     const onPlay = vi.fn();
 
-    const { unmount } = renderHook(() => useMediaEvents(media, { onPlay }));
+    const { unmount } = render(<Harness media={media} onPlay={onPlay} />);
 
     unmount();
+    media.dispatchEvent(new Event('play'));
+
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes when the ref is cleared with null, as React 18 does', () => {
+    const media = new EventTarget();
+    const onPlay = vi.fn();
+    let eventsRef!: ReturnType<typeof useMediaEvents>['ref'];
+
+    function Capture() {
+      const result = useMediaEvents({ onPlay }, media);
+
+      eventsRef = result.ref;
+      return null;
+    }
+
+    render(<Capture />);
+    eventsRef(document.createElement('div'));
+    eventsRef(null);
     media.dispatchEvent(new Event('play'));
 
     expect(onPlay).not.toHaveBeenCalled();

--- a/packages/react/src/utils/tests/use-media-events.test.tsx
+++ b/packages/react/src/utils/tests/use-media-events.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { useMediaEvents } from '../use-media-events';
+
+afterEach(cleanup);
+
+describe('useMediaEvents', () => {
+  it('calls media event handlers when the adapter dispatches the event', () => {
+    const media = new EventTarget();
+    const onPlay = vi.fn((event: Event) => event.currentTarget);
+    const onTimeUpdate = vi.fn();
+
+    renderHook(() => useMediaEvents(media, { onPlay, onTimeUpdate }));
+
+    media.dispatchEvent(new Event('play'));
+    media.dispatchEvent(new Event('timeupdate'));
+    media.dispatchEvent(new Event('pause'));
+
+    expect(onPlay).toHaveBeenCalledTimes(1);
+    expect(onTimeUpdate).toHaveBeenCalledTimes(1);
+    expect(onPlay).toHaveReturnedWith(media);
+  });
+
+  it('strips media event props and returns the rest', () => {
+    const media = new EventTarget();
+
+    const { result } = renderHook(() =>
+      useMediaEvents(media, { onPlay: vi.fn(), onError: vi.fn(), id: 'player', onLoad: vi.fn() })
+    );
+
+    expect(Object.keys(result.current)).toEqual(['id', 'onLoad']);
+  });
+
+  it('calls the latest handler without resubscribing', () => {
+    const media = new EventTarget();
+    const first = vi.fn();
+    const second = vi.fn();
+    const addEventListener = vi.spyOn(media, 'addEventListener');
+
+    const { rerender } = renderHook(({ onPause }) => useMediaEvents(media, { onPause }), {
+      initialProps: { onPause: first as (() => void) | undefined },
+    });
+    const subscriptions = addEventListener.mock.calls.length;
+
+    rerender({ onPause: second });
+    media.dispatchEvent(new Event('pause'));
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(addEventListener).toHaveBeenCalledTimes(subscriptions);
+  });
+
+  it('ignores events once a handler is removed', () => {
+    const media = new EventTarget();
+    const onEnded = vi.fn();
+
+    const { rerender } = renderHook(({ onEnded }) => useMediaEvents(media, { onEnded }), {
+      initialProps: { onEnded: onEnded as (() => void) | undefined },
+    });
+
+    rerender({ onEnded: undefined });
+    media.dispatchEvent(new Event('ended'));
+
+    expect(onEnded).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes from the adapter on unmount', () => {
+    const media = new EventTarget();
+    const onPlay = vi.fn();
+
+    const { unmount } = renderHook(() => useMediaEvents(media, { onPlay }));
+
+    unmount();
+    media.dispatchEvent(new Event('play'));
+
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/utils/use-media-events.ts
+++ b/packages/react/src/utils/use-media-events.ts
@@ -1,0 +1,100 @@
+import { isFunction } from '@videojs/utils/predicate';
+import { useEffect } from 'react';
+
+import { useLatestRef } from './use-latest-ref';
+
+/**
+ * React event prop names for the standard media events, mapped to the event type each one handles. Mirrors the media
+ * subset of React's `DOMAttributes` so a handler written for `<video>` reads the same on an embed.
+ */
+const MEDIA_EVENT_PROPS = {
+  onAbort: 'abort',
+  onCanPlay: 'canplay',
+  onCanPlayThrough: 'canplaythrough',
+  onDurationChange: 'durationchange',
+  onEmptied: 'emptied',
+  onEnded: 'ended',
+  onError: 'error',
+  onLoadedData: 'loadeddata',
+  onLoadedMetadata: 'loadedmetadata',
+  onLoadStart: 'loadstart',
+  onPause: 'pause',
+  onPlay: 'play',
+  onPlaying: 'playing',
+  onProgress: 'progress',
+  onRateChange: 'ratechange',
+  onSeeked: 'seeked',
+  onSeeking: 'seeking',
+  onStalled: 'stalled',
+  onSuspend: 'suspend',
+  onTimeUpdate: 'timeupdate',
+  onVolumeChange: 'volumechange',
+  onWaiting: 'waiting',
+} as const;
+
+export type MediaEventPropName = keyof typeof MEDIA_EVENT_PROPS;
+
+const MEDIA_EVENT_PROP_NAMES = Object.keys(MEDIA_EVENT_PROPS) as MediaEventPropName[];
+
+/**
+ * Handler for a standard media event dispatched by a playback adapter.
+ *
+ * The event is the plain `Event` the adapter dispatched on itself, so `currentTarget` is the adapter rather than a DOM
+ * element; read playback state such as `currentTime` or `paused` from it the way a `<video>` handler would.
+ */
+export type MediaEventHandler<Target extends EventTarget = EventTarget> = (
+  event: Event & { readonly currentTarget: Target }
+) => void;
+
+/**
+ * Standard media event props for a media component whose playback engine is not an `HTMLMediaElement`, such as an
+ * iframe embed. Named after the React props on `<video>` (`onPlay`, `onTimeUpdate`, …) so handlers port across.
+ */
+export type MediaEventProps<Target extends EventTarget = EventTarget> = {
+  [Prop in MediaEventPropName]?: MediaEventHandler<Target> | undefined;
+};
+
+/**
+ * Route standard media event props to a playback adapter that dispatches media events on itself.
+ *
+ * React only wires `onPlay`, `onTimeUpdate`, and friends to `<video>` and `<audio>`; on an `<iframe>` they go nowhere.
+ * This splits those props out, subscribes them on the adapter, and returns everything else for the rendered element.
+ * Listeners are bound once per adapter and always call the latest handler, so re-renders never resubscribe.
+ *
+ * @param media - Adapter that dispatches the standard media events, or `null` while there is none to listen to yet.
+ * @param props - Component props, which may include media event handlers.
+ */
+export function useMediaEvents<Target extends EventTarget, Props extends Record<string, unknown>>(
+  media: Target | null,
+  props: Props
+): Omit<Props, MediaEventPropName> {
+  const handlers: Partial<Record<MediaEventPropName, unknown>> = {};
+  const rest: Record<string, unknown> = {};
+
+  for (const key in props) {
+    if (key in MEDIA_EVENT_PROPS) handlers[key as MediaEventPropName] = props[key];
+    else rest[key] = props[key];
+  }
+
+  const handlersRef = useLatestRef(handlers);
+
+  useEffect(() => {
+    if (!media) return;
+
+    const controller = new AbortController();
+
+    for (const prop of MEDIA_EVENT_PROP_NAMES) {
+      const listener = (event: Event) => {
+        const handler = handlersRef.current[prop];
+
+        if (isFunction(handler)) handler(event);
+      };
+
+      media.addEventListener(MEDIA_EVENT_PROPS[prop], listener, { signal: controller.signal });
+    }
+
+    return () => controller.abort();
+  }, [media, handlersRef]);
+
+  return rest as Omit<Props, MediaEventPropName>;
+}

--- a/packages/react/src/utils/use-media-events.ts
+++ b/packages/react/src/utils/use-media-events.ts
@@ -1,5 +1,5 @@
 import { isFunction } from '@videojs/utils/predicate';
-import { useEffect } from 'react';
+import { type RefCallback, useCallback, useRef } from 'react';
 
 import { useLatestRef } from './use-latest-ref';
 
@@ -58,16 +58,21 @@ export type MediaEventProps<Target extends EventTarget = EventTarget> = {
  * Route standard media event props to a playback adapter that dispatches media events on itself.
  *
  * React only wires `onPlay`, `onTimeUpdate`, and friends to `<video>` and `<audio>`; on an `<iframe>` they go nowhere.
- * This splits those props out, subscribes them on the adapter, and returns everything else for the rendered element.
- * Listeners are bound once per adapter and always call the latest handler, so re-renders never resubscribe.
+ * This splits those props out, subscribes them on the adapter, and returns everything else for the rendered element
+ * along with a ref for that element. Listeners bind from the ref rather than an effect: adapters dispatch `loadstart`
+ * (or `error`) synchronously inside `attach()`, and effects run after every ref has fired, so an effect-bound
+ * `onLoadStart` would miss the initial load. Compose the ref ahead of the one that attaches the media so the listeners
+ * are in place first. Listeners bind once per adapter and always call the latest handler, so re-renders never
+ * resubscribe.
  *
- * @param media - Adapter that dispatches the standard media events, or `null` while there is none to listen to yet.
  * @param props - Component props, which may include media event handlers.
+ * @param media - Adapter that dispatches the standard media events. Omit it when the rendered element is the media
+ *   itself, such as a third-party web component; the listeners then bind to whatever the ref receives.
  */
-export function useMediaEvents<Target extends EventTarget, Props extends Record<string, unknown>>(
-  media: Target | null,
-  props: Props
-): Omit<Props, MediaEventPropName> {
+export function useMediaEvents<Props extends Record<string, unknown>>(
+  props: Props,
+  media?: EventTarget | null
+): useMediaEvents.Result<Props> {
   const handlers: Partial<Record<MediaEventPropName, unknown>> = {};
   const rest: Record<string, unknown> = {};
 
@@ -77,24 +82,45 @@ export function useMediaEvents<Target extends EventTarget, Props extends Record<
   }
 
   const handlersRef = useLatestRef(handlers);
+  // React 18 signals detach by calling the ref with `null` and ignores the returned cleanup, so the controller is kept
+  // where that call can reach it.
+  const controllerRef = useRef<AbortController | null>(null);
 
-  useEffect(() => {
-    if (!media) return;
+  const ref = useCallback<RefCallback<EventTarget>>(
+    (element) => {
+      controllerRef.current?.abort();
+      controllerRef.current = null;
 
-    const controller = new AbortController();
+      const target = element && (media ?? element);
+      if (!target) return;
 
-    for (const prop of MEDIA_EVENT_PROP_NAMES) {
-      const listener = (event: Event) => {
-        const handler = handlersRef.current[prop];
+      const controller = new AbortController();
 
-        if (isFunction(handler)) handler(event);
-      };
+      controllerRef.current = controller;
 
-      media.addEventListener(MEDIA_EVENT_PROPS[prop], listener, { signal: controller.signal });
-    }
+      for (const prop of MEDIA_EVENT_PROP_NAMES) {
+        const listener = (event: Event) => {
+          const handler = handlersRef.current[prop];
 
-    return () => controller.abort();
-  }, [media, handlersRef]);
+          if (isFunction(handler)) handler(event);
+        };
 
-  return rest as Omit<Props, MediaEventPropName>;
+        target.addEventListener(MEDIA_EVENT_PROPS[prop], listener, { signal: controller.signal });
+      }
+
+      return () => controller.abort();
+    },
+    [media, handlersRef]
+  );
+
+  return { ref, props: rest as Omit<Props, MediaEventPropName> };
+}
+
+export namespace useMediaEvents {
+  export interface Result<Props> {
+    /** Ref for the rendered element; compose it ahead of the ref that attaches the media. */
+    ref: RefCallback<EventTarget>;
+    /** The props left over once the media event handlers are taken out. */
+    props: Omit<Props, MediaEventPropName>;
+  }
 }

--- a/site/src/utils/mediaReferenceModel.ts
+++ b/site/src/utils/mediaReferenceModel.ts
@@ -117,7 +117,8 @@ const REACT_SUBSECTIONS: readonly MediaSubsectionDefinition<ReactMediaReference>
     key: 'events',
     title: 'Events',
     id: 'events',
-    isEmpty: (react) => !react.acceptsNativeProps,
+    // Iframe medias route the standard media event props to their playback adapter.
+    isEmpty: (react) => !react.acceptsNativeProps && react.target !== 'iframe',
   },
 ]);
 

--- a/site/src/utils/tests/mediaReferenceModel.test.ts
+++ b/site/src/utils/tests/mediaReferenceModel.test.ts
@@ -156,6 +156,16 @@ describe('createMediaReferenceModel', () => {
 
     expect(model.platforms.react!.sections.some((section) => section.key === 'events')).toBe(false);
   });
+
+  it('keeps React events for an iframe media that routes them to its adapter', () => {
+    const ref = makeRef();
+
+    ref.platforms.react!.target = 'iframe';
+    ref.platforms.react!.acceptsNativeProps = false;
+    const model = createMediaReferenceModel('YouTubeVideo', ref)!;
+
+    expect(model.platforms.react!.sections.some((section) => section.key === 'events')).toBe(true);
+  });
 });
 
 describe('buildMediaReferenceTocHeadings', () => {


### PR DESCRIPTION
## Summary

The React embed medias (`YouTubeVideo`, `VimeoVideo`, `TikTokVideo`, `TwitchVideo`, `CloudflareVideo`, `SpotifyAudio`, `WistiaVideo`) silently ignored `onPlay`, `onTimeUpdate`, and the other standard media event props. They now fire the same way they do on `Video`, for the events each embed reports.

## Changes

- React only wires media event props to `<video>` and `<audio>`. On an `<iframe>` or custom element they went nowhere, even though the adapters already dispatch `play`, `pause`, `timeupdate`, `seeking`, `volumechange`, … on themselves.
- New `useMediaEvents` hook (exported from `@videojs/react`) splits the standard media event props out and returns `{ ref, props }`: a ref that subscribes the handlers on the adapter, and the remaining props for the rendered element. Listeners bind once per adapter and always call the latest handler, so re-renders never resubscribe.
- Listeners bind from the ref rather than an effect, composed ahead of the ref that calls `attach()`. Adapters dispatch `loadstart` (and sometimes `error`) synchronously while attaching, and effects run after every ref has fired, so an effect-bound `onLoadStart` would miss the initial load.
- Handlers receive the adapter's own `Event`, so `event.currentTarget` is the media and reads like a `<video>` handler (`currentTarget.currentTime`, `.paused`, …). Each embed's props are typed with `MediaEventProps<XAdapter>`.
- `WistiaVideo` is a custom element rather than an iframe but has the same gap; the element is the media, so the hook's ref listens on it directly.
- Site: the React reference's Events section now renders for iframe medias too.

## Testing

- `pnpm -F @videojs/react test` — hook tests (dispatch, element-as-media, ref ordering, prop stripping, latest handler without resubscribe, removal, media swap, unmount and React 18 `null` cleanup) plus component tests on `VimeoVideo` (including the attach-time `loadstart`) and `WistiaVideo`.
- `pnpm -F site test src/utils/tests/mediaReferenceModel.test.ts`
- `pnpm typecheck`, `pnpm lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ref ordering and event subscription across all embed adapters; behavior change is intentional but timing-sensitive (e.g. `onLoadStart`); mitigated by focused tests.
> 
> **Overview**
> Embed React components (`YouTubeVideo`, `VimeoVideo`, TikTok, Twitch, Cloudflare, Spotify, and **WistiaVideo**) previously accepted `onPlay`, `onTimeUpdate`, and other standard media handlers but React never wired those on `<iframe>` or custom elements, so they were no-ops.
> 
> This PR adds **`useMediaEvents`** (exported from `@videojs/react` with `MediaEventProps` / `MediaEventHandler` types). It peels those props off, attaches listeners on the playback adapter (or the element when the element is the media, as with Wistia), and returns the remaining DOM props. Ref composition puts the events ref **before** the attach ref so synchronous `loadstart` during `attach()` is not missed. Handlers get the adapter’s native `Event` with `currentTarget` set to the media.
> 
> Docs on the site now show the React **Events** reference section for iframe targets that route events this way. Coverage includes dedicated hook tests plus Vimeo/Wistia component tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67efa60e24399fb4f8a323b744396f368005f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
