### PR TITLE
fix(i18n): correct pt-BR button labels, casing and a grammar error

### DIFF
--- a/packages/core/src/core/i18n/locales/pt-BR.ts
+++ b/packages/core/src/core/i18n/locales/pt-BR.ts
@@ -2,10 +2,10 @@ import type { Translations } from '../params';
 
 export default {
   buttons: {
-    play: 'Tocar',
+    play: 'Reproduzir',
     pause: 'Pausar',
-    replay: 'Tocar novamente',
-    mute: 'Mudo',
+    replay: 'Reproduzir novamente',
+    mute: 'Silenciar',
     unmute: 'Ativar o som',
   },
   seek: {
@@ -13,7 +13,7 @@ export default {
     backward: 'Retroceder {seconds} segundos',
   },
   fullscreen: {
-    enter: 'Tela Cheia',
+    enter: 'Entrar em tela cheia',
     exit: 'Sair da tela cheia',
   },
   captions: {
@@ -21,8 +21,8 @@ export default {
     disable: 'Desativar legendas',
   },
   pip: {
-    enter: 'Picture-in-Picture',
-    exit: 'Sair de Picture-in-Picture',
+    enter: 'Entrar em picture-in-picture',
+    exit: 'Sair do picture-in-picture',
   },
   live: {
     playing: 'Reproduzindo ao vivo',
@@ -42,9 +42,9 @@ export default {
     seek: 'Buscar',
   },
   time: {
-    current: 'Tempo',
+    current: 'Tempo atual',
     duration: 'Duração',
-    remaining: 'Tempo Restante',
+    remaining: 'Tempo restante',
     elapsedSuffix: '{duration} de tempo decorrido',
     durationSuffix: '{duration} de duração',
     remainingSuffix: 'Restam {duration}',
@@ -78,10 +78,10 @@ export default {
     label: 'Reprodutor de mídia',
   },
   errors: {
-    aborted: 'Você parou a execução do vídeo.',
+    aborted: 'Você interrompeu a reprodução da mídia antes de ela terminar.',
     network: 'Um erro na rede causou falha durante o download da mídia.',
     decode:
-      'A reprodução foi interrompida devido à um problema de mídia corrompida ou porque a mídia utiliza funções que seu navegador não suporta.',
+      'A reprodução foi interrompida devido a um problema de mídia corrompida ou porque a mídia utiliza funções que seu navegador não suporta.',
     source: 'A mídia não pode ser carregada, por uma falha de rede ou servidor ou o formato não é suportado.',
     encrypted: 'A mídia está criptografada e não temos as chaves para descriptografar.',
     unplayable: 'Esta mídia não é suportada pelo reprodutor.',


### PR DESCRIPTION
By @rennanribeiro, closes https://github.com/videojs/v10/issues/2537

The pt-BR locale had never been read by a native speaker: its strings arrived through bulk passes that added keys as the English side grew. Its sibling pt-PT was reviewed, and the two disagree on the same decisions.

- `buttons.mute` was 'Mudo', an adjective on a button whose value becomes an `aria-label`. Its own pair 'Ativar o som' is a verb phrase, and the file already says 'Silenciado' for the state.
- `fullscreen.enter` and `pip.enter` named the destination instead of the action their English counterparts describe, and capitalised it, contradicting 'Tela cheia' and 'Picture-in-picture' under `status` in the same file.
- `buttons.play` was 'Tocar' while the same file announces 'Reproduzindo' and labels the player 'Reprodutor de mídia'. pt-PT already uses 'Reproduzir'.
- `time.current` dropped the qualifier the English 'Current time' carries, leaving 'Tempo' next to 'Duração'.
- `errors.decode` read 'devido à um problema', a crase before a masculine noun.
- `errors.aborted` said 'vídeo' where the player also serves audio.

`pt.ts` re-exports this file, so it picks up the same corrections.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only locale updates with no logic or API changes; low risk aside from minor UX wording differences for pt-BR/pt users.
> 
> **Overview**
> This PR **refines Brazilian Portuguese (`pt-BR`) player copy** so controls, accessibility labels, and errors read naturally and stay consistent with the rest of the locale (and with **pt-PT** where it matters).
> 
> **Playback controls** use **Reproduzir** / **Reproduzir novamente** instead of **Tocar**, and **Silenciar** instead of **Mudo** so button text matches verb-style pairs like **Ativar o som**. **Fullscreen** and **picture-in-picture** enter actions are phrased as **Entrar em…** (lowercase) rather than naming the mode in title case.
> 
> **Time labels** gain **Tempo atual** and normalized **Tempo restante** casing. **Error strings** fix grammar (**devido a**), broaden **aborted** from “vídeo” to **mídia**, and leave decode wording aligned with media-player scope.
> 
> Because **`pt.ts` re-exports `pt-BR`**, the same strings apply for generic `lang="pt"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1740afc8c02382865f3b1543f6d4a89a50f13d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->