### PR TITLE
fix(skin): simplify the slider styles

### DIFF
--- a/apps/e2e/suites/skin-parity/tests/vjsc-audio-skin-styling.spec.ts
+++ b/apps/e2e/suites/skin-parity/tests/vjsc-audio-skin-styling.spec.ts
@@ -409,17 +409,23 @@ async function audioSeekContract(root: Locator) {
 
   await expect
     .poll(() =>
-      slider.evaluate((element) =>
-        [...element.querySelectorAll('*')]
+      slider.evaluate((element) => {
+        const fills = [...element.querySelectorAll('*')]
           .map((target) => getComputedStyle(target))
           .filter((style) =>
             style.transitionProperty
               .split(',')
               .map((value) => value.trim())
-              .includes('clip-path')
+              .includes('inset')
+          );
+
+        return (
+          fills.length > 0 &&
+          fills.every((style) =>
+            style.transitionDuration.split(',').some((duration) => Number.parseFloat(duration) > 0)
           )
-          .every((style) => style.transitionDuration.split(',').some((duration) => Number.parseFloat(duration) > 0))
-      )
+        );
+      })
     )
     .toBe(true);
 
@@ -446,7 +452,7 @@ async function audioSeekContract(root: Locator) {
         candidate.transitionProperty
           .split(',')
           .map((value) => value.trim())
-          .includes('clip-path')
+          .includes('inset')
       );
     const rect = element.getBoundingClientRect();
     const lag = Math.abs(rect.x + rect.width / 2 - expectedX);

--- a/apps/e2e/suites/skin-parity/tests/vjsc-video-skin-styling.spec.ts
+++ b/apps/e2e/suites/skin-parity/tests/vjsc-video-skin-styling.spec.ts
@@ -132,6 +132,90 @@ for (const variant of CASES) {
     await expectSameRendering(testInfo, reference, tailwind.root);
   });
 
+  test(`${variant.framework} ${variant.skin} keeps slider paint within the track thickness`, async ({ page }) => {
+    const { panels } = await openComparison(page, { ...variant, media: 'mp4-1', width: 618 }, async ({ root }) =>
+      expect(root.getByRole('slider', { name: 'Seek' })).toBeVisible()
+    );
+
+    for (const { root } of panels) {
+      const layers = root
+        .getByRole('slider', { name: 'Seek' })
+        .locator('..')
+        .locator(
+          'media-slider-fill, media-slider-buffer, .media-slider-fill, .media-slider-buffer, [class~="before:bg-media-primary"], [class~="before:bg-current/20"]'
+        );
+      const caps = await layers.evaluateAll((elements) =>
+        elements
+          .filter(
+            (element): element is HTMLElement =>
+              element instanceof HTMLElement && getComputedStyle(element).position === 'absolute'
+          )
+          .flatMap((element) => {
+            const layer = element;
+
+            return ['horizontal', 'vertical'].flatMap((orientation) =>
+              [0, 0.5, 4, 20, 100].map((size) => {
+                layer.setAttribute('data-orientation', orientation);
+                Object.assign(layer.style, {
+                  transition: 'none',
+                  inset: '0 auto auto 0',
+                  width: `${orientation === 'horizontal' ? size : 4}px`,
+                  height: `${orientation === 'vertical' ? size : 4}px`,
+                });
+                const paint = getComputedStyle(layer, '::before');
+
+                return {
+                  width: paint.width,
+                  height: paint.height,
+                  clip: getComputedStyle(layer).clipPath,
+                  orientation,
+                  size,
+                };
+              })
+            );
+          })
+      );
+
+      expect(caps.length).toBeGreaterThan(0);
+
+      for (const { orientation, size, ...cap } of caps) {
+        // A short segment reveals part of the track's circular cap, never a compressed vertical pill.
+        expect(cap).toEqual({
+          width: `${orientation === 'horizontal' ? Math.max(4, size) : 4}px`,
+          height: `${orientation === 'vertical' ? Math.max(4, size) : 4}px`,
+          clip: orientation === 'horizontal' ? 'inset(-1px 0px)' : 'inset(0px -1px)',
+        });
+      }
+    }
+  });
+
+  test(`${variant.framework} ${variant.skin} animates seeks while focused`, async ({ page }) => {
+    const { panels } = await openComparison(page, { ...variant, media: 'mp4-1', width: 618 }, async ({ root }) =>
+      expect(root.getByRole('slider', { name: 'Seek' })).toBeEnabled()
+    );
+
+    for (const { root } of panels) {
+      const thumb = root.getByRole('slider', { name: 'Seek' });
+
+      await thumb.press('Home');
+      await root.evaluate((element) => {
+        if (element instanceof HTMLElement) element.style.setProperty('--media-duration-slider', '1s');
+      });
+      await thumb.press('ArrowRight');
+
+      const properties = await thumb
+        .locator('..')
+        .evaluate((element) =>
+          element
+            .getAnimations({ subtree: true })
+            .flatMap((animation) => (animation instanceof CSSTransition ? [animation.transitionProperty] : []))
+        );
+
+      expect(properties).toContain('right');
+      expect(properties).toContain('left');
+    }
+  });
+
   test(`${variant.framework} ${variant.skin} keeps seek dragging attached to the pointer`, async ({ page }) => {
     const { css, tailwind } = await openVariants(page, variant, 800);
     const cssContract = await seekDragContract(css.root);
@@ -496,44 +580,56 @@ for (const skin of ['default-video', 'minimal-video'] as const) {
   }
 }
 
-test('React chapter segments match across styles and retain their generated range props', async ({ page }) => {
-  const { panels } = await openComparison(page, { ...REACT_DEFAULT, media: 'hls-7', width: 855 }, async ({ root }) =>
-    expect(root).toBeVisible()
-  );
-  const contracts = [];
-
-  for (const panel of panels) {
-    const chapters = panel.section.locator('.media-time-slider-chapter, [class~="group/chapter"]');
-
-    await expect(chapters).toHaveCount(8);
-    contracts.push(
-      await chapters.evaluateAll((elements) =>
-        elements.map((element) => {
-          if (!(element instanceof HTMLElement)) throw new Error('Expected a rendered chapter element.');
-
-          const track = element.firstElementChild;
-
-          return {
-            end: element.style.getPropertyValue('--media-slider-chapter-end'),
-            orientation: element.getAttribute('data-orientation'),
-            segment: getComputedStyle(element).clipPath,
-            start: element.style.getPropertyValue('--media-slider-chapter-start'),
-            track: track && getComputedStyle(track, '::before').clipPath !== 'none' ? 'clipped' : 'none',
-          };
-        })
-      )
+for (const framework of ['react', 'html'] as const) {
+  test(`${framework} chapter segments match across styles and retain their generated range props`, async ({ page }) => {
+    const { panels } = await openComparison(
+      page,
+      { ...REACT_DEFAULT, framework, media: 'hls-7', width: 855 },
+      async ({ root }) => expect(root).toBeVisible()
     );
-  }
+    const contracts = [];
 
-  expect(contracts[1]).toEqual(contracts[0]);
-  expect(contracts[0]).toHaveLength(8);
-  expect(
-    contracts[0]?.every(
-      ({ orientation, segment, track }) => orientation === 'horizontal' && segment !== 'none' && track !== 'none'
-    )
-  ).toBe(true);
-  expect(new Set(contracts[0]?.map(({ start }) => start)).size).toBe(8);
-});
+    for (const panel of panels) {
+      const chapters = panel.section.locator('.media-time-slider-chapter, [class~="group/chapter"]');
+
+      await expect(chapters).toHaveCount(8);
+      contracts.push(
+        await chapters.evaluateAll((elements) =>
+          elements.map((element) => {
+            if (!(element instanceof HTMLElement)) throw new Error('Expected a rendered chapter element.');
+
+            const track = element.firstElementChild;
+
+            return {
+              end: element.style.getPropertyValue('--media-slider-chapter-end'),
+              insetStart: Number(getComputedStyle(element).getPropertyValue('--media-chapter-inset-start')),
+              insetEnd: Number(getComputedStyle(element).getPropertyValue('--media-chapter-inset-end')),
+              orientation: element.getAttribute('data-orientation'),
+              segment: getComputedStyle(element).clipPath,
+              start: element.style.getPropertyValue('--media-slider-chapter-start'),
+              track: track && getComputedStyle(track, '::before').clipPath !== 'none' ? 'clipped' : 'none',
+            };
+          })
+        )
+      );
+    }
+
+    expect(contracts[1]).toEqual(contracts[0]);
+    expect(contracts[0]).toHaveLength(8);
+
+    for (const contract of contracts) {
+      expect(contract.map(({ insetStart }) => insetStart)).toEqual([0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]);
+      expect(contract.map(({ insetEnd }) => insetEnd)).toEqual([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0]);
+    }
+
+    expect(
+      contracts[0]?.every(
+        ({ orientation, segment, track }) => orientation === 'horizontal' && segment !== 'none' && track !== 'none'
+      )
+    ).toBe(true);
+    expect(new Set(contracts[0]?.map(({ start }) => start)).size).toBe(8);
+  });
+}
 
 test('menu item and moving-highlight styling matches across styles', async ({ page }) => {
   for (const variant of CASES) {
@@ -628,9 +724,9 @@ test('VJSC preserves the shared skin motion contract', async ({ page }) => {
           properties: style === 'css' ? ['opacity', 'scale'] : ['transform', 'translate', 'scale', 'rotate'],
         },
         slider: {
-          buffer: { duration: '0.1s', properties: ['clip-path'] },
+          buffer: { duration: '0.1s', properties: ['inset'] },
           chapterTrack: { duration: '0.2s', properties: ['height', 'width'] },
-          fill: { duration: '0.1s', properties: ['clip-path'] },
+          fill: { duration: '0.1s', properties: ['inset'] },
           focusRing: variant.skin === 'default-video' ? { duration: '0.15s', properties: ['opacity', 'scale'] } : null,
           pointer: { duration: '0.2s', properties: ['opacity', 'scale'] },
           thumb: {
@@ -949,7 +1045,7 @@ async function seekDragContract(root: Locator) {
         style.transitionProperty
           .split(',')
           .map((value) => value.trim())
-          .includes('clip-path')
+          .includes('inset')
       );
     const rect = element.getBoundingClientRect();
     const lag = Math.abs(rect.x + rect.width / 2 - expectedX);

--- a/packages/skins/src/components/sliders/time-slider.tsx
+++ b/packages/skins/src/components/sliders/time-slider.tsx
@@ -27,8 +27,8 @@ export function TimeSlider({
       <$.TimeSlider.Chapters className={styles.chapters}>
         <Template name="chapter" className={styles.chapter}>
           <$.TimeSlider.Track $render={SliderTrack} className={styles.chapterTrack}>
-            <$.TimeSlider.Buffer $render={SliderBuffer} />
-            <$.TimeSlider.Fill $render={SliderFill} />
+            <$.TimeSlider.Buffer $render={SliderBuffer} className={styles.chapterLayer} />
+            <$.TimeSlider.Fill $render={SliderFill} className={styles.chapterLayer} />
           </$.TimeSlider.Track>
         </Template>
       </$.TimeSlider.Chapters>

--- a/packages/skins/src/styles/sliders/slider.styles.ts
+++ b/packages/skins/src/styles/sliders/slider.styles.ts
@@ -1,12 +1,12 @@
 import { styles } from 'vjsc/styles';
 
+// Reveal part of a full round cap for tiny values instead of squeezing it into a vertical pill.
 const trackLayer = [
-  'pointer-events-none absolute inset-0 before:absolute before:inset-0 before:rounded-media-control',
-  'data-[orientation=horizontal]:before:left-(--media-slider-layer-start) data-[orientation=horizontal]:before:right-(--media-slider-layer-end)',
-  'data-[orientation=vertical]:before:top-(--media-slider-layer-end) data-[orientation=vertical]:before:bottom-(--media-slider-layer-start)',
-  'before:transition-[left,right,top,bottom] before:duration-[inherit] before:ease-out',
-  'transition-[clip-path] duration-media-slider ease-out',
-  'group-data-dragging/slider:duration-0 group-data-seeking/slider:duration-0 group-focus-within/slider:duration-0',
+  'pointer-events-none absolute inset-0 before:absolute before:size-full before:rounded-media-control',
+  'data-[orientation=horizontal]:before:left-0 data-[orientation=horizontal]:before:min-w-1',
+  'data-[orientation=vertical]:before:bottom-0 data-[orientation=vertical]:before:min-h-1',
+  'transition-[inset] duration-media-slider ease-out',
+  'group-data-dragging/slider:duration-0',
 ] as const;
 
 export default styles({
@@ -52,10 +52,9 @@ export default styles({
     },
     thumb: {
       utilities: [
-        'absolute z-10 top-1/2 left-(--media-slider-fill) size-3 -translate-x-1/2 -translate-y-1/2 rounded-media-control bg-current',
+        'absolute z-10 top-1/2 left-(--media-slider-fill) size-3 -translate-x-1/2 -translate-y-1/2 rounded-media-control bg-white',
         'select-none transition-[opacity,height,width,outline-offset,left,top,scale] duration-media-slider ease-out',
         'group-data-dragging/slider:transition-[opacity,height,width,outline-offset,scale]',
-        'group-focus-within/slider:transition-[opacity,height,width,outline-offset,scale]',
         'group-data-dragging/slider:scale-90',
         'data-[orientation=vertical]:top-[calc(100%-var(--media-slider-fill))] data-[orientation=vertical]:left-1/2',
         'group-data-dragging/slider:data-[orientation=horizontal]:left-(--media-slider-pointer)',

--- a/packages/skins/src/styles/sliders/time-slider.styles.ts
+++ b/packages/skins/src/styles/sliders/time-slider.styles.ts
@@ -14,7 +14,7 @@ export default styles({
       utilities: [
         'group/chapter absolute inset-0 flex min-h-0 min-w-0 items-center justify-center',
         '[--media-chapter-inset-start:0.5] [--media-chapter-inset-end:0.5]',
-        'first:[--media-chapter-inset-start:0] last:[--media-chapter-inset-end:0]',
+        'first-of-type:[--media-chapter-inset-start:0] last-of-type:[--media-chapter-inset-end:0]',
         'data-[orientation=horizontal]:clip-media-chapter-x data-[orientation=vertical]:clip-media-chapter-y',
       ],
     },
@@ -24,6 +24,12 @@ export default styles({
         'data-[orientation=horizontal]:before:clip-media-chapter-track-x data-[orientation=vertical]:before:clip-media-chapter-track-y',
         'group-data-highlighted/chapter:data-[orientation=horizontal]:h-1.75',
         'group-data-highlighted/chapter:data-[orientation=vertical]:w-1.75',
+      ],
+    },
+    chapterLayer: {
+      utilities: [
+        'group-data-highlighted/chapter:data-[orientation=horizontal]:before:min-w-1.75',
+        'group-data-highlighted/chapter:data-[orientation=vertical]:before:min-h-1.75',
       ],
     },
     thumb: {

--- a/packages/skins/src/styles/tailwind.css
+++ b/packages/skins/src/styles/tailwind.css
@@ -331,28 +331,24 @@
   transition: inset var(--media-duration-fast) ease-in-out;
 }
 
-/* Horizontal slider layer clipped to a progress variable, for example `clip-media-x-[--media-slider-fill]`. */
+/* Horizontal slider layer sized to progress and chapter bounds. */
 @utility clip-media-x-* {
-  --media-slider-layer-start: calc(
-    var(--media-slider-chapter-start, 0%) + var(--media-spacing) * var(--media-chapter-inset-start, 0)
-  );
-  --media-slider-layer-end: max(
+  left: calc(var(--media-slider-chapter-start, 0%) + var(--media-spacing) * var(--media-chapter-inset-start, 0));
+  right: max(
     calc(100% - var(--value([*]))),
     calc(100% - var(--media-slider-chapter-end, 100%) + var(--media-spacing) * var(--media-chapter-inset-end, 0))
   );
-  clip-path: inset(-1px calc(var(--media-slider-layer-end) - 1px) -1px calc(var(--media-slider-layer-start) - 1px));
+  clip-path: inset(-1px 0);
 }
 
-/* Vertical slider layer clipped to a progress variable. */
+/* Vertical slider layer sized to progress and chapter bounds. */
 @utility clip-media-y-* {
-  --media-slider-layer-start: calc(
-    var(--media-slider-chapter-start, 0%) + var(--media-spacing) * var(--media-chapter-inset-start, 0)
-  );
-  --media-slider-layer-end: max(
+  bottom: calc(var(--media-slider-chapter-start, 0%) + var(--media-spacing) * var(--media-chapter-inset-start, 0));
+  top: max(
     calc(100% - var(--value([*]))),
     calc(100% - var(--media-slider-chapter-end, 100%) + var(--media-spacing) * var(--media-chapter-inset-end, 0))
   );
-  clip-path: inset(calc(var(--media-slider-layer-end) - 1px) -1px calc(var(--media-slider-layer-start) - 1px) -1px);
+  clip-path: inset(0 -1px);
 }
 
 /* Horizontal chapter segment clipped to its start and end. */

--- a/packages/skins/src/styles/vars.ts
+++ b/packages/skins/src/styles/vars.ts
@@ -428,14 +428,6 @@ export const vars = {
     kind: 'runtime',
     description: 'Buffered percentage published by Slider and consumed by the Skin.',
   },
-  '--media-slider-layer-start': {
-    kind: 'internal',
-    description: 'Start inset of a painted slider layer, including its chapter gap.',
-  },
-  '--media-slider-layer-end': {
-    kind: 'internal',
-    description: 'End inset of a painted slider layer, limited by progress and its chapter gap.',
-  },
   '--media-slider-chapter-end': {
     kind: 'runtime',
     description: 'Chapter end percentage published by Time Slider and consumed by the Skin.',


### PR DESCRIPTION
- Simplify the previously added slider styles to fix the sub pixel rendering in some scenarios. 
- Restore the slider transitions when not dragging the thumb. 
- Fix the slider clipping offset in HTML skins. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core timeline rendering and motion across CSS/Tailwind skins; behavior is heavily covered by expanded skin-parity e2e, but visual regressions on edge sizes or chapters are still possible.
> 
> **Overview**
> **Reworks seek-slider fill/buffer painting** so progress is driven by **`left`/`right` (or vertical equivalents) plus a light end-cap `clip-path`**, instead of animating **`clip-path`** on the layer. Fill/buffer layers now **`transition-[inset]`**, with duration zeroed only while **dragging** (restoring smooth seeks when not dragging). Track paint uses a full-width **`::before`** with **minimum cap size** so tiny values show a round cap rather than a squashed pill; the thumb is **`bg-white`** again.
> 
> **Time-slider chapters:** buffer/fill get **`chapterLayer`** (wider mins when a chapter is highlighted), and edge chapter gaps use **`first-of-type` / `last-of-type`**. Internal **`--media-slider-layer-*`** tokens are removed.
> 
> **E2E:** parity contracts expect **`inset`** transitions; new video tests cover **paint within track thickness** and **keyboard seek animations** (`left`/`right`); chapter parity runs for **React and HTML** and asserts **`--media-chapter-inset-*`** values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76722d3e3c8660ca7c434ee1cd09f5a08189abb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->