### PR TITLE
fix(i18n): retranslate pt-BR error strings and playback-rate label

### DIFF
--- a/packages/core/src/core/i18n/locales/pt-BR.ts
+++ b/packages/core/src/core/i18n/locales/pt-BR.ts
@@ -2,10 +2,10 @@ import type { Translations } from '../params';
 
 export default {
   buttons: {
-    play: 'Tocar',
+    play: 'Reproduzir',
     pause: 'Pausar',
-    replay: 'Tocar novamente',
-    mute: 'Mudo',
+    replay: 'Reproduzir novamente',
+    mute: 'Silenciar',
     unmute: 'Ativar o som',
   },
   seek: {
@@ -13,7 +13,7 @@ export default {
     backward: 'Retroceder {seconds} segundos',
   },
   fullscreen: {
-    enter: 'Tela Cheia',
+    enter: 'Entrar em tela cheia',
     exit: 'Sair da tela cheia',
   },
   captions: {
@@ -21,8 +21,8 @@ export default {
     disable: 'Desativar legendas',
   },
   pip: {
-    enter: 'Picture-in-Picture',
-    exit: 'Sair de Picture-in-Picture',
+    enter: 'Entrar em picture-in-picture',
+    exit: 'Sair do picture-in-picture',
   },
   live: {
     playing: 'Reproduzindo ao vivo',
@@ -42,9 +42,9 @@ export default {
     seek: 'Buscar',
   },
   time: {
-    current: 'Tempo',
+    current: 'Tempo atual',
     duration: 'Duração',
-    remaining: 'Tempo Restante',
+    remaining: 'Tempo restante',
     elapsedSuffix: '{duration} de tempo decorrido',
     durationSuffix: '{duration} de duração',
     remainingSuffix: 'Restam {duration}',
@@ -78,10 +78,10 @@ export default {
     label: 'Reprodutor de mídia',
   },
   errors: {
-    aborted: 'Você parou a execução do vídeo.',
+    aborted: 'Você interrompeu a reprodução da mídia antes de ela terminar.',
     network: 'Um erro na rede causou falha durante o download da mídia.',
     decode:
-      'A reprodução foi interrompida devido à um problema de mídia corrompida ou porque a mídia utiliza funções que seu navegador não suporta.',
+      'A reprodução foi interrompida devido a um problema de mídia corrompida ou porque a mídia utiliza funções que seu navegador não suporta.',
     source: 'A mídia não pode ser carregada, por uma falha de rede ou servidor ou o formato não é suportado.',
     encrypted: 'A mídia está criptografada e não temos as chaves para descriptografar.',
     unplayable: 'Esta mídia não é suportada pelo reprodutor.',


### PR DESCRIPTION
Stacked on #2751 (merge that first; this PR then shows only the additional rows). Also note `pt.ts` aliases this file.

`pt-BR.ts` was audited by a native speaker in #2537, and #2751 is the resulting fix — ten strings, still open as of this writing. This PR covers what #2751 does not: one label that has lost a qualifier, one aria-label that does not parse, and five `errors.*` strings that still translate the English copy PR #1822 replaced. On the `errors.*` rows this PR **overrides an explicit judgement** by #2537's reporter, who looked at that copy and called it "wordier than the English but not wrong", adding that rewriting it "would be a style pass rather than a fix"; the argument here is that those strings drifted against the *post*-#1822 English (`errors.source` in particular described a network/server failure, duplicating `errors.network`), which the reporter may not have re-checked. Everything #2751 changes is treated as correct and is not re-reported here. Checked against YouTube Help pt-BR, Microsoft's pt-BR player docs and Netflix's Brazilian help centre. Every value here reaches the DOM as an `aria-label`, so these are announced by a screen reader rather than merely displayed. **A native-speaker check is requested before merge**, ideally from #2537's reporter, specifically on the `errors.*` rows.

## Changes

| key | current (post-#2751) | proposed | why (source link) |
| --- | --- | --- | --- |
| `playback.rate` | `Velocidade {rate}` | `Velocidade de reprodução {rate}` | `en.ts` is "Playback rate {rate}", and the same file already spells it out as `menu.playbackRate: 'Velocidade de reprodução'`. As an aria-label, bare "Velocidade 1,5" is indistinguishable from a volume level. ([Microsoft pt-BR player docs](https://support.microsoft.com/pt-br/clipchamp/stream-pages/using-video-player-settings-to-control-playback-experience)) |
| `live.seekToEdge` | `Ir para o ao vivo` | `Ir para a transmissão ao vivo` | "ao vivo" is adverbial and cannot take "o" — a word-for-word rendering of "the live edge". YouTube pt-BR names the object "**transmissão ao vivo**". This is the live button's aria-label. ([YouTube pt-BR](https://support.google.com/youtube/answer/9879686?hl=pt-BR)) |

### Error strings retranslated against current English

PR #1822 rewrote the English `errors.*` copy but reused the existing foreign values verbatim, so these Brazilian strings still translate the *old* English text. This is drift against the current English rather than a gap in #2537 — as noted above, the reporter read these strings and declined to change them.

| key | current (post-#2751) | proposed | why (source link) |
| --- | --- | --- | --- |
| `errors.network` | `Um erro na rede causou falha durante o download da mídia.` | `Não foi possível carregar esta mídia devido a um problema de rede ou do servidor.` | Still translates the pre-#1822 English ("A network error caused the media download to fail."). Current `en.ts` names the **server** as a possible cause and drops the "download" framing. ([YouTube pt-BR](https://support.google.com/youtube/answer/9879686?hl=pt-BR)) |
| `errors.decode` | `A reprodução foi interrompida devido a um problema de mídia corrompida ou porque a mídia utiliza funções que seu navegador não suporta.` | `Não foi possível reproduzir esta mídia. Ela pode estar corrompida ou seu navegador pode não suportar o formato.` | #2751 fixed the crase on this line but kept the old meaning. `en.ts` now reads "This media could not be played. It **may be** corrupted, or your browser may not support its **format**." — playback never started, the corruption is hedged, and the browser gap is about the format, not about "funções". **This row applies on top of #2751's version of this line**, which is why the PR is stacked. ([YouTube pt-BR](https://support.google.com/youtube/answer/7631406?hl=pt-BR)) |
| `errors.source` | `A mídia não pode ser carregada, por uma falha de rede ou servidor ou o formato não é suportado.` | `Não foi possível carregar esta mídia. Ela pode estar indisponível ou seu navegador pode não suportar o formato.` | `en.ts` separates source from network: "It may be **unavailable**…". Today `errors.network` and `errors.source` read as near-duplicates. Also fixes the tense (`não pode` → `não foi possível`). ([YouTube pt-BR](https://support.google.com/youtube/answer/9879686?hl=pt-BR)) |
| `errors.encrypted` | `A mídia está criptografada e não temos as chaves para descriptografar.` | `Não foi possível reproduzir esta mídia porque não foi possível descriptografá-la.` | `en.ts` no longer mentions keys: "…because it could not be decrypted." The current string is also the only one in the file that speaks in the first person ("não temos"). Keeps the Brazilian verb *descriptografar*. ([Netflix pt](https://help.netflix.com/pt/node/372)) |
| `errors.unexpected` | `Ocorreu um erro. Tente novamente.` | `Ocorreu um erro inesperado.` | `en.ts`: "An **unexpected** error occurred." The qualifier is dropped and a "try again" instruction the dialog does not offer is invented — its only control dismisses it. |

## Deliberately left alone

- **Everything #2751 changes** — its values are the baseline of this PR, not subjects of this review.
- `buttons.unmute: 'Ativar o som'` — matches YouTube pt-BR ("Desativar/ativar o som do vídeo"); the asymmetry with #2751's `Silenciar` is the native reviewer's own choice.
- `seek.forward` / `seek.backward` — exactly YouTube pt-BR's verbs ("Retroceder 10 segundos", "Avançar 10 segundos", [YouTube pt-BR](https://support.google.com/youtube/answer/7631406?hl=pt-BR)).
- `slider.seek: 'Buscar'` and `volume.label: 'Nível de volume'` — #2537's reporter saw both and left them; no source shows either is wrong.
- `menu.captions` / `menu.subtitles`, both `Legendas` — pt-BR does have a closed-caption term ("legendas ocultas" at Netflix, "legenda descritiva" at YouTube), but `captions.*`, `status.*` and `menu.*` all use plain "legendas" here; splitting only the menu key would introduce a new inconsistency. Worth a native decision rather than a unilateral change.
- `menu.audio: 'Áudio'` — also the fallback label for an unnamed audio track, where "Faixa de áudio" would be more informative, but nothing shows the current value is wrong for the menu.
- `container.label`, `menu.settings`, `menu.default`, `status.playing`, `errors.title` — correct Brazilian forms. The European Portuguese review proposes different words for several of these (`leitor`, `Definições`, `Predefinição`, `A reproduzir`, `Algo correu mal.`); the two files must stay apart.
- `time.unknown` and `common.ok: 'Fechar'` — already correct (the latter is only used as the error dialog's dismiss button).

## Testing

```bash
pnpm lint:fix:file packages/core/src/core/i18n/locales/pt-BR.ts
pnpm check:workspace
CI=1 pnpm -F @videojs/core exec vitest run src/core/i18n
git diff --check
```

All passed: 10/10 workspace checks, 6 test files / 59 tests.

## Independent verification

A second pass re-checked every row and citation against the sources, independently of the review that produced this PR. **Verdict: MERGE.** No string value changed as a result; the only fix was to this description, which previously called the `errors.*` rows "the residue #2537 never looked at" and "the class of drift #2537 never examined". That was inaccurate: the reporter examined those strings and declined them as "wordier than the English but not wrong", so this PR overrides a stated native-speaker judgement rather than filling a gap he missed. The override holds up on the merits — compared against `origin/main`'s `en.ts`, `errors.source` described a network/server failure and duplicated `errors.network` — but a maintainer should merge it knowing that, which is why the sign-off request above is now specific.

Also verified independently: nine of the ten rows #2537 asked for are applied character for character, the tenth (the `devido à um` crase) is eliminated rather than reintroduced, and all three strings the reporter deliberately left alone are still untouched. One citation could not be confirmed — the [Microsoft pt-BR player docs](https://support.microsoft.com/pt-br/clipchamp/stream-pages/using-video-player-settings-to-control-playback-experience) link for `playback.rate`; that row stands on the intra-file `menu.playbackRate` evidence regardless.

### Questions for a native speaker

- `errors.network` / `errors.source` / `errors.encrypted` / `errors.unexpected` — for #2537's reporter specifically: you wrote that the remaining `errors.*` copy was "wordier than the English but not wrong". This PR rewrites four of those strings on the grounds that they translate the pre-#1822 English — in particular `errors.source` described a network/server failure, duplicating `errors.network`. Do you agree these are correctness fixes rather than a style pass?
- `errors.encrypted` — is the double "Não foi possível … porque não foi possível …" acceptable, or would "… porque não pôde ser descriptografada" be better?
- `errors.decode` / `errors.source` — both use "suportar o formato"; some Brazilian style guides prefer "ser compatível com o formato". Is "suportar" fine here? (Firefox pt-BR does use "não suportado".)
- `fullscreen.enter` — the file uses "tela cheia" (as does YouTube pt-BR) while Firefox pt-BR and VLC pt_BR use "tela inteira". Confirming "tela cheia" is right for this player.
- `pt.ts` alias — `pt.ts` re-exports `pt-BR.ts`, so `lang="pt"` users in Portugal get Brazilian strings. Out of scope for this PR, but worth a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RUzGdFxhbHjtqXvhgFAuq

---
_Generated by [Claude Code](https://claude.ai/code/session_011RUzGdFxhbHjtqXvhgFAuq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Locale-only string updates for accessibility and copy alignment; no auth, data, or player behavior changes.
> 
> **Overview**
> **Refines Brazilian Portuguese (`pt-BR`) copy** used for player controls, time labels, and screen-reader announcements—no runtime logic changes.
> 
> Control and mode labels shift toward standard media wording (e.g. **Reproduzir** / **Silenciar**, **Entrar em tela cheia** and picture-in-picture phrasing, **Velocidade de reprodução {rate}** so the rate control is not confused with volume). **live.seekToEdge** becomes **Ir para a transmissão ao vivo** to fix ungrammatical “o ao vivo”. Minor time-label tweaks (**Tempo atual**, sentence case on **Tempo restante**).
> 
> **errors.*** strings are retranslated to match current English: clearer load/play/decrypt failures, **errors.source** no longer duplicates network/server failure language, and **errors.unexpected** drops invented “try again” copy. Because **`pt.ts` re-exports this file**, `lang="pt"` users get the same strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e491375cd321c1cbf7f4459fa976419efdafb9f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->