### PR TITLE
feat(mux-video): load the asset title from the mux metadata api

### DIFF
--- a/apps/sandbox/app/styles.css
+++ b/apps/sandbox/app/styles.css
@@ -56,6 +56,18 @@
   aspect-ratio: auto;
 }
 
+/* The skins don't place the title; the Mux pages overlay it to show the one the media loads for the asset. */
+.sandbox-media-title {
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 1;
+  padding: 0.75rem 1rem 2.5rem;
+  background: linear-gradient(to bottom, rgb(0 0 0 / 0.7), transparent);
+  color: white;
+  font-weight: 600;
+  pointer-events: none;
+}
+
 #root :has(> :is(audio-player, live-audio-player)) {
   max-width: var(--sandbox-player-width, 36rem);
 }

--- a/apps/sandbox/templates/html-mux-video-spf/main.ts
+++ b/apps/sandbox/templates/html-mux-video-spf/main.ts
@@ -4,6 +4,7 @@ import '@videojs/html/live-video/player';
 import '@videojs/html/extensions/google-cast';
 import '@videojs/html/extensions/mux-data';
 import '@videojs/html/media/mux-video/spf';
+import '@videojs/html/ui/title';
 import { createHtmlSandbox, html } from '@app/shared/html/sandbox';
 
 // The SPF-backed `<mux-video>`, alongside the hls.js-backed `<mux-video>` in
@@ -28,6 +29,8 @@ createHtmlSandbox({
       <${skinTag} class="sandbox-video-frame mx-auto max-w-4xl">
         <!-- The player fills in the poster; the slotted image paints a blurred placeholder underneath while it loads. -->
         ${placeholder ? html`<img slot="poster" alt="" crossorigin style="background: url('${placeholder}') var(--media-object-position, center) / contain no-repeat" />` : ''}
+        <!-- The title Mux publishes for the asset, loaded into contentData.title; see html-mux-video. -->
+        <media-title class="sandbox-media-title"></media-title>
         <!-- The storyboard track is derived automatically from the Mux src. -->
         <mux-video${src} ${attrs} playsinline crossorigin></mux-video>
         <!-- Opt-in media components; no env key is needed for Mux-hosted sources. -->

--- a/apps/sandbox/templates/html-mux-video/main.ts
+++ b/apps/sandbox/templates/html-mux-video/main.ts
@@ -4,6 +4,7 @@ import '@videojs/html/live-video/player';
 import '@videojs/html/extensions/google-cast';
 import '@videojs/html/extensions/mux-data';
 import '@videojs/html/media/mux-video';
+import '@videojs/html/ui/title';
 import { createHtmlSandbox, html } from '@app/shared/html/sandbox';
 
 createHtmlSandbox({
@@ -22,6 +23,9 @@ createHtmlSandbox({
         <!-- The storyboard track is derived automatically from the Mux src. The slotted image replaces the skin's
              preview image so it can carry its own loading hints; the skin still fills in the frame under the pointer. -->
         <img slot="thumbnail" alt="" decoding="async" fetchpriority="low" />
+        <!-- The skins don't place the title; this overlay shows the one Mux publishes for the asset, which the media
+             loads into contentData.title. Nothing sets content-title on the player, so what appears is the asset's own. -->
+        <media-title class="sandbox-media-title"></media-title>
         <mux-video${src} ${attrs} playsinline crossorigin>${chapters}</mux-video>
         <!-- Mux Data and Cast are opt-in media components; no env key is needed for Mux-hosted sources. -->
         <mux-data player-software-name="mux-video"></mux-data>

--- a/apps/sandbox/templates/react-mux-video-spf/main.tsx
+++ b/apps/sandbox/templates/react-mux-video-spf/main.tsx
@@ -4,6 +4,7 @@ import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useSandbox } from '@app/shared/react/use-sandbox';
 import { getPlaceholderSrc, getPosterSrc, isLiveSource, SOURCES } from '@app/shared/sources';
+import { Title } from '@videojs/react';
 import { GoogleCast } from '@videojs/react/extensions/google-cast';
 import { MuxData } from '@videojs/react/extensions/mux-data';
 import { MuxVideo } from '@videojs/react/media/mux-video/spf';
@@ -47,6 +48,8 @@ function App() {
           }
           live={live}
         >
+          {/* The title Mux publishes for the asset, loaded into `contentData.title`; see react-mux-video. */}
+          <Title className="sandbox-media-title" />
           {/* The storyboard track is derived automatically from the Mux src. */}
           <MuxVideo
             {...(muxSource ? { source: muxSource } : { src: url ?? '' })}

--- a/apps/sandbox/templates/react-mux-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-video/main.tsx
@@ -5,6 +5,7 @@ import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useSandbox } from '@app/shared/react/use-sandbox';
 import { getChapters, getPlaceholderSrc, getPosterSrc, isLiveSource, SOURCES } from '@app/shared/sources';
+import { Title } from '@videojs/react';
 import { GoogleCast } from '@videojs/react/extensions/google-cast';
 import { MuxData } from '@videojs/react/extensions/mux-data';
 import { MuxVideo } from '@videojs/react/media/mux-video';
@@ -42,6 +43,9 @@ function App() {
           renderThumbnail={<img alt="" decoding="async" fetchPriority="low" />}
           live={live}
         >
+          {/* The skins don't place the title; this overlay shows the one Mux publishes for the asset, which the
+              media loads into `contentData.title`. Nothing sets `title` on the player, so what appears is the asset's own. */}
+          <Title className="sandbox-media-title" />
           {/* The storyboard track is derived automatically from the Mux src. */}
           <MuxVideo
             {...(muxSource ? { source: muxSource } : { src: url ?? '' })}

--- a/packages/adapters/mux-audio/src/spf/tests/adapter.test.ts
+++ b/packages/adapters/mux-audio/src/spf/tests/adapter.test.ts
@@ -5,9 +5,24 @@
  * What's worth asserting here is that applying it to the audio-only Media keeps that surface intact — the two extend
  * different bases, so nothing guarantees it but a test — plus the two things this flavor decides for itself.
  */
-import { describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { MuxAudioAdapter } from '../adapter';
+
+// The document Mux serves for the asset, the first chapter standing for it.
+const DOCUMENT = [{ 'start-time': 0, titles: [{ language: 'und', title: 'Big Buck Bunny' }] }];
+
+// Every Mux source fetches its metadata, so no test here reaches the network.
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify(DOCUMENT), { status: 200 }))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('MuxAudioAdapter', () => {
   it('defaults source to null', () => {
@@ -72,6 +87,18 @@ describe('MuxAudioAdapter', () => {
     media.source = { playbackId: 'abc123' };
 
     expect(onContentDataChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads the title from the asset metadata, like the video flavor', async () => {
+    const media = new MuxAudioAdapter();
+
+    media.source = { playbackId: 'abc123' };
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(fetch).toHaveBeenCalledWith('https://stream.mux.com/abc123/metadata.json', expect.anything());
+    expect(media.contentData.title).toBe('Big Buck Bunny');
   });
 
   it('points unplayable-source copy at the hls.js-backed Media', () => {

--- a/packages/adapters/mux-video/src/adapter.ts
+++ b/packages/adapters/mux-video/src/adapter.ts
@@ -5,8 +5,10 @@ import {
   createMuxVideoURL,
   type MuxContentData,
   type MuxDrmParams,
+  MuxMetadataLoader,
   type MuxSourceBase,
   parseMuxVideoURL,
+  toMuxContentData,
 } from '@videojs/mux';
 import { shallowEqual } from '@videojs/utils/object';
 
@@ -32,7 +34,8 @@ export interface MuxVideoAdapterProps {
 /**
  * @fires sourcechange - Fired when `source` changes, either directly or by parsing a new `src`. Read `source` for the
  *   new value.
- * @fires contentdatachange - Fired when the derived `contentData` changes. Read `contentData` for the new value.
+ * @fires contentdatachange - Fired when `contentData` changes: the derived URLs with `source`, and the metadata once it
+ *   loads. Read `contentData` for the new value.
  */
 export class MuxVideoAdapter extends HlsJsAdapter implements MuxVideoAdapterProps {
   static override readonly defaultProps: Omit<HlsJsAdapterProps, 'source'> & MuxVideoAdapterProps = {
@@ -43,6 +46,14 @@ export class MuxVideoAdapter extends HlsJsAdapter implements MuxVideoAdapterProp
 
   #source: MuxSource | null = MuxVideoAdapter.defaultProps.source;
   #contentData: MuxContentData = {};
+  #metadata = new MuxMetadataLoader(() => {
+    if (this.#refreshContentData()) this.dispatchEvent(new Event('contentdatachange'));
+  });
+
+  override destroy() {
+    this.#metadata.destroy();
+    super.destroy();
+  }
 
   /**
    * Media source URL. Setting a Mux stream URL (`https://stream.mux.com/<playback-id>.m3u8?...`) extracts the playback
@@ -101,6 +112,7 @@ export class MuxVideoAdapter extends HlsJsAdapter implements MuxVideoAdapterProp
     if (source === this.#source) return;
 
     this.#source = source;
+    this.#metadata.reset(source);
 
     // Refresh the bag before the base announces `sourcechange`, because
     // listeners read `contentData` from that event. Announcing its own change
@@ -120,24 +132,37 @@ export class MuxVideoAdapter extends HlsJsAdapter implements MuxVideoAdapterProp
   }
 
   /**
-   * Image URLs `source` describes rather than plays: `poster` from its `poster` params, `storyboard` from its
-   * `storyboard` params. A key is absent when the URL can't be built — no playback ID, or signed playback without a
-   * matching image token.
+   * What `source` says about its content. `poster` and `storyboard` are image URLs it describes rather than plays, from
+   * its `poster` and `storyboard` params; a key is absent when the URL can't be built — no playback ID, or signed
+   * playback without a matching image token. `title` and the rest come from the metadata Mux publishes for the asset,
+   * which loads with the source, so they arrive later than the URLs and are absent until then.
    *
-   * Derived from `source` and nothing else. The same object is handed back until one of those URLs changes, and
-   * `contentdatachange` announces it when it does. Nothing here is applied for you, apart from the thumbnail track
-   * `<mux-video>` adds from `storyboard` (and drops for live streams).
+   * The same object is handed back until something in it changes, and `contentdatachange` announces it when it does.
+   * Nothing here is applied for you, apart from the thumbnail track `<mux-video>` adds from `storyboard` (and drops for
+   * live streams).
    */
   get contentData(): MuxContentData {
     return this.#contentData;
   }
 
-  /** Rebuild the derived bag, reporting whether anything about it changed. */
+  override load() {
+    const loading = super.load();
+
+    // The metadata goes with the load rather than the assignment: the same
+    // playback ID may be assigned several times over without playing, and one
+    // small request per source that actually loads is the right cost.
+    this.#metadata.load();
+
+    return loading;
+  }
+
+  /** Rebuild the bag from `source` and the metadata, reporting whether anything about it changed. */
   #refreshContentData(): boolean {
     const poster = createMuxPosterURL(this.#source);
     const storyboard = createMuxStoryboardURL(this.#source);
 
     const next: MuxContentData = {
+      ...toMuxContentData(this.#metadata.metadata),
       ...(poster && { poster }),
       ...(storyboard && { storyboard }),
     };

--- a/packages/adapters/mux-video/src/spf/mixin.ts
+++ b/packages/adapters/mux-video/src/spf/mixin.ts
@@ -3,8 +3,10 @@ import {
   createMuxStoryboardURL,
   createMuxVideoURL,
   type MuxContentData,
+  MuxMetadataLoader,
   type MuxSourceBase,
   parseMuxVideoURL,
+  toMuxContentData,
 } from '@videojs/mux';
 import { shallowEqual } from '@videojs/utils/object';
 import type { Constructor, MixinReturn } from '@videojs/utils/types';
@@ -29,9 +31,13 @@ export interface MuxAdapterAPI extends MuxAdapterProps {
  * Unlike the hls.js-backed `MuxVideoAdapter`, there is no inherited `source` to delegate to — the SPF Medias know only
  * `src` — so this owns the structured source and dispatches `sourcechange` itself.
  *
+ * The metadata Mux publishes for the asset is fetched as soon as a playback ID is known. The hls.js-backed flavor waits
+ * for its `load()`; SPF has no such step — assigning `src` is the load — so the assignment is the moment here.
+ *
  * @fires sourcechange - Fired when `source` changes, either directly or by parsing a new `src`. Read `source` for the
  *   new value.
- * @fires contentdatachange - Fired when the derived `contentData` changes. Read `contentData` for the new value.
+ * @fires contentdatachange - Fired when `contentData` changes: the derived URLs with `source`, and the metadata once it
+ *   loads. Read `contentData` for the new value.
  */
 export function MuxMixin<Base extends Constructor<any>>(BaseClass: Base) {
   class MuxImpl extends BaseClass {
@@ -54,6 +60,14 @@ export function MuxMixin<Base extends Constructor<any>>(BaseClass: Base) {
 
     #source: MuxSourceBase | null = MuxImpl.defaultProps.source;
     #contentData: MuxContentData = {};
+    #metadata = new MuxMetadataLoader(() => {
+      if (this.#refreshContentData()) this.dispatchEvent?.(new Event('contentdatachange'));
+    });
+
+    destroy() {
+      this.#metadata.destroy();
+      super.destroy?.();
+    }
 
     /**
      * Media source URL. Setting a Mux stream URL (`https://stream.mux.com/<playback-id>.m3u8?...`) extracts the
@@ -91,6 +105,7 @@ export function MuxMixin<Base extends Constructor<any>>(BaseClass: Base) {
       if (source === this.#source) return;
 
       this.#source = source;
+      this.#metadata.reset(source);
 
       // Refresh the bag before announcing `sourcechange`, because listeners read
       // `contentData` from that event. Announcing its own change waits until
@@ -102,25 +117,29 @@ export function MuxMixin<Base extends Constructor<any>>(BaseClass: Base) {
       this.dispatchEvent?.(new Event('sourcechange'));
 
       if (contentDataChanged) this.dispatchEvent?.(new Event('contentdatachange'));
+
+      this.#metadata.load();
     }
 
     /**
-     * Image URLs `source` describes rather than plays: `poster` from its `poster` params, `storyboard` from its
-     * `storyboard` params.
+     * What `source` says about its content. `poster` and `storyboard` are image URLs it describes rather than plays,
+     * from its `poster` and `storyboard` params. `title` and the rest come from the metadata Mux publishes for the
+     * asset, which loads with the source, so they arrive later than the URLs and are absent until then.
      *
-     * Derived from `source` and nothing else. The same object is handed back until one of those URLs changes, and
-     * `contentdatachange` announces it when it does. Nothing here is applied for you.
+     * The same object is handed back until something in it changes, and `contentdatachange` announces it when it does.
+     * Nothing here is applied for you.
      */
     get contentData(): MuxContentData {
       return this.#contentData;
     }
 
-    /** Rebuild the derived bag, reporting whether anything about it changed. */
+    /** Rebuild the bag from `source` and the metadata, reporting whether anything about it changed. */
     #refreshContentData(): boolean {
       const poster = createMuxPosterURL(this.#source);
       const storyboard = createMuxStoryboardURL(this.#source);
 
       const next: MuxContentData = {
+        ...toMuxContentData(this.#metadata.metadata),
         ...(poster && { poster }),
         ...(storyboard && { storyboard }),
       };

--- a/packages/adapters/mux-video/src/spf/tests/adapter.test.ts
+++ b/packages/adapters/mux-video/src/spf/tests/adapter.test.ts
@@ -5,9 +5,50 @@
  * (`packages/adapters/mux-video/src/tests/adapter.test.ts`), minus everything that flavor's `engine` / `preferPlayback`
  * options carry — this source is Mux identity and nothing else.
  */
-import { describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { MuxVideoAdapter } from '../adapter';
+
+// The document Mux serves: Apple's JSON chapters, the first chapter standing
+// for the asset.
+const DOCUMENT = [
+  {
+    'start-time': 0,
+    titles: [{ language: 'und', title: 'Big Buck Bunny' }],
+    metadata: [{ key: 'com.mux.video.branding', value: 'mux-free-plan' }],
+  },
+];
+
+function stubFetch(body: unknown = DOCUMENT, status = 200) {
+  const fetchMock = vi.fn(async (_input: string | URL | Request) => new Response(JSON.stringify(body), { status }));
+
+  vi.stubGlobal('fetch', fetchMock);
+
+  return fetchMock;
+}
+
+// The engine fetches the manifest through the same global; only the metadata
+// requests are of interest here.
+function metadataRequests(fetchMock: ReturnType<typeof stubFetch>) {
+  return fetchMock.mock.calls.map(([input]) => String(input)).filter((url) => url.includes('metadata.json'));
+}
+
+// Let a resolved fetch settle into `contentData`.
+function flush() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+// Every Mux source fetches its metadata, so no test here reaches the network.
+beforeEach(() => {
+  stubFetch();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe('MuxVideoAdapter', () => {
   it('defaults source to null', () => {
@@ -223,5 +264,133 @@ describe('MuxVideoAdapter', () => {
     // import path, since this one Media is reached through three packages.
     expect(MuxVideoAdapter.alternativeMediaSuggestion).toContain('hls-js');
     expect(MuxVideoAdapter.alternativeMediaSuggestion).not.toContain('@videojs/');
+  });
+
+  describe('metadata', () => {
+    it('fetches the metadata as soon as a playback id is known', async () => {
+      const fetchMock = stubFetch();
+      const media = new MuxVideoAdapter();
+      const handler = vi.fn();
+
+      media.addEventListener('contentdatachange', handler);
+      media.source = { playbackId: 'abc123', playback: { token: 'jwt' } };
+
+      // SPF surfaces no session data, so there is no manifest to wait on.
+      expect(metadataRequests(fetchMock)).toEqual(['https://stream.mux.com/abc123/metadata.json?token=jwt']);
+      expect(media.contentData.title).toBeUndefined();
+
+      await flush();
+
+      // Signed playback without image tokens derives no URLs, so the metadata
+      // is the one change announced.
+      expect(media.contentData).toEqual({
+        title: 'Big Buck Bunny',
+        'com.mux.video.branding': 'mux-free-plan',
+      });
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fetch for a non-Mux source', () => {
+      const fetchMock = stubFetch();
+      const media = new MuxVideoAdapter();
+
+      media.source = { src: 'https://example.com/stream.m3u8' };
+
+      expect(metadataRequests(fetchMock)).toEqual([]);
+    });
+
+    it('keeps the title when only image params change', async () => {
+      const fetchMock = stubFetch();
+      const media = new MuxVideoAdapter();
+
+      media.source = { playbackId: 'abc123' };
+      await flush();
+
+      // What `poster-time` does through the element: same stream, new object.
+      media.source = { playbackId: 'abc123', poster: { time: 3 } };
+      await flush();
+
+      expect(media.contentData.title).toBe('Big Buck Bunny');
+      expect(media.contentData.poster).toBe('https://image.mux.com/abc123/thumbnail.webp?time=3');
+      expect(metadataRequests(fetchMock)).toHaveLength(1);
+    });
+
+    it('drops the title with the playback id, before the next one loads', async () => {
+      const fetchMock = stubFetch();
+      const media = new MuxVideoAdapter();
+
+      media.source = { playbackId: 'abc123' };
+      await flush();
+
+      const seen: (string | null | undefined)[] = [];
+
+      media.addEventListener('sourcechange', () => seen.push(media.contentData.title));
+      media.source = { playbackId: 'xyz789' };
+
+      expect(seen).toEqual([undefined]);
+
+      await flush();
+
+      expect(metadataRequests(fetchMock)).toEqual([
+        'https://stream.mux.com/abc123/metadata.json',
+        'https://stream.mux.com/xyz789/metadata.json',
+      ]);
+      expect(media.contentData.title).toBe('Big Buck Bunny');
+    });
+
+    it('clears the title with the source', async () => {
+      const media = new MuxVideoAdapter();
+
+      media.source = { playbackId: 'abc123' };
+      await flush();
+
+      media.source = null;
+
+      expect(media.contentData).toEqual({});
+    });
+
+    it('has no title for an asset without metadata', async () => {
+      stubFetch([{ 'start-time': 0 }]);
+
+      const media = new MuxVideoAdapter();
+      const handler = vi.fn();
+
+      media.source = { playbackId: 'abc123' };
+      media.addEventListener('contentdatachange', handler);
+      await flush();
+
+      expect(media.contentData.title).toBeUndefined();
+      // An empty document changes nothing, so nothing is announced.
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('has no title when the document fails to load', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      stubFetch('', 500);
+
+      const media = new MuxVideoAdapter();
+
+      media.source = { playbackId: 'abc123' };
+      await flush();
+
+      expect(media.contentData.title).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('500'));
+    });
+
+    it('aborts the request in flight on destroy', () => {
+      const fetchMock = vi.fn((_url: string, _init?: RequestInit) => new Promise<Response>(() => {}));
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      const media = new MuxVideoAdapter();
+
+      media.source = { playbackId: 'abc123' };
+      media.destroy();
+
+      const request = fetchMock.mock.calls.find(([url]) => url.includes('metadata.json'));
+
+      expect(request?.[1]?.signal?.aborted).toBe(true);
+    });
   });
 });

--- a/packages/adapters/mux-video/src/tests/adapter.test.ts
+++ b/packages/adapters/mux-video/src/tests/adapter.test.ts
@@ -1,7 +1,17 @@
 import { Hls, HlsJsAdapter } from '@videojs/hlsjs-video';
-import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { MuxVideoAdapter, type MuxSource } from '..';
+
+// Every Mux source fetches its metadata, and native playback fetches the
+// manifest alongside; neither should reach the network from here. Tests that
+// care about a response stub their own.
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('', { status: 404 }))
+  );
+});
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -604,7 +614,11 @@ describe('MuxVideoAdapter', () => {
         requestMediaKeySystemAccess: async () => ({ createMediaKeys: async () => mediaKeys }),
       });
 
-      const fetchMock = vi.fn(async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(4) }) as Response);
+      // Answers the certificate request, and the metadata one every Mux source
+      // makes alongside it.
+      const fetchMock = vi.fn(
+        async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(4), json: async () => [] }) as Response
+      );
 
       vi.stubGlobal('fetch', fetchMock);
       return fetchMock;
@@ -690,9 +704,10 @@ describe('MuxVideoAdapter', () => {
       fireEncrypted(video);
       await flushLoad();
 
-      // The caller named no certificate URL, so nothing is fetched — least of all
-      // from the servers the token would have derived.
-      expect(fetchMock).not.toHaveBeenCalled();
+      // The caller named no certificate URL, so no certificate is fetched — least
+      // of all from the servers the token would have derived. (The one request
+      // made is for the asset's metadata, which every Mux source loads.)
+      expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining('license.mux.com'), expect.anything());
     });
 
     it('lets a license server named alongside the token replace the derived one', async () => {
@@ -765,6 +780,196 @@ describe('MuxVideoAdapter', () => {
       await flushLoad();
 
       expect(loadstart).toHaveBeenCalled();
+    });
+  });
+
+  describe('metadata', () => {
+    // The document Mux serves: Apple's JSON chapters, the first chapter standing
+    // for the asset.
+    const DOCUMENT = [
+      {
+        'start-time': 0,
+        titles: [{ language: 'und', title: 'Big Buck Bunny' }],
+        metadata: [{ key: 'com.mux.video.branding', value: 'mux-free-plan' }],
+      },
+    ];
+
+    function stubFetch(body: unknown = DOCUMENT, status = 200) {
+      const fetchMock = vi.fn(async (input: string | URL | Request) => {
+        const url = input instanceof Request ? input.url : String(input);
+        // The native live mixin fetches the manifest in parallel; only the
+        // metadata document is answered here.
+        if (!url.includes('metadata.json')) return new Response('', { status: 404 });
+
+        return new Response(JSON.stringify(body), { status });
+      });
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      return fetchMock;
+    }
+
+    function metadataRequests(fetchMock: ReturnType<typeof stubFetch>) {
+      return fetchMock.mock.calls.map(([input]) => String(input)).filter((url) => url.includes('metadata.json'));
+    }
+
+    it('has no title until the metadata has loaded', () => {
+      stubFetch();
+
+      const media = new MuxVideoAdapter();
+
+      media.source = { playbackId: 'abc123' };
+
+      expect(media.contentData.title).toBeUndefined();
+    });
+
+    it('loads the metadata with the source, over hls.js', async () => {
+      vi.spyOn(Hls, 'isSupported').mockReturnValue(true);
+
+      const fetchMock = stubFetch();
+      const media = new MuxVideoAdapter();
+      const handler = vi.fn();
+
+      media.attach(document.createElement('video'));
+      media.addEventListener('contentdatachange', handler);
+      media.source = { playbackId: 'abc123' };
+      await flushLoad();
+
+      expect(media.engine).not.toBeNull();
+      expect(metadataRequests(fetchMock)).toEqual(['https://stream.mux.com/abc123/metadata.json']);
+      expect(media.contentData).toEqual({
+        title: 'Big Buck Bunny',
+        'com.mux.video.branding': 'mux-free-plan',
+        poster: 'https://image.mux.com/abc123/thumbnail.webp',
+        storyboard: 'https://image.mux.com/abc123/storyboard.vtt?format=webp',
+      });
+      // Once for the URLs with `source`, once for the metadata.
+      expect(handler).toHaveBeenCalledTimes(2);
+
+      media.destroy();
+    });
+
+    it('loads the metadata with the source, over native playback, with the playback token', async () => {
+      const fetchMock = stubFetch();
+      const media = new MuxVideoAdapter();
+
+      media.attach(document.createElement('video'));
+      media.source = { playbackId: 'abc123', preferPlayback: 'native', playback: { token: 'jwt' } };
+      await flushLoad();
+
+      // Signed playback answers 403 without it.
+      expect(metadataRequests(fetchMock)).toEqual(['https://stream.mux.com/abc123/metadata.json?token=jwt']);
+      expect(media.contentData.title).toBe('Big Buck Bunny');
+
+      media.destroy();
+    });
+
+    it('does not fetch for a non-Mux source', async () => {
+      const fetchMock = stubFetch();
+      const media = new MuxVideoAdapter();
+
+      media.attach(document.createElement('video'));
+      media.source = { src: 'https://example.com/custom.m3u8', preferPlayback: 'native' };
+      await flushLoad();
+
+      expect(metadataRequests(fetchMock)).toEqual([]);
+
+      media.destroy();
+    });
+
+    it('keeps the title when only image params change', async () => {
+      const fetchMock = stubFetch();
+      const media = new MuxVideoAdapter();
+
+      media.attach(document.createElement('video'));
+      media.source = { playbackId: 'abc123', preferPlayback: 'native' };
+      await flushLoad();
+
+      // What `poster-time` does through the element: same stream, new object,
+      // and no reload to fetch the document again on.
+      media.source = { playbackId: 'abc123', preferPlayback: 'native', poster: { time: 3 } };
+      await flushLoad();
+
+      expect(media.contentData.title).toBe('Big Buck Bunny');
+      expect(media.contentData.poster).toBe('https://image.mux.com/abc123/thumbnail.webp?time=3');
+      expect(metadataRequests(fetchMock)).toHaveLength(1);
+
+      media.destroy();
+    });
+
+    it('drops the title with the playback id, before the next one loads', async () => {
+      const fetchMock = stubFetch();
+      const media = new MuxVideoAdapter();
+
+      media.attach(document.createElement('video'));
+      media.source = { playbackId: 'abc123', preferPlayback: 'native' };
+      await flushLoad();
+
+      const seen: (string | null | undefined)[] = [];
+
+      media.addEventListener('sourcechange', () => seen.push(media.contentData.title));
+      media.source = { playbackId: 'xyz789', preferPlayback: 'native' };
+
+      expect(seen).toEqual([undefined]);
+
+      await flushLoad();
+
+      expect(metadataRequests(fetchMock)).toEqual([
+        'https://stream.mux.com/abc123/metadata.json',
+        'https://stream.mux.com/xyz789/metadata.json',
+      ]);
+      expect(media.contentData.title).toBe('Big Buck Bunny');
+
+      media.destroy();
+    });
+
+    it('clears the title with the source', async () => {
+      stubFetch();
+
+      const media = new MuxVideoAdapter();
+
+      media.attach(document.createElement('video'));
+      media.source = { playbackId: 'abc123', preferPlayback: 'native' };
+      await flushLoad();
+
+      media.source = null;
+
+      expect(media.contentData).toEqual({});
+    });
+
+    it('has no title for an asset without metadata', async () => {
+      stubFetch([{ 'start-time': 0 }]);
+
+      const media = new MuxVideoAdapter();
+      const handler = vi.fn();
+
+      media.attach(document.createElement('video'));
+      media.source = { playbackId: 'abc123', preferPlayback: 'native' };
+      media.addEventListener('contentdatachange', handler);
+      await flushLoad();
+
+      expect(media.contentData.title).toBeUndefined();
+      // An empty document changes nothing, so nothing is announced.
+      expect(handler).not.toHaveBeenCalled();
+
+      media.destroy();
+    });
+
+    it('has no title when the document fails to load', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      stubFetch('', 500);
+
+      const media = new MuxVideoAdapter();
+
+      media.attach(document.createElement('video'));
+      media.source = { playbackId: 'abc123', preferPlayback: 'native' };
+      await flushLoad();
+
+      expect(media.contentData.title).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('500'));
+
+      media.destroy();
     });
   });
 });

--- a/packages/adapters/mux/src/index.ts
+++ b/packages/adapters/mux/src/index.ts
@@ -1,1 +1,2 @@
+export * from './metadata';
 export * from './source';

--- a/packages/adapters/mux/src/metadata.ts
+++ b/packages/adapters/mux/src/metadata.ts
@@ -1,0 +1,157 @@
+import { isAbortError, isPlainObject, isString } from '@videojs/utils/predicate';
+
+import { createMuxQuery, MUX_VIDEO_DOMAIN, type MuxContentData, type MuxSourceBase } from './source';
+
+/**
+ * The metadata Mux publishes for an asset, flattened to one value per key: `title` from the document's title list, and
+ * every `{ key, value }` entry under its own key — Mux Data's names (`video_title`, …) and Mux's reverse-DNS ones such
+ * as `com.mux.video.branding`.
+ */
+export type MuxMetadata = Readonly<Record<string, string>>;
+
+/**
+ * Build the metadata URL for a source. Every Mux asset has a document there, titled or not, and signed playback carries
+ * its `playback.token` along — the document sits under the playback ID like every other URL the token covers, and
+ * answers `403` without it.
+ */
+export function createMuxMetadataURL(source?: MuxSourceBase | null): string | undefined {
+  if (!source?.playbackId) return undefined;
+
+  const { playbackId, customDomain = MUX_VIDEO_DOMAIN, playback } = source;
+
+  return `https://stream.${customDomain}/${playbackId}/metadata.json${createMuxQuery({ token: playback?.token })}`;
+}
+
+/**
+ * Flatten the metadata document to one value per key.
+ *
+ * The document is Apple's JSON chapters format: a list of chapters, the first of which stands for the asset. Its
+ * `titles` carry the asset title (`[{ language, title }]`, the first being the default), and its `metadata` carries `{
+ * key, value }` entries. An asset without metadata still has a document, just without either, so anything unexpected
+ * flattens to an empty object rather than failing.
+ */
+export function parseMuxMetadata(json: unknown): MuxMetadata {
+  const metadata: Record<string, string> = {};
+
+  const [first] = Array.isArray(json) ? json : [];
+  if (!isPlainObject(first)) return metadata;
+
+  const { titles, metadata: entries } = first;
+
+  if (Array.isArray(entries)) {
+    for (const entry of entries) {
+      if (isPlainObject(entry) && isString(entry.key) && entry.key && isString(entry.value)) {
+        metadata[entry.key] = entry.value;
+      }
+    }
+  }
+
+  const [defaultTitle] = Array.isArray(titles) ? titles : [];
+  const title = isPlainObject(defaultTitle) ? defaultTitle.title : undefined;
+
+  if (isString(title) && title) metadata.title = title;
+
+  return metadata;
+}
+
+/**
+ * Fetch and flatten the metadata document at `url`.
+ *
+ * Resolves `undefined` when there is nothing to apply: the request was aborted, or it failed. Metadata is optional and
+ * playback never depends on it, so a failure is never fatal — a `404` says the document does not exist and stays quiet,
+ * and any other failure is only announced in development.
+ */
+export async function loadMuxMetadata(url: string, signal?: AbortSignal): Promise<MuxMetadata | undefined> {
+  try {
+    const response = await fetch(url, signal ? { signal } : {});
+    if (response.ok) return parseMuxMetadata(await response.json());
+
+    if (__DEV__ && response.status !== 404) {
+      console.warn(`[vjs-mux] Failed to load the Mux metadata at ${url}: ${response.status} ${response.statusText}`);
+    }
+  } catch (error) {
+    if (__DEV__ && !signal?.aborted && !isAbortError(error)) {
+      console.warn(`[vjs-mux] Failed to load the Mux metadata at ${url}.`, error);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * The content data a metadata document contributes: every key as it stands, so a consumer can read what the shared
+ * vocabulary does not name, with a `video_title` entry standing in for `title` when the document names none.
+ */
+export function toMuxContentData(metadata?: MuxMetadata): MuxContentData {
+  if (!metadata) return {};
+
+  const title = metadata.title || metadata.video_title;
+
+  return { ...metadata, ...(title && { title }) };
+}
+
+/**
+ * The metadata document for one Mux source, across the request that fetches it.
+ *
+ * Keyed by the source's identity — playback ID, domain, and playback token — so a source assignment that keeps those
+ * keeps the document (an image param changing, say), and one that moves them drops it along with any request in flight.
+ * A Media owns one of these next to its `source`, and folds `metadata` into `contentData` when `onChange` says it
+ * moved.
+ */
+export class MuxMetadataLoader {
+  #key: string | undefined;
+  #metadata: MuxMetadata | undefined;
+  #request: AbortController | null = null;
+  readonly #onChange: () => void;
+
+  constructor(onChange: () => void) {
+    this.#onChange = onChange;
+  }
+
+  /** The document for the current source, once it has arrived. */
+  get metadata(): MuxMetadata | undefined {
+    return this.#metadata;
+  }
+
+  /**
+   * Re-key to `source`. A source with the same identity leaves everything alone; any other drops the document and
+   * aborts a request in flight. Quiet either way — the owner rebuilds its `contentData` right after.
+   */
+  reset(source: MuxSourceBase | null | undefined): void {
+    const key = createMuxMetadataURL(source);
+    if (key === this.#key) return;
+
+    this.#key = key;
+    this.#abort();
+    this.#metadata = undefined;
+  }
+
+  /**
+   * Fetch the document for the current source. Ignored without a Mux source, and once the document is here or on its
+   * way — so repeated loads of one source cost one request.
+   */
+  load(): void {
+    if (!this.#key || this.#metadata || this.#request) return;
+
+    const request = (this.#request = new AbortController());
+
+    void loadMuxMetadata(this.#key, request.signal).then((metadata) => {
+      if (request.signal.aborted) return;
+
+      this.#request = null;
+      // A failed request settles as an empty document, so the source is not
+      // asked for again on the next load.
+      this.#metadata = metadata ?? {};
+      this.#onChange();
+    });
+  }
+
+  destroy(): void {
+    this.#abort();
+  }
+
+  #abort(): void {
+    this.#request?.abort();
+    this.#request = null;
+  }
+}

--- a/packages/adapters/mux/src/source.ts
+++ b/packages/adapters/mux/src/source.ts
@@ -202,14 +202,19 @@ function parseMuxParamValue(value: string): string | number | boolean {
 }
 
 /**
- * Image URLs a Mux source describes rather than plays, as every Mux Media exposes them through `contentData`. A key is
- * absent when its URL can't be built — no playback ID, or signed playback without a matching image token.
+ * What a Mux source says about its content, as every Mux Media exposes it through `contentData`.
  *
- * Names the two keys a Mux source actually derives. The index signature comes from `MediaContentData`, which the shared
- * `contentData` capability is typed as, so it can't be closed off here — extending it is what keeps this assignable to
- * that contract.
+ * `poster` and `storyboard` are image URLs the source describes rather than plays, derived from it alone. A key is
+ * absent when its URL can't be built — no playback ID, or signed playback without a matching image token. `title` comes
+ * from the metadata document Mux publishes for the asset, so it arrives once that has loaded — see `MuxMetadataLoader`
+ * — and is absent until then, or when the asset has none. The document's other entries ride along under their own
+ * keys.
+ *
+ * The index signature comes from `MediaContentData`, which the shared `contentData` capability is typed as, so it can't
+ * be closed off here — extending it is what keeps this assignable to that contract.
  */
 export interface MuxContentData extends MediaContentData {
+  readonly title?: string;
   readonly poster?: string;
   readonly storyboard?: string;
 }

--- a/packages/adapters/mux/src/tests/metadata.test.ts
+++ b/packages/adapters/mux/src/tests/metadata.test.ts
@@ -1,0 +1,377 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import {
+  createMuxMetadataURL,
+  loadMuxMetadata,
+  MuxMetadataLoader,
+  parseMuxMetadata,
+  toMuxContentData,
+} from '../metadata';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// The document Mux serves: Apple's JSON chapters, the first chapter standing
+// for the asset. `titles` is what a titled asset carries today; `metadata` is
+// the format's key/value list, for the entries the free plan adds.
+const DOCUMENT = [
+  {
+    'start-time': 0,
+    titles: [{ language: 'und', title: 'Big Buck Bunny' }],
+    metadata: [{ key: 'com.mux.video.branding', value: 'mux-free-plan' }],
+  },
+];
+
+const FLATTENED = { title: 'Big Buck Bunny', 'com.mux.video.branding': 'mux-free-plan' };
+
+function stubFetch(handler: (url: string) => Response | Promise<Response>) {
+  const fetchMock = vi.fn((input: string | URL | Request) =>
+    Promise.resolve(handler(input instanceof Request ? input.url : String(input)))
+  );
+
+  vi.stubGlobal('fetch', fetchMock);
+
+  return fetchMock;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+// Let a resolved fetch settle through the loader's `then`.
+function flush() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+describe('createMuxMetadataURL', () => {
+  it('returns undefined without a playbackId', () => {
+    expect(createMuxMetadataURL()).toBeUndefined();
+    expect(createMuxMetadataURL(null)).toBeUndefined();
+    expect(createMuxMetadataURL({ src: 'https://example.com/custom.m3u8' })).toBeUndefined();
+  });
+
+  it('builds the predictable URL from a playbackId', () => {
+    expect(createMuxMetadataURL({ playbackId: 'abc123' })).toBe('https://stream.mux.com/abc123/metadata.json');
+  });
+
+  it('uses the custom domain', () => {
+    expect(createMuxMetadataURL({ playbackId: 'abc123', customDomain: 'example.com' })).toBe(
+      'https://stream.example.com/abc123/metadata.json'
+    );
+  });
+
+  it('carries the playback token and nothing else from the playback params', () => {
+    expect(createMuxMetadataURL({ playbackId: 'abc123', playback: { token: 'jwt', maxResolution: '1080p' } })).toBe(
+      'https://stream.mux.com/abc123/metadata.json?token=jwt'
+    );
+
+    expect(createMuxMetadataURL({ playbackId: 'abc123', playback: { maxResolution: '1080p' } })).toBe(
+      'https://stream.mux.com/abc123/metadata.json'
+    );
+  });
+});
+
+describe('parseMuxMetadata', () => {
+  it('flattens the title and the entries on the first chapter', () => {
+    expect(parseMuxMetadata(DOCUMENT)).toEqual(FLATTENED);
+  });
+
+  it('takes the first title as the default', () => {
+    expect(
+      parseMuxMetadata([
+        {
+          titles: [
+            { language: 'en', title: 'English' },
+            { language: 'fr', title: 'Français' },
+          ],
+        },
+      ])
+    ).toEqual({ title: 'English' });
+  });
+
+  it('is empty for an untitled asset without entries', () => {
+    // What Mux serves for every asset that has no metadata.
+    expect(parseMuxMetadata([{ 'start-time': 0 }])).toEqual({});
+    expect(parseMuxMetadata([{ 'start-time': 0, titles: [], metadata: [] }])).toEqual({});
+    expect(parseMuxMetadata([{ titles: [{ language: 'und', title: '' }] }])).toEqual({});
+    expect(parseMuxMetadata([])).toEqual({});
+  });
+
+  it('is empty for anything that is not the document', () => {
+    expect(parseMuxMetadata(undefined)).toEqual({});
+    expect(parseMuxMetadata(null)).toEqual({});
+    expect(parseMuxMetadata('nope')).toEqual({});
+    expect(parseMuxMetadata({ titles: [{ title: 'x' }] })).toEqual({});
+    expect(parseMuxMetadata([{ titles: 'nope', metadata: 'nope' }])).toEqual({});
+    expect(parseMuxMetadata([{ titles: [{ title: 42 }] }])).toEqual({});
+  });
+
+  it('skips entries without a string key and value', () => {
+    expect(
+      parseMuxMetadata([
+        {
+          metadata: [
+            { key: 'video_title', value: 'x' },
+            { key: '', value: 'blank key' },
+            { key: 'no_value' },
+            { key: 'numeric', value: 1 },
+            'nope',
+            null,
+          ],
+        },
+      ])
+    ).toEqual({ video_title: 'x' });
+  });
+});
+
+describe('loadMuxMetadata', () => {
+  it('resolves the flattened document', async () => {
+    const fetchMock = stubFetch(() => jsonResponse(DOCUMENT));
+
+    await expect(loadMuxMetadata('https://stream.mux.com/abc123/metadata.json')).resolves.toEqual(FLATTENED);
+    expect(fetchMock).toHaveBeenCalledWith('https://stream.mux.com/abc123/metadata.json', {});
+  });
+
+  it('passes the signal through', async () => {
+    const fetchMock = stubFetch(() => jsonResponse(DOCUMENT));
+    const { signal } = new AbortController();
+
+    await loadMuxMetadata('https://stream.mux.com/abc123/metadata.json', signal);
+
+    expect(fetchMock).toHaveBeenCalledWith('https://stream.mux.com/abc123/metadata.json', { signal });
+  });
+
+  it('resolves undefined quietly for a 404', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    stubFetch(() => jsonResponse({ error: { type: 'not_found' } }, 404));
+
+    await expect(loadMuxMetadata('https://stream.mux.com/abc123/metadata.json')).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('resolves undefined and warns for another failed response', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // What signed playback answers without its token.
+    stubFetch(() => jsonResponse({ error: { type: 'not_authorized' } }, 403));
+
+    await expect(loadMuxMetadata('https://stream.mux.com/abc123/metadata.json')).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('403');
+  });
+
+  it('resolves undefined and warns for a network failure', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    stubFetch(() => Promise.reject(new TypeError('Failed to fetch')));
+
+    await expect(loadMuxMetadata('https://stream.mux.com/abc123/metadata.json')).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves undefined quietly when aborted', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const controller = new AbortController();
+
+    stubFetch(() => {
+      controller.abort();
+      return Promise.reject(new DOMException('Aborted', 'AbortError'));
+    });
+
+    await expect(
+      loadMuxMetadata('https://stream.mux.com/abc123/metadata.json', controller.signal)
+    ).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('toMuxContentData', () => {
+  it('is empty without metadata', () => {
+    expect(toMuxContentData()).toEqual({});
+    expect(toMuxContentData({})).toEqual({});
+  });
+
+  it('keeps every key as it stands', () => {
+    expect(toMuxContentData(FLATTENED)).toEqual(FLATTENED);
+  });
+
+  it('lets a video_title entry stand in for a missing title', () => {
+    expect(toMuxContentData({ video_title: 'Big Buck Bunny' })).toEqual({
+      title: 'Big Buck Bunny',
+      video_title: 'Big Buck Bunny',
+    });
+    expect(toMuxContentData({ title: 'Titled', video_title: 'Entry' })).toEqual({
+      title: 'Titled',
+      video_title: 'Entry',
+    });
+  });
+
+  it('leaves title absent for an empty video_title', () => {
+    expect(toMuxContentData({ video_title: '' })).toEqual({ video_title: '' });
+  });
+});
+
+describe('MuxMetadataLoader', () => {
+  it('starts without metadata', () => {
+    expect(new MuxMetadataLoader(() => {}).metadata).toBeUndefined();
+  });
+
+  it('loads the document for the source and announces it', async () => {
+    const fetchMock = stubFetch(() => jsonResponse(DOCUMENT));
+    const onChange = vi.fn();
+    const loader = new MuxMetadataLoader(onChange);
+
+    loader.reset({ playbackId: 'abc123' });
+    loader.load();
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://stream.mux.com/abc123/metadata.json');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(loader.metadata).toEqual(FLATTENED);
+  });
+
+  it('does nothing without a Mux source', async () => {
+    const fetchMock = stubFetch(() => jsonResponse(DOCUMENT));
+    const loader = new MuxMetadataLoader(() => {});
+
+    loader.load();
+
+    loader.reset({ src: 'https://example.com/custom.m3u8' });
+    loader.load();
+    await flush();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('requests each source once, across repeated loads', async () => {
+    const fetchMock = stubFetch(() => jsonResponse(DOCUMENT));
+    const loader = new MuxMetadataLoader(() => {});
+
+    loader.reset({ playbackId: 'abc123' });
+    loader.load();
+    loader.load();
+    await flush();
+    loader.load();
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles a failed request so the source is not asked again', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const fetchMock = stubFetch(() => new Response('', { status: 500 }));
+    const onChange = vi.fn();
+    const loader = new MuxMetadataLoader(onChange);
+
+    loader.reset({ playbackId: 'abc123' });
+    loader.load();
+    await flush();
+    loader.load();
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(loader.metadata).toEqual({});
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the document across a source with the same identity', async () => {
+    const fetchMock = stubFetch(() => jsonResponse(DOCUMENT));
+    const loader = new MuxMetadataLoader(() => {});
+
+    loader.reset({ playbackId: 'abc123' });
+    loader.load();
+    await flush();
+
+    // What `poster-time` does through the element: same stream, new object.
+    loader.reset({ playbackId: 'abc123', poster: { time: 3 } });
+    loader.load();
+    await flush();
+
+    expect(loader.metadata?.title).toBe('Big Buck Bunny');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the document when the identity moves, and loads the new one', async () => {
+    const fetchMock = stubFetch((url) =>
+      jsonResponse([{ titles: [{ title: url.includes('xyz789') ? 'second' : 'first' }] }])
+    );
+    const loader = new MuxMetadataLoader(() => {});
+
+    loader.reset({ playbackId: 'abc123' });
+    loader.load();
+    await flush();
+
+    loader.reset({ playbackId: 'xyz789' });
+
+    expect(loader.metadata).toBeUndefined();
+
+    loader.load();
+    await flush();
+
+    expect(loader.metadata?.title).toBe('second');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats the playback token as part of the identity', async () => {
+    const fetchMock = stubFetch(() => jsonResponse(DOCUMENT));
+    const loader = new MuxMetadataLoader(() => {});
+
+    loader.reset({ playbackId: 'abc123' });
+    loader.load();
+    await flush();
+
+    loader.reset({ playbackId: 'abc123', playback: { token: 'jwt' } });
+    loader.load();
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://stream.mux.com/abc123/metadata.json?token=jwt');
+  });
+
+  it('ignores a request that was in flight when the source moved', async () => {
+    let release!: (response: Response) => void;
+    const fetchMock = stubFetch(
+      () =>
+        new Promise<Response>((resolve) => {
+          release = resolve;
+        })
+    );
+    const onChange = vi.fn();
+    const loader = new MuxMetadataLoader(onChange);
+
+    loader.reset({ playbackId: 'abc123' });
+    loader.load();
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+
+    loader.reset({ playbackId: 'xyz789' });
+
+    expect(init.signal?.aborted).toBe(true);
+
+    release(jsonResponse(DOCUMENT));
+    await flush();
+
+    expect(loader.metadata).toBeUndefined();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('aborts the request in flight on destroy', () => {
+    const fetchMock = stubFetch(() => new Promise<Response>(() => {}));
+    const loader = new MuxMetadataLoader(() => {});
+
+    loader.reset({ playbackId: 'abc123' });
+    loader.load();
+    loader.destroy();
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+
+    expect(init.signal?.aborted).toBe(true);
+  });
+});

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -478,6 +478,8 @@ media.contentData;
 
 It's read-only and derived from `source`, so read it again after `sourcechange`. A key is missing when its URL can't be built: no playback ID, or signed playback with no matching image token. Changing the URLs means changing the params they're built from.
 
+One more key arrives later. Mux publishes a small metadata document for each asset, and the media loads it alongside the stream, so `contentData.title` fills in with the asset's title once it does — `contentdatachange` announces it. The player reads it as the fallback for its own title, so a Mux asset titled in the dashboard names itself without a `title` on the player. Any other entries the document carries ride along under their own keys. An untitled asset adds nothing.
+
 `source.poster` takes the [full set of Mux image modifiers](https://www.mux.com/docs/guides/get-images-from-a-video), so a narrower still for a small viewport is a `width`:
 
 <FrameworkCase frameworks={["react"]}>

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -351,6 +351,8 @@ For display, use `content-title` on the player.
 For display, use `title` on the player.
 </FrameworkCase>
 
+An asset titled in the Mux dashboard supplies its own: the Mux media loads the asset's metadata and the player falls back to that title when none is set on it, so the display title is optional for Mux-hosted video.
+
 The title reaches player state, but the packaged skins don't place it in their layouts. Add the <DocsLink slug="reference/title">Title</DocsLink> component as a child of a packaged skin, or place it in an ejected or custom layout, when you want viewers to see it:
 
 <FrameworkCase frameworks={["html"]}>


### PR DESCRIPTION
Refs #1662

## Summary

`<mux-video>` (and `<mux-audio>`) now load the metadata document Mux publishes for each asset and expose the asset title through `contentData.title`, so a Mux asset titled in the dashboard names itself in the player without a `title` / `content-title` being set.

## Changes

- Every Mux flavor — hls.js, native HLS, and SPF — fetches `https://stream.{domain}/{playbackId}/metadata.json` when the source loads. The document is Apple's JSON chapters format; the asset title is `titles[0].title`, and any `metadata` `{ key, value }` entries ride along under their own keys in `contentData` (that's where `com.mux.video.branding` would land).
- Signed playback appends `playback.token`; the endpoint answers `403` without it.
- The document is keyed by playback identity: a `poster-time` / image-param change keeps it, a playback ID change drops it and aborts the request in flight. One request per source.
- Failures never affect playback: `404` is quiet, other 4xx/5xx and network errors warn in dev only.
- `MuxContentData` gains `title`; the core `metadataFeature` picks it up as the fallback for the player's own title.
- Sandbox: the four Mux video pages overlay `<media-title>` / `<Title>` so the fetched title is visible. Docs updated in the media-sources concept and the Mux Player migration guide.

<details>
<summary>Why not the manifest's session data?</summary>

The issue suggests reading the metadata URL from `#EXT-X-SESSION-DATA` on hls.js's `MANIFEST_LOADED`. I implemented that first, then checked every Mux stream in the sandbox and docs — public, signed, and DRM: none of their manifests carry a session-data tag, while all of them serve the predictable `/{playbackId}/metadata.json` (titled ones with `titles`). A manifest-driven route would deliver nothing for any of these assets today, so the predictable URL is the one route for every engine. Reintroducing session data as a preferred URL is straightforward if Mux starts emitting the tag.

Also: the issue names `stream.mux.com/metadata/{playbackId}.json`; that form returns `400`. `/{playbackId}/metadata.json` is what `@mux/playback-core` uses as well.

</details>

## Testing

- `pnpm -F @videojs/mux -F @videojs/mux-video -F @videojs/mux-audio test` — new coverage for URL building, document parsing (`titles`, `metadata`, untitled assets, garbage input), load failures, the loader's identity/abort/dedupe behavior, and both adapter flavors (hls.js engine, native delegate with token, SPF). Existing suites stub `fetch` so no unit test reaches the network.
- `pnpm typecheck`, `pnpm lint` clean.
- Verified in Chromium against live Mux streams via the sandbox: `html-mux-video`, `html-mux-video-spf`, `react-mux-video`, `react-mux-video-spf` with `hls-1`, `hls-3`, and `mux-signed` all render the asset's title ("Big Buck Bunny", "VJS City"), with no `[vjs-mux]` metadata warnings.

## TODO (follow-ups, not in this PR)

- [ ] **Free-plan logo.** The `com.mux.video.branding: mux-free-plan` entry surfaces on `contentData` when Mux sends it, but nothing renders it yet. That likely needs a `logo` component (HTML + React) and a standardized `logo` field on `MediaContentData` / the metadata feature, in the spirit of `title` and `poster`, so the Mux media can contribute a branding logo and skins can place it.
- [ ] **Non-fatal error reporting to Mux Data.** There's no non-fatal error channel from adapters to `MuxDataExtension` today (every layer drops `!fatal`, and an `error` event would trip the player's error UI), so metadata failures are dev-warned only.
- [ ] **MP4 static renditions.** v10 has no Mux-identity source for `/{id}/high.mp4` URLs (they become a plain `source.src`), so the metadata fetch covers HLS on every engine; MP4 will pick it up once that identity exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds network fetches and async `contentData` updates across all Mux adapter flavors; playback is unaffected on failure, but consumers listening to `contentdatachange` may see an extra event and new keys on `contentData`.
> 
> **Overview**
> Mux video and audio adapters now fetch each asset’s `metadata.json` and merge the result into **`contentData`**, including **`title`** and any extra `{ key, value }` fields (e.g. branding). Poster/storyboard URLs still come from `source` immediately; metadata arrives asynchronously and triggers **`contentdatachange`** when it lands. Signed playback sends **`playback.token`** on the metadata URL; failures are non-fatal (dev warnings only), with abort/dedupe when the playback identity changes.
> 
> **hls.js** Mux adapters load metadata in **`load()`**; **SPF** loads on **`source`** assignment. Shared **`MuxMetadataLoader`** / parsing lives in **`@videojs/mux`**.
> 
> Sandbox Mux demos overlay **`Title`** / **`media-title`** with new **`sandbox-media-title`** styling so the fetched title is visible. Docs cover **`contentData.title`** and optional display titles for dashboard-titled assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 289793c06c3adade7183aa7ab4af0612b86b3822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->