### PR TITLE
fix(skin): animate slider progress continuously across chapters

### DIFF
--- a/apps/e2e/suites/skin-parity/tests/vjsc-audio-skin-styling.spec.ts
+++ b/apps/e2e/suites/skin-parity/tests/vjsc-audio-skin-styling.spec.ts
@@ -410,14 +410,9 @@ async function audioSeekContract(root: Locator) {
   await expect
     .poll(() =>
       slider.evaluate((element) => {
-        const fills = [...element.querySelectorAll('*')]
+        const fills = [element]
           .map((target) => getComputedStyle(target))
-          .filter((style) =>
-            style.transitionProperty
-              .split(',')
-              .map((value) => value.trim())
-              .includes('inset')
-          );
+          .filter((style) => style.transitionProperty.includes('--media-slider-fill'));
 
         return (
           fills.length > 0 &&
@@ -446,14 +441,9 @@ async function audioSeekContract(root: Locator) {
     const style = getComputedStyle(element);
     const root = element.parentElement;
     const expectedX = (root?.getBoundingClientRect().x ?? 0) + expectedOffset;
-    const fills = [...(root?.querySelectorAll('*') ?? [])]
-      .map((target) => getComputedStyle(target))
-      .filter((candidate) =>
-        candidate.transitionProperty
-          .split(',')
-          .map((value) => value.trim())
-          .includes('inset')
-      );
+    const fills = (root ? [getComputedStyle(root)] : []).filter((candidate) =>
+      candidate.transitionProperty.includes('--media-slider-fill')
+    );
     const rect = element.getBoundingClientRect();
     const lag = Math.abs(rect.x + rect.width / 2 - expectedX);
     const positionProperties = new Set(style.transitionProperty.split(',').map((value) => value.trim()));

--- a/apps/e2e/suites/skin-parity/tests/vjsc-video-skin-styling.spec.ts
+++ b/apps/e2e/suites/skin-parity/tests/vjsc-video-skin-styling.spec.ts
@@ -189,6 +189,61 @@ for (const variant of CASES) {
     }
   });
 
+  test(`${variant.framework} ${variant.skin} animates progress continuously across chapters`, async ({ page }) => {
+    const { panels } = await openComparison(page, { ...variant, media: 'hls-7', width: 618 }, async ({ root }) =>
+      expect(root.getByRole('slider', { name: 'Seek' })).toBeEnabled()
+    );
+
+    for (const { root } of panels) {
+      const slider = root.getByRole('slider', { name: 'Seek' }).locator('..');
+
+      await expect(slider.locator('.media-time-slider-chapter, [class~="group/chapter"]')).toHaveCount(8);
+      const progress = await slider.evaluate((element) => {
+        if (!(element instanceof HTMLElement)) throw new Error('Expected a slider element.');
+
+        const properties = ['--media-slider-fill', '--media-slider-buffer'];
+        const layers = element.querySelectorAll(
+          'media-slider-fill, media-slider-buffer, .media-slider-fill, .media-slider-buffer, [class~="before:bg-media-primary"], [class~="before:bg-current/20"]'
+        );
+        const widths = () => [...layers].map((layer) => layer.getBoundingClientRect().width);
+        const setProgress = (value: string) => {
+          for (const property of properties) element.style.setProperty(property, value);
+        };
+
+        element.style.transitionDuration = '0s';
+
+        setProgress('50%');
+        const expected = widths();
+
+        setProgress('0%');
+        widths();
+
+        element.style.transitionDuration = '1s';
+        element.style.transitionTimingFunction = 'linear';
+
+        setProgress('100%');
+        widths();
+
+        const animations = element
+          .getAnimations()
+          .filter(
+            (animation) => animation instanceof CSSTransition && properties.includes(animation.transitionProperty)
+          );
+
+        for (const animation of animations) {
+          animation.pause();
+          animation.currentTime = 500;
+        }
+
+        return { expected, actual: widths(), animations: animations.length };
+      });
+
+      expect(progress.animations).toBe(2);
+      expect(progress.expected.length).toBeGreaterThan(0);
+      expect(progress.actual).toEqual(progress.expected);
+    }
+  });
+
   test(`${variant.framework} ${variant.skin} animates seeks while focused`, async ({ page }) => {
     const { panels } = await openComparison(page, { ...variant, media: 'mp4-1', width: 618 }, async ({ root }) =>
       expect(root.getByRole('slider', { name: 'Seek' })).toBeEnabled()
@@ -211,8 +266,9 @@ for (const variant of CASES) {
             .flatMap((animation) => (animation instanceof CSSTransition ? [animation.transitionProperty] : []))
         );
 
-      expect(properties).toContain('right');
-      expect(properties).toContain('left');
+      expect(properties).toContain('--media-slider-fill');
+      expect(properties).not.toContain('left');
+      expect(properties).not.toContain('width');
     }
   });
 
@@ -724,14 +780,14 @@ test('VJSC preserves the shared skin motion contract', async ({ page }) => {
           properties: style === 'css' ? ['opacity', 'scale'] : ['transform', 'translate', 'scale', 'rotate'],
         },
         slider: {
-          buffer: { duration: '0.1s', properties: ['inset'] },
+          buffer: { duration: '0s', properties: ['all'] },
           chapterTrack: { duration: '0.2s', properties: ['height', 'width'] },
-          fill: { duration: '0.1s', properties: ['inset'] },
+          fill: { duration: '0s', properties: ['all'] },
           focusRing: variant.skin === 'default-video' ? { duration: '0.15s', properties: ['opacity', 'scale'] } : null,
           pointer: { duration: '0.2s', properties: ['opacity', 'scale'] },
           thumb: {
             duration: '0.1s',
-            properties: ['opacity', 'height', 'width', 'outline-offset', 'left', 'top', 'scale'],
+            properties: ['opacity', 'height', 'width', 'outline-offset', 'scale'],
           },
         },
         preview: {
@@ -1038,15 +1094,10 @@ async function seekDragContract(root: Locator) {
     const style = getComputedStyle(element);
     const sliderElement = element.parentElement?.closest('[data-orientation]');
     const expectedX = (sliderElement?.getBoundingClientRect().x ?? 0) + expectedOffset;
-    const slider = [...(sliderElement?.querySelectorAll('*') ?? [])];
+    const slider = sliderElement ? [sliderElement] : [];
     const fills = slider
       .map((target) => getComputedStyle(target))
-      .filter((style) =>
-        style.transitionProperty
-          .split(',')
-          .map((value) => value.trim())
-          .includes('inset')
-      );
+      .filter((style) => style.transitionProperty.includes('--media-slider-fill'));
     const rect = element.getBoundingClientRect();
     const lag = Math.abs(rect.x + rect.width / 2 - expectedX);
     const positionProperties = new Set(style.transitionProperty.split(',').map((value) => value.trim()));

--- a/packages/skins/src/styles/base.css
+++ b/packages/skins/src/styles/base.css
@@ -6,6 +6,19 @@
 @import "./themes/minimal.css";
 @import "./themes/preferences.css";
 
+/* Interpolate progress before chapter bounds are applied. */
+@property --media-slider-fill {
+  syntax: "<percentage>";
+  inherits: true;
+  initial-value: 0%;
+}
+
+@property --media-slider-buffer {
+  syntax: "<percentage>";
+  inherits: true;
+  initial-value: 0%;
+}
+
 @layer base {
   @scope (.media-skin) {
     :scope {

--- a/packages/skins/src/styles/sliders/slider.styles.ts
+++ b/packages/skins/src/styles/sliders/slider.styles.ts
@@ -5,8 +5,6 @@ const trackLayer = [
   'pointer-events-none absolute inset-0 before:absolute before:size-full before:rounded-media-control',
   'data-[orientation=horizontal]:before:left-0 data-[orientation=horizontal]:before:min-w-1',
   'data-[orientation=vertical]:before:bottom-0 data-[orientation=vertical]:before:min-h-1',
-  'transition-[inset] duration-media-slider ease-out',
-  'group-data-dragging/slider:duration-0',
 ] as const;
 
 export default styles({
@@ -17,6 +15,7 @@ export default styles({
       utilities: [
         'group/slider relative flex flex-1 cursor-pointer items-center justify-center outline-hidden',
         'data-disabled:pointer-events-none',
+        'transition-[--media-slider-fill,--media-slider-buffer] duration-media-slider ease-out data-dragging:duration-0',
         'rounded-media-pill',
         'data-[orientation=horizontal]:[height:var(--media-slider-height,--spacing(8))]',
         'data-[orientation=vertical]:w-8 data-[orientation=vertical]:min-w-0',
@@ -53,8 +52,7 @@ export default styles({
     thumb: {
       utilities: [
         'absolute z-10 top-1/2 left-(--media-slider-fill) size-3 -translate-x-1/2 -translate-y-1/2 rounded-media-control bg-white',
-        'select-none transition-[opacity,height,width,outline-offset,left,top,scale] duration-media-slider ease-out',
-        'group-data-dragging/slider:transition-[opacity,height,width,outline-offset,scale]',
+        'select-none transition-[opacity,height,width,outline-offset,scale] duration-media-slider ease-out',
         'group-data-dragging/slider:scale-90',
         'data-[orientation=vertical]:top-[calc(100%-var(--media-slider-fill))] data-[orientation=vertical]:left-1/2',
         'group-data-dragging/slider:data-[orientation=horizontal]:left-(--media-slider-pointer)',


### PR DESCRIPTION
## Summary

Fix seek and buffer transitions that animate each chapter independently. Register the shared fill and buffer percentages with `@property` and animate them on the slider before applying chapter bounds, so progress moves continuously through the track.

## Changes

- Keep the thumb aligned with the animated fill and dragging immediate.
- Preserve the existing chapter clipping and rounded paint geometry.
- Add midpoint regression coverage for fill and buffer progression across chapters, and update audio and video transition assertions.

## Testing

- 20 focused Chromium and WebKit E2E checks passed across HTML/React and CSS/Tailwind.
- `pnpm -F @videojs/skins test`: 48 passed.
- Formatting, lint and `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core seek/buffer rendering and transition behavior across video/audio skins; regressions would show as janky seeks or chapter-boundary jumps, though coverage was expanded in E2E.
> 
> **Overview**
> Seek and buffer progress now animate via registered **`--media-slider-fill`** and **`--media-slider-buffer`** custom properties instead of per-layer **`inset`** transitions, so playback moves smoothly across chapter segments.
> 
> **`base.css`** adds **`@property`** rules so those percentages interpolate. **`slider.styles.ts`** moves **`transition-[--media-slider-fill,--media-slider-buffer]`** to the slider root (instant while **`data-dragging`**), drops inset animation from track layers, and stops transitioning the thumb’s **`left`/`top`** at rest while keeping pointer-based positioning during drag.
> 
> Skin-parity E2E tests assert **`--media-slider-fill`** transitions on the root, add a chaptered HLS case that fill/buffer widths stay in sync mid-animation, and refresh the shared motion contract (fill/buffer no longer **`inset`**-driven; thumb omits position properties).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c471e5e1d493a70093c3c5d86bb11bc7a48f80b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->