### PR TITLE
test: fix e2e tests for volume slider

### DIFF
--- a/apps/e2e/shared/fixtures/volume-slider.ts
+++ b/apps/e2e/shared/fixtures/volume-slider.ts
@@ -48,6 +48,16 @@ export async function holdVolumeKey(
     await page.waitForTimeout(17);
   }
 
+  // Let the final keyboard step finish animating before checking for a jump on release.
+  await slider.evaluate(async (element) => {
+    let animations = element.getAnimations({ subtree: true });
+
+    while (animations.length) {
+      await Promise.allSettled(animations.map((animation) => animation.finished));
+      animations = element.getAnimations({ subtree: true }).filter((animation) => animation.playState !== 'finished');
+    }
+  });
+
   const beforeRelease = await getThumbPercent(slider);
 
   await page.keyboard.up(key);


### PR DESCRIPTION
Fix the test failures for the volume slider. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a Playwright fixture; no production behavior affected.
> 
> **Overview**
> Stabilizes the volume slider keyboard e2e helper by **waiting for in-flight CSS/Web Animations** on the slider (including subtree) to finish after the repeated key presses, and only then sampling `beforeRelease`.
> 
> That timing fix targets flaky failures in `slider-keyboard.spec.ts` where release thumb position is expected to match the pre-release value—previously the check could run while the thumb was still animating from the last key step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98de68afffbfc90b3560347eb2ab0a05c953662c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->