### PR TITLE
fix(core): apply popup starting styles before showing

### DIFF
--- a/apps/e2e/suites/player/tests/video-controls.spec.ts
+++ b/apps/e2e/suites/player/tests/video-controls.spec.ts
@@ -6,6 +6,7 @@ import { DATA_ATTRS, SELECTORS } from '../../../shared/fixtures/selectors';
 import { PlayerPage } from '../../../shared/page-objects/player';
 
 const UI_VIDEO_PAGES = VIDEO_PAGES.filter(({ media }) => media === 'video');
+const HTML_VIDEO_MP4_PATH = '/pages/html-video-mp4.html';
 
 function getMediaVolume(page: Page): Promise<number> {
   return page.evaluate((selector) => {
@@ -347,3 +348,51 @@ for (const { name, path } of UI_VIDEO_PAGES) {
     });
   });
 }
+
+test.describe('Video Controls — HTML settings transition', () => {
+  let player: PlayerPage;
+
+  test.beforeEach(async ({ page }) => {
+    player = new PlayerPage(page);
+    await page.goto(HTML_VIDEO_MP4_PATH);
+    await player.waitForMediaReady();
+    await player.showControls();
+  });
+
+  test('applies starting styles before the settings menu first becomes visible', async () => {
+    const initialFrame = await player.settingsButton.evaluate(
+      (element) =>
+        new Promise<{ filter: string; opacity: string; open: boolean; scale: string; starting: boolean }>((resolve) => {
+          const root = element.getRootNode();
+
+          if (!(element instanceof HTMLElement) || (!(root instanceof Document) && !(root instanceof ShadowRoot))) {
+            throw new Error('Expected the HTML settings menu trigger.');
+          }
+
+          const popup = root.querySelector<HTMLElement>('media-menu.media-menu-popup');
+          if (!popup) throw new Error('Expected the HTML settings menu popup.');
+
+          element.click();
+          requestAnimationFrame(() => {
+            const style = getComputedStyle(popup);
+
+            resolve({
+              filter: style.filter,
+              opacity: style.opacity,
+              open: popup.matches(':popover-open'),
+              scale: style.scale,
+              starting: popup.hasAttribute('data-starting-style'),
+            });
+          });
+        })
+    );
+
+    expect(initialFrame).toEqual({
+      filter: 'blur(4px)',
+      opacity: '0',
+      open: true,
+      scale: '0.95',
+      starting: true,
+    });
+  });
+});

--- a/packages/core/src/dom/ui/popover/popover.ts
+++ b/packages/core/src/dom/ui/popover/popover.ts
@@ -189,6 +189,7 @@ export function createPopover(options: PopoverOptions): PopoverApi {
 
       tryShowPopover(popupEl);
     });
+
     options.group?.()?.open(groupMember);
 
     opening.then(() => {

--- a/packages/core/src/dom/ui/popover/popover.ts
+++ b/packages/core/src/dom/ui/popover/popover.ts
@@ -181,7 +181,14 @@ export function createPopover(options: PopoverOptions): PopoverApi {
     const opening = layer.open(() => popupEl);
     if (!opening) return;
 
-    tryShowPopover(popupEl);
+    // Let platform adapters commit `data-starting-style` before exposing an
+    // already-mounted popup. Showing synchronously starts the transition from
+    // its visible styles before reactive HTML updates can apply the start state.
+    queueMicrotask(() => {
+      if (layer.signal.aborted || !state.current.active || state.current.status === 'ending') return;
+
+      tryShowPopover(popupEl);
+    });
     options.group?.()?.open(groupMember);
 
     opening.then(() => {

--- a/packages/core/src/dom/ui/popover/tests/popover.test.ts
+++ b/packages/core/src/dom/ui/popover/tests/popover.test.ts
@@ -38,7 +38,7 @@ describe('createPopover', () => {
       expect(popover.input.current).toEqual({ active: true, status: 'ending' });
     });
 
-    it('shows an already-mounted popup when a deferred open is committed', () => {
+    it('shows an already-mounted popup after a deferred open is committed', async () => {
       const { popover } = createTestPopover({ deferOpenChanges: true });
       const popup = document.createElement('div');
       const showPopover = vi.fn();
@@ -50,7 +50,29 @@ describe('createPopover', () => {
       expect(showPopover).not.toHaveBeenCalled();
 
       popover.syncOpen(true);
+      expect(showPopover).not.toHaveBeenCalled();
+
+      await Promise.resolve();
+
       expect(showPopover).toHaveBeenCalledOnce();
+    });
+
+    it('does not show a deferred popup that closes before the opening microtask', async () => {
+      const { popover } = createTestPopover({ deferOpenChanges: true });
+      const popup = document.createElement('div');
+      const showPopover = vi.fn();
+
+      Object.defineProperty(popup, 'showPopover', { value: showPopover });
+      popover.setPopupElement(popup);
+
+      popover.open();
+      popover.syncOpen(true);
+      popover.close();
+      popover.syncOpen(false);
+
+      await Promise.resolve();
+
+      expect(showPopover).not.toHaveBeenCalled();
     });
 
     it('updates input state and calls onOpenChange when opening', () => {

--- a/packages/html/src/ui/menu/tests/element.test.ts
+++ b/packages/html/src/ui/menu/tests/element.test.ts
@@ -70,6 +70,25 @@ afterEach(() => {
 });
 
 describe('MenuElement', () => {
+  it('applies starting styles before showing the popup', async () => {
+    const { root } = createMenu();
+    const startingStates: boolean[] = [];
+    const showPopover = vi.fn(() => {
+      startingStates.push(root.hasAttribute('data-starting-style'));
+    });
+
+    Object.defineProperty(root, 'showPopover', { configurable: true, value: showPopover });
+    document.body.append(root);
+    await root.updateComplete;
+
+    root.openMenu();
+    await root.updateComplete;
+    await Promise.resolve();
+
+    expect(showPopover).toHaveBeenCalled();
+    expect(startingStates.every(Boolean)).toBe(true);
+  });
+
   it('owns popup state while Content owns menu semantics', async () => {
     const { root, content } = createMenu();
 

--- a/packages/html/src/ui/popover/tests/element.test.ts
+++ b/packages/html/src/ui/popover/tests/element.test.ts
@@ -21,6 +21,25 @@ afterEach(() => {
 });
 
 describe('PopoverElement', () => {
+  it('applies starting styles before showing the popup', async () => {
+    const popover = createPopover();
+    const startingStates: boolean[] = [];
+    const showPopover = vi.fn(() => {
+      startingStates.push(popover.hasAttribute('data-starting-style'));
+    });
+
+    Object.defineProperty(popover, 'showPopover', { configurable: true, value: showPopover });
+    document.body.append(popover);
+    await popover.updateComplete;
+
+    popover.open = true;
+    await popover.updateComplete;
+    await Promise.resolve();
+
+    expect(showPopover).toHaveBeenCalled();
+    expect(startingStates.every(Boolean)).toBe(true);
+  });
+
   it('assigns safe identity to an adjacent source-owned trigger', async () => {
     const firstTrigger = document.createElement('button');
     const firstPopover = createPopover();

--- a/packages/react/src/ui/menu/tests/root.test.tsx
+++ b/packages/react/src/ui/menu/tests/root.test.tsx
@@ -459,6 +459,22 @@ describe('MenuContent', () => {
     expect(screen.queryByTestId('quality-content')).toBeNull();
   });
 
+  it('shows a popup kept mounted for option state when it opens', async () => {
+    render(<MountedOptionMenuFixture />);
+
+    const popup = screen.getByTestId('settings-popup');
+    const showPopover = vi.fn();
+
+    Object.defineProperty(popup, 'showPopover', { configurable: true, value: showPopover });
+    fireEvent.click(screen.getByTestId('settings-trigger'));
+
+    await waitFor(() => {
+      expect(showPopover).toHaveBeenCalled();
+      expect(popup.hasAttribute('hidden')).toBe(false);
+      expect(popup.hasAttribute('data-starting-style')).toBe(true);
+    });
+  });
+
   it('includes the root trigger in sequential focus', () => {
     render(
       <MenuRoot>


### PR DESCRIPTION
Closes #2708

## Summary

Prevent HTML popups from briefly rendering their final styles before the opening transition begins. Deferred native popover activation now waits for platform adapters to commit `data-starting-style`, while retained React menu popups continue to open normally.

## Changes

- Defer eager `showPopover()` activation until reactive adapters have applied opening styles
- Skip deferred activation when a popup closes or is destroyed before the microtask runs
- Cover HTML menu/popover ordering and retained React popup behavior
- Verify the settings menu first visible frame across Chromium, Firefox, and WebKit

## Testing

- `pnpm -F @videojs/core test src/dom/ui/popover/tests/popover.test.ts`
- `pnpm -F @videojs/html test src/ui/menu/tests/element.test.ts src/ui/popover/tests/element.test.ts`
- `pnpm -F @videojs/react test src/ui/menu/tests/root.test.tsx`
- `pnpm -F @videojs/e2e exec playwright test --config suites/player/playwright.config.ts video-controls.spec.ts --grep "applies starting styles before the settings menu first becomes visible"`
- `pnpm typecheck`
- Scoped formatter and lint checks for all changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing of popover visibility across core/HTML/React UI; low security impact but could affect edge cases around rapid open/close and already-mounted popups.
> 
> **Overview**
> Fixes a flash where HTML popovers (e.g. the player settings menu) appeared at full opacity before the open animation by **deferring** native `showPopover()` until a microtask runs, so Lit/React can set `data-starting-style` first.
> 
> `commitOpen` in the core popover layer no longer shows the popup synchronously; it bails out if the layer was closed or is ending before that microtask. Unit tests cover HTML menu/popover elements, deferred React `keepMounted` menus, and the race where open is cancelled before the microtask. A Playwright case asserts the settings popup’s first painted frame is blurred, scaled down, transparent, and still marked with starting styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a70e7360c95acfb9d67268484c20849b7d6b829f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->